### PR TITLE
docs(verification): bless co-located proof + add table-first review layout (ADR-0026)

### DIFF
--- a/docs/decisions/0026-colocated-table-first-proof.md
+++ b/docs/decisions/0026-colocated-table-first-proof.md
@@ -1,0 +1,44 @@
+# 0026. Co-located proof-of-done + table-first review layout (additive)
+
+Date: 2026-06-09
+Status: Accepted
+Relates-to: ADR-0025 (proof-of-done ship gate, the gate this rides on), the proof-of-done convention (docs/verification/README.md), lib/proof-ledger.sh (the diff-keyed gate), ops-toolkit SPEC-016 (the consumer adoption that drove this)
+
+## Decision (one line)
+
+Bless a co-located `tools/<name>/docs/proof-of-done.md` as a first-class home for a tool's canonical proof (packaged with the code), and add an optional **table-first review layout** for any proof, both ADDITIVELY: every existing shape (`docs/verification/<slug>/{test-design.md, runs/}`, the flat `<slug>.md`) and the gate markers stay exactly as they were.
+
+## Context
+
+The canonical convention prescribes `docs/verification/<slug>/{test-design.md, runs/}` at the repo root and lists co-located `tools/<name>/docs/proof-of-done.md` as **back-compat**. Two things pushed back:
+
+1. **Packaging.** For a tool in a `tools/<name>/` monorepo (ops-toolkit), a proof detached at the repo root drifts from the code it proves and is easy to miss in review. Teams want the proof to travel WITH the tool.
+2. **Review ergonomics.** The run-record shape (`runs/<ts>.md`: Command/Exit/Output/Verdict) is optimized for an immutable execution log, not for a reviewer scanning "what does done mean here, was it met, when, and how do I re-run." A reviewer wants acceptance criteria first, then implementation, then a timestamped confirmation table.
+
+The gate (`lib/proof-ledger.sh`, ADR-0025) already accepts a file named `proof-of-done.md` anywhere via the regex `(^|/)proof-of-done\.md$`. So co-location is already gate-legal; it was just labeled "back-compat." This ADR promotes it and adds the review layout, without changing the gate or breaking any consumer.
+
+## Decision
+
+1. **Co-located proof is first-class for tool work.** For a tool living at `tools/<name>/`, its canonical proof MAY live at `tools/<name>/docs/proof-of-done.md`. It is gate-visible via the `proof-of-done.md` filename (not via a repo-root path). Optional immutable history co-locates at `tools/<name>/docs/runs/<ts>.md`; optional design at `tools/<name>/docs/test-design.md`. The repo-root `docs/verification/<slug>/` layout remains equally valid (use whichever fits; co-location is encouraged for `tools/` monorepos, the root layout for feature branches without a tool home).
+
+2. **The filename is load-bearing.** Because the gate's only co-located match is a file named `proof-of-done.md`, a co-located `runs/` directory is invisible to the gate. So a co-located canonical proof MUST be the `proof-of-done.md` file itself and MUST carry the literal gate markers (`Command:`, `Exit:`, `NEGATIVE CONTROL`, `rollback` / `[UNAVAILABLE`) in its body.
+
+3. **Optional table-first review layout.** Any proof (co-located or root) MAY use a table-first layout: Acceptance criteria (table) -> Implementation -> Confirmation (timestamped run table) -> Run detail (the gate markers, full depth) -> Reproduce. The tables are a human review surface; the run-detail section keeps the literal markers so the gate is unaffected. The existing run-record shape stays valid for repos/teams that prefer it.
+
+4. **Work-type dialects (one spine, the body adapts).** The same proof spine carries four common shapes: one-shot CLI / data tool (green + negative control), stateful daemon / service (liveness + kill-to-RED + restore/rollback), recurring action / loop / workflow / cron (an append-only run ledger + a monitoring signal), and eval / experiment (a thin pointer to `experiments/<slug>/TEST-REPORT.md`, which stays the single source of measured numbers).
+
+5. **Strictly additive.** No gate change. No marker change. Every shape that validated before still validates. Consumers (dfoundation, trading, ops-toolkit) need no migration; they adopt the new shape only when they choose to.
+
+## Alternatives considered
+
+- **Replace the root layout with co-location.** Rejected: breaks existing proofs in consumer repos and the kit's own worked examples. Additive is the only safe upstream.
+- **Leave co-location as "back-compat" only.** Rejected: that wording discourages the very packaging teams want; it was already gate-legal, so the cost of blessing it is zero.
+- **Make the gate parse a co-located `runs/` directory.** Rejected here (a gate change with real blast radius across every consumer). Out of scope; the `proof-of-done.md`-as-canonical path solves the packaging need without touching the gate.
+- **Ops-toolkit-only convention (no upstream).** Rejected by the consumer (ops-toolkit SPEC-016 D-016-B): a local fork drifts from the kit worked examples; the format belongs in the canonical.
+
+## Consequences
+
+- Tool monorepos can keep proof packaged with code; reviewers get a top-down scannable proof.
+- The canonical README now documents two equally-valid homes (root layout, co-located) and an optional presentation layer; authors pick per context. Slightly more surface to explain, mitigated by the work-type dialect table.
+- Because nothing about the gate or markers changed, this ADR is reversible by reverting the docs alone; no consumer proof is invalidated either way.
+- Worked reference: ops-toolkit `tools/{zedra-deploy,growatt-pull,spec-to-cli}/docs/proof-of-done.md` (SPEC-016).

