### PR TITLE
fix(ci): bash 3.2 and util-linux portability in the quality-wave tests

### DIFF
--- a/docs/verification/ci-env-tests.md
+++ b/docs/verification/ci-env-tests.md
@@ -1,0 +1,67 @@
+# Proof of done: ci-env-tests (bug lane, 2026-06-10)
+
+Defect: master CI red on both matrix platforms since the quality wave merged (every push
+from PR #45 onward, first failing run 27284452444). Two independent platform-portability
+bugs, one per runner. Root cause was recorded in the debug ledger BEFORE any fix
+(`.claude/debug/ci-env-tests.md`, session-local: `.claude/` is gitignored, so the
+load-bearing content is mirrored here).
+
+## Root cause
+
+1. **macOS runner, `stack-merge: zero-arg chain` expected 64 got 1.** bash 3.2 (`/bin/bash`
+   on stock macOS and macOS runners) aborts on `set -u` + empty-array expansion
+   (`args[@]: unbound variable`, exit 1) before the usage check can return 64; bash 4.4+
+   allows it. Dev Macs resolve `bash` to brew bash 5.x, hence "passes locally".
+2. **ubuntu runner, `colors: PTY progress emits escape bytes` false.** The test used the
+   BSD form `script -q /dev/null bash -c "<cmd>"`; util-linux `script` takes only the
+   typescript file positionally and errors `unexpected number of arguments` (stderr
+   swallowed by `2>/dev/null`), so zero escape bytes were counted.
+
+Eliminated en route: "PR #49 broke CI" (master itself red before #49's run; #49 is
+doc-only) and "flaky PTY timing" (both failures deterministic, reproduced outside CI on
+first try). Same-class sweep: all other `[@]` expansions in lib/ + hooks/ are
+count-guarded or static; only stack-merge.sh was exposed.
+
+## Fix
+
+- `lib/stack-merge.sh` main() dispatch: `${args[@]+"${args[@]}"}` guard on `next` and `chain` (4425f4d).
+- `tests/test-hooks.sh` colors test: detect script(1) flavor via `script --version | grep util-linux`, use `script -qec "<cmd>" /dev/null` on util-linux, BSD positional form otherwise (568cb58).
+
+## Green run
+
+Command: `/bin/bash lib/stack-merge.sh chain --dry-run` (bash 3.2.57, the failing interpreter)
+Exit: 64, output `usage: chain <pr#> [<pr#>...] [--dry-run]`
+
+Command: `/bin/bash tests/test-hooks.sh` (full suite under 3.2, macOS CI parity)
+Exit: 0, output (tail): `Passed: 316 / 316`
+
+Command: full suite in ubuntu:24.04 container (util-linux 2.39.3, ubuntu CI parity)
+Output: `PASS colors: PTY progress emits escape bytes`, `PASS colors: piped progress emits ZERO escape bytes`
+
+Command: `bash tests/test-meta.sh`
+Exit: 0, output (tail): `Passed: 426 / 426`
+
+CI (the real acceptance seam, run 27286820530 on PR #51):
+test (macos-latest) pass 30s; test (ubuntu-latest) pass 25s.
+
+## NEGATIVE CONTROL (revert -> RED -> restore -> GREEN)
+
+Run 2026-06-10 after the green run, on the fix branch:
+
+1. `git checkout HEAD~2 -- lib/stack-merge.sh tests/test-hooks.sh` then
+   `/bin/bash lib/stack-merge.sh chain --dry-run` -> `line 85: args[@]: unbound variable`, exit 1 (RED).
+   Restore (`git checkout HEAD -- ...`) -> exit 64 with usage (GREEN).
+2. `git checkout HEAD~1 -- tests/test-hooks.sh` then suite in ubuntu:24.04 container ->
+   `FAIL colors: PTY progress emits escape bytes (condition false)` (RED).
+   Restore -> `PASS colors: PTY progress emits escape bytes` (GREEN).
+
+## Reproduce
+
+- RED side, bug 1: check out 0469c65 (or revert 4425f4d) and run `/bin/bash lib/stack-merge.sh chain --dry-run` on any macOS box; expect exit 1.
+- RED side, bug 2: revert 568cb58 and run `bash tests/test-hooks.sh` on any util-linux distro; expect the PTY colors FAIL.
+- GREEN side: this branch; CI run 27286820530.
+
+## Telemetry
+
+Escaped-defect markers recorded against the owning specs for retro aggregation:
+`gate-ledger.sh action ci-env-tests "escaped-from=stack-merge"` and `"escaped-from=quality-followups"`.

--- a/lib/stack-merge.sh
+++ b/lib/stack-merge.sh
@@ -81,8 +81,10 @@ main() {
     [ "$a" = "--dry-run" ] && DRY=1 || args+=("$a")
   done
   case "$sub" in
-    next)  next_link "${args[@]}" ;;
-    chain) chain "${args[@]}" ;;
+    # ${args[@]+...}: bash 3.2's set -u errors on empty-array expansion (fixed in 4.4);
+    # stock macOS /bin/bash is 3.2, so a bare "${args[@]}" turns zero-arg usage into exit 1
+    next)  next_link ${args[@]+"${args[@]}"} ;;
+    chain) chain ${args[@]+"${args[@]}"} ;;
     *) echo "usage: stack-merge.sh {next <pr#>|chain <pr#>...} [--dry-run]" >&2; return 64 ;;
   esac
 }

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -246,7 +246,13 @@ assert_true "seam: lane-telemetry greps the agreed literal" "$(grep -q "grep -q 
 if command -v script >/dev/null 2>&1; then
   # falsifiable: progress under a real PTY must emit escape bytes; piped (same command,
   # no PTY) must emit zero. Breaking the TTY gate in either direction flips one of these.
