### PR TITLE
fix(verification): make negative-control tests history-independent

### DIFF
--- a/docs/verification/verif-test-portability/runs/2026-06-08-1902.md
+++ b/docs/verification/verif-test-portability/runs/2026-06-08-1902.md
@@ -1,0 +1,27 @@
+## 2026-06-08 19:02 PASS -- verif-test-portability [green]
+- Command: `bash tests/test-proof-dir-layout.sh && bash tests/test-classify-md-inert.sh`
+- Exit: 0
+- Output (excerpt):
+  ```
+  PASS set-wise-stripped lib BLOCKS the split layout (the set-wise code is load-bearing)
+  ALL PASS (3/3)
+  PASS inert-FIRST-stripped lib classifies md-only 'migrate' as stateful (the bug; fix is load-bearing)
+  ALL PASS (4/4)
+  ```
+- Verdict: PASS
+- Note: both tests now pass on master. The negative controls are history-independent: they
+  strip the feature block from the current lib (awk) instead of fetching a pre-change lib from
+  git, so they hold even though master now contains the feature.
+
+## 2026-06-08 19:00 RED-as-expected -- verif-test-portability [negative-control]
+- Command: (pre-fix, git-history negative control) `bash tests/test-proof-dir-layout.sh ; bash tests/test-classify-md-inert.sh`  on master
+- Exit: 1 (both)
+- Output (excerpt):
+  ```
+  # dir-layout: FAIL  (NC-B could not find a pre-change lib; master HAS set-wise)
+  # classify-md-inert: FAIL  (NC could not find a lib without inert-FIRST; master HAS it)
+  ```
+- Verdict: RED-as-expected
+- Note: NEGATIVE CONTROL. This is the exact failure the fix removes: reading the pre-change lib
+  from git history goes red once the feature is merged to master. Observed live during the
+  post-merge sync, before this fix.

--- a/docs/verification/verif-test-portability/test-design.md
+++ b/docs/verification/verif-test-portability/test-design.md
@@ -1,0 +1,20 @@
+# Test design -- verif-test-portability
+Profile: feature
+Proof class: behavioral
+
+## Hypothesis / assumptions
+- Hypothesis: a test's negative control must not read the "pre-change" lib from git history.
+  `test-proof-dir-layout.sh` and `test-classify-md-inert.sh` did exactly that (merge-base /
+  HEAD `:lib/proof-ledger.sh`), so they passed pre-merge but went RED once the feature merged
+  to master (master then HAS the change, so there is no pre-change version to fetch).
+- Fix: construct the pre-change lib from the CURRENT one by stripping the feature block (awk),
+  so the negative control holds regardless of git state.
+
+## Test design
+- AC1: both tests pass on master after the fix (the strip-based negative control resolves).
+- AC2: the strip genuinely reproduces the bug , the set-wise-stripped lib BLOCKS the split
+  layout, and the inert-FIRST-stripped lib classifies a markdown-only "migrate" diff as stateful.
+- Negative control: the pre-fix tests (git-history negative control) exit non-zero on master.
+
+## How to re-run
+- `bash tests/test-proof-dir-layout.sh && bash tests/test-classify-md-inert.sh` (both exit 0).

--- a/tests/test-classify-md-inert.sh
+++ b/tests/test-classify-md-inert.sh
@@ -40,15 +40,16 @@ F=/tmp/cls-codemig; build "$F" code "migrate the database schema"
 F=/tmp/cls-code; build "$F" code "tweak the helper"
 [ "$(cls "$LIB" "$F")" = behavioral ] && pass "code-only diff -> behavioral" || fail "code-only should be behavioral, got $(cls "$LIB" "$F")"
 
-# AC2 negative control: the pre-fix lib (merge-base) classifies md-only 'migrate' as stateful
+# AC2 negative control: a lib with the inert-FIRST block STRIPPED classifies md-only 'migrate'
+# as stateful (the bug). History-independent: construct the pre-fix lib from the CURRENT one
+# (awk the inert-FIRST block out), so this stays valid even after the fix is merged to master.
 F=/tmp/cls-md   # reuse the md-only 'migrate' fixture
 OLD=/tmp/cls-oldlib.sh
