### PR TITLE
feat(kit): adopt @AGENTS.md loader + --dry-run/--refresh

### DIFF
--- a/docs/absorption/2026-06-10-repository-harness.md
+++ b/docs/absorption/2026-06-10-repository-harness.md
@@ -1,0 +1,47 @@
+# Absorption proposal: hoangnb24/repository-harness
+
+Date: 2026-06-10. Proposal-only (per `docs/ABSORPTION.md`). Source read from the README +
+`docs/FEATURE_INTAKE.md` + `scripts/install-harness.sh` behavior (WebFetch, 2026-06-10).
+
+## Source in one line
+
+A tool-agnostic "context-engineering" harness: a curl-able installer injects an `AGENTS.md` shim +
+a `docs/` scaffold (HARNESS, FEATURE_INTAKE, ARCHITECTURE, TEST_MATRIX, stories/, decisions/,
+templates/) + a prebuilt Rust `harness-cli` into any repo. It SHAPES agent work (intent ->
+contract -> feature intake -> story packet -> validation -> implementation -> decision capture).
+**No enforcement/blocking gates** (confirmed: no hooks/CI-block in the README). The opposite axis
+from dwarves-kit, which is enforcing-but-Claude-Code-only.
+
+## Candidates (prioritized)
+
+| # | Candidate | Why | Effort/Risk | Call |
+|---|---|---|---|---|
+| A1 | CLAUDE.md `@AGENTS.md` import instead of a prose "read AGENTS.md" pointer (their `--claude` shim) | The import actually loads the contract into context; a pointer only hopes the agent reads it | Low/Low | **ABSORBED in this PR** |
+| A2 | adopt `--dry-run` (preview) + `--refresh` (re-sync the managed block) (their installer modes) | adopt was merge-only; preview-before-write + re-sync-after-a-kit-update are everyday needs | Low/Low | **ABSORBED in this PR** |
+| A3 | Explicit 10-flag risk checklist + count-based decision tree (0-1/2-3/4+ flags, hard gates) for lane classification | Our `lane-classify` is keyword-prose and under-classified the adopt command as `normal` this cycle; a flag-count tree is auditable and would catch kit-machinery changes | Med/Med | PROPOSE (next) |
+| A4 | Decision-capture as a routine terminal lane step (their `docs/decisions/` flow) | Make the reflect gate emit a short structured decision file, not just narrative | Med/Low | PROPOSE (next) |
+| A5 | `--directory` + `--override` adopt modes | Round out the mode set; `--directory` is covered by our positional arg | Low | DEFER (low value) |
+| B1 | Prebuilt Rust `harness-cli` + sha256 + CI version-bump | Compiled binary + release burden for no enforcement gain on our single-platform bash + CC surface | High | **SKIP** |
+| B2 | PowerShell installer / Windows | We are macOS + CC only | Med | **SKIP** |
+| B3 | Rich in-repo scaffold (stories/, product/, demo/, templates/, HARNESS_BACKLOG.md) | Against our deliberate thin-contract design (engine stays in the install) | High | **SKIP** (maybe steal `templates/` later) |
+| C1 | Tool-agnostic enforcement (AGENTS.md shim for any runtime) | Their advisory model is portable for free; ours enforces and is CC-coupled | High | **WATCH** (v3.x multi-runtime) |
+
+## Absorbed here (A1 + A2)
+
+`lib/adopt.sh`: the CLAUDE.md loader now emits `@AGENTS.md` (a real import) inside paired markers
+`<!-- kit:adopt -->` / `<!-- /kit:adopt -->`; new `--dry-run` (prints the plan, writes nothing)
+and `--refresh` (re-syncs the WORKFLOW pointer + the CLAUDE.md managed block; AGENTS.md + the
+proof marker are still never overwritten). Verified: `tests/test-adopt.sh` 8/8 (5 prior + @-import,
+dry-run, refresh), meta 392/392.
+
+## The honest framing
+
+We are not converging with the harness; we are the enforcing dual of it. The right absorptions are
+the *packaging ergonomics* (A1, A2) and the *classification rigor* (A3), not the philosophy (their
+advisory + tool-agnostic + heavy-scaffold model is a different bet from our enforcing + CC-only +
+thin-contract one).
+
+## Footer (seed tracking)
+
+repository-harness is a non-Credits external source. If we keep tracking it, add it to
+`docs/ABSORPTION.md` `## Seed list`. Source HEAD not pinned (read via README, not a clone).

