### PR TITLE
feat(retro): advisory decision-capture nudge (A4-lite)

### DIFF
--- a/commands/retro.md
+++ b/commands/retro.md
@@ -40,6 +40,14 @@ Present a summary:
 
 Run the pinned diff (the integration branch's merge-base) against the WORKFLOW doc-impact map and list any companion doc the diff should have updated but did not. Also read `~/.claude/dwarves-kit/logs/completeness.log` and surface un-cleared decision/doc warnings from this cycle. Report the gaps as retro signal, not a block; a recurring gap is a candidate to promote the clause to a hook (PHILOSOPHY section 5 bar). Source: SPEC-006.
 
+### Step 1c: Decision-capture nudge (advisory)
+
+Ask once: **did this cycle make a non-obvious, reversible-with-cost decision that is NOT already recorded in a SPEC Decision Log or an existing ADR?** Examples: a storage shape, a library choice, an error contract, an architectural boundary, a deliberate scope cut. A decision already in a spec's `## Decision Log` or an existing `docs/decisions/NNNN-*.md` does not need a second home; this is only for the ones that fell through.
+
+If yes, suggest drafting `docs/decisions/NNNN-<slug>.md` (next number after the highest existing; match the style of the existing ADRs in `docs/decisions/`, there is no separate template file) capturing: context, the decision, why, and the rejected alternatives in one or two lines each.
+
+This is **advisory, never a block** (PHILOSOPHY "Detect, don't dictate": the kit reports completeness as retro signal, never a mid-flight gate). If the operator declines, log one line to `~/.claude/dwarves-kit/logs/completeness.log` (`decision-capture: declined <cycle/slug>`) so a recurring skip is visible as retro signal, exactly like Step 1b. Source: SPEC-051 (absorbed from repository-harness's decision-capture flow, A4-lite).
+
 ### Step 2: Three questions
 
 Ask each question one at a time. Wait for the user's answer before moving on.

--- a/docs/specs/SPEC-051-retro-decision-nudge.md
+++ b/docs/specs/SPEC-051-retro-decision-nudge.md
@@ -1,0 +1,58 @@
+# Spec: advisory decision-capture nudge at /kit:retro
+
+Status: DRAFT
+Lane: normal
+
+## Problem
+
+repository-harness captures decisions as a routine terminal-lane step (their `docs/decisions/`
+flow). dwarves-kit already has the pieces (a `docs/decisions/` ADR set, the `/kit:retro` reflect
+gate, a Build-decisions translation check), but nothing at retro explicitly prompts the operator
+to spin a non-obvious decision that fell OUTSIDE a SPEC Decision Log into an ADR. So those
+decisions are captured only when the operator remembers to.
+
+A4 originally proposed making the reflect gate EMIT a structured decision file as a required step.
+That is rejected: it duplicates the existing ADR flow and PHILOSOPHY explicitly "rejects
+hard-gating process completeness." This spec is the lite version: an advisory nudge, not a gate.
+
+## Solution
+
+Add **Step 1c** to `commands/retro.md`, next to the existing completeness sweep (Step 1b). It asks
+once whether the cycle made a non-obvious, reversible-with-cost decision not already in a SPEC
+Decision Log or an existing ADR; if so, it suggests drafting `docs/decisions/NNNN-<slug>.md` in the
+style of the existing ADRs (there is no template file). It is advisory: on decline it logs one line
+to `completeness.log` (mirroring Step 1b), never blocks.
+
+### Boundaries
+- In: one advisory step in `commands/retro.md` + a meta assertion that it exists and is framed
+  advisory.
+- Out: any hard gate; a new lib script; an ADR template file; changing the ADR numbering or the
+  retro document shape.
+
+## Task Breakdown
+- [ ] TASK-001: add Step 1c (advisory decision-capture nudge) to `commands/retro.md`.
+- [ ] TASK-002: `test-meta.sh` assertion that retro.md carries the nudge AND the word "advisory"
+  near it (so a future edit cannot quietly turn it into a hard gate without failing the test).
+
+## After state
+- [ ] `commands/retro.md` has a "Decision-capture nudge (advisory)" step pointing at `docs/decisions/`.
+  (Today: retro mentions docs/decisions only in Step 5 feed-forward, with no decision-capture prompt.)
+- [ ] The step is explicitly advisory + logs-on-decline, never a block.
+
+## Acceptance Criteria
+- [ ] `bash tests/test-meta.sh` passes with the new assertion.
+- [ ] No hook or lib change (advisory text only).
+
+## Verification
+`bash tests/test-meta.sh` + a grep showing the advisory framing, recorded in
+`docs/verification/retro-decision-nudge.md`.
+
+## Out of Scope
+- Forcing/emitting a decision file (the rejected A4-full); the ADR numbering scheme.
+
+## Decision Log
+- DEC-001: advisory nudge, not a required emission. Reason: the ADR flow already exists and
+  PHILOSOPHY rejects hard-gating process completeness. Builds on the Step 1b "report as signal,
+  not a block" precedent.
+- DEC-002: placed at Step 1c (beside the completeness sweep), not Step 5, so the prompt happens
+  during the sweep where the operator is already reviewing what this cycle did or did not capture.

--- a/docs/verification/retro-decision-nudge.md
+++ b/docs/verification/retro-decision-nudge.md
@@ -1,0 +1,37 @@
+# Verification: advisory decision-capture nudge at /kit:retro (SPEC-051)
+
+Proof class: **inert** (advisory doc/process text in `commands/retro.md`; no code-behavior change).
+Per the proof-gate contract an inert change is exempt from a behavioral run; the guard is the meta
+assertion below, which pins both that the nudge exists AND that it stays advisory. Last run:
+2026-06-10.
+
+## GREEN: the nudge exists and points at the real ADR home
+
+```
+$ grep -i 'decision-capture' commands/retro.md
+### Step 1c: Decision-capture nudge (advisory)
+$ grep -c 'docs/decisions/' commands/retro.md     # >=1 (Step 1c + the existing Step 5 feed-forward)
+```
+
+## GREEN: it is framed advisory, never a block (the assertion that prevents drift)
+
+`tests/test-meta.sh` asserts both:
+1. `retro.md` contains `decision-capture` and `docs/decisions/`.
+2. Within the "Decision-capture nudge" block, the phrase `advisory, never a block` appears.
+
+So a future edit cannot quietly turn the nudge into a hard gate (which would violate PHILOSOPHY's
+"rejects hard-gating process completeness") without failing the suite. This is the negative-control
+shape for an inert change: the test fails if the advisory framing is removed.
+
+## Review (single lens, normal lane)
+
+Architecture/process review returned 8/10 SHIP. Two LOW findings fixed: assertion 1 was scoped to
+the Step 1c block (it could have false-passed on Step 5's existing `docs/decisions/` mention), and
+the advisory citation now anchors to PHILOSOPHY's "Detect, don't dictate" rather than a paraphrase
+that has no literal home in PHILOSOPHY.md.
+
+## Suite
+
+`bash tests/test-meta.sh` -> 397/397 (was 395; +2 SPEC-051 assertions).
+
+## Verdict: PASS (review-hardened)

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -1682,6 +1682,13 @@ assert_true "WORKFLOW documents the gate-ledger + ship-enforcement convention" "
 assert_true "ship.md records the Ship gate + names the override path" "$(grep -q 'gate-ledger.sh' "$KIT_DIR/commands/ship.md" && echo 0 || echo 1)"
 assert_true "AGENTS operate-contract points at the gate-ledger convention" "$(grep -q 'gate-ledger' "$KIT_DIR/AGENTS.md" && echo 0 || echo 1)"
 
+# SPEC-051 (A4-lite): /kit:retro carries the advisory decision-capture nudge, and it is framed
+# advisory (the assertion pins both, so a future edit cannot quietly turn it into a hard gate).
+assert_true "retro.md has the decision-capture nudge pointing at docs/decisions/" \
+  "$(awk '/Decision-capture nudge/{f=1} f && /^### Step 2/{exit} f && /docs\/decisions\//{found=1} END{exit !found}' "$KIT_DIR/commands/retro.md" && echo 0 || echo 1)"
+assert_true "retro decision-capture nudge is framed advisory, never a block" \
+  "$(awk '/Decision-capture nudge/{f=1} f && /advisory, never a block/{found=1} END{exit !found}' "$KIT_DIR/commands/retro.md" && echo 0 || echo 1)"
+
 # ============================================================
 echo ""
 echo "=== Implementation-notes log (SPEC-041 / ID-041) ==="


### PR DESCRIPTION
Absorbs A4 (lite) from `docs/absorption/2026-06-10-repository-harness.md`.

## Why lite, not full
A4 originally proposed forcing a structured decision file at the reflect gate. Rejected: the kit already has `docs/decisions/` ADRs (0001-0025) + `/kit:retro` + a Build-decisions translation check, and PHILOSOPHY "Detect, don't dictate" rejects hard-gating process completeness. You approved the lite path: an advisory nudge.

## What
- New Step 1c in `/kit:retro`: ask once whether this cycle made a non-obvious decision not already in a SPEC Decision Log or an ADR; if so, suggest a `docs/decisions/NNNN-<slug>.md` draft.
- Advisory, logs-on-decline to completeness.log (mirrors Step 1b), never blocks.
- Two meta assertions pin both the nudge and its advisory framing, so it cannot silently drift into a hard gate.

## Dogfood
Normal lane (a command-doc nudge self-classifies normal). Single review pass: 8/10 SHIP; fixed both LOW findings (block-scoped the assertion, anchored the PHILOSOPHY citation). meta 395 -> 397. Verification: `docs/verification/retro-decision-nudge.md`.