### PR TITLE
docs(spec): mark the install hook-materialization spec shipped

### DIFF
--- a/docs/specs/SPEC-025-install-hook-materialization.md
+++ b/docs/specs/SPEC-025-install-hook-materialization.md
@@ -1,7 +1,8 @@
 # Spec: Installer materializes hooks at the path settings.json references
 
 Generated: 2026-05-21
-Status: VALIDATED
+Status: SHIPPED
+Shipped: 2026-05-21 (PR #5, squash-merged to master)
 Source: live defect, 2026-05-21. A fresh session on a dev checkout (`~/workspace/tieubao/dwarves-kit`) opened with `SessionStart:startup hook error ... bash: /Users/<user>/.claude/dwarves-kit/hooks/context-readiness.sh: No such file or directory`. Retroactive spec: the fix shipped first (PR #5) under the bug lane; this records the contract and the in-place regression the SDD pass then caught.
 Depends on: `install.sh` (the bash install path), `settings.json` (hook command paths), `tests/test-meta.sh` (the structural guard). No new ADR: the chosen mechanism (per-file symlink from `KIT_DIR` into `~/.claude/...`) is the same pattern `install.sh` already uses for `commands/`, not a new architectural axis.
 Lane: bug (a defect: the installer never placed the scripts the settings reference). Root cause recorded before the fix, per the bug lane's iron law.


### PR DESCRIPTION
One-line follow-up to #5: flip SPEC-025 `Status:` from VALIDATED to SHIPPED (DEC-005) now that #5 is merged to master, and record the shipped date.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)