### PR TITLE
feat: WORKFLOW.md orchestration contract (SPEC-003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to dwarves-kit are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`WORKFLOW.md`** (repo root): the agent-facing workflow contract. Names each lifecycle phase, routes work by risk tier (tiny / normal / full), and points at the existing guardrail that enforces each boundary. Delivered via the `CLAUDE.md` pointer (auto-loaded each session); it suggests and routes, it does not block. Downstream template ships at `examples/hello-spec/WORKFLOW.md` (`.planning/` path convention). Source: SPEC-003; harness-experimental intake model + the AGENTS.md pattern.
+- **`tests/test-meta.sh`**: 6 assertions for the WORKFLOW.md contract (four pinned section headers + per-file path-convention checks). Suite total: 104 → 110.
+
+### Changed
+
+- **`CLAUDE.md` Workflow section** (kit root + `examples/hello-spec/`): replaced the duplicated step list with a pointer to `WORKFLOW.md`, so the cycle lives in exactly one place.
+- **`docs/PHILOSOPHY.md`**: reconciled the canonical lifecycle phase count to 8 (Think, Spec, Validate, Build, Review, Docs, Ship, Reflect); it previously said 7 in one place and 9 in another.
+- **`README.md`, `MANUAL.md`, `docs/architecture.md`**: one-line cross-reference to `WORKFLOW.md` (the architecture pointer frames it as the imperative companion to the data-flow diagram).
+
 ## [1.5.1] - 2026-04-21
 
 Audit-fix release. Same-day patch following a retroactive `/review-team` and `/retro` that surfaced gaps in the v1.4/v1.5 SDLC application.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,18 +57,7 @@ The kit's hooks/commands still reference `.planning/SPEC.md` for downstream proj
 
 ## Workflow
 
-The kit eats its own dog food. Active development cycles:
-
-1. `/user:start` to detect state (in this repo, usually "no in-flight spec; start with /think or /spec").
-2. `/user:think` for any non-trivial change.
-3. `/user:spec` writes to `.planning/SPEC.md` by default; for kit-on-kit work, draft directly at `docs/specs/SPEC-NNN-<slug>.md` (current spec format).
-4. `/user:spec-validate` runs 4 adversarial reviewers.
-5. `/user:execute` (autonomous, verification pipeline) OR `/user:next` (manual, you drive).
-6. `/user:review-team` for any change touching hooks or security; `/user:review` for small docs/refactor changes.
-7. `/user:docs` syncs README/CHANGELOG with code.
-8. `/user:ship` gates on review verdict, bumps VERSION, writes CHANGELOG, tags, opens PR.
-9. `/user:retro` writes `docs/retro/v<version>.md`.
-10. After ship: flip the spec's `Status:` header to SHIPPED (no file move if drafted in `docs/specs/` already).
+The kit eats its own dog food. The full lifecycle, the risk-tier lanes, and the gate at each phase boundary live in one place: the [`WORKFLOW.md`](WORKFLOW.md) contract. Read it after this file. For kit-on-kit work, spec drafts live in `docs/specs/` (see Spec location above), not `.planning/`.
 
 `/user:kit-health` is the maintainer-only self-assessment against PHILOSOPHY.md. Run it before tagging.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,9 @@ These are the kit's own dev rules. They apply to PRs into dwarves-kit. The same 
 
 ## Spec location
 
-In-flight work lives in `.planning/SPEC.md` (the working scratch dir that hooks and commands reference). When a release ships, the maintainer moves the finalized spec to `docs/specs/SPEC-NNN-<slug>.md` as historical record, then clears `.planning/`. See `docs/decisions/0002-planning-dir-convention.md` for the rationale.
+For the kit's own work, specs live at `docs/specs/SPEC-NNN-<slug>.md` from draft to ship. The file's `Status:` header (DRAFT / VALIDATED / SHIPPED) tracks state in place; no migration step. Matches ops-toolkit `tools/tide/docs/specs/` shape.
+
+The kit's hooks/commands still reference `.planning/SPEC.md` for downstream projects that follow GSD's two-directory convention. That path remains valid for kit USERS; the kit ITSELF skips the indirection. See ADR-0002 for the convention split.
 
 ## Workflow
 
@@ -59,14 +61,14 @@ The kit eats its own dog food. Active development cycles:
 
 1. `/user:start` to detect state (in this repo, usually "no in-flight spec; start with /think or /spec").
 2. `/user:think` for any non-trivial change.
-3. `/user:spec` writes to `.planning/SPEC.md`.
+3. `/user:spec` writes to `.planning/SPEC.md` by default; for kit-on-kit work, draft directly at `docs/specs/SPEC-NNN-<slug>.md` (current spec format).
 4. `/user:spec-validate` runs 4 adversarial reviewers.
 5. `/user:execute` (autonomous, verification pipeline) OR `/user:next` (manual, you drive).
 6. `/user:review-team` for any change touching hooks or security; `/user:review` for small docs/refactor changes.
 7. `/user:docs` syncs README/CHANGELOG with code.
 8. `/user:ship` gates on review verdict, bumps VERSION, writes CHANGELOG, tags, opens PR.
 9. `/user:retro` writes `docs/retro/v<version>.md`.
-10. After ship: move `.planning/SPEC.md` to `docs/specs/`.
+10. After ship: flip the spec's `Status:` header to SHIPPED (no file move if drafted in `docs/specs/` already).
 
 `/user:kit-health` is the maintainer-only self-assessment against PHILOSOPHY.md. Run it before tagging.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,6 +1,6 @@
 # MANUAL
 
-Operator reference for dwarves-kit. For the WHY behind any choice, see `docs/PHILOSOPHY.md`. For component fit, see `docs/architecture.md`. For diagnosing a misbehaving hook, see `RUNBOOK.md`.
+Operator reference for dwarves-kit. For the WHY behind any choice, see `docs/PHILOSOPHY.md`. For component fit, see `docs/architecture.md`. For diagnosing a misbehaving hook, see `RUNBOOK.md`. For the end-to-end workflow contract (phases, risk-tier lanes, gates), see `WORKFLOW.md`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A solo technical lead handing off implementation to contractors. The kit covers 
 
 Also for: a builder using Claude Code 6-8 hours/day who wants a context-budget HUD, automatic safety guards, session-state persistence across compaction, and slop detection at stop points.
 
-See `examples/hello-spec/` for a small, self-contained walkthrough of the artifacts the kit produces.
+See `examples/hello-spec/` for a small, self-contained walkthrough of the artifacts the kit produces. The end-to-end workflow an agent follows (phases, risk-tier lanes, and the gate at each boundary) is the [`WORKFLOW.md`](WORKFLOW.md) contract.
 
 ## Who this is NOT for
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -18,7 +18,7 @@ Pick a lane before you start. Smaller work skips ceremony.
 |--------|------|------|
 | tiny   | typo, copy, comment, one obvious edit | edit, verify, done. No spec. |
 | normal | one bounded feature or fix | /spec, /execute, /review, /ship |
-| full   | touches auth, authz, data model, data loss, audit/security, an external provider, an API contract, a migration, or weakens validation | /think, /spec, /spec-validate, /execute, /review-team, /docs, /ship, /retro |
+| full   | touches auth, authz, hooks, data model, data loss, audit/security, an external provider, an API contract, a migration, or weakens validation | /think, /spec, /spec-validate, /execute, /review-team, /docs, /ship, /retro |
 
 When in doubt between two lanes, take the heavier one. Anything in the full-lane
 trigger list uses the full lane unless you explicitly narrow the scope and say why.
@@ -32,7 +32,7 @@ trigger list uses the full lane unless you explicitly narrow the scope and say w
 | Build    | /user:execute or /user:next | tasks checked, verifier PASS | verification pipeline (worker, verifier, fix; max 2) |
 | Review   | /user:review or /user:review-team | review verdict recorded | advisory |
 | Docs     | /user:docs | README/CHANGELOG match code | advisory |
-| Ship     | /user:ship | tagged + PR | ship gate (blocks on FIX-REQUIRED), push-to-main blocker |
+| Ship     | /user:ship | tagged + PR | ship gate (blocks on DO NOT SHIP), push-to-main blocker |
 | Reflect  | /user:retro | docs/retro/v<version>.md written | advisory |
 
 Throughout: safety-gate blocks destructive Bash; anti-rationalization blocks

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,53 @@
+# WORKFLOW.md: the cycle, the lanes, the gates
+
+> Agent-facing contract. Read after CLAUDE.md. It names the lifecycle, routes
+> work by risk, and points at the guardrail that enforces each boundary.
+> It suggests and routes; it does not block. The only hard stops are the
+> safety-gate hook, the push-to-main blocker, the anti-rationalization Stop
+> hook, and the verification pipeline.
+
+## Required reading (in order)
+1. CLAUDE.md            - project context: stack, structure, rules
+2. docs/specs/SPEC-NNN-<slug>.md - the active spec; the shared contract for the cycle
+3. docs/architecture.md - how the pieces fit (reference; not required per task)
+
+## Size the work first (risk-tiered intake)
+Pick a lane before you start. Smaller work skips ceremony.
+
+| Lane   | When | Path |
+|--------|------|------|
+| tiny   | typo, copy, comment, one obvious edit | edit, verify, done. No spec. |
+| normal | one bounded feature or fix | /spec, /execute, /review, /ship |
+| full   | touches auth, authz, data model, data loss, audit/security, an external provider, an API contract, a migration, or weakens validation | /think, /spec, /spec-validate, /execute, /review-team, /docs, /ship, /retro |
+
+When in doubt between two lanes, take the heavier one. Anything in the full-lane
+trigger list uses the full lane unless you explicitly narrow the scope and say why.
+
+## The cycle (phase, exit, enforcer)
+| Phase    | Command | Exit when | Enforced by |
+|----------|---------|-----------|-------------|
+| Think    | /user:think | decision brief written (if BUILD) | advisory |
+| Spec     | /user:spec | spec exists, Status: DRAFT | spec-drift-guard hook |
+| Validate | /user:spec-validate | Status: VALIDATED | advisory (full lane) |
+| Build    | /user:execute or /user:next | tasks checked, verifier PASS | verification pipeline (worker, verifier, fix; max 2) |
+| Review   | /user:review or /user:review-team | review verdict recorded | advisory |
+| Docs     | /user:docs | README/CHANGELOG match code | advisory |
+| Ship     | /user:ship | tagged + PR | ship gate (blocks on FIX-REQUIRED), push-to-main blocker |
+| Reflect  | /user:retro | docs/retro/v<version>.md written | advisory |
+
+Throughout: safety-gate blocks destructive Bash; anti-rationalization blocks
+premature "done"; auto-format runs on edit; session-state-save and
+post-compact-reinject protect long sessions.
+
+## Completion contract
+A task is done only when its acceptance criteria are met and the verifier has
+actually run the tests, not when you claim they pass. If you cannot run the
+check, report that plainly; the anti-rationalization hook is the backstop for
+premature completion. Self-reported "done" is not proof; the task-verifier is.
+
+## What this contract does NOT do
+It does not lock phases. An experienced operator may skip /spec-validate on a
+normal-lane change or go straight to /next. The kit detects state
+(context-readiness hook) and suggests the next step; it never blocks
+progression. Hard stops are reserved for irreversible cost: destructive
+commands, push-to-main, premature completion, failed verification.

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -48,7 +48,7 @@ We believe a unified kit covering Think-through-Retro is more valuable than 4 be
 
 ### "Shallow and wide beats deep and narrow"
 
-We believe covering 7 lifecycle phases at 70% depth each is better than covering 2 phases at 100% depth. The biggest failures in AI-assisted development come from skipped phases (no spec, no review, no retro), not from insufficient depth in any one phase.
+We believe covering 8 lifecycle phases (Think, Spec, Validate, Build, Review, Docs, Ship, Reflect) at 70% depth each is better than covering 2 phases at 100% depth. The biggest failures in AI-assisted development come from skipped phases (no spec, no review, no retro), not from insufficient depth in any one phase.
 
 **Decision this already made:** /execute uses Claude Code's native Task tool for subagent dispatch. It's not as sophisticated as GSD v2's Pi SDK runtime (which has crash recovery, token tracking, and automated git branching). But it exists, and it covers the execution gap that 0 commands would leave.
 
@@ -165,7 +165,7 @@ End of day or end of sprint: /retro to capture learnings.
 Reject a proposed feature if ANY of these are true:
 
 1. **It duplicates an external tool.** If Context Hub, GSD, gstack, or a plugin already does it well, depend on it instead.
-2. **It serves fewer than 2 of the 9 workflow phases.** Single-purpose tools belong as standalone scripts, not kit features.
+2. **It serves fewer than 2 of the 8 workflow phases.** Single-purpose tools belong as standalone scripts, not kit features.
 3. **It requires the user to change their existing Notion/GitHub workflow.** The kit adapts to how Dwarves already works. It doesn't impose a new project management system.
 4. **It can't be explained in one sentence.** If you can't describe what the hook/command does in one line of the README table, it's too complex.
 5. **It has no source citation.** Per the "synthesize, don't originate" principle, every pattern must trace to a proven implementation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,8 @@ The kit is intentionally flat. Component dirs sit at the top of the repo, not ne
 
 ## Data flow through `.planning/SPEC.md`
 
+> The imperative companion to the descriptive map below is [`WORKFLOW.md`](../WORKFLOW.md) (repo root): the same lifecycle phrased as the contract an agent follows, with risk-tier lanes and the gate at each boundary.
+
 `.planning/SPEC.md` is the shared contract for the full lifecycle. It is the single source of truth that crosses command boundaries:
 
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ The kit is intentionally flat. Component dirs sit at the top of the repo, not ne
                  writes: docs/retro/v<version>.md
 ```
 
-After a release ships, the maintainer moves the finalized `.planning/SPEC.md` to `docs/specs/SPEC-NNN-<slug>.md` as the historical record. `.planning/` stays in-flight only.
+**Convention split (kit-on-kit vs downstream projects)**: the diagram above describes the downstream-project flow, where hooks/commands write to `.planning/SPEC.md`. For the KIT ITSELF as a project, specs are drafted directly at `docs/specs/SPEC-NNN-<slug>.md` and tracked in place via a `Status:` header (DRAFT / VALIDATED / SHIPPED). No migration step. See ADR-0002.
 
 ## Verification pipeline (the load-bearing piece)
 

--- a/docs/decisions/0002-planning-dir-convention.md
+++ b/docs/decisions/0002-planning-dir-convention.md
@@ -16,5 +16,5 @@ Adopted GSD's `.planning/` convention. Spec files live there. Hooks (context-rea
 ## Consequences
 - Compatible with GSD if user also installs GSD (both check .planning/).
 - context-readiness hook also checks for `.gsd/` as a fallback.
-- Contractors see specs in a predictable location across all Dwarves projects.
-- Historical archive of shipped specs lives in `docs/specs/SPEC-NNN-<slug>.md`. `.planning/` is for in-flight work; `docs/specs/` is for the record. Migration of a shipped spec is a manual step at release time.
+- Contractors see specs in a predictable location across all Dwarves projects that use the kit's tools.
+- **Convention split (added 2026-05-20)**: the kit's hooks/commands write to `.planning/SPEC.md` for the downstream-project case. For the kit ITSELF as a project, specs are drafted directly at `docs/specs/SPEC-NNN-<slug>.md` (matching ops-toolkit `tools/tide/` shape). The `.planning/` to `docs/specs/` migration step is retired for the kit's own work; the file's `Status:` header (DRAFT / VALIDATED / SHIPPED) tracks state in place. Downstream projects that use the kit continue to follow the `.planning/` convention until a future kit refactor unifies the two.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,9 +1,9 @@
 # docs/specs
 
-Historical record of shipped specs. One file per release that introduced a spec.
+Numbered specs for every cycle of work on the kit. Drafts and shipped specs both live here. The file's `Status:` header (DRAFT / VALIDATED / SHIPPED) tells you the state.
 
-In-flight work lives in `.planning/SPEC.md` (single working file the kit's hooks and commands reference). At release time, the maintainer moves the finalized SPEC here as `SPEC-NNN-<slug>.md` so the history survives the next cycle.
+Naming: `SPEC-NNN-<short-slug>.md`, zero-padded sequential, assigned when the file is created. Subsequent changes to a shipped feature get a new SPEC; do not edit a SHIPPED spec in place (use a new spec or an ADR).
 
-Numbering: zero-padded sequential, assigned at the moment of move. The file's content is the spec as it was at ship time, including the Decision Log. Subsequent fixes get their own SPEC; do not edit a shipped SPEC in place.
+Pattern source: ops-toolkit `tools/tide/docs/specs/`. dwarves-kit's prior convention (`.planning/SPEC.md` for working, migrate to `docs/specs/` at ship) was inherited from GSD and has been retired for the kit's own work; see ADR-0002.
 
-See ADR-0002 for why `.planning/` stays as the working dir.
+The kit's hooks and commands still reference `.planning/SPEC.md` for downstream projects that follow the GSD-style separation. That path remains the documented convention for kit USERS. For the kit ITSELF as a project, specs live here from day one.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -2,7 +2,7 @@
 
 Numbered specs for every cycle of work on the kit. Drafts and shipped specs both live here. The file's `Status:` header (DRAFT / VALIDATED / SHIPPED) tells you the state.
 
-Naming: `SPEC-NNN-<short-slug>.md`, zero-padded sequential, assigned when the file is created. Subsequent changes to a shipped feature get a new SPEC; do not edit a SHIPPED spec in place (use a new spec or an ADR).
+Naming: `SPEC-NNN-<short-slug>.md`, zero-padded sequential, assigned when the file is created. The slug names the feature or change (e.g. `upstream-audit`, `orchestration-layer`), not the release it ships in. Do not put a version in the filename: the version belongs in the spec's title and `Status:` header, so a spec that slips to a later release does not need a rename. Slug target: 2-4 kebab-case words. Subsequent changes to a shipped feature get a new SPEC; do not edit a SHIPPED spec in place (use a new spec or an ADR).
 
 Pattern source: ops-toolkit `tools/tide/docs/specs/`. dwarves-kit's prior convention (`.planning/SPEC.md` for working, migrate to `docs/specs/` at ship) was inherited from GSD and has been retired for the kit's own work; see ADR-0002.
 

--- a/docs/specs/SPEC-001-polish.md
+++ b/docs/specs/SPEC-001-polish.md
@@ -1,7 +1,7 @@
 # Spec: v1.5.0 Polish (CI + README hero + demo + contributing)
 Generated: 2026-04-21
-Status: VALIDATED
-Note: Previous v1.4 spec preserved in git history at commit 711b8a9.
+Status: SHIPPED
+Note: Previous v1.4 spec preserved in git history at commit 711b8a9. Shipped in v1.5.0 (CI, README hero, demo, CONTRIBUTING); follow-up fixes in v1.5.1.
 
 ## Problem
 

--- a/docs/specs/SPEC-002-upstream-audit.md
+++ b/docs/specs/SPEC-002-upstream-audit.md
@@ -3,7 +3,7 @@
 Generated: 2026-05-20
 Status: VALIDATED
 Source: upstream-audit-2026-05-20 (this session's audit of the 10 source repos against current upstream HEADs)
-Prior spec: docs/specs/SPEC-001-v1.5-polish.md
+Prior spec: docs/specs/SPEC-001-polish.md
 Validation: 4 reviewers run 2026-05-20 (security, failure-mode, assumption-destroyer, scope-critic). 1 critical + 8 warnings resolved inline. See Decision Log entries DEC-006 through DEC-014.
 
 ## Problem
@@ -119,7 +119,7 @@ Tasks are independent. No inter-task dependencies; can run in any order.
 - [ ] `.claude-plugin/plugin.json` version bumped to match (regression from v1.5.0 caught by `test-meta.sh` parity check)
 - [ ] Atomic conventional commits, one per TASK + 1 docs + 1 version bump
 - [ ] Tag `v1.6.0`
-- [ ] Flip this file's Status header to `SHIPPED` after the v1.6.0 tag lands (no move needed; the spec was drafted directly at `docs/specs/SPEC-002-v1.6-upstream-audit.md` per the post-cleanup convention)
+- [ ] Flip this file's Status header to `SHIPPED` after the v1.6.0 tag lands (no move needed; the spec was drafted directly at `docs/specs/SPEC-002-upstream-audit.md` per the post-cleanup convention)
 - [ ] Write `docs/retro/v1.6.md` after ship per the v1.5.1 retro action item ("add /retro to every release ritual")
 - [ ] Write `docs/handoff/v1.6.md` after ship (per v1.5.1 retro convention; build-narrative complementary to CHANGELOG's what-shipped record). See DEC-012.
 

--- a/docs/specs/SPEC-002-v1.6-upstream-audit.md
+++ b/docs/specs/SPEC-002-v1.6-upstream-audit.md
@@ -1,0 +1,210 @@
+# Spec: v1.6 (upstream-audit absorption + lineage hygiene)
+
+Generated: 2026-05-20
+Status: VALIDATED
+Source: upstream-audit-2026-05-20 (this session's audit of the 10 source repos against current upstream HEADs)
+Prior spec: docs/specs/SPEC-001-v1.5-polish.md
+Validation: 4 reviewers run 2026-05-20 (security, failure-mode, assumption-destroyer, scope-critic). 1 critical + 8 warnings resolved inline. See Decision Log entries DEC-006 through DEC-014.
+
+## Problem
+
+The 2026-05-20 upstream audit checked the 10 repos dwarves-kit pattern-matched from (GSD, gstack, Trail of Bits, ClaudeKit, Context Hub, oh-my-claudecode, CCGS, OMC, Smart Ralph, obra/superpowers) against their current HEADs. Five concrete gaps surfaced:
+
+1. **No behavioral test for `/review-team`.** superpowers v5.1.0 ships a test that plants known-bad fixtures (SQL injection, plaintext password) and asserts the security lens flags every one. We have 42 hook tests + 104 meta tests but zero behavioral assertions on what the review pipeline actually catches. The v1.5.1 retro lesson "verify before proceeding" has no hard-test equivalent for the review side of the pipeline.
+2. **No structural check on agent/command frontmatter.** CCGS v1.0 fixed missing `model:` and `description:` frontmatter across 17 skills in a recent audit. Our `tests/test-meta.sh` checks `name:` and `description:` on agents but does NOT assert `model:` is present or `description:` is on commands. Same class of bug we caught in v1.5.1 (plugin.json version drift): grep-only checks pass while structural parity silently rots.
+3. **`/start` output is one-size-fits-all.** GSD v1.43-rc2 added tiered help (`--brief`, default, `--full`). Our `/start` always emits the same level of detail. Returning users want a one-line cue; new users want the full state-detection report. No way to dial.
+4. **OMC source lineage in README Credits does not trace.** The audit could not anchor v1.2's task-verifier pattern to `1mancompany/OneManCompany` (the repo currently associated with the "OMC" name); that project is a pixel-art agent-company OS, not an architect-verifier pattern. Either re-anchor to a real source or own the pattern as synthesized from the family of architect-verifier loops.
+5. **PHILOSOPHY.md has no explicit "won't accept" section for upstream anti-patterns.** The audit observed four anti-patterns in upstream repos (vendor-skill sprawl, UI-shell creep, agent-persona theater, slop-PR submissions) that we want to actively reject. Today PHILOSOPHY enumerates rejected ideas implicitly through "Decision this would reject" snippets. A dedicated section makes the rejection wall scannable.
+
+## Solution
+
+Five additive content edits. No new hooks. No new commands. No new agents. No new dependencies.
+
+| Task | Files | Type |
+|---|---|---|
+| TASK-1 | `tests/test-review-team-plants.sh` (new) + `tests/test-meta.sh` (link) | New test |
+| TASK-2 | `tests/test-meta.sh` (extend) | Extend test |
+| TASK-3 | `commands/start.md` (refactor) | Modify command |
+| TASK-4 | `README.md` (Credits) + `docs/decisions/0005-separate-verifier-subagent.md` (Source) | Lineage edit |
+| TASK-5 | `docs/PHILOSOPHY.md` (new section) | Append philosophy |
+
+Tasks are independent. No inter-task dependencies; can run in any order.
+
+## Task Breakdown
+
+### Phase 1: Tests (run first so subsequent task work is verified)
+
+- [ ] **TASK-1: Behavioral test for `/review-team` security lens**
+  - Files: `tests/test-review-team-plants.sh` (new)
+  - Approach: the test creates a fixture dir via `mktemp -d "$TMPDIR/dwarves-kit-test.XXXXXX"` with planted-bad files (Python file with a string-interpolated SQL query; config file with a hardcoded credential; shell script using `os.system($user_input)` shape). Trap-based cleanup removes the fixture on exit. The test then runs a static check: greps the kit's security review prompts for the required detection vocabulary. The grep terms below are pre-verified as already present in current prompts (see DEC-006). No prompt edits required.
+  - Required grep terms (must appear in EITHER `agents/security-auditor.md` OR `agents/reviewer.md`):
+    - "SQL injection"
+    - "Command injection"
+    - "Path traversal"
+    - "XSS"
+    - "hardcoded" (matches: hardcoded API keys / passwords / tokens / secrets)
+    - "PII"
+    - "CORS"
+  - Acceptance criteria:
+    - [ ] `tests/test-review-team-plants.sh` exists, executable (`chmod +x`), runs in under 5 seconds
+    - [ ] Uses `mktemp -d "$TMPDIR/dwarves-kit-test.XXXXXX"` for the fixture dir; trap-based cleanup runs on EXIT
+    - [ ] Fixture dir contains at least 3 planted vulnerability files covering 3 distinct classes from the required-terms list above
+    - [ ] Test greps each required term in BOTH `agents/security-auditor.md` and `agents/reviewer.md`; FAIL if any term is missing from BOTH files (a term in either file is OK; the reviewer's security lens inherits security-auditor's checklist per the prompt's own statement)
+    - [ ] Test exits 0 on current kit (verified at spec time via pre-check)
+    - [ ] Test would exit non-zero if a future edit drops any required term from BOTH prompts
+    - [ ] Added to `.github/workflows/test.yml` alongside the existing two test scripts (same matrix, same job)
+    - [ ] No fixture data committed to repo (fixture dir is under `$TMPDIR`, not under the repo root)
+  - Source: superpowers v5.1.0 `tests/security-fixtures/` pattern. Adapted: superpowers can dispatch a real reviewer in their test environment; we cannot, so we test the prompt completeness instead. Same intent (regression-guard the reviewer), different mechanism.
+
+- [ ] **TASK-2: Frontmatter parity audit in `tests/test-meta.sh`**
+  - Files: `tests/test-meta.sh` (extend, ~25 lines). **No source-file edits required** (pre-check at spec time confirmed all 9 agents have `model:` and all 12 commands have frontmatter + `description:`).
+  - Approach: add assertions for every `commands/*.md` and `agents/*.md`: file starts with `---`, contains `description:`, and (for agents) contains `model:` with a value in the accepted set `{sonnet, haiku, opus}`. The existing meta test checks `name:` + `description:` on agents already; this extends to `model:` on agents and frontmatter + `description:` on commands.
+  - Acceptance criteria:
+    - [ ] Every `commands/*.md` is asserted to have YAML frontmatter starting with `---` and a `description:` field
+    - [ ] Every `agents/*.md` is asserted to have a `model:` field whose value matches `^(sonnet|haiku|opus)$` (after stripping whitespace)
+    - [ ] Total meta test count rises by approximately 33 (12 commands x 2 checks + 9 agents x 1 check)
+    - [ ] All tests land green on current kit (no source-file fixes needed per pre-check)
+    - [ ] If any future agent uses a model value outside the accepted set, the assertion fails and the maintainer updates EITHER the file OR the regex (whichever is correct given the actual Claude Code model surface at that time)
+  - Source: CCGS v1.0 skill audit pattern. Adapted: same structural-integrity intent, scoped to the kit's commands + agents.
+
+### Phase 2: User-facing surface
+
+- [ ] **TASK-3: Tiered `/start` output (`--brief` / default / `--full`)**
+  - Files: `commands/start.md` (modify), `MANUAL.md` (arg-shape doc)
+  - Approach: command prompt grows three modes via Claude Code's `$ARGUMENTS` substitution. `--brief` outputs one line. Default keeps existing output BYTE-FOR-BYTE (regression-safe). `--full` adds: full SPEC.md task checklist, hook log summary (counts only, NOT raw lines), last 5 commits, full command table grouped by phase.
+  - Sub-step: confirm the kit's slash-command runtime supports `$ARGUMENTS` (Claude Code's documented placeholder); if a different mechanism applies on the deployed Claude Code version, adapt and document the actual mechanism in the command file's body.
+  - Acceptance criteria:
+    - [ ] `commands/start.md` references `$ARGUMENTS` (or the actual runtime-supported placeholder, if different, with a body comment naming what it is)
+    - [ ] `--brief` output is a single line, max 120 characters including any leading prefix, contains current state + suggested next command
+    - [ ] **Default-mode regression check**: the prompt's default-mode behavior is byte-for-byte identical to the current prompt; only `--brief` and `--full` code paths are added. Verify by diffing the post-edit default-mode pseudocode against the current file's prompt body; the diff must show only additions in `--brief` / `--full` branches
+    - [ ] `--full` output adds: SPEC task checklist (parsed from `.planning/SPEC.md` checkboxes), hook log activity as **line counts per log file from the last 7 days only** (NOT raw log content, to avoid leaking paths or command fragments), last 5 commits via `git log -5 --oneline`, command table grouped by Think/Spec/Build/Review/Ship/Reflect phases
+    - [ ] CHANGELOG entry mentions `--brief` and `--full`
+    - [ ] MANUAL.md `/user:start` section updated with the new arg shape and example outputs
+  - Source: GSD v1.43-rc2 `gsd-help --brief|--full|<topic>` pattern. Adapted: `--brief / --full` only (no `<topic>` mode per DEC-002; the kit's state space is small enough that section-level help is overkill).
+
+### Phase 3: Documentation hygiene
+
+- [ ] **TASK-4: OMC lineage correction**
+  - Files: `README.md` (Credits section), `docs/decisions/0005-separate-verifier-subagent.md` (Source line), `CHANGELOG.md` (v1.6 entry)
+  - Approach: 10-minute search for Option A (re-anchor to a real architect-verifier-in-Ralph-loop source, e.g. Geoff Huntley's "Ralph Wiggum" post at `https://ghuntley.com/ralph/`). If Option A passes verification, take it. Otherwise default to Option B (own as synthesized). See DEC-003 + DEC-011.
+  - **"Verified" criterion for Option A**: the candidate URL returns HTTP 200 AND the fetched page contains at least one of these phrases (case-insensitive): "architect verifier", "verifier loop", "verify after execution", "Ralph loop". Capture the `archive.org` snapshot URL at citation time alongside the live URL, so the citation survives future link rot.
+  - Acceptance criteria:
+    - [ ] README Credits no longer lists OMC pointing at `1mancompany/OneManCompany`
+    - [ ] If Option A taken: cited URL returns 200, content contains one of the required phrases, AND the citation in README Credits includes both the live URL and an archive.org snapshot URL captured during this task
+    - [ ] If Option B taken: ADR-0005's Source line is updated to "Synthesized from the family of architect-verifier-in-Ralph-loop patterns documented across AI-coding-agent projects in 2024-2025" and README Credits has the OMC bullet removed
+    - [ ] CHANGELOG v1.6 entry includes a "Lineage correction: OMC credit removed" bullet under `Fixed`
+    - [ ] No silent drift between README Credits and ADR-0005 Source line (both updated in the same commit)
+  - Source: 2026-05-20 upstream audit, lineage-correction recommendation. Decision codified in DEC-003.
+
+- [ ] **TASK-5: PHILOSOPHY.md "What we explicitly reject (from upstream observation)" section**
+  - Files: `docs/PHILOSOPHY.md` (append new section, ~40 lines)
+  - Approach: add a new section after the principles enumeration that lists 4 anti-patterns observed in upstream projects with explicit rejection rationale. Each anti-pattern names the observed example, the principle it violates, and the kit-level criterion that would catch it in review.
+  - Acceptance criteria:
+    - [ ] New PHILOSOPHY.md section heading: `## What we explicitly reject (from upstream observation)`
+    - [ ] Lists exactly 4 anti-patterns: vendor-skill sprawl, UI-shell creep, agent-persona theater, slop-PR submissions
+    - [ ] Each anti-pattern has: one-line description, observed example with repo + version, principle violated, and the review-criterion that catches it
+    - [ ] CONTRIBUTING.md gets a one-line cross-reference to the new section under "What we will not accept"
+    - [ ] `commands/kit-health.md` rejection list (Step 4) updated if any of the 4 anti-patterns are not already there
+  - Source: 2026-05-20 upstream audit, anti-patterns column.
+
+### Phase 4: Verify, docs, ship
+
+- [ ] All 5 task acceptance criteria met
+- [ ] `bash tests/test-hooks.sh` exit 0 (42/42)
+- [ ] `bash tests/test-meta.sh` exit 0 (104+ tests; new count documented)
+- [ ] `bash tests/test-review-team-plants.sh` exit 0 (new)
+- [ ] CHANGELOG entry under `[1.6.0]` listing all 5 tasks
+- [ ] No new ADR for v1.6 itself (changes additive within existing principles). ADR-0005 Source line edit per TASK-4 is a correction, not a new decision.
+- [ ] `VERSION` -> `1.6.0`
+- [ ] `.claude-plugin/plugin.json` version bumped to match (regression from v1.5.0 caught by `test-meta.sh` parity check)
+- [ ] Atomic conventional commits, one per TASK + 1 docs + 1 version bump
+- [ ] Tag `v1.6.0`
+- [ ] Flip this file's Status header to `SHIPPED` after the v1.6.0 tag lands (no move needed; the spec was drafted directly at `docs/specs/SPEC-002-v1.6-upstream-audit.md` per the post-cleanup convention)
+- [ ] Write `docs/retro/v1.6.md` after ship per the v1.5.1 retro action item ("add /retro to every release ritual")
+- [ ] Write `docs/handoff/v1.6.md` after ship (per v1.5.1 retro convention; build-narrative complementary to CHANGELOG's what-shipped record). See DEC-012.
+
+## Acceptance Criteria (global)
+
+- [ ] All 5 task ACs met
+- [ ] Hook tests: 42/42
+- [ ] Meta tests: 104+ (rises with TASK-2 frontmatter checks)
+- [ ] Behavioral test: passes
+- [ ] No file deleted; no breaking changes; no new dependencies
+- [ ] No new env var, no new settings.json field
+- [ ] README Credits is self-consistent with ADR Source citations after TASK-4
+
+## Edge Cases
+
+1. **TASK-1's static prompt grep is too weak.** If the security-auditor prompt doesn't literally say "SQL injection" (the prompt may use "injection attack" or similar), the test fails on TASK-1 day one. Mitigation: read both prompts during TASK-1 implementation, choose grep terms that genuinely appear AND that we want to lock in as required vocabulary. If a term is missing from the current prompt, fix the prompt as part of TASK-1, not the test.
+2. **TASK-2 reveals current files miss `model:` frontmatter.** Likely true for at least some commands. Mitigation: fix in-file FIRST, then add the assertion. AC explicitly forbids landing a red test.
+3. **TASK-3 default-mode regression risk.** `/start` is invoked both by user typing and (per ADR-0009 pattern) potentially by SessionStart hook readouts. Mitigation: AC includes "Default output unchanged from current behavior". Confirm by diffing current and post-edit default outputs before merge.
+4. **TASK-4 Option A's source verification fails mid-task.** Geoff Huntley's "Ralph Wiggum" post may not exist, may be deleted, may not actually describe the architect-verifier pattern as we used it. Mitigation: 10-minute search budget; if Option A fails, fall back to Option B without further search.
+5. **TASK-5 anti-patterns overlap existing rejection criteria.** The audit's anti-patterns may already be captured implicitly in PHILOSOPHY's "Synthesize, don't originate" or "Bash over binaries". Mitigation: AC requires each anti-pattern have a distinct example + principle. If an anti-pattern is genuinely already covered, drop it from the list rather than duplicate.
+
+## Out of Scope
+
+- The 4 DEFER items from the audit (oh-my-claudecode HUD cache GC, gstack `/freeze`+`/unfreeze`, Smart Ralph thin-orchestrator refactor, Smart Ralph `references/` extraction). These remain in `_meta/BACKLOG.md` v2 candidates. No spec work this cycle.
+- The 3 SKIP items (Trail of Bits stable; ClaudeKit vendor-skill drift; Context Hub npm-only). No action.
+- Multi-harness packaging (still deferred per ADR-0009).
+- Submitting to Anthropic's `claude-plugins-official` marketplace (manual maintainer step; not blocking).
+- `/qa` command, Agent Teams parallel dispatch, `SessionEnd` knowledge-capture hook (all v2 candidates with no signal yet).
+- Rewriting OMC lineage in CHANGELOG.md (historical record stays frozen per the v1.5.1 retro convention).
+
+## Decision Log
+
+- **DEC-001**: TASK-1 implements as a static-grep assertion on reviewer prompts, NOT as a live `/review-team` dispatch.
+  - **Rationale**: bash CI cannot dispatch Claude Code sessions; the kit has no test-harness equivalent. A static grep on the prompt content catches regressions in WHAT we ask reviewers to look for, which is the actual failure mode we observed when adopting superpowers v5.1.0 (reviewers drift, prompts get edited, vulnerability classes silently dropped). Live dispatch belongs in a maintainer's manual `/user:kit-health` run, not CI.
+  - **Rejected alternative**: shell out to Claude Code via headless. Too brittle, requires API keys in CI, adds external dep.
+
+- **DEC-002**: TASK-3 supports `--brief` and `--full` only, no `<topic>` mode.
+  - **Rationale**: GSD has dozens of commands and a richer state model that justifies topic-level help. dwarves-kit has 12 commands and a flat state model. `--brief` + default + `--full` covers the 3 user shapes (returning, default, new). A `<topic>` mode would be carrying superpowers we don't need.
+  - **Rejected alternative**: also add `--commands` to dump just the command list. Same content available via `--full`. YAGNI.
+
+- **DEC-003**: TASK-4 takes Option B (own as synthesized) UNLESS a verifiable source can be cited in 10 minutes.
+  - **Rationale**: honesty beats elegance. Citing a wrong source is worse than admitting we synthesized the pattern. Time-box the source hunt to avoid yak-shaving.
+  - **Rejected alternative**: keep the OMC bullet "for historical reasons". No, the v1.5.1 retro's lesson is that broken citations rot and confuse future readers. Fix it now.
+
+- **DEC-004**: TASK-5 explicitly avoids lifting the "94% PR rejection rate" stat from superpowers.
+  - **Rationale**: same logic as ADR-0008's stat-lifting rejection. We have no rejection-rate data of our own. Adopting voice and structure is fine; adopting numbers we did not measure is phantom-feature territory.
+
+- **DEC-005**: No new ADR for v1.6 itself.
+  - **Rationale**: all 5 tasks fit within existing principles. ADR-0005 gets a Source-line correction (TASK-4), not a new decision. PHILOSOPHY gets a new section (TASK-5), which is content addition, not a principle change.
+
+- **DEC-006**: TASK-1 grep-term list locked at spec time, not implementation time.
+  - **Rationale**: spec-validate Critical 1. The most-subjective decision in TASK-1 was being pushed into the worker's context. Pre-checking which terms exist in current prompts at spec time means TASK-1 lands with zero prompt edits (current prompts already cover the locked 7-term set). If the implementer finds a term genuinely missing, that becomes a separate scoped sub-task, not silent prompt mutation.
+
+- **DEC-007**: TASK-1 fixture lives under `$TMPDIR`, never in the repo.
+  - **Rationale**: spec-validate Security finding 2. Planted SQL-i and credential strings inside the repo are scanning-hazardous (security scanners + future grep audits may snag on them). Using `mktemp -d` + trap-cleanup gets the fixture out of the repo lifecycle entirely.
+
+- **DEC-008**: TASK-2 scope locked to test-extension only; no source-file fixes needed.
+  - **Rationale**: spec-validate Scope finding 3. Pre-check showed all 9 agents have `model:`, all 12 commands have `description:` + frontmatter. The spec's original "fix files first" hedge was based on an assumption that pre-check invalidated.
+
+- **DEC-009**: TASK-3 default-mode regression check is a body-diff assertion in the AC.
+  - **Rationale**: spec-validate Failure finding 4. "Default unchanged" needs a verification mechanism. Added explicit AC: prompt body diff shows only additions in `--brief` / `--full` branches.
+
+- **DEC-010**: TASK-3 `--full` log activity is line counts only, no raw lines.
+  - **Rationale**: spec-validate Security finding 7. Hook logs may contain command fragments with secret-bearing paths or args. Counts give signal without leak.
+
+- **DEC-011**: TASK-4 "verified" criterion for Option A is HTTP 200 + required-phrase presence + archive.org snapshot.
+  - **Rationale**: spec-validate Failure finding 8. Vague "10-minute search" needs a concrete pass/fail bar. The phrase list is the same conceptual content we claim the source covers; archive snapshot insulates against future link rot.
+
+- **DEC-012**: `docs/handoff/v1.6.md` is in scope for Phase 4.
+  - **Rationale**: spec-validate Assumption finding 9. v1.5.1 retro recommended every release produces both retro AND handoff. Spec originally listed retro but not handoff; closing that gap. Handoff captures build narrative (what was decided, where surprises happened); retro captures cycle-level lessons; CHANGELOG captures what shipped. Three different layers, three different files.
+
+- **DEC-013**: TASK-3 slash-command arg passing uses `$ARGUMENTS` placeholder.
+  - **Rationale**: spec-validate Assumption finding 5. Today's kit commands take no args; `$ARGUMENTS` is Claude Code's documented pattern. Sub-step requires confirming the placeholder actually substitutes on the deployed Claude Code version; if not, the body of `commands/start.md` documents the actual mechanism.
+
+- **DEC-014**: TASK-3 `--brief` length cap is 120 characters single line, not "~20-40 words".
+  - **Rationale**: spec-validate Scope finding 6. Word ranges aren't testable; character cap is.
+
+## Source citations
+
+- TASK-1 pattern: obra/superpowers v5.1.0 (https://github.com/obra/superpowers, fetched 2026-05-20). Specifically the security-fixture behavioral test pattern.
+- TASK-2 pattern: CCGS v1.0 (https://github.com/Donchitos/Claude-Code-Game-Studios) skill frontmatter audit.
+- TASK-3 pattern: GSD v1.43-rc2 (https://github.com/gsd-build/get-shit-done) tiered `gsd-help` command.
+- TASK-4: 2026-05-20 upstream audit findings.
+- TASK-5: 2026-05-20 upstream audit anti-patterns column.
+
+## Validation
+
+To be filled by `/spec-validate`. Status flips to `VALIDATED` only after all 4 reviewers (security, failure-mode, assumption-destroyer, scope-critic) report no blocking concerns.

--- a/docs/specs/SPEC-003-orchestration-layer.md
+++ b/docs/specs/SPEC-003-orchestration-layer.md
@@ -1,0 +1,240 @@
+# Spec: Orchestration layer (the workflow contract)
+
+Generated: 2026-05-20
+Status: VALIDATED
+Source: agent-workflow-enforcement research, 2026-05-20 (full landscape + enforcement taxonomy at `ops-toolkit/research/2026-05-20-agent-workflow-enforcement-patterns.md`). Inspiration: hoangnb24/harness-experimental `AGENTS.md`; obra/superpowers; github/spec-kit; bmad-code-org/BMAD-METHOD; Cline Memory Bank; ghuntley/ralph; the AGENTS.md standard.
+Prior spec: docs/specs/SPEC-002-upstream-audit.md
+Validation: 4 reviewers run 2026-05-20 (scope-critic, assumption-destroyer, failure-mode, philosophy-fidelity). 6 blocking + multiple warnings resolved inline; see Decision Log DEC-006 through DEC-013 and the Validation section.
+
+## Problem
+
+dwarves-kit covers the whole lifecycle (`/think → /spec → /execute → /review → /ship → /retro`), but the *workflow itself* is not written down as one artifact an agent can follow. It is scattered: the data-flow diagram lives in `docs/architecture.md` (maintainer-facing, descriptive), the per-phase instructions live inside each command prompt, the soft "what's next" routing lives in `hooks/context-readiness.sh`, and the principles live in `docs/PHILOSOPHY.md`. A coding agent told "build this feature" has no single instruction file that says: here are the phases, here is how to size the work, here is the gate at each boundary, here is who enforces it.
+
+The community pattern for this is the **harness/orchestration layer**: a single instruction file (harness-experimental's `AGENTS.md`, Spec Kit's command templates, superpowers' `using-superpowers`) that embeds the end-to-end workflow the agent must follow, as distinct from a library of *atomic* skills/commands. The research note distilled how these files make a stochastic agent comply, and the one load-bearing finding: **markdown cannot enforce a workflow on its own; it only biases the next token. Real enforcement comes from a mechanism outside the prose: a loop, a re-read-this-file discipline, or a test gate.**
+
+dwarves-kit already owns the strongest such mechanism (the verification pipeline). What it lacks is the readable spine that names the workflow and routes work by size. This spec adds that spine without violating the kit's two governing tensions: **"Guardrails over guidance"** (advice is ~70%; enforce with hooks) and **"Detect, don't dictate"** (no rigid phase gates).
+
+## Decision: chosen version
+
+**Ship a single agent-facing `WORKFLOW.md` contract at the repo root, delivered through `CLAUDE.md` (which Claude Code auto-loads every session), that routes work by risk tier and delegates every hard gate to the guardrails that already exist.**
+
+The orchestration layer is two things, not one new mechanism:
+
+1. **`WORKFLOW.md`** (new doc, repo root): the readable spine. Required-reading order, a risk-tier intake table, a phase→exit→enforcer map, and a completion contract. Voiced in the kit's opinionated register. Short enough to read in under a minute.
+2. **Risk-tiered intake** (the one net-new idea, cited to harness-experimental): a `tiny / normal / full` lane router so trivial work skips the ceremony. Routing by work size is "Detect, don't dictate" applied to process weight, and it addresses the "full lifecycle on a one-line fix" failure Anthropic explicitly warns about.
+
+**Delivery is via `CLAUDE.md`, not the `context-readiness` hook.** Claude Code natively loads `CLAUDE.md` into context at the start of every session (100% present, the strongest delivery available for a guidance-grade artifact). `CLAUDE.md` gains a one-line pointer to `WORKFLOW.md`; the doc rides that native load. The earlier draft routed delivery through a one-line addition to `context-readiness.sh`; that is **cut** (DEC-002). By this spec's own thesis a markdown pointer in a hook string is still guidance, it does not make the doc "active," and it carried a real `set -euo pipefail` failure mode plus a compaction-durability gap (`post-compact-reinject` does not know the file). Cutting it is more minimal and removes a false "active delivery" claim. No hook is touched by this spec.
+
+Crucially, the contract **suggests and routes; it does not block.** Every hard stop is an existing guardrail: the safety-gate hook (destructive Bash), the push-to-main blocker, the anti-rationalization Stop hook (premature "done"), and the verification pipeline (worker → task-verifier → fix-agent, max 2). `WORKFLOW.md` names these gates and points at them; it invents no new ones and uses no coercion prose.
+
+**Form chosen: `WORKFLOW.md` referenced from `CLAUDE.md`, not a second auto-loaded `AGENTS.md`, and not a section folded into `architecture.md`.** The kit is Claude-Code-native and `CLAUDE.md` is its single instruction channel; a competing auto-loaded `AGENTS.md` would create two sources of truth (violates "One kit, whole cycle"). A separate file rather than an `architecture.md` section is required because downstream projects ship `WORKFLOW.md` (via `examples/hello-spec/`) but do **not** ship the kit's `architecture.md`; the contract must stand alone. The AGENTS.md *pattern* is the cited source; the filename is the adaptation.
+
+### Tradeoff table (chosen vs rejected alternatives)
+
+| | **CHOSEN: WORKFLOW.md + CLAUDE.md pointer + risk tiers** | Alt A: `/user:flow` autopilot command | Alt B: BMAD/Spec-Kit hard-gate machine (HALT/CAPS) | Alt C: passive standalone AGENTS.md | Alt D: new section inside architecture.md |
+|---|---|---|---|---|---|
+| Single readable spine | yes | no (logic in a command prompt) | yes | yes | yes |
+| "Detect, don't dictate" | honored (suggests + routes, blocks nothing) | violated (runs think→ship in one shot) | violated (phase-locking is a verbatim rejection) | honored | honored |
+| "Guardrails over guidance" | honored (gates = existing hooks/verifier; doc openly guidance-grade) | partial | violated (CAPS prose ~70-85%; ADR-0008) | partial | honored |
+| Delivery | CLAUDE.md native auto-load (100% present each session) | a command (must be invoked) | passive-ish | passive (ADR-0008: "may not be the active reference") | rides architecture.md (read on demand) |
+| One source of truth | yes (CLAUDE.md → WORKFLOW.md) | yes | risky (logic in two places) | no (two auto-loaded files) | yes |
+| Downstream portability | yes (template ships standalone) | no (command is kit-internal) | n/a | yes | **no (downstream gets no architecture.md)** |
+| Source lineage | harness-experimental intake + AGENTS.md pattern | Spec Kit `/implement` | BMAD/Spec-Kit gates | AGENTS.md standard | n/a |
+
+Alt A rejected: a full-cycle autopilot dictates the whole sequence (anti "Detect, don't dictate") and duplicates `/start` (routing) plus `/execute` (build autopilot). Alt B rejected: hard phase gates are an explicit PHILOSOPHY rejection, and coercion CAPS is the exact ~70-85% guidance ADR-0008 chose hooks over. Alt C rejected: ADR-0008 passivity precedent, plus a second auto-loaded instruction file breaks single-source-of-truth. Alt D rejected: the strongest minimalism option, but `architecture.md` is maintainer-facing and is not shipped to downstream projects, so an agent-facing contract folded into it cannot travel; the verb-split (descriptive map vs imperative spine) also keeps the two genuinely distinct.
+
+### Enforcement-taxonomy mapping
+
+Every design element maps to a named row in `ops-toolkit/research/2026-05-20-agent-workflow-enforcement-patterns.md` Part 5. Three rows are deliberately declined, which is itself a design decision (DEC-005).
+
+| Taxonomy mechanism | How this design uses it |
+|---|---|
+| Programmatic backpressure (tests/lint gate completion) | **Delegated** to the verification pipeline (worker → task-verifier → fix-agent) + the ship gate. The kit's existing moat; `WORKFLOW.md` points at it, does not reinvent it. |
+| Forced state-file re-read | `.planning/SPEC.md` (downstream) / `docs/specs/SPEC-NNN` (kit-on-kit) is the re-read state; `WORKFLOW.md` lists it as required reading. |
+| Harness re-injects rules each turn | `CLAUDE.md` is auto-loaded by Claude Code each session and points at `WORKFLOW.md`. (Presence-each-session, not mid-session re-read; see Known limitations.) |
+| Self-audit pass | The anti-rationalization Stop hook catches premature completion; the completion contract phrases the self-check. |
+| Anti-fabrication clause | Completion contract: "done only when the verifier has actually run the tests, not when you claim they pass" → points at task-verifier. |
+| Risk-tiered routing | **New element.** The `tiny / normal / full` intake table, cited to harness-experimental. Self-attested, not detected (see Known limitations). |
+| Next-step lock-in (soft) | The existing `context-readiness` hook's `next:` suggestion + `/start`; suggestion only, never a lock. Unchanged by this spec. |
+| Identity / stake framing | **Declined.** Persona theater is an anti-pattern (ADR-0008 rejects skill coercion). |
+| Outer bash `while` loop | **Declined.** Autonomous-runtime territory; PHILOSOPHY §3 routes that to GSD v2 / OMC. The kit is one-session. |
+
+### PHILOSOPHY check
+
+| Principle | Compliance |
+|---|---|
+| Guardrails over guidance | ✓ All enforcement delegated to existing hooks + verifier. The doc is openly labeled guidance-grade; it never claims its prose enforces. |
+| Synthesize, don't originate | ✓-with-caveat. Workflow-file pattern cited to harness-experimental + AGENTS.md standard. The risk-tier router is **net-new, single-source, experimental-grade lineage** (harness-experimental is an experimental repo, not 3-months-in-production). Accepted under the "indirect lineage / originated in-kit but grounded" carve-out (PHILOSOPHY §1) and labeled as such; it has NOT met the §5 "1 week on a real project" bar. See Known limitations. |
+| One kit, whole cycle | ✓ Single source of truth preserved: `CLAUDE.md` → `WORKFLOW.md`; references the spec + `architecture.md` rather than copying them. No new format. |
+| Shallow and wide beats deep and narrow | ✓ Indexes all 8 phases at spine depth; adds no per-phase depth. (`WORKFLOW.md` is connective tissue across the lifecycle, like `architecture.md`; it does not "serve" a phase the way `/spec` or task-verifier does. Justified as cross-phase connective tissue, NOT under the "serves 2+ phases" gate.) |
+| Verify before proceeding / Verify, then trust | ✓ The completion contract and Build gate defer to the verification pipeline. |
+| Bash over binaries | ✓ One doc + one template + pointer edits + one meta test. No binary, no runtime, no hook touched. |
+| Detect, don't dictate | ✓ Routes by risk tier and indexes next phases; blocks nothing (verified: no code change adds blocking behavior). Hard stops remain the existing safety/verify hooks. The doc says plainly "this contract does not lock phases." |
+| External tools are dependencies, not features | ✓ No new external dependency. |
+| NO list (§3) | ✓ No compiled binary, no paid dep, no LLM API in a hook, no hook touched, one-sentence describable, source-cited. File budget: current 79 files → 81 (+2: root doc + downstream template). No hard cap; each new file justified. |
+
+One-sentence description (NO-list gate 4): *"`WORKFLOW.md` is the agent-facing contract that names each lifecycle phase, routes work by risk tier, and points at the existing guardrail that enforces each boundary."*
+
+## Solution
+
+Additive. One new doc, one new template, pointer edits, one meta test. No new command, no new agent, no new dependency, no hook touched, no new hard gate.
+
+| Task | Files | Type |
+|---|---|---|
+| TASK-1 | `WORKFLOW.md` (new, repo root; `docs/specs/` paths per ADR-0002) | New doc |
+| TASK-2 | `CLAUDE.md` (Workflow section → pointer, kit root) + `examples/hello-spec/CLAUDE.md` (Workflow body → pointer, **keep the `## Workflow` header**) + `examples/hello-spec/WORKFLOW.md` (new template; `.planning/` paths) | Pointer edits + template |
+| TASK-3 | `tests/test-meta.sh` (assert both WORKFLOW.md files exist, four pinned headers, and path correctness) | Extend test |
+| TASK-4 | `README.md` + `MANUAL.md` + `docs/architecture.md` (one-line cross-reference each) + CHANGELOG | Doc hygiene |
+
+### Task Breakdown
+
+**Phase 1: The artifact**
+- [ ] **TASK-1: Author `WORKFLOW.md`** at repo root. Content = the embedded draft below. Kit-root version uses `docs/specs/SPEC-NNN-<slug>.md` in required-reading (per ADR-0002), NOT `.planning/`.
+  - Acceptance: file exists; ≤ ~80 lines; contains the four headers pinned in TASK-3; every gate named maps to an existing hook/agent/command (no invented gate); kit's opinionated register; no CAPS coercion; no em dash in any header (ASCII-clean headers so the meta grep is stable).
+
+**Phase 2: Single source of truth + downstream template**
+- [ ] **TASK-2: Replace, don't duplicate.** Shrink the kit-root `CLAUDE.md` "Workflow" section to a one-line pointer to `WORKFLOW.md`. Add `examples/hello-spec/WORKFLOW.md` (downstream template, same shape, `.planning/SPEC.md` paths). In `examples/hello-spec/CLAUDE.md`, **keep the `## Workflow` H2 header** (the demo CLAUDE.md is section-tested by `test-meta.sh`) and replace only its body with the pointer line.
+  - Acceptance: no workflow step list exists in two places after this task; kit-root `CLAUDE.md` Workflow section is a pointer; demo `## Workflow` header survives; downstream template present, self-consistent, uses `.planning/`; `architecture.md` data-flow diagram is referenced by `WORKFLOW.md`, not copied.
+
+**Phase 3: Guardrail**
+- [ ] **TASK-3: Structural test in `tests/test-meta.sh`.** New block titled `=== WORKFLOW.md contract ===` (distinct from the existing `=== Workflow file ===` CI-YAML block). Assert, matching on stable ASCII prefixes:
+  - `WORKFLOW.md` exists and contains `^## Required reading`, `^## Size the work first`, `^## The cycle`, `^## Completion contract`
+  - `examples/hello-spec/WORKFLOW.md` exists and `grep -q '.planning/SPEC.md'` in it
+  - kit-root `WORKFLOW.md` `grep -q 'docs/specs/'`
+  - Acceptance: meta count rises from 104 to 110 (+6); green on the kit after TASK-1/TASK-2; would fail if a future edit drops a required section or swaps the path convention. The four assertion strings MUST byte-match the embedded-draft headers (verified internally consistent in this spec).
+
+**Phase 4: Hygiene**
+- [ ] **TASK-4: Cross-references.** One-line pointer to `WORKFLOW.md` from `README.md`, `MANUAL.md`, and `docs/architecture.md` ("imperative companion to the data-flow diagram below"). CHANGELOG entry. Reconcile the canonical phase count (PHILOSOPHY says "7" in one place and "9" in another; this spec standardizes on **8**: Think, Spec, Validate, Build, Review, Docs, Ship, Reflect) in the same docs pass.
+
+**Phase 5: Verify**
+- [ ] `bash tests/test-hooks.sh` exit 0 (42/42; no hook touched, so unchanged)
+- [ ] `bash tests/test-meta.sh` exit 0 (110)
+- [ ] No workflow step list duplicated across files
+- [ ] No new command, agent, dependency, env var, settings.json field, or hook edit
+- [ ] CHANGELOG entry under the next version
+- [ ] Flip this spec's Status to SHIPPED after the tag
+
+## Embedded draft artifact: `WORKFLOW.md`
+
+> The complete kit-root draft to land as TASK-1. The downstream template (TASK-2) is identical except required-reading line 2 reads `.planning/SPEC.md`. Kept short by design. Headers are ASCII-clean to keep the TASK-3 grep stable.
+
+```markdown
+# WORKFLOW.md: the cycle, the lanes, the gates
+
+> Agent-facing contract. Read after CLAUDE.md. It names the lifecycle, routes
+> work by risk, and points at the guardrail that enforces each boundary.
+> It suggests and routes; it does not block. The only hard stops are the
+> safety-gate hook, the push-to-main blocker, the anti-rationalization Stop
+> hook, and the verification pipeline.
+
+## Required reading (in order)
+1. CLAUDE.md            - project context: stack, structure, rules
+2. docs/specs/SPEC-NNN-<slug>.md - the active spec; the shared contract for the cycle
+3. docs/architecture.md - how the pieces fit (reference; not required per task)
+
+## Size the work first (risk-tiered intake)
+Pick a lane before you start. Smaller work skips ceremony.
+
+| Lane   | When | Path |
+|--------|------|------|
+| tiny   | typo, copy, comment, one obvious edit | edit, verify, done. No spec. |
+| normal | one bounded feature or fix | /spec, /execute, /review, /ship |
+| full   | touches auth, authz, data model, data loss, audit/security, an external provider, an API contract, a migration, or weakens validation | /think, /spec, /spec-validate, /execute, /review-team, /docs, /ship, /retro |
+
+When in doubt between two lanes, take the heavier one. Anything in the full-lane
+trigger list uses the full lane unless you explicitly narrow the scope and say why.
+
+## The cycle (phase, exit, enforcer)
+| Phase    | Command | Exit when | Enforced by |
+|----------|---------|-----------|-------------|
+| Think    | /user:think | decision brief written (if BUILD) | advisory |
+| Spec     | /user:spec | spec exists, Status: DRAFT | spec-drift-guard hook |
+| Validate | /user:spec-validate | Status: VALIDATED | advisory (full lane) |
+| Build    | /user:execute or /user:next | tasks checked, verifier PASS | verification pipeline (worker, verifier, fix; max 2) |
+| Review   | /user:review or /user:review-team | review verdict recorded | advisory |
+| Docs     | /user:docs | README/CHANGELOG match code | advisory |
+| Ship     | /user:ship | tagged + PR | ship gate (blocks on FIX-REQUIRED), push-to-main blocker |
+| Reflect  | /user:retro | docs/retro/v<version>.md written | advisory |
+
+Throughout: safety-gate blocks destructive Bash; anti-rationalization blocks
+premature "done"; auto-format runs on edit; session-state-save and
+post-compact-reinject protect long sessions.
+
+## Completion contract
+A task is done only when its acceptance criteria are met and the verifier has
+actually run the tests, not when you claim they pass. If you cannot run the
+check, report that plainly; the anti-rationalization hook is the backstop for
+premature completion. Self-reported "done" is not proof; the task-verifier is.
+
+## What this contract does NOT do
+It does not lock phases. An experienced operator may skip /spec-validate on a
+normal-lane change or go straight to /next. The kit detects state
+(context-readiness hook) and suggests the next step; it never blocks
+progression. Hard stops are reserved for irreversible cost: destructive
+commands, push-to-main, premature completion, failed verification.
+```
+
+## Acceptance Criteria (global)
+- [ ] `WORKFLOW.md` exists, ≤ ~80 lines, four required sections present, headers ASCII-clean
+- [ ] Every gate named maps to a real existing hook/agent/command (no invented gate)
+- [ ] No CAPS coercion prose anywhere in the artifact
+- [ ] Workflow step list exists in exactly one place (others are pointers)
+- [ ] Demo `## Workflow` header survives; demo template uses `.planning/`; kit-root uses `docs/specs/`
+- [ ] Meta test asserts both files, four pinned headers, and path correctness; count is 110
+- [ ] No new command, agent, dependency, env var, settings.json field, or hook edit
+- [ ] CHANGELOG entry; phase count reconciled to 8 across PHILOSOPHY + WORKFLOW.md
+
+## Known limitations
+1. **The doc is guidance-grade by design.** Per the kit's own thesis, markdown biases but does not enforce. Its real enforcement is delegated to the verification pipeline + safety hooks. The genuinely new payload is the risk-tier table; the rest restates guardrails the agent already gets at 100% from the hooks. This is acceptable: the contract's job is to *name and route*, not to enforce.
+2. **Risk-tier classification is self-attested, not detected.** The agent picks its own lane, and an agent biased toward completion may under-classify to skip ceremony (pick "tiny" on work that deserves "full"). There is no diff-scanner forcing the lane. Mitigation: the safety-gate, push-to-main blocker, and anti-rationalization hook still fire regardless of lane, so a mis-classified change cannot do irreversible damage; it can only skip *ceremony*. A future spec could add a real detector (grep the diff for auth/migration patterns) if mis-classification shows up in retros. Not built now (no signal yet; PHILOSOPHY §5 bar).
+3. **`WORKFLOW.md` and `architecture.md` can drift.** Mitigation: `WORKFLOW.md` links to the data-flow diagram rather than restating it, and the TASK-3 test asserts section headers (not command names) to avoid ossification. The phase-order agreement between the two is a ship-time reviewer check, which is guidance-grade; accepted because the cost of drift here is confusion, not breakage.
+
+## Edge Cases
+1. **Phase/command name drift.** TASK-1 uses live command names; TASK-3 asserts section headers, not command names, so it will not ossify the command list.
+2. **Two path conventions.** Downstream template uses `.planning/`; kit-root uses `docs/specs/` (ADR-0002). TASK-3 asserts each path in the correct file so a copy-paste error is caught.
+3. **No `WORKFLOW.md` in a repo.** Nothing breaks: `CLAUDE.md` simply has a pointer to a file that is absent until the project adds it. No hook depends on the file (the hook edit was cut).
+
+## Out of Scope
+- A `/user:flow` autopilot command (Alt A, rejected).
+- Any new hard phase gate, hook, or hook edit (anti "Detect, don't dictate"; the hook delivery was cut).
+- Coercion/persona prose (anti ADR-0008).
+- A diff-scanning risk detector (Known limitation 2; deferred until a real mis-classification signal exists).
+- An outer execution loop / multi-session orchestration (GSD v2 / OMC territory per PHILOSOPHY §3).
+- Claiming the `AGENTS.md` filename / dual auto-loaded instruction files (Alt C, rejected).
+- Multi-harness packaging of `WORKFLOW.md` (deferred per ADR-0009).
+
+## Decision Log
+- **DEC-001**: Form is `WORKFLOW.md` referenced from `CLAUDE.md`, not a standalone auto-loaded `AGENTS.md` (single source of truth) and not a section in `architecture.md` (which is not shipped downstream). The AGENTS.md *pattern* is the cited source; the filename is the adaptation.
+- **DEC-002**: The `context-readiness.sh` pointer (in the prior draft) is **cut**. Rationale (scope-critic B2 + assumption-destroyer W1 + failure-mode BLOCK-3): a markdown pointer in a hook string is still guidance by this spec's own thesis, it does not make the doc "active," it carried a `set -euo pipefail` trailing-`&&` abort risk for every repo without the file, and `post-compact-reinject` does not surface the file. `CLAUDE.md` native auto-load is the honest, stronger, zero-code-change delivery. No hook is touched.
+- **DEC-003**: Risk-tiered intake is the only net-new idea, accepted under the indirect-lineage carve-out and labeled as single-source/experimental, not as a battle-tested pattern. Source: harness-experimental `FEATURE_INTAKE.md` lane model, simplified to one trigger list (no flag-counting arithmetic) per scope-critic W3. It has not met the §5 1-week-on-a-real-project bar; that is recorded as Known limitation 1, not hidden.
+- **DEC-004**: No hard gates added. All hard stops remain the existing safety/verify hooks; the contract names and points at them.
+- **DEC-005**: Identity-framing and outer-loop mechanisms from the taxonomy are deliberately declined (persona theater per ADR-0008; loops are autonomous-runtime territory). Declining is recorded so a future reader does not "add them back."
+- **DEC-006**: The persona-theater decline is grounded in "Synthesize, don't originate" + ADR-0008 (which exist today), NOT in PHILOSOPHY's proposed "v1.6 explicit-reject list." Rationale (philosophy-fidelity B1): SPEC-002 is only VALIDATED, so that section is not in live `PHILOSOPHY.md`; citing it would be forward-dated. If/when SPEC-002 ships, a docs pass may re-anchor.
+- **DEC-007**: Risk-tier table simplified to one trigger list, no numeric flag-counting (scope-critic W3). "2-3 flags / 4+ flags" arithmetic is process weight, not relief; a plain "touches auth/data/contracts → full" trigger is lighter and more "Detect, don't dictate."
+- **DEC-008**: `WORKFLOW.md` is justified as cross-phase connective tissue (like `architecture.md`), NOT under the NO-list "serves 2+ phases" gate (scope-critic B3). Indexing phases is not serving them; the honest justification is lifecycle-connective-tissue, the same basis `architecture.md` stands on.
+- **DEC-009**: File-budget stated as honest arithmetic: 79 → 81 (+2 files), no hard cap, each justified (scope-critic B1 + assumption-destroyer W5). The earlier "net-neutral" framing was a byte-count claim mislabeled as a file-count claim.
+- **DEC-010**: Kit-root embedded draft uses `docs/specs/` in required-reading, not `.planning/` (failure-mode WARN-3 + ADR-0002). The downstream template uses `.planning/`. TASK-3 asserts each.
+- **DEC-011**: TASK-3 assertion strings are pinned verbatim to the embedded-draft headers, matched on ASCII prefixes (failure-mode BLOCK-2). Headers are ASCII-clean (no arrows, no em dash) so the grep cannot drift on Unicode.
+- **DEC-012**: TASK-2 keeps the demo `## Workflow` H2 header and replaces only the body (failure-mode BLOCK-1); `test-meta.sh` section-tests the demo CLAUDE.md.
+- **DEC-013**: Canonical phase count standardized at 8; PHILOSOPHY's 7-vs-9 internal inconsistency reconciled in the TASK-4 docs pass.
+
+## Source citations
+- Workflow-file / harness pattern: hoangnb24/harness-experimental `AGENTS.md` + `HARNESS.md` + `FEATURE_INTAKE.md` (fetched 2026-05-20).
+- Risk-tier intake: harness-experimental `FEATURE_INTAKE.md` lane model. Simplified to one trigger list.
+- Workflow-in-instruction-file pattern + the "markdown biases, mechanism enforces" finding: `ops-toolkit/research/2026-05-20-agent-workflow-enforcement-patterns.md`.
+- Delivery via CLAUDE.md native auto-load + enforcement-over-coercion stance: ADR-0008.
+
+## Validation
+4 reviewers run 2026-05-20 (scope-critic, assumption-destroyer, failure-mode, philosophy-fidelity). Aggregate pre-fix verdict: FIX-REQUIRED.
+
+Blocking concerns, all resolved inline:
+- Hook-edit false "active" premise + `set -e` bug + compaction gap → TASK-2 hook edit cut (DEC-002).
+- Forward-dated "v1.6 reject list" citation → re-grounded in existing principles (DEC-006).
+- "Serves 2+ phases" gate gamed → re-justified as connective tissue (DEC-008).
+- "Net-neutral file budget" false → honest 79→81 arithmetic (DEC-009).
+- Kit-root draft hardcoded `.planning/` → switched to `docs/specs/` (DEC-010).
+- TASK-1 headers vs TASK-3 assertions unpinned → pinned ASCII prefixes (DEC-011); demo `## Workflow` header preserved (DEC-012).
+
+Warnings addressed: risk-tier self-classification skew recorded as Known limitation 2; risk-tier arithmetic simplified (DEC-007); "Synthesize" mark downgraded to ✓-with-caveat with the experimental-lineage gap stated; "forces"/"stop" prose softened to advice-grade in the embedded draft; phase count reconciled (DEC-013).
+
+Status flipped to VALIDATED after inline resolution. Re-run `/user:spec-validate` if the design changes materially before execute.

--- a/examples/hello-spec/CLAUDE.md
+++ b/examples/hello-spec/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — spm
+# CLAUDE.md: spm
 
 ## Project
 

--- a/examples/hello-spec/CLAUDE.md
+++ b/examples/hello-spec/CLAUDE.md
@@ -55,9 +55,7 @@ spm/
 
 ## Workflow
 
-This project uses dwarves-kit. Available commands: `/user:start`, `/user:think`, `/user:spec`, `/user:spec-validate`, `/user:execute`, `/user:next`, `/user:review`, `/user:review-team`, `/user:docs`, `/user:ship`, `/user:retro`, `/user:kit-health`.
-
-Hooks (safety-gate, anti-rationalization, auto-format, spec-drift-guard, context-readiness, session-state-save, etc.) run automatically. See the kit README for the full list.
+This project uses dwarves-kit. The phases, the risk-tier lanes, and the gate at each boundary are defined in the [`WORKFLOW.md`](WORKFLOW.md) contract; read it after this file.
 
 ## Spec Location
 

--- a/examples/hello-spec/README.md
+++ b/examples/hello-spec/README.md
@@ -49,10 +49,10 @@ PASS -> next task; FAIL:fixable -> fix-agent (max 2 retries); FAIL:escalate -> h
 
 ## Reading order
 
-1. Read `CLAUDE.md` first — it's the project anchor a contractor sees first.
-2. Then `.planning/SPEC.md` — the actual feature plan.
+1. Read `CLAUDE.md` first; it's the project anchor a contractor sees first.
+2. Then `.planning/SPEC.md`: the actual feature plan.
 3. Notice: no `--version` code yet. The spec is the input to `/user:execute`. The example stops at "spec ready to build", not "feature implemented", to keep the example readable.
 
 ---
 
-*Synthetic demo. The `spm` package and the feature it describes are fabricated for documentation purposes — there is no real `pip install spm`. The shape of `CLAUDE.md` and `.planning/SPEC.md`, however, is exactly what the kit's `/user:spec` command produces.*
+*Synthetic demo. The `spm` package and the feature it describes are fabricated for documentation purposes; there is no real `pip install spm`. The shape of `CLAUDE.md` and `.planning/SPEC.md`, however, is exactly what the kit's `/user:spec` command produces.*

--- a/examples/hello-spec/WORKFLOW.md
+++ b/examples/hello-spec/WORKFLOW.md
@@ -18,7 +18,7 @@ Pick a lane before you start. Smaller work skips ceremony.
 |--------|------|------|
 | tiny   | typo, copy, comment, one obvious edit | edit, verify, done. No spec. |
 | normal | one bounded feature or fix | /spec, /execute, /review, /ship |
-| full   | touches auth, authz, data model, data loss, audit/security, an external provider, an API contract, a migration, or weakens validation | /think, /spec, /spec-validate, /execute, /review-team, /docs, /ship, /retro |
+| full   | touches auth, authz, hooks, data model, data loss, audit/security, an external provider, an API contract, a migration, or weakens validation | /think, /spec, /spec-validate, /execute, /review-team, /docs, /ship, /retro |
 
 When in doubt between two lanes, take the heavier one. Anything in the full-lane
 trigger list uses the full lane unless you explicitly narrow the scope and say why.
@@ -32,7 +32,7 @@ trigger list uses the full lane unless you explicitly narrow the scope and say w
 | Build    | /user:execute or /user:next | tasks checked, verifier PASS | verification pipeline (worker, verifier, fix; max 2) |
 | Review   | /user:review or /user:review-team | review verdict recorded | advisory |
 | Docs     | /user:docs | README/CHANGELOG match code | advisory |
-| Ship     | /user:ship | tagged + PR | ship gate (blocks on FIX-REQUIRED), push-to-main blocker |
+| Ship     | /user:ship | tagged + PR | ship gate (blocks on DO NOT SHIP), push-to-main blocker |
 | Reflect  | /user:retro | docs/retro/v<version>.md written | advisory |
 
 Throughout: safety-gate blocks destructive Bash; anti-rationalization blocks

--- a/examples/hello-spec/WORKFLOW.md
+++ b/examples/hello-spec/WORKFLOW.md
@@ -1,0 +1,53 @@
+# WORKFLOW.md: the cycle, the lanes, the gates
+
+> Agent-facing contract. Read after CLAUDE.md. It names the lifecycle, routes
+> work by risk, and points at the guardrail that enforces each boundary.
+> It suggests and routes; it does not block. The only hard stops are the
+> safety-gate hook, the push-to-main blocker, the anti-rationalization Stop
+> hook, and the verification pipeline.
+
+## Required reading (in order)
+1. CLAUDE.md            - project context: stack, structure, rules
+2. .planning/SPEC.md   - the active spec; the shared contract for the cycle
+3. docs/architecture.md - how the pieces fit (reference; not required per task)
+
+## Size the work first (risk-tiered intake)
+Pick a lane before you start. Smaller work skips ceremony.
+
+| Lane   | When | Path |
+|--------|------|------|
+| tiny   | typo, copy, comment, one obvious edit | edit, verify, done. No spec. |
+| normal | one bounded feature or fix | /spec, /execute, /review, /ship |
+| full   | touches auth, authz, data model, data loss, audit/security, an external provider, an API contract, a migration, or weakens validation | /think, /spec, /spec-validate, /execute, /review-team, /docs, /ship, /retro |
+
+When in doubt between two lanes, take the heavier one. Anything in the full-lane
+trigger list uses the full lane unless you explicitly narrow the scope and say why.
+
+## The cycle (phase, exit, enforcer)
+| Phase    | Command | Exit when | Enforced by |
+|----------|---------|-----------|-------------|
+| Think    | /user:think | decision brief written (if BUILD) | advisory |
+| Spec     | /user:spec | spec exists, Status: DRAFT | spec-drift-guard hook |
+| Validate | /user:spec-validate | Status: VALIDATED | advisory (full lane) |
+| Build    | /user:execute or /user:next | tasks checked, verifier PASS | verification pipeline (worker, verifier, fix; max 2) |
+| Review   | /user:review or /user:review-team | review verdict recorded | advisory |
+| Docs     | /user:docs | README/CHANGELOG match code | advisory |
+| Ship     | /user:ship | tagged + PR | ship gate (blocks on FIX-REQUIRED), push-to-main blocker |
+| Reflect  | /user:retro | docs/retro/v<version>.md written | advisory |
+
+Throughout: safety-gate blocks destructive Bash; anti-rationalization blocks
+premature "done"; auto-format runs on edit; session-state-save and
+post-compact-reinject protect long sessions.
+
+## Completion contract
+A task is done only when its acceptance criteria are met and the verifier has
+actually run the tests, not when you claim they pass. If you cannot run the
+check, report that plainly; the anti-rationalization hook is the backstop for
+premature completion. Self-reported "done" is not proof; the task-verifier is.
+
+## What this contract does NOT do
+It does not lock phases. An experienced operator may skip /spec-validate on a
+normal-lane change or go straight to /next. The kit detects state
+(context-readiness hook) and suggests the next step; it never blocks
+progression. Hard stops are reserved for irreversible cost: destructive
+commands, push-to-main, premature completion, failed verification.

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -256,6 +256,47 @@ fi
 
 # ============================================================
 echo ""
+echo "=== WORKFLOW.md contract ==="
+# ============================================================
+
+WF_ROOT="$KIT_DIR/WORKFLOW.md"
+WF_DEMO="$KIT_DIR/examples/hello-spec/WORKFLOW.md"
+
+# Kit-root WORKFLOW.md carries the four pinned sections (matched on ASCII prefixes
+# so the grep cannot drift on a parenthetical or a Unicode glyph in the header).
+for SECTION in "^## Required reading" "^## Size the work first" "^## The cycle" "^## Completion contract"; do
+  TOTAL=$((TOTAL + 1))
+  if grep -q "$SECTION" "$WF_ROOT" 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC} WORKFLOW.md has '$SECTION'"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} WORKFLOW.md missing '$SECTION'"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+# Downstream template uses the .planning/ convention; kit-root uses docs/specs/
+# (ADR-0002). Asserting each in its own file catches a copy-paste path error.
+TOTAL=$((TOTAL + 1))
+if grep -q '.planning/SPEC.md' "$WF_DEMO" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC} examples/hello-spec/WORKFLOW.md uses .planning/SPEC.md"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC} examples/hello-spec/WORKFLOW.md missing .planning/SPEC.md"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+if grep -q 'docs/specs/' "$WF_ROOT" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC} WORKFLOW.md uses docs/specs/ convention"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC} WORKFLOW.md missing docs/specs/ convention"
+  FAIL=$((FAIL + 1))
+fi
+
+# ============================================================
+echo ""
 echo "=== Results ==="
 # ============================================================
 echo -e "Passed: ${GREEN}${PASS}${NC} / ${TOTAL}"

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -278,7 +278,7 @@ done
 # Downstream template uses the .planning/ convention; kit-root uses docs/specs/
 # (ADR-0002). Asserting each in its own file catches a copy-paste path error.
 TOTAL=$((TOTAL + 1))
-if grep -q '.planning/SPEC.md' "$WF_DEMO" 2>/dev/null; then
+if grep -qF '.planning/SPEC.md' "$WF_DEMO" 2>/dev/null; then
   echo -e "  ${GREEN}PASS${NC} examples/hello-spec/WORKFLOW.md uses .planning/SPEC.md"
   PASS=$((PASS + 1))
 else
@@ -287,7 +287,7 @@ else
 fi
 
 TOTAL=$((TOTAL + 1))
-if grep -q 'docs/specs/' "$WF_ROOT" 2>/dev/null; then
+if grep -qF 'docs/specs/' "$WF_ROOT" 2>/dev/null; then
   echo -e "  ${GREEN}PASS${NC} WORKFLOW.md uses docs/specs/ convention"
   PASS=$((PASS + 1))
 else


### PR DESCRIPTION
## Summary

Adds `WORKFLOW.md`, the agent-facing workflow contract for the kit (SPEC-003: orchestration layer), plus the spec-location housekeeping it builds on. The contract names each lifecycle phase, routes work by risk tier (tiny / normal / full), and points at the existing guardrail that enforces each boundary. It is delivered through the `CLAUDE.md` pointer (auto-loaded each session); it suggests and routes, it does not block. Every hard gate stays an existing hook/verifier.

## What's in this PR (6 commits)

**SPEC-003 orchestration layer**
- `feat: add WORKFLOW.md orchestration contract` — new `WORKFLOW.md` (kit root, `docs/specs/` paths) + downstream template `examples/hello-spec/WORKFLOW.md` (`.planning/` paths); both CLAUDE.md Workflow sections shrunk to a pointer (single source of truth, no duplicated step list); `test-meta.sh` +6 assertions (104 -> 110); README / MANUAL / architecture cross-references; PHILOSOPHY phase count reconciled to 8 (was 7 and 9).
- `docs(examples): replace em dashes in hello-spec template` — ASCII-clean the shipped template.
- `fix(workflow): correct review-team findings` — M1 ship-gate verdict string, M2 `hooks` full-lane trigger, M3 `grep -qF` path asserts.

**Spec housekeeping (groundwork)**
- `docs(spec): add SPEC-003 orchestration-layer draft` — the validated spec.
- `docs(spec): drop version from spec filenames; mark SPEC-001 shipped` — slug names the feature, not the release; SPEC-001 flipped to SHIPPED.
- `docs(spec): draft v1.6 directly in docs/specs/, retire .planning indirection` — kit-on-kit specs live in `docs/specs/` from day one.

## Review

`/review-team` (security + architecture + test-coverage lenses), combined 8.2/10. Original verdict FIX THEN SHIP; all three MEDIUM findings fixed in `ea4a8fd`, verdict now SHIP. No CRITICAL/HIGH. Three LOWs noted, none blocking.

## Tests

- `tests/test-hooks.sh`: 42/42
- `tests/test-meta.sh`: 110/110

## Not in this PR / follow-ups

- No VERSION bump or tag; changes sit under CHANGELOG `[Unreleased]`. Decide at merge whether SPEC-003 ships under v1.6 alongside SPEC-002, or its own version.
- SPEC-003 `Status:` stays VALIDATED; flip to SHIPPED after the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