--- a/docs/verification/kit-adopt.md
+++ b/docs/verification/kit-adopt.md
@@ -49,3 +49,43 @@ idempotency (a 2nd adopt = clean `git diff`) is covered by `tests/test-adopt.sh`
 `docs/architecture.md` inventory row for `/kit:adopt`).
 
 ## Verdict: PASS
+
+---
+
+## 2026-06-10 hardening: @AGENTS.md loader + --dry-run/--refresh (PR #25), review-driven fixes
+
+The absorption PR (A1 `@AGENTS.md` import, A2 `--dry-run`/`--refresh`) went through the kit's own
+3-lens review-team. Review caught a **CRITICAL data-loss path** (3 reviewers independently): on
+`--refresh`, the awk block-strip ran to EOF when the `<!-- /kit:adopt -->` END marker was missing,
+silently truncating CLAUDE.md. Fixed: a pre-check refuses `--refresh` when START has no matching
+END, an awk `END{if(drop)exit 3}` + `|| exit 1` backstop, exact-line (`grep -qxF`) marker matching,
+atomic WORKFLOW.md write, a temp-cleanup trap, and `cmp`-before-reporting-"updated".
+
+### GREEN: --refresh refuses to truncate (the fix)
+
+```
+$ R=$(mktemp -d); git -C "$R" init -q; bash lib/adopt.sh "$R" >/dev/null
+$ printf 'IMPORTANT-PROJECT-RULES-AFTER-BLOCK\n' >> "$R/CLAUDE.md"
+$ grep -v '<!-- /kit:adopt -->' "$R/CLAUDE.md" > x && mv -f x "$R/CLAUDE.md"   # drop the END marker
+$ wc -l < "$R/CLAUDE.md"          # 9
+$ bash lib/adopt.sh --refresh "$R"
+adopt: ... has '<!-- kit:adopt -->' but no '<!-- /kit:adopt -->' line; refusing --refresh (would truncate).
+$ echo $?                          # 1
+$ wc -l < "$R/CLAUDE.md"          # 9 (untouched; the tail line survived)
+```
+
+### NEGATIVE CONTROL: the OLD awk on the same file (proves the bug was real)
+
+```
+$ awk -v s='<!-- kit:adopt -->' -v e='<!-- /kit:adopt -->' \
+    '$0==s{drop=1} drop&&$0==e{drop=0;next} !drop{print}' "$R/CLAUDE.md" | wc -l
+1     # the pre-fix code collapses 9 lines to 1: it would have eaten the project rules
+```
+
+### Suite (expanded)
+
+`bash tests/test-adopt.sh` -> PASS=12 FAIL=0 (added: refuse-on-missing-END, real stale-body
+re-sync, no-clobber-on-refresh of AGENTS.md + proof marker, dry-run-on-adopted writes nothing).
+`bash tests/test-meta.sh` -> 392/392.
+
+## Verdict: PASS (review-hardened)

--- a/lib/adopt.sh
+++ b/lib/adopt.sh
@@ -22,7 +22,10 @@ SRC_ROOT="$(cd "$SELF_DIR/.." && pwd)"   # the dwarves-kit repo root when run fr
 START="<!-- kit:adopt -->"               # managed-block markers in the consumer CLAUDE.md
 END="<!-- /kit:adopt -->"
 