--- a/docs/implementation-notes/colocated-table-first-proof.md
+++ b/docs/implementation-notes/colocated-table-first-proof.md
@@ -1,0 +1,31 @@
+# Implementation notes: co-located + table-first proof (ADR-0026)
+
+Kit-side (Phase A) of ops-toolkit SPEC-016. Upstreams two additions to the canonical
+verification convention, additively, so existing consumers (dfoundation, trading) keep working.
+
+## 2026-06-09 11:50 , branch in-place, not a worktree
+- Context: the always-worktree policy. I was already inside an ops-toolkit worktree session;
+  `EnterWorktree` is single-repo + non-nestable, and hand `git worktree add` is forbidden by policy.
+- Decision: branched dwarves-kit in-place (`docs/colocated-proof`) on its clean checkout.
+- Why: no native way to nest a worktree into a second repo from within another repo's worktree;
+  this is a doc-only, single-writer, sequential change on a clean tree.
+- Impact: the unrelated `M docs/ABSORPTION.md` in the kit checkout is left untouched/unstaged.
+
+## 2026-06-09 11:50 , additive, not a replacement
+- Context: the canonical README is the single source of truth across all consumer repos.
+- Decision: ADR-0026 + README changes are ADDITIVE. Co-located `tools/<name>/docs/proof-of-done.md`
+  is promoted from "back-compat" to a blessed first-class shape for tool work; the table-first
+  review layout is added as an OPTIONAL presentation; the existing `docs/verification/<slug>/{test-design,runs}`
+  layout and the flat shape stay fully valid. Gate markers (`Command:`/`Exit:`/`NEGATIVE CONTROL`/
+  `rollback`) are unchanged, so no consumer's existing proofs break.
+- Why: dfoundation + trading have existing proofs in the current shapes; a breaking change would
+  invalidate them. Additive keeps the gate green everywhere.
+- Alternatives: replace the layout (rejected, breaks consumers); ops-toolkit-only fork (rejected by
+  the user, would drift from the kit worked examples).
+
+## 2026-06-09 11:50 , the filename constraint is the load-bearing fact
+- Context: why co-location must use the name `proof-of-done.md`.
+- Decision: documented in the README that the gate's co-located path is ONLY a file named
+  `proof-of-done.md` (the regex `(^|/)proof-of-done\.md$` in `lib/proof-ledger.sh`); a co-located
+  `runs/` dir is invisible to the gate.
+- Impact: the table-first proof MUST keep the literal markers in its run-detail section.

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -48,10 +48,54 @@ docs/verification/<slug>/
 ```
 
 `<slug>` is the feature branch name minus its `type/` prefix (same slug as the spec and
-`docs/implementation-notes/<slug>.md`). **Back-compat:** the older flat shape
-`docs/verification/<slug>.md` (append-entry, one file) and a co-located
-`tools/<name>/docs/proof-of-done.md` are still accepted by the gate; new work uses the
-directory layout.
+`docs/implementation-notes/<slug>.md`). The older flat shape `docs/verification/<slug>.md`
+(append-entry, one file) is still accepted by the gate.
+
+## Two homes: repo-root layout or co-located with the tool (ADR-0026)
+
+A proof has two equally-valid homes. Pick per context:
+
+- **Repo-root** `docs/verification/<slug>/{test-design.md, runs/}` , the default for a feature
+  branch with no single tool home.
+- **Co-located** `tools/<name>/docs/proof-of-done.md` , first-class for a tool in a `tools/<name>/`
+  monorepo, so the proof travels WITH the code it proves. Optional `tools/<name>/docs/runs/<ts>.md`
+  (immutable history) and `tools/<name>/docs/test-design.md` sit beside it.
+
+**The filename is load-bearing.** The gate's only co-located match is a file literally named
+`proof-of-done.md` (regex `(^|/)proof-of-done\.md$` in `lib/proof-ledger.sh`); a co-located `runs/`
+directory is invisible to the gate. So a co-located canonical proof MUST be the `proof-of-done.md`
+file itself and MUST carry the literal gate markers (`Command:`, `Exit:`, `NEGATIVE CONTROL`,
+`rollback` / `[UNAVAILABLE`) in its body.
+
+### Optional table-first review layout
+
+Any proof (either home) MAY use a **table-first** layout optimized for a reviewer scanning top-down,
+instead of the run-log shape below. The tables are the human surface; the run-detail section keeps the
+literal markers, so the gate is unaffected:
+
+```markdown
+# Proof of done: <name>
+Profile: tool-build|feature|eval   Proof class: stateful|behavioral|inert
+
+## 1. Acceptance criteria     | # | Criterion | Status | Evidence |   (the AC table, at the top)
+## 2. Implementation          | Aspect | Detail |   (What / Where / How it runs / Reversibility)
+## 3. Confirmation (runs)      | Run | When (ISO+tz) | Command | Exit | Verdict |
+## 4. Run detail               ### R1 GREEN — Command: … Exit: … Verdict: PASS
+                               ### R2 NEGATIVE CONTROL — … ; ### R3 ROLLBACK/RESTORE — …
+## 5. Reproduce                `<idempotent re-run command>`
+```
+
+### Work-type dialects (one spine, the body adapts)
+
+| Work-type | Confirmation shape | extra |
+|---|---|---|
+| one-shot CLI / data tool | green run + negative control (revert -> RED) | reversibility = git revert / N-A |
+| stateful daemon / service | green = liveness; negative control = kill -> down; restore = rollback | topology (what runs where) |
+| recurring action / loop / workflow / cron | an append-only run ledger (row + detail per execution) + a liveness/monitoring signal | schedule + monitored signal |
+| eval / experiment | a thin pointer to `experiments/<slug>/TEST-REPORT.md` (the single source of measured numbers) | numbers never copied out |
+
+Worked reference: ops-toolkit `tools/{zedra-deploy,growatt-pull,spec-to-cli}/docs/proof-of-done.md`
+(SPEC-016). New work uses the directory layout OR the co-located `proof-of-done.md`; both are first-class.
 
 ## Three profiles of one spine (not three reinventions)
 

--- a/docs/verification/colocated-proof.md
+++ b/docs/verification/colocated-proof.md
@@ -1,0 +1,64 @@
+# Proof of done: co-located + table-first proof convention (ADR-0026)
+
+| | |
+|---|---|
+| **Profile** | feature (convention/docs) |
+| **Proof class** | inert (docs-only: ADR + canonical README + implementation-notes) , but regression-checked |
+| **Canonical** | this file (dogfoods the new table-first layout) |
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| AC1 | Change is additive: every prior proof shape + the gate markers still validate | PASS | R1, R2 |
+| AC2 | Editing the canonical README does not break the meta-pin (prior lesson) | PASS | R1 |
+| AC3 | The gate's set-wise + per-file validation is unchanged | PASS | R2, R3 |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | ADR-0026 + additive README section blessing co-located `proof-of-done.md` + the table-first layout + work-type dialects |
+| Where | `docs/decisions/0026-colocated-table-first-proof.md`, `docs/verification/README.md` |
+| How it runs | docs only; no code, no gate change, no marker change |
+| Reversibility | revert the docs; no consumer proof is invalidated either way |
+
+## 3. Confirmation (recorded runs)
+
+| Run | When | Command | Exit | Verdict |
+|---|---|---|---|---|
+| R1 meta | 2026-06-09 | `bash tests/test-meta.sh` | 0 | PASS (390/390) |
+| R2 proof layout | 2026-06-09 | `bash tests/test-proof-dir-layout.sh` | 0 | PASS (3/3) |
+| R3 ship-gate profiles | 2026-06-09 | `bash tests/test-ship-gate-profiles.sh` | 0 | PASS (6/6) |
+
+## 4. Run detail
+
+### R1 GREEN, meta-pin intact after the README edit
+- Command: `bash tests/test-meta.sh`
+- Exit: 0
+- Output (excerpt): `Passed: 390 / 390 ... All meta tests passed.`
+- Verdict: PASS. The additive section did not drop a pinned token (the prior README-edit regression class).
+
+### R2, proof-dir-layout (carries its own NEGATIVE CONTROL)
+- Command: `bash tests/test-proof-dir-layout.sh`
+- Exit: 0
+- Output (excerpt):
+  ```
+  PASS green-only correctly BLOCKED (negative control is required)
+  PASS set-wise-stripped lib BLOCKS the split layout (the set-wise code is load-bearing)
+  ```
+- Verdict: PASS. The gate's required-negative-control + set-wise behavior are unchanged by this docs change , these are the in-suite negative controls.
+
+### R3, ship-gate profiles (allow + block)
+- Command: `bash tests/test-ship-gate-profiles.sh`
+- Exit: 0
+- Output (excerpt): `PASS [tool-build] negative-control run missing -> ship-gate BLOCKS the push`
+- Verdict: PASS. Allow-on-proof and block-on-missing both hold.
+
+## 5. Reproduce
+
+```sh
+bash tests/test-meta.sh && bash tests/test-proof-dir-layout.sh && bash tests/test-ship-gate-profiles.sh
+```
+
+Note: the change itself is inert (docs); these runs are the regression check that the canonical edit did not move the gate. The gate's RED-when-absent behavior is exercised by R2/R3's in-suite negative controls.


### PR DESCRIPTION
## What

Two **additive** changes to the canonical verification convention (ADR-0026):

1. Promote co-located `tools/<name>/docs/proof-of-done.md` from "back-compat" to a **first-class** home for a tool's proof, so the proof travels with the code in a `tools/<name>/` monorepo.
2. Add an optional **table-first review layout** (Acceptance criteria -> Implementation -> Confirmation run-table -> Run detail -> Reproduce) + a **work-type dialect** table (one-shot CLI / stateful daemon / recurring workflow / eval).

## Strictly additive , nothing breaks

- **No gate change, no marker change.** `lib/proof-ledger.sh` already accepts a file named `proof-of-done.md` anywhere (regex `(^|/)proof-of-done\.md$`); this just blesses + documents it.
- Every existing shape (`docs/verification/<slug>/{test-design,runs}`, flat `<slug>.md`) stays equally valid. Consumer repos (dfoundation, trading) need **no migration**.
- The filename is load-bearing: a co-located `runs/` dir is invisible to the gate, so a co-located canonical proof must be the `proof-of-done.md` file and carry the literal markers. Documented.

## Why

Driven by ops-toolkit **SPEC-016** ([tieubao/ops-toolkit#160](https://github.com/tieubao/ops-toolkit/pull/160)), which co-located + reformatted the proofs for zedra-deploy / growatt-pull / spec-to-cli. The format belongs in the canonical, not a consumer fork.

## Verification

Regression-checked (the prior README-edit-breaks-meta-pin lesson): `tests/test-meta.sh` 390/390, `tests/test-proof-dir-layout.sh` 3/3, `tests/test-ship-gate-profiles.sh` 6/6. Recorded at `docs/verification/colocated-proof.md` (which dogfoods the new table-first layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)