### PR TITLE
fix(kit): ship AGENTS.md + WORKFLOW.md into the install

### DIFF
--- a/docs/implementation-notes/install-ships-contract.md
+++ b/docs/implementation-notes/install-ships-contract.md
@@ -1,0 +1,20 @@
+# Implementation notes: install ships the operate-contract (sub-goal 04 of kit-adopt-enforce)
+
+Spec: SPEC-049. Branch: `feat/kit-adopt-04-install` off master. Lane: normal (lane-classify
+returned `normal`; packaging change, not enforcement). Normal lane = spec, build, review, ship.
+
+## 2026-06-09, the fix
+
+- Context: sub-goal 03 surfaced that `~/.claude/dwarves-kit/` lacks AGENTS.md + WORKFLOW.md, so
+  adopt (needs a source AGENTS.md) and gate-ledger (reads `$KIT_ROOT/WORKFLOW.md`) break from the
+  install. install.sh symlinks hooks + lib but never the two root contract files.
+- Decision: symlink `AGENTS.md` + `WORKFLOW.md` into `$CLAUDE_DIR/dwarves-kit/` in install.sh's
+  out-of-place branch (mirroring hooks + lib: a symlink keeps repo edits live). In-place installs
+  already have them. Uninstall removes the two symlinks. No change to adopt.sh / gate-ledger
+  resolution logic (the symlink fixes them as-is).
+- Applied LIVE: created the two symlinks in `~/.claude/dwarves-kit/` so adopt + the lane gate work
+  for Han now, not only after a fresh install. Re-tested the exact sub-goal 03 failures: both pass.
+- Verification: `tests/test-install-contract.sh` 3/3 (adopt from install, gate-ledger reads matrix,
+  control fails without the symlinks); `tests/test-meta.sh` 392/392.
+- This closes the gap between the mega-goal's 3 original sub-goals and the destination
+  "self-install" actually holding from the install.

--- a/docs/specs/SPEC-049-install-ships-contract.md
+++ b/docs/specs/SPEC-049-install-ships-contract.md
@@ -1,0 +1,54 @@
+# Spec: install.sh deploys AGENTS.md + WORKFLOW.md into the install
+
+Status: DRAFT
+Lane: normal
+
+## Problem
+
+`install.sh` symlinks `hooks/` and `lib/` into `~/.claude/dwarves-kit/` but never deploys the root
+`AGENTS.md` or `WORKFLOW.md`. So when run from the install (the normal case, not the repo):
+- `lib/adopt.sh` can't find a source `AGENTS.md` (it looks in `$KIT_ROOT` = the install) -> adopt
+  fails with "no source AGENTS.md".
+- `lib/gate-ledger.sh` reads `$KIT_ROOT/WORKFLOW.md` for the lane x phase matrix -> "awk: can't
+  open WORKFLOW.md", so the lane-completeness check silently passes (empty required set).
+
+Surfaced dogfooding sub-goal 03 (adopting ops-toolkit): adopt + the lane gate only worked by
+resolving from the kit repo. This is the gap between the shipped sub-goals and the destination
+"self-install" actually holding.
+
+## Design
+
+In `install.sh`'s out-of-place branch (the one that symlinks hooks + lib), symlink `AGENTS.md` and
+`WORKFLOW.md` into `$CLAUDE_DIR/dwarves-kit/` too (same pattern: a symlink keeps repo edits live).
+The in-place install needs nothing (the files are already there). Add their removal to the
+uninstall block (only a symlink is removed).
+
+## Scope
+
+**In:** the contract-deploy block in `install.sh` (install + uninstall), a test.
+**Out:** changing adopt.sh / gate-ledger resolution logic (the symlink fixes them as-is); the
+lane/proof taxonomy.
+**Not:** copying lib (stays a symlink); a packaging format change; shipping more than these two
+files.
+
+## Acceptance criteria
+
+- [ ] After the install block runs (out-of-place), `$CLAUDE_DIR/dwarves-kit/AGENTS.md` and
+  `WORKFLOW.md` exist (symlinks to the repo).
+- [ ] From a simulated install dir (lib + AGENTS.md + WORKFLOW.md symlinked), `bash
+  $INSTALL/lib/adopt.sh <tmprepo>` creates the contract (finds the source AGENTS.md), and
+  `gate-ledger required full` (KIT_ROOT=$INSTALL) prints the 11-gate matrix (reads WORKFLOW.md).
+- [ ] Uninstall removes the two symlinks.
+- [ ] `bash tests/test-install-contract.sh` passes; `bash tests/test-meta.sh` stays green.
+
+## Test plan
+
+| Scenario | assert |
+|---|---|
+| simulated install: adopt from install | AGENTS.md found, 4 artifacts land in the tmp repo |
+| simulated install: gate-ledger reads matrix | `required full` lists 11 gates (non-empty) |
+| (control) install WITHOUT the contract symlinks | adopt fails "no source AGENTS.md" |
+
+## Resolved decisions
+
+- Symlink (not copy) to mirror hooks/lib and keep repo edits live.