-usage() { echo "usage: adopt.sh [--check | --dry-run | --refresh] <target-dir>" >&2; exit 64; }
+tmp=""                                   # scratch file; the trap cleans it up on any early exit
+trap 'rm -f "$tmp"' EXIT
+
+usage() { echo "usage: adopt.sh [--check | --dry-run | --refresh] [--] <target-dir>" >&2; exit 64; }
 
 CHECK=0 DRY=0 REFRESH=0
 while [ $# -gt 0 ]; do
@@ -44,8 +47,10 @@ claude="$TARGET/CLAUDE.md"
 marker="$TARGET/docs/verification/README.md"
 
 is_adopted() {
+  # -qxF: the marker must be its own full line (matches how awk strips the block). A substring
+  # grep would mis-detect a marker quoted inside prose and skip the append path (review #6).
   [ -f "$agents" ] && [ -f "$marker" ] && [ -f "$claude" ] \
-    && grep -q "$START" "$claude" 2>/dev/null
+    && grep -qxF "$START" "$claude" 2>/dev/null
 }
 
 if [ "$CHECK" -eq 1 ]; then
@@ -90,25 +95,41 @@ if [ ! -f "$agents" ]; then
   did=1
 fi
 
-# 2. WORKFLOW.md pointer -- create if absent; --refresh overwrites to current.
+# 2. WORKFLOW.md pointer -- create if absent; --refresh overwrites to current. Write atomically
+# (tmp + mv) so a kill / full disk mid-write can't leave a half-written pointer (review #3).
 if [ ! -f "$workflow" ] || { [ "$REFRESH" -eq 1 ] && ! cmp -s <(workflow_block) "$workflow"; }; then
-  if [ "$DRY" -eq 1 ]; then note "write WORKFLOW.md pointer"; else workflow_block > "$workflow"; fi
+  if [ "$DRY" -eq 1 ]; then note "write WORKFLOW.md pointer"; else
+    tmp="$(mktemp)"; workflow_block > "$tmp"; mv "$tmp" "$workflow"
+  fi
   did=1
 fi
 
 # 3. CLAUDE.md loader (@AGENTS.md import) -- append once; --refresh replaces the managed block.
-if [ ! -f "$claude" ] || ! grep -q "$START" "$claude" 2>/dev/null; then
+if [ ! -f "$claude" ] || ! grep -qxF "$START" "$claude" 2>/dev/null; then
   if [ "$DRY" -eq 1 ]; then note "append the CLAUDE.md @AGENTS.md loader block"; else
     tmp="$(mktemp)"; { [ -f "$claude" ] && cat "$claude"; printf '\n'; claude_block; } > "$tmp"; mv "$tmp" "$claude"
   fi
   did=1
 elif [ "$REFRESH" -eq 1 ]; then
-  if [ "$DRY" -eq 1 ]; then note "refresh the CLAUDE.md loader block"; else
-    tmp="$(mktemp)"
-    awk -v s="$START" -v e="$END" '$0==s{drop=1} drop&&$0==e{drop=0;next} !drop{print}' "$claude" > "$tmp"
-    claude_block >> "$tmp"; mv "$tmp" "$claude"
+  # Refuse to refresh a block with a START but no END: the awk strip would drop everything from
+  # START to EOF and mv would install the truncated file (silent data loss; review CRITICAL #1).
+  # This is exactly the legacy single-sentinel shape, so the operator migrates it by hand.
+  if ! grep -qxF "$END" "$claude" 2>/dev/null; then
+    echo "adopt: $claude has '$START' but no '$END' line; refusing --refresh (would truncate)." >&2
+    echo "adopt: add an '$END' line after the managed block, or delete the block, then re-run." >&2
+    exit 1
   fi
-  did=1
+  if [ "$DRY" -eq 1 ]; then note "refresh the CLAUDE.md loader block"; did=1; else
+    tmp="$(mktemp)"
+    # END{if(drop)exit 3}: belt-and-suspenders against an unterminated block slipping past the
+    # guard above; the `|| exit` stops us from mv-ing a truncated file when awk bails.
+    awk -v s="$START" -v e="$END" '
+      $0==s{drop=1; next} drop&&$0==e{drop=0; next} !drop{print}
+      END{if(drop) exit 3}' "$claude" > "$tmp" \
+      || { echo "adopt: failed to strip the managed block from $claude (unterminated?)" >&2; exit 1; }
+    claude_block >> "$tmp"
+    if cmp -s "$tmp" "$claude"; then rm -f "$tmp"; else mv "$tmp" "$claude"; did=1; fi
+  fi
 fi
 
 # 4. proof marker -- presence opts this repo into the ship-gate. NEVER overwritten.

--- a/lib/adopt.sh
+++ b/lib/adopt.sh
@@ -4,21 +4,37 @@
 # Adoption = the per-repo trigger that makes an agent classify + pick a lane and that makes the
 # ship-gate engage. It injects the CONTRACT + a proof marker + pointers; it never copies the
 # engine (lib/, the full WORKFLOW matrix) -- the gate machinery reads those from the install
-# ($KIT_ROOT). Non-destructive: existing files are never overwritten; re-run is a clean no-op.
+# ($KIT_ROOT). Non-destructive: AGENTS.md + the proof marker are never overwritten.
 #
-# Usage: adopt.sh [--check] <target-dir>
-#   --check : report status only (exit 0 adopted / 1 not), write nothing.
+# The CLAUDE.md loader uses an `@AGENTS.md` import (Claude Code includes the file, not just a
+# "go read it" pointer; absorbed from repository-harness's --claude shim).
+#
+# Usage: adopt.sh [--check | --dry-run | --refresh] <target-dir>
+#   --check   : report status only (exit 0 adopted / 1 not), write nothing.
+#   --dry-run : print what would change, write nothing.
+#   --refresh : re-sync the kit-managed pieces (WORKFLOW pointer + the CLAUDE.md loader block)
+#               to their current form. AGENTS.md + the proof marker are still never overwritten.
 set -uo pipefail
 
 KIT_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/dwarves-kit}"
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_ROOT="$(cd "$SELF_DIR/.." && pwd)"   # the dwarves-kit repo root when run from its lib/
-MARKER="<!-- kit:adopt -->"              # idempotency sentinel in the consumer CLAUDE.md
+START="<!-- kit:adopt -->"               # managed-block markers in the consumer CLAUDE.md
+END="<!-- /kit:adopt -->"
 