-BASEREF=$(git -C "$KIT" merge-base HEAD master 2>/dev/null || git -C "$KIT" rev-parse master 2>/dev/null)
-git -C "$KIT" show "${BASEREF:-HEAD}:lib/proof-ledger.sh" > "$OLD" 2>/dev/null
+awk '/# inert FIRST/{s=1} /^  subjects=/{s=0} !s' "$LIB" > "$OLD"
 if [ -s "$OLD" ] && grep -q 'stateful: deploy' "$OLD" && ! grep -q 'inert FIRST' "$OLD"; then
-  [ "$(cls "$OLD" "$F")" = stateful ] && pass "pre-fix lib classifies md-only 'migrate' as stateful (the bug; fix is load-bearing)" || fail "pre-fix lib should reproduce the stateful bug, got $(cls "$OLD" "$F")"
+  [ "$(cls "$OLD" "$F")" = stateful ] && pass "inert-FIRST-stripped lib classifies md-only 'migrate' as stateful (the bug; fix is load-bearing)" || fail "stripped lib should reproduce the stateful bug, got $(cls "$OLD" "$F")"
 else
-  echo "[NO EXECUTABLE CHECK: could not resolve a pre-fix lib without the inert-first reorder]"; fails=$((fails+1))
+  echo "[NO EXECUTABLE CHECK: could not strip the inert-FIRST block]"; fails=$((fails+1))
 fi
 
 echo "---"

--- a/tests/test-proof-dir-layout.sh
+++ b/tests/test-proof-dir-layout.sh
@@ -58,24 +58,21 @@ else
   pass "green-only correctly BLOCKED (negative control is required)"
 fi
 
-# 3. NEGATIVE CONTROL B: pre-change lib on the split fixture -> BLOCK (set-wise is load-bearing).
-# Take the lib as it was at the fork point (merge-base with master), so this stays valid no
-# matter how many commits land on the branch after the set-wise change. HEAD would be wrong
-# once the change is committed (HEAD then HAS set-wise).
+# 3. NEGATIVE CONTROL B: a lib with the set-wise block STRIPPED -> BLOCKS the split layout.
+# History-independent: construct the pre-change lib from the CURRENT one (awk the set-wise
+# block out), so this stays valid even after the feature is merged to master. Reading the lib
+# from git history breaks the moment master HAS the change.
 F=/tmp/vf-gate-split   # reuse the split fixture (has both runs/ files)
 OLD=/tmp/vf-oldlib.sh
-BASEREF=$(git -C "$KIT" merge-base HEAD master 2>/dev/null \
-  || git -C "$KIT" merge-base HEAD origin/master 2>/dev/null \
-  || git -C "$KIT" rev-parse master 2>/dev/null)
-git -C "$KIT" show "${BASEREF:-HEAD}:lib/proof-ledger.sh" > "$OLD" 2>/dev/null
+awk '/# set-wise \(directory layout\)/{s=1} /\[ "\$ok" -eq 0 \] && return 0/{s=0} !s' "$LIB" > "$OLD"
 if [ -s "$OLD" ] && ! grep -q 'set-wise' "$OLD"; then
   if bash "$OLD" check "$F" "$(base "$F")" vf-fix >/dev/null 2>&1; then
-    fail "pre-change lib should BLOCK the split layout but it passed"
+    fail "set-wise-stripped lib should BLOCK the split layout but it passed"
   else
-    pass "pre-change lib BLOCKS the split layout (the set-wise code is load-bearing)"
+    pass "set-wise-stripped lib BLOCKS the split layout (the set-wise code is load-bearing)"
   fi
 else
-  echo "[NO EXECUTABLE CHECK: cannot read HEAD:lib/proof-ledger.sh]"; fails=$((fails+1))
+  echo "[NO EXECUTABLE CHECK: could not strip the set-wise block]"; fails=$((fails+1))
 fi
 
 echo "---"


### PR DESCRIPTION
Follow-up to #18. The negative controls in `test-proof-dir-layout.sh` and `test-classify-md-inert.sh` read the pre-change lib from git history (merge-base / HEAD), so they passed pre-merge but went RED once #18 merged to master (master then HAS the feature, so there is no pre-change version to fetch).

Fix: construct the pre-change lib from the current one by stripping the feature block (awk). The negative control now holds regardless of git state. Both tests pass on master; proof in `docs/verification/verif-test-portability/` (green + the observed pre-fix RED as the negative control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)