--- a/docs/verification/install-ships-contract.md
+++ b/docs/verification/install-ships-contract.md
@@ -1,0 +1,37 @@
+# Verification: install ships the operate-contract (SPEC-049)
+
+Proof class: behavioral (changes what the install deploys). Reproduce:
+`bash tests/test-install-contract.sh` (3/3) + the live check below. Last run: 2026-06-09.
+
+## GREEN: adopt + gate-ledger work FROM a simulated install
+
+`tests/test-install-contract.sh` builds an install dir with install.sh's out-of-place symlink
+layout (lib + AGENTS.md + WORKFLOW.md symlinked), then:
+
+- `bash $INSTALL/lib/adopt.sh <tmp>` -> creates the contract (the source AGENTS.md now resolves
+  at `$KIT_ROOT/AGENTS.md`).
+- `gate-ledger required full` (KIT_ROOT=$INSTALL) -> prints the 11-gate matrix (reads
+  `$INSTALL/WORKFLOW.md`).
+
+## GREEN: the LIVE install (the sub-goal 03 failure, re-tested)
+
+After symlinking the two files into `~/.claude/dwarves-kit/` (what the new install.sh does):
+
+```
+$ bash ~/.claude/dwarves-kit/lib/adopt.sh <tmp>
+adopt: <tmp> (updated)          # was: "no source AGENTS.md" before this fix
+$ bash ~/.claude/dwarves-kit/lib/gate-ledger.sh required full | wc -l
+11                              # was: "awk: can't open WORKFLOW.md" before this fix
+```
+
+## NEGATIVE CONTROL: an install WITHOUT the contract symlinks
+
+`tests/test-install-contract.sh` scenario 3: a bare install (lib only, no AGENTS.md/WORKFLOW.md)
+-> `adopt.sh` exits non-zero with "no source AGENTS.md". The fix is load-bearing: remove the
+symlinks and adopt breaks again.
+
+## Suite
+
+`bash tests/test-install-contract.sh` -> PASS=3 FAIL=0. `bash tests/test-meta.sh` -> 392/392.
+
+## Verdict: PASS

--- a/docs/verification/install-ships-contract.md
+++ b/docs/verification/install-ships-contract.md
@@ -35,3 +35,40 @@ symlinks and adopt breaks again.
 `bash tests/test-install-contract.sh` -> PASS=3 FAIL=0. `bash tests/test-meta.sh` -> 392/392.
 
 ## Verdict: PASS
+
+---
+
+## 2026-06-10 review-driven hardening (PR #24)
+
+The kit's own 3-lens review-team (dogfooded) returned two real findings:
+
+1. **Security HIGH:** the install block did `[ -f "$LINK" ] && rm -f "$LINK"`, which would
+   silently destroy a user's REAL `AGENTS.md`/`WORKFLOW.md` placed at `~/.claude/dwarves-kit/`.
+   Fixed: only a symlink is removed-and-refreshed; a real file is left intact with a `[skip]`
+   notice (adopt resolves the source from `$KIT_ROOT` either way).
+2. **Test-coverage HIGH:** `test-install-contract.sh` simulated the install layout (hand-built
+   symlinks) but never invoked `install.sh`, so the shipping installer could regress undetected.
+   Fixed: `test-meta.sh`'s real-install block now asserts `install.sh` materializes AGENTS.md +
+   WORKFLOW.md, and that `--uninstall` removes them.
+
+### GREEN: a pre-existing real file is preserved (security fix)
+
+```
+$ H=$(mktemp -d); mkdir -p "$H/.claude/dwarves-kit"
+$ printf 'MY-REAL-AGENTS-FILE-DO-NOT-DESTROY\n' > "$H/.claude/dwarves-kit/AGENTS.md"
+$ HOME="$H" bash install.sh
+[skip] AGENTS.md at .../dwarves-kit/AGENTS.md is a real file, not a symlink; leaving it untouched
+[ok] Linked AGENTS.md + WORKFLOW.md into .../dwarves-kit/
+$ grep -c MY-REAL-AGENTS-FILE-DO-NOT-DESTROY "$H/.claude/dwarves-kit/AGENTS.md"   # 1 (survived)
+$ [ -L "$H/.claude/dwarves-kit/WORKFLOW.md" ] && echo linked                       # WORKFLOW still linked
+```
+
+Negative-control framing: pre-fix, the `rm -f` would delete the real file and the `grep -c`
+would print `0`.
+
+### Suite (expanded)
+
+`bash tests/test-install-contract.sh` -> PASS=3 FAIL=0. `bash tests/test-meta.sh` -> 395/395
+(added: install materializes AGENTS.md + WORKFLOW.md, uninstall removes the two symlinks).
+
+## Verdict: PASS (review-hardened)