-usage() { echo "usage: adopt.sh [--check] <target-dir>" >&2; exit 64; }
+usage() { echo "usage: adopt.sh [--check | --dry-run | --refresh] <target-dir>" >&2; exit 64; }
 
-CHECK=0
-[ "${1:-}" = "--check" ] && { CHECK=1; shift; }
+CHECK=0 DRY=0 REFRESH=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) CHECK=1; shift;;
+    --dry-run) DRY=1; shift;;
+    --refresh) REFRESH=1; shift;;
+    --) shift; break;;
+    -*) usage;;
+    *) break;;
+  esac
+done
 TARGET="${1:-}"; [ -n "$TARGET" ] || usage
 [ -d "$TARGET" ] || { echo "adopt: target dir not found: $TARGET" >&2; exit 1; }
 
@@ -29,14 +45,13 @@ marker="$TARGET/docs/verification/README.md"
 
 is_adopted() {
   [ -f "$agents" ] && [ -f "$marker" ] && [ -f "$claude" ] \
-    && grep -q "$MARKER" "$claude" 2>/dev/null
+    && grep -q "$START" "$claude" 2>/dev/null
 }
 
 if [ "$CHECK" -eq 1 ]; then
   is_adopted && { echo "adopted: $TARGET"; exit 0; } || { echo "not adopted: $TARGET"; exit 1; }
 fi
 
-# Adoption is filesystem-level, but a non-git target usually means a wrong path; warn (SPEC-047 edge 3).
 git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1 \
   || echo "adopt: warning: $TARGET is not a git repo (adopting at filesystem level anyway)" >&2
 
@@ -47,46 +62,72 @@ for c in "$SRC_ROOT/AGENTS.md" "$KIT_ROOT/AGENTS.md"; do
 done
 [ -n "$src_agents" ] || { echo "adopt: no source AGENTS.md (looked in $SRC_ROOT, $KIT_ROOT)" >&2; exit 1; }
 