-  TTY_ESC=$(script -q /dev/null bash -c "DWARVES_KIT_LOG_DIR='$BD_DIR/logs' bash '$KIT_DIR/lib/gate-ledger.sh' progress spec-done normal" 2>/dev/null | od -c | grep -c '033' || true)
+  # script(1) syntax differs per flavor: BSD/macOS takes [file [command...]],
+  # util-linux takes -c "command" [file] and errors on the BSD positional form
+  if script --version 2>/dev/null | grep -qi util-linux; then
+    TTY_ESC=$(script -qec "DWARVES_KIT_LOG_DIR='$BD_DIR/logs' bash '$KIT_DIR/lib/gate-ledger.sh' progress spec-done normal" /dev/null 2>/dev/null | od -c | grep -c '033' || true)
+  else
+    TTY_ESC=$(script -q /dev/null bash -c "DWARVES_KIT_LOG_DIR='$BD_DIR/logs' bash '$KIT_DIR/lib/gate-ledger.sh' progress spec-done normal" 2>/dev/null | od -c | grep -c '033' || true)
+  fi
   assert_true "colors: PTY progress emits escape bytes" "$([ "${TTY_ESC:-0}" -ge 1 ]; echo $?)"
   PIPE_ESC=$(DWARVES_KIT_LOG_DIR="$BD_DIR/logs" bash "$KIT_DIR/lib/gate-ledger.sh" progress spec-done normal 2>/dev/null | od -c | grep -c '033' || true)
   assert_true "colors: piped progress emits ZERO escape bytes" "$([ "${PIPE_ESC:-0}" -eq 0 ]; echo $?)"


### PR DESCRIPTION
## What
Master CI has been red on both matrix platforms since the quality wave merged (every push from #45 onward). Two independent portability bugs, one fix each:

1. **macOS runner: `stack-merge: zero-arg chain` expected 64, got 1.** `set -u` + `"${args[@]}"` on an empty array is an 'unbound variable' abort on bash 3.2 (stock macOS; macOS runners resolve `bash` to /bin/bash 3.2); bash 4.4+ allows it. Fixed with the `${args[@]+...}` guard in `lib/stack-merge.sh` main() dispatch (covers `next` and `chain`). Swept lib/ + hooks/ for the same class: all other `[@]` expansions are count-guarded or static.
2. **ubuntu runner: `colors: PTY progress emits escape bytes` false.** The test used the BSD `script -q /dev/null bash -c ...` form; util-linux `script` errors 'unexpected number of arguments' (stderr swallowed), so zero escape bytes were counted. The test now detects the flavor and uses `script -qec "<cmd>" /dev/null` on util-linux.

## Why
Bug lane: master CI breakage blocks every PR's checks (including #49). Root cause recorded before any fix per /kit:debug; acceptance record at `docs/verification/ci-env-tests.md` (the .claude/debug ledger is gitignored; its content is mirrored there), escaped-from markers recorded against stack-merge and quality-followups.

## Testing
- Repro before fix: `/bin/bash lib/stack-merge.sh chain --dry-run` -> 'args[@]: unbound variable', exit 1; ubuntu:24.04 container: BSD script form -> 'unexpected number of arguments'
- After fix: same bash 3.2 invocation -> usage + exit 64; full `tests/test-hooks.sh` under /bin/bash 3.2: 316/316 pass
- ubuntu:24.04 container: both colors assertions PASS (PTY >=1 escape byte, piped = 0)
- `tests/test-meta.sh`: 426/426 pass
- CI on this PR is the final arbiter for both runner images

## Checklist
- [x] Tests pass (local 3.2 + container + meta)
- [x] Root cause ledger filled before fix
- [ ] CI green on both platforms
- [ ] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)