--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,12 @@ if [ "${1:-}" = "--uninstall" ]; then
     echo "[ok] Removed lib symlink: $LIB_DEST"
   fi
 
+  # Remove the operate-contract symlinks (SPEC-049). Only symlinks are removed.
+  for CONTRACT in AGENTS.md WORKFLOW.md; do
+    LINK="$CLAUDE_DIR/dwarves-kit/$CONTRACT"
+    if [ -L "$LINK" ]; then rm "$LINK" && echo "[ok] Removed $CONTRACT symlink: $LINK"; fi
+  done
+
   # Remove dwarves-kit hooks from settings.json
   if [ -f "$SETTINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
     # Backup first
@@ -162,6 +168,22 @@ else
   [ -d "$LIB_DEST" ] && [ ! -L "$LIB_DEST" ] && rm -rf "$LIB_DEST"
   ln -s "$KIT_DIR/lib" "$LIB_DEST"
   echo "[ok] Linked lib into $LIB_DEST"
+fi
+
+# 1d. Deploy the operate-contract files so they resolve from the stable install path. adopt.sh
+# needs a source AGENTS.md at $KIT_ROOT; gate-ledger reads the lane x phase matrix from
+# $KIT_ROOT/WORKFLOW.md. Without these, adopt + the lane gate are broken from the install
+# (SPEC-049). Symlink to keep repo edits live, mirroring hooks + lib.
+if [ -n "$DEST_REAL" ] && [ "$KIT_REAL" = "$DEST_REAL" ]; then
+  echo "[ok] Kit is installed in place; AGENTS.md + WORKFLOW.md already at \$HOME/.claude/dwarves-kit/"
+else
+  mkdir -p "$CLAUDE_DIR/dwarves-kit"
+  for CONTRACT in AGENTS.md WORKFLOW.md; do
+    LINK="$CLAUDE_DIR/dwarves-kit/$CONTRACT"
+    if [ -L "$LINK" ] || [ -f "$LINK" ]; then rm -f "$LINK"; fi
+    ln -s "$KIT_DIR/$CONTRACT" "$LINK"
+  done
+  echo "[ok] Linked AGENTS.md + WORKFLOW.md into $CLAUDE_DIR/dwarves-kit/"
 fi
 
 # 2. Merge settings.json

--- a/install.sh
+++ b/install.sh
@@ -180,7 +180,15 @@ else
   mkdir -p "$CLAUDE_DIR/dwarves-kit"
   for CONTRACT in AGENTS.md WORKFLOW.md; do
     LINK="$CLAUDE_DIR/dwarves-kit/$CONTRACT"
-    if [ -L "$LINK" ] || [ -f "$LINK" ]; then rm -f "$LINK"; fi
+    if [ -L "$LINK" ]; then
+      rm "$LINK"                              # refresh a stale symlink
+    elif [ -e "$LINK" ]; then
+      # A real file here (a user's own AGENTS.md, or a manual install) is left intact and used
+      # as-is; clobbering it with rm -f would be silent data loss (review HIGH). adopt resolves
+      # the source from $KIT_ROOT either way, so a real file still works.
+      echo "[skip] $CONTRACT at $LINK is a real file, not a symlink; leaving it untouched"
+      continue
+    fi
     ln -s "$KIT_DIR/$CONTRACT" "$LINK"
   done
   echo "[ok] Linked AGENTS.md + WORKFLOW.md into $CLAUDE_DIR/dwarves-kit/"

--- a/tests/test-install-contract.sh
+++ b/tests/test-install-contract.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# test-install-contract.sh -- adopt.sh + gate-ledger work from an INSTALL that has AGENTS.md +
+# WORKFLOW.md deployed (SPEC-049). Simulates install.sh's out-of-place symlink layout.
+set -uo pipefail
+KIT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+ok() { PASS=$((PASS + 1)); echo "ok - $1"; }
+no() { FAIL=$((FAIL + 1)); echo "NOT ok - $1"; }
+
+mkinstall() { # $1=dir  $2=with-contract(yes/no): mirror install.sh's out-of-place symlinks
+  mkdir -p "$1"
+  ln -s "$KIT/lib" "$1/lib"
+  if [ "$2" = yes ]; then ln -s "$KIT/AGENTS.md" "$1/AGENTS.md"; ln -s "$KIT/WORKFLOW.md" "$1/WORKFLOW.md"; fi
+}
+
+# 1. adopt run FROM the install finds the source AGENTS.md + lands the contract
+INSTALL="$(mktemp -d)/dwarves-kit"; mkinstall "$INSTALL" yes
+TMP="$(mktemp -d)"; git -C "$TMP" init -q
+if CLAUDE_PLUGIN_ROOT="$INSTALL" bash "$INSTALL/lib/adopt.sh" "$TMP" >/dev/null 2>&1 \
+  && [ -f "$TMP/AGENTS.md" ] && [ -f "$TMP/WORKFLOW.md" ]; then
+  ok "adopt from the install creates the contract (source AGENTS.md resolved)"
+else
+  no "adopt from the install failed to find/create the contract"
+fi
+
+# 2. gate-ledger reads the lane matrix from the install's WORKFLOW.md
+N=$(CLAUDE_PLUGIN_ROOT="$INSTALL" bash "$INSTALL/lib/gate-ledger.sh" required full 2>/dev/null | wc -l | tr -d ' ')
+[ "${N:-0}" -ge 5 ] && ok "gate-ledger reads the lane matrix from the install ($N gates)" || no "gate-ledger could not read WORKFLOW.md from the install (got $N)"
+
+# 3. CONTROL: an install WITHOUT the contract symlinks -> adopt fails (proves the fix is load-bearing)
+BARE="$(mktemp -d)/dwarves-kit"; mkinstall "$BARE" no
+TMP2="$(mktemp -d)"; git -C "$TMP2" init -q
+if CLAUDE_PLUGIN_ROOT="$BARE" bash "$BARE/lib/adopt.sh" "$TMP2" >/dev/null 2>&1; then
+  no "control: adopt should FAIL from an install without the contract symlinks"
+else
+  ok "control: adopt without the contract symlinks fails as expected"
+fi
+
+echo "---"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -156,6 +156,17 @@ if HOME="$TMP_HOME" bash "$KIT_DIR/install.sh" >/dev/null 2>&1; then
   # but dwarves-kit). -e follows the dir symlink to the real file.
   [ -e "$TMP_HOME/.claude/dwarves-kit/lib/proof-ledger.sh" ]
   assert_true "install.sh materializes lib/proof-ledger.sh (SPEC-045)" $?
+  # SPEC-049: install must materialize the operate-contract too, so adopt (needs a source
+  # AGENTS.md) + gate-ledger (reads WORKFLOW.md) work from the install, not only the dev
+  # checkout. Asserts the REAL install run, not test-install-contract.sh's simulated layout.
+  [ -e "$TMP_HOME/.claude/dwarves-kit/AGENTS.md" ]
+  assert_true "install.sh materializes AGENTS.md (SPEC-049)" $?
+  [ -e "$TMP_HOME/.claude/dwarves-kit/WORKFLOW.md" ]
+  assert_true "install.sh materializes WORKFLOW.md (SPEC-049)" $?
+  # SPEC-049: uninstall removes the two contract symlinks (the new uninstall code path).
+  HOME="$TMP_HOME" bash "$KIT_DIR/install.sh" --uninstall >/dev/null 2>&1
+  { [ ! -L "$TMP_HOME/.claude/dwarves-kit/AGENTS.md" ] && [ ! -L "$TMP_HOME/.claude/dwarves-kit/WORKFLOW.md" ]; }
+  assert_true "uninstall removes the AGENTS.md + WORKFLOW.md symlinks (SPEC-049)" $?
 else
   assert_eq "install.sh runs cleanly into an isolated HOME" "ok" "failed"
 fi


### PR DESCRIPTION
## What

Closes the install-packaging gap found dogfooding the kit-adopt-enforce mega-goal (sub-goal 03): `~/.claude/dwarves-kit/` had `hooks/` + `lib/` symlinked but never `AGENTS.md` / `WORKFLOW.md`, so from the install `lib/adopt.sh` failed ("no source AGENTS.md") and `gate-ledger` couldn't read the lane matrix ("awk: can't open WORKFLOW.md"). `install.sh` now symlinks both into the install dir (mirroring hooks + lib; a symlink keeps repo edits live); uninstall removes them.

## Verify

- `bash tests/test-install-contract.sh` -> 3/3: adopt from a simulated install creates the contract, gate-ledger reads the 11-gate matrix, and a control without the symlinks fails (load-bearing).
- `bash tests/test-meta.sh` -> 392/392.
- Live: after symlinking into `~/.claude/dwarves-kit/`, `adopt.sh` and `gate-ledger required full` (11 gates) both work (was broken before). Proof: `docs/verification/install-ships-contract.md`.

## Notes

SPEC-049, normal lane (spec/build/review/ship). Follow-up to mega-goal kit-adopt-enforce (PRs #22, #23 merged; #163 merged). Do not merge until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)