-changed=0
-
-# 1. AGENTS.md -- the operate-contract. Never overwrite.
-if [ ! -f "$agents" ]; then cp "$src_agents" "$agents"; changed=1; fi
-
-# 2. WORKFLOW.md -- a POINTER, not the 49KB matrix (the gate reads the install's copy).
-if [ ! -f "$workflow" ]; then
-  cat > "$workflow" <<EOF
+workflow_block() {
+  cat <<EOF
 # WORKFLOW.md (pointer)
 
 This repo is adopted into the dwarves-kit. The canonical lanes and the lane x phase gate matrix
 live in the installed kit: \`$KIT_ROOT/WORKFLOW.md\`. Read that for the lanes and the gate at each
 phase boundary. The gate machinery (gate-ledger, ship-gate) parses that copy, not this file.
 EOF
-  changed=1
+}
+
+claude_block() {
+  printf '%s\n' "$START"
+  printf '## Operating layer (dwarves-kit)\n\n'
+  printf '@AGENTS.md\n\n'
+  printf 'Before touching code, classify the lane: `bash %s/lib/lane-classify.sh classify "<task>"`.\n' "$KIT_ROOT"
+  printf 'A full-lane change records its gates via `%s/lib/gate-ledger.sh` or the ship-gate blocks the push.\n' "$KIT_ROOT"
+  printf '%s\n' "$END"
+}
+
+did=0
+note() { echo "adopt: would $*"; }
+
+# 1. AGENTS.md -- the operate-contract. NEVER overwritten (even on --refresh).
+if [ ! -f "$agents" ]; then
+  if [ "$DRY" -eq 1 ]; then note "create AGENTS.md (from $src_agents)"; else cp "$src_agents" "$agents"; fi
+  did=1
 fi
 
-# 3. CLAUDE.md loader pointer -- Claude Code auto-loads CLAUDE.md, not AGENTS.md. Append once.
-if [ ! -f "$claude" ] || ! grep -q "$MARKER" "$claude" 2>/dev/null; then
-  {
-    printf '\n%s\n' "$MARKER"
-    printf '## Operating layer (dwarves-kit)\n\n'
-    printf 'Read **AGENTS.md** first: it is the operate-contract. Before touching code, classify\n'
-    printf 'the work and pick a lane: `bash %s/lib/lane-classify.sh classify "<task>"`. A full-lane\n' "$KIT_ROOT"
-    printf 'change records its gates via `%s/lib/gate-ledger.sh` or the ship-gate blocks the push.\n' "$KIT_ROOT"
-  } >> "$claude"
-  changed=1
+# 2. WORKFLOW.md pointer -- create if absent; --refresh overwrites to current.
+if [ ! -f "$workflow" ] || { [ "$REFRESH" -eq 1 ] && ! cmp -s <(workflow_block) "$workflow"; }; then
+  if [ "$DRY" -eq 1 ]; then note "write WORKFLOW.md pointer"; else workflow_block > "$workflow"; fi
+  did=1
 fi
 
-# 4. proof marker -- presence opts this repo into the ship-gate.
+# 3. CLAUDE.md loader (@AGENTS.md import) -- append once; --refresh replaces the managed block.
+if [ ! -f "$claude" ] || ! grep -q "$START" "$claude" 2>/dev/null; then
+  if [ "$DRY" -eq 1 ]; then note "append the CLAUDE.md @AGENTS.md loader block"; else
+    tmp="$(mktemp)"; { [ -f "$claude" ] && cat "$claude"; printf '\n'; claude_block; } > "$tmp"; mv "$tmp" "$claude"
+  fi
+  did=1
+elif [ "$REFRESH" -eq 1 ]; then
+  if [ "$DRY" -eq 1 ]; then note "refresh the CLAUDE.md loader block"; else
+    tmp="$(mktemp)"
+    awk -v s="$START" -v e="$END" '$0==s{drop=1} drop&&$0==e{drop=0;next} !drop{print}' "$claude" > "$tmp"
+    claude_block >> "$tmp"; mv "$tmp" "$claude"
+  fi
+  did=1
+fi
+
+# 4. proof marker -- presence opts this repo into the ship-gate. NEVER overwritten.
 if [ ! -f "$marker" ]; then
-  mkdir -p "$(dirname "$marker")"
-  cat > "$marker" <<EOF
+  if [ "$DRY" -eq 1 ]; then note "create docs/verification/README.md (proof marker)"; else
+    mkdir -p "$(dirname "$marker")"
+    cat > "$marker" <<EOF
 # Verification (proof-of-done marker)
 
 Presence of this file opts this repo into the dwarves-kit proof-of-done ship-gate. A
 behavioral/stateful change owes a recorded run here; the shape per loop type comes from the
 install: \`bash $KIT_ROOT/lib/proof-gate.sh contract "<task>"\`.
 EOF
-  changed=1
+  fi
+  did=1
 fi
 
-echo "adopt: $TARGET ($([ "$changed" -eq 1 ] && echo updated || echo 'already adopted, no-op'))"
+if [ "$DRY" -eq 1 ]; then
+  echo "adopt: --dry-run for $TARGET ($([ "$did" -eq 1 ] && echo 'changes above' || echo 'already adopted, nothing to do'))"
+else
+  echo "adopt: $TARGET ($([ "$did" -eq 1 ] && echo updated || echo 'already adopted, no-op'))"
+fi

--- a/tests/test-adopt.sh
+++ b/tests/test-adopt.sh
@@ -35,7 +35,24 @@ printf 'SENTINEL-DO-NOT-CLOBBER\n' > "$T3/AGENTS.md"
 bash lib/adopt.sh "$T3" >/dev/null
 if grep -q SENTINEL-DO-NOT-CLOBBER "$T3/AGENTS.md"; then ok "existing AGENTS.md is not clobbered"; else no "AGENTS.md was clobbered"; fi
 
-rm -rf "$T1" "$T2" "$T3"
+# 5. CLAUDE.md loader uses an @AGENTS.md import + paired markers
+if grep -q '@AGENTS.md' "$T1/CLAUDE.md" && grep -q '<!-- /kit:adopt -->' "$T1/CLAUDE.md"; then
+  ok "CLAUDE.md loader uses @AGENTS.md import + paired end marker"
+else
+  no "CLAUDE.md loader missing @-import or end marker"
+fi
+
+# 6. --dry-run writes nothing
+T4="$(newrepo)"
+bash lib/adopt.sh --dry-run "$T4" >/dev/null
+if [ ! -f "$T4/AGENTS.md" ] && [ ! -f "$T4/CLAUDE.md" ]; then ok "--dry-run writes nothing"; else no "--dry-run wrote files"; fi
+
+# 7. --refresh keeps exactly one managed block (idempotent replace)
+bash lib/adopt.sh --refresh "$T1" >/dev/null
+s=$(grep -c '<!-- kit:adopt -->' "$T1/CLAUDE.md"); e=$(grep -c '<!-- /kit:adopt -->' "$T1/CLAUDE.md")
+if [ "$s" = 1 ] && [ "$e" = 1 ]; then ok "--refresh keeps a single managed block"; else no "--refresh duplicated the block (s=$s e=$e)"; fi
+
+rm -rf "$T1" "$T2" "$T3" "$T4"
 echo "---"
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/test-adopt.sh
+++ b/tests/test-adopt.sh
@@ -52,7 +52,49 @@ bash lib/adopt.sh --refresh "$T1" >/dev/null
 s=$(grep -c '<!-- kit:adopt -->' "$T1/CLAUDE.md"); e=$(grep -c '<!-- /kit:adopt -->' "$T1/CLAUDE.md")
 if [ "$s" = 1 ] && [ "$e" = 1 ]; then ok "--refresh keeps a single managed block"; else no "--refresh duplicated the block (s=$s e=$e)"; fi
 
-rm -rf "$T1" "$T2" "$T3" "$T4"
+# 8. --refresh REFUSES to truncate a block whose END marker is gone (review CRITICAL #1: the awk
+#    strip would otherwise drop everything from START to EOF and mv the truncated file).
+T5="$(newrepo)"
+bash lib/adopt.sh "$T5" >/dev/null
+printf 'TAIL-SENTINEL-KEEP-ME\n' >> "$T5/CLAUDE.md"
+grep -v '<!-- /kit:adopt -->' "$T5/CLAUDE.md" > "$T5/CLAUDE.noend" && mv "$T5/CLAUDE.noend" "$T5/CLAUDE.md"
+cp "$T5/CLAUDE.md" "$T5/CLAUDE.before"
+if bash lib/adopt.sh --refresh "$T5" >/dev/null 2>&1; then
+  no "--refresh should FAIL on a block missing its END marker"
+elif cmp -s "$T5/CLAUDE.md" "$T5/CLAUDE.before" && grep -q TAIL-SENTINEL-KEEP-ME "$T5/CLAUDE.md"; then
+  ok "--refresh refuses to truncate a block missing its END marker (file untouched)"
+else
+  no "--refresh mutated a file it should have refused (tail lost)"
+fi
+
+# 9. --refresh re-syncs a STALE block body (the actual purpose, not just idempotency) and keeps
+#    the surrounding prose.
+T6="$(newrepo)"
+printf '# Repo\n\n<!-- kit:adopt -->\nSTALE-BODY\n<!-- /kit:adopt -->\n\n## Keep this tail\n' > "$T6/CLAUDE.md"
+bash lib/adopt.sh --refresh "$T6" >/dev/null
+if ! grep -q STALE-BODY "$T6/CLAUDE.md" && grep -q '@AGENTS.md' "$T6/CLAUDE.md" && grep -q 'Keep this tail' "$T6/CLAUDE.md"; then
+  ok "--refresh replaces a stale block body and preserves surrounding content"
+else
+  no "--refresh did not re-sync the stale block or lost surrounding content"
+fi
+
+# 10. --refresh never overwrites AGENTS.md or the proof marker (documented invariant).
+T7="$(newrepo)"
+bash lib/adopt.sh "$T7" >/dev/null
+printf 'AGENTS-SENTINEL\n' >> "$T7/AGENTS.md"
+printf 'MARKER-SENTINEL\n' >> "$T7/docs/verification/README.md"
+bash lib/adopt.sh --refresh "$T7" >/dev/null
+if grep -q AGENTS-SENTINEL "$T7/AGENTS.md" && grep -q MARKER-SENTINEL "$T7/docs/verification/README.md"; then
+  ok "--refresh preserves AGENTS.md + proof marker (never overwritten)"
+else
+  no "--refresh overwrote AGENTS.md or the proof marker"
+fi
+
+# 11. --dry-run on an already-adopted repo writes nothing (T1 was committed in test 2).
+bash lib/adopt.sh --dry-run "$T1" >/dev/null
+if git -C "$T1" diff --quiet; then ok "--dry-run on an adopted repo writes nothing"; else no "--dry-run dirtied an adopted repo"; fi
+
+rm -rf "$T1" "$T2" "$T3" "$T4" "$T5" "$T6" "$T7"
 echo "---"
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

Absorbs two ergonomics from `hoangnb24/repository-harness` (full proposal: `docs/absorption/2026-06-10-repository-harness.md`):

- **A1, @-import loader:** `lib/adopt.sh`'s CLAUDE.md block now emits `@AGENTS.md` (a real Claude Code include) inside paired markers `<!-- kit:adopt -->` / `<!-- /kit:adopt -->`, instead of a prose "read AGENTS.md" pointer. The contract is loaded, not just referenced.
- **A2, modes:** `--dry-run` (print the plan, write nothing) and `--refresh` (re-sync the WORKFLOW pointer + the managed CLAUDE.md block to current). `AGENTS.md` and the proof marker are still never overwritten.

## Verify

- `bash tests/test-adopt.sh` -> 8/8 (5 prior + @-import-present, dry-run-writes-nothing, refresh-keeps-single-block).
- `bash tests/test-meta.sh` -> 392/392.

## Also in this PR

A dated, proposal-only absorption report. A3 (a 10-flag risk checklist + count-based lane decision tree, which would fix the lane under-classification seen in the kit-adopt-enforce dogfood) and A4 (decision-capture as a routine lane step) are proposed for follow-up, not done here. Rust CLI / Windows / heavy in-repo scaffold explicitly skipped (different philosophy).

Do not merge until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)