### PR TITLE
docs(kit): SPEC + ADR for inter-sub-goal context hygiene

### DIFF
--- a/docs/decisions/0027-context-hygiene.md
+++ b/docs/decisions/0027-context-hygiene.md
@@ -1,4 +1,4 @@
-# 0027. Inter-sub-goal context hygiene: distilled returns + operator checkpoint, never self-/clear
+# 0027. Inter-sub-goal context hygiene: move the loop out of the LLM session (non-LLM orchestrator)
 
 Date: 2026-06-29
 Status: Proposed
@@ -6,39 +6,42 @@ Relates-to: SPEC-087 (the design this records), ops-toolkit token-hygiene mega-g
 
 ## Decision (one line)
 
-The kit reduces a mega-goal run's marathon-context growth two ways, both additive: (1) dispatched subagents return a distilled summary the lead absorbs instead of full output, and (2) the loop emits an operator checkpoint signal at each sub-goal boundary so the operator can `/clear` and resume from POINTER_PROMPT. The kit never self-`/clear`s.
+A mega-goal run stops being one un-cleared marathon by moving the loop OUT of the LLM session: a non-LLM orchestrator runs each sub-goal in a fresh `claude -p` session (so the `/clear` is free), each session writes a feed-forward `HANDOFF.md` for the next (so the fresh start skips re-discovery), and inside a sub-goal the dispatched subagents return distilled summaries. The kit never self-`/clear`s, and the orchestrator halts at gate sub-goals.
 
 ## Context
 
-A mega-goal run is one un-cleared session whose context grows across 6-10h, and the cost of an LLM turn scales with the context re-read each turn (`cache_read`, ~58.5% of measured spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). Two kit behaviors feed that growth:
+A mega-goal run is one un-cleared session whose context grows across 6-10h, and the cost of an LLM turn scales with the context re-read each turn (`cache_read`, ~58.5% of measured spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). Three behaviors feed the growth:
 
-1. **Full subagent returns.** `/kit:execute` fans out 5-9 subagents per sub-goal and the lead absorbs each one's full output. The state flow distils nothing between phases (`WORKFLOW.md:651-652`), and the execute loop re-enters the lead after every increment (`WORKFLOW.md:707-712`), so each 16-25K-token return is permanent context for the rest of the run.
+1. **One marathon session.** The `/goal` loop runs every sub-goal in a single session whose context only grows.
+2. **Full subagent returns.** `/kit:execute` fans out 5-9 subagents per sub-goal and the lead absorbs each one's full output (`WORKFLOW.md:651-652`, `707-712`); each 16-25K-token return is permanent context for the rest of the run.
+3. **Re-discovery tax.** Each step re-finds context an earlier step already knew, because nothing is handed forward (operator observation, 2026-06-29).
 
-2. **No safe-seam signal.** The loop never marks a point where `/clear` is lossless, so the marathon never breaks into clear-able units.
-
-The obvious fix for (2), a `/clear` inside the loop, is unavailable: clearing the session that drives the loop kills the loop. Whatever the kit does about (2) must keep the loop alive, which means the actual clear is the operator's (or an outer harness's), not the kit's.
+This ADR's v1 proposed an advisory "safe to /clear" signal that a human performs. Rejected on review (Han, 2026-06-29): a human-in-the-middle clear defeats the kit's reason to exist (unattended automation). The clear that the kit cannot do to itself, an outer driver can do for free by simply starting a new session.
 
 ## Decision
 
-1. **Return contract (Mechanism 1).** Every kit-dispatched subagent role (worker, task-verifier, integration-checker, reviewer / review-team, research-*) gains a return contract: its final message, the thing the lead absorbs, is a bounded structured summary (`verdict`, `key findings`, `artifacts`, `read-next`), not the full diff / log / transcript. The full output remains recoverable in the subagent's own transcript; the lead pulls detail only when a finding demands it.
+1. **Non-LLM orchestrator (Mechanism A).** A dumb driver (`lib/orchestrate.sh`, bash; the Agent SDK is the upgrade path) owns the loop and runs each sub-goal in a fresh `claude -p` session. No session holds more than one sub-goal's context, so the marathon growth is gone. The driver MUST NOT be an LLM context: an LLM orchestrator spawning a subagent per sub-goal would re-accumulate every return and become the new marathon. This is the load-bearing call.
 
-2. **Operator checkpoint signal (Mechanism 2).** At a sub-goal boundary (merged-or-held + ROADMAP updated) the loop prints an advisory checkpoint: "safe to `/clear`, resume from POINTER_PROMPT", gated on a POINTER_PROMPT-freshness check so the advised clear is always lossless. The operator or an outer harness performs the clear.
+2. **Feed-forward handoff (Mechanism B).** Each sub-goal session writes a grounded `HANDOFF.md` (next sub-goal, files/symbols already located, fixed constraints, open risks); the orchestrator injects it into the next session's prompt, turning re-discovery into a read. It is dynamic and per-transition, distinct from the static `POINTER_PROMPT.md`, and the receiver verifies before trusting.
 
-3. **Never self-`/clear`.** The kit emits the signal but never executes the clear; doing so would destroy its own driving context. This is the hard boundary that shapes the whole design.
+3. **Distilled subagent returns (Mechanism C, phase 2).** Within a sub-goal, each dispatched role returns a bounded structured summary (`verdict`, `key findings`, `artifacts`, `read-next`) instead of full output; the full output stays recoverable in the transcript. Bounds the within-sub-goal growth that the orchestrator does not touch.
 
-4. **Strictly additive.** Both mechanisms are convention + prompt + advisory-output changes. No change to the three-store state model, the execute control flow, or any gate. The implementation (token-hygiene SG-04) realizes this; this ADR + SPEC-087 are design only.
+4. **Gate sub-goals halt the orchestrator; the kit never self-`/clear`s.** The auto chain runs unattended; a shared-repo (`gate`) sub-goal stops the loop for team review. The kit emits no `/clear` against its own session.
+
+5. **Additive.** No change to the three-store state model, the execute control flow, or any gate. The interactive `/goal` loop still works for hands-on runs; the orchestrator is an additional outer driver.
 
 ## Alternatives considered
 
-- **Self-`/clear` inside the loop.** Rejected: kills the loop's own context. This is the constraint, not an option.
-- **Route full subagent output to a side file the lead re-reads on demand.** Rejected (SPEC-087 DEC-001): re-reading is still absorption; distilling at the source is the cheaper token.
-- **Rely on the operator runbook (token-hygiene SG-02) alone.** Rejected: the runbook is the manual practice; the structural win needs the kit to shrink returns by default, not by operator vigilance.
+- **Operator checkpoint signal (this ADR's v1).** Rejected: needs a human to perform the clear; defeats the automation premise.
+- **LLM orchestrator that spawns a subagent per sub-goal.** Rejected (DEC-004): the orchestrating session re-accumulates every return and becomes the new marathon. The driver must be dumb.
+- **Self-`/clear` inside the loop.** Rejected: kills the loop's own driving context.
+- **Route full subagent output to a side file the lead re-reads.** Rejected: re-reading is still absorption; distilling at the source is cheaper.
 - **A hard token budget that aborts the loop.** Rejected: blunt; the goal is lower cost per equivalent run, not a truncated run.
 
 ## Consequences
 
-- The lead grows by hundreds of tokens per subagent instead of tens of thousands; each sub-goal becomes a clear-able unit, so `/clear` + resume between sub-goals removes the dominant `cache_read` growth.
-- Evidence is preserved: distillation points at the full transcript rather than discarding it.
-- Reversible: the change is docs + prompts + one advisory output; reverting the SG-04 diff restores prior behavior with no state migration.
-- Success is measurable: a before / after `token-forensic --loops` comparison of an equivalent run (lower `cache_read`/turn and lower total) is the mega-goal's acceptance metric (SPEC-087 AC5).
-- Slightly more prose in each dispatched-role definition (the return contract); mitigated by a shared contract shape reused across roles.
+- The dominant cost driver (a context that grows for hours and is re-read every turn) is removed structurally, not trimmed: each sub-goal runs in a near-fresh session.
+- A bounded cold-start tax replaces it (each fresh session reloads CLAUDE.md + pointer + handoff, a few K tokens); the grounded handoff keeps it small. Net win is large and measurable via `token-forensic --loops` (before / after an equivalent run).
+- Reversible: the orchestrator is additive bash + a doc convention; removing it restores the in-session loop with no state migration.
+- The orchestrator is harder to watch live than one session, but yields one clean transcript per sub-goal (better post-hoc forensics).
+- Evidence preserved throughout: handoffs and distilled returns point at full artifacts rather than discarding them.

--- a/docs/decisions/0027-context-hygiene.md
+++ b/docs/decisions/0027-context-hygiene.md
@@ -30,6 +30,8 @@ This ADR's v1 proposed an advisory "safe to /clear" signal that a human performs
 
 5. **Additive.** No change to the three-store state model, the execute control flow, or any gate. The interactive `/goal` loop still works for hands-on runs; the orchestrator is an additional outer driver.
 
+6. **Carve-out from ADR-0022's goal-ordering-chain fence.** ADR-0022 keeps goal-ordering chains (B waits for A to merge) at L5, and the README says the kit stops short of a DAG scheduler / coordinating daemon / cross-machine orchestration. This orchestrator runs sub-goals in order and advances on a checkbox flip, which is a *linear* ordering chain, so the boundary must be argued, not assumed. It is in scope because it is narrowly bounded: ONE mega-goal, ONE machine, a one-shot script (not a daemon), strictly LINEAR (not a DAG, no parallel fan-out), and it HALTS at the first gate (it never auto-crosses a shared-repo merge). What stays fenced at L5 / out of scope is unchanged: cross-repo or cross-machine coordination, 3+ concurrent operators, parallel DAG fan-out, and any always-on supervising daemon. The orchestrator is the linear-single-mega-goal slice of that space, deliberately the smallest thing that removes the marathon.
+
 ## Alternatives considered
 
 - **Operator checkpoint signal (this ADR's v1).** Rejected: needs a human to perform the clear; defeats the automation premise.

--- a/docs/decisions/0027-context-hygiene.md
+++ b/docs/decisions/0027-context-hygiene.md
@@ -1,0 +1,44 @@
+# 0027. Inter-sub-goal context hygiene: distilled returns + operator checkpoint, never self-/clear
+
+Date: 2026-06-29
+Status: Proposed
+Relates-to: SPEC-087 (the design this records), ops-toolkit token-hygiene mega-goal (the driver), ops-toolkit `research/2026-06-28-token-spend-forensic.md` (the evidence), WORKFLOW.md `## State model` + the execute loop (the accumulation surface), ADR-0022 (multi-session boundary, the prior art on session limits)
+
+## Decision (one line)
+
+The kit reduces a mega-goal run's marathon-context growth two ways, both additive: (1) dispatched subagents return a distilled summary the lead absorbs instead of full output, and (2) the loop emits an operator checkpoint signal at each sub-goal boundary so the operator can `/clear` and resume from POINTER_PROMPT. The kit never self-`/clear`s.
+
+## Context
+
+A mega-goal run is one un-cleared session whose context grows across 6-10h, and the cost of an LLM turn scales with the context re-read each turn (`cache_read`, ~58.5% of measured spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). Two kit behaviors feed that growth:
+
+1. **Full subagent returns.** `/kit:execute` fans out 5-9 subagents per sub-goal and the lead absorbs each one's full output. The state flow distils nothing between phases (`WORKFLOW.md:651-652`), and the execute loop re-enters the lead after every increment (`WORKFLOW.md:707-712`), so each 16-25K-token return is permanent context for the rest of the run.
+
+2. **No safe-seam signal.** The loop never marks a point where `/clear` is lossless, so the marathon never breaks into clear-able units.
+
+The obvious fix for (2), a `/clear` inside the loop, is unavailable: clearing the session that drives the loop kills the loop. Whatever the kit does about (2) must keep the loop alive, which means the actual clear is the operator's (or an outer harness's), not the kit's.
+
+## Decision
+
+1. **Return contract (Mechanism 1).** Every kit-dispatched subagent role (worker, task-verifier, integration-checker, reviewer / review-team, research-*) gains a return contract: its final message, the thing the lead absorbs, is a bounded structured summary (`verdict`, `key findings`, `artifacts`, `read-next`), not the full diff / log / transcript. The full output remains recoverable in the subagent's own transcript; the lead pulls detail only when a finding demands it.
+
+2. **Operator checkpoint signal (Mechanism 2).** At a sub-goal boundary (merged-or-held + ROADMAP updated) the loop prints an advisory checkpoint: "safe to `/clear`, resume from POINTER_PROMPT", gated on a POINTER_PROMPT-freshness check so the advised clear is always lossless. The operator or an outer harness performs the clear.
+
+3. **Never self-`/clear`.** The kit emits the signal but never executes the clear; doing so would destroy its own driving context. This is the hard boundary that shapes the whole design.
+
+4. **Strictly additive.** Both mechanisms are convention + prompt + advisory-output changes. No change to the three-store state model, the execute control flow, or any gate. The implementation (token-hygiene SG-04) realizes this; this ADR + SPEC-087 are design only.
+
+## Alternatives considered
+
+- **Self-`/clear` inside the loop.** Rejected: kills the loop's own context. This is the constraint, not an option.
+- **Route full subagent output to a side file the lead re-reads on demand.** Rejected (SPEC-087 DEC-001): re-reading is still absorption; distilling at the source is the cheaper token.
+- **Rely on the operator runbook (token-hygiene SG-02) alone.** Rejected: the runbook is the manual practice; the structural win needs the kit to shrink returns by default, not by operator vigilance.
+- **A hard token budget that aborts the loop.** Rejected: blunt; the goal is lower cost per equivalent run, not a truncated run.
+
+## Consequences
+
+- The lead grows by hundreds of tokens per subagent instead of tens of thousands; each sub-goal becomes a clear-able unit, so `/clear` + resume between sub-goals removes the dominant `cache_read` growth.
+- Evidence is preserved: distillation points at the full transcript rather than discarding it.
+- Reversible: the change is docs + prompts + one advisory output; reverting the SG-04 diff restores prior behavior with no state migration.
+- Success is measurable: a before / after `token-forensic --loops` comparison of an equivalent run (lower `cache_read`/turn and lower total) is the mega-goal's acceptance metric (SPEC-087 AC5).
+- Slightly more prose in each dispatched-role definition (the return contract); mitigated by a shared contract shape reused across roles.

--- a/docs/implementation-notes/context-hygiene.md
+++ b/docs/implementation-notes/context-hygiene.md
@@ -1,0 +1,24 @@
+# Implementation notes: SPEC-087 inter-sub-goal context hygiene (design)
+
+Delta-only notes for the design sub-goal (token-hygiene SG-03). The design itself is in
+SPEC-087 + ADR-0027; this records off-spec authoring decisions.
+
+## 2026-06-29 Numbering: skipped SPEC-086 to avoid an in-flight collision
+- Context: master's highest SPEC is SPEC-085; next free is 086. But the active
+  `feat/proof-visual-evidence` branch already claims `SPEC-086-stop-hook-scan-cost.md`
+  (uncommitted on that branch).
+- Decision: used **SPEC-087** so this design does not collide when that branch merges.
+  ADR-0027 has no such conflict (master highest is 0026, the feature branch adds no ADR).
+- Impact: a one-number gap on master until 086 lands; harmless.
+
+## 2026-06-29 Isolated worktree created off origin/master by hand
+- Context: the native EnterWorktree tool operates on the session's current repo (ops-toolkit);
+  it cannot create a worktree in a second repo. The kit checkout had 9 uncommitted files on
+  `feat/proof-visual-evidence` that must not be disturbed.
+- Decision: created `.claude/worktrees/context-hygiene` off `origin/master` via `git worktree
+  add` at the sanctioned path. Reversible; cleaned up after the gate PR is opened.
+
+## 2026-06-29 Lane = normal; design-only, no kit code
+- Decision: SPEC declares `Lane: normal`. The diff is markdown-only (SPEC + ADR), which the
+  proof-gate classifies inert, so no proof-of-done is owed. Gate-ledger recorded for the
+  normal lane so the kit ship-gate does not block the push.

--- a/docs/implementation-notes/context-hygiene.md
+++ b/docs/implementation-notes/context-hygiene.md
@@ -38,3 +38,13 @@ SPEC-087 + ADR-0027; this records off-spec authoring decisions.
 - Decision: SPEC declares `Lane: normal`. The diff is markdown-only (SPEC + ADR), which the
   proof-gate classifies inert, so no proof-of-done is owed. Gate-ledger recorded for the
   normal lane so the kit ship-gate does not block the push.
+
+## 2026-06-29 v3: review fixes (PR #80 review)
+- Resolved OQ-001 (a HIGH review gap that would block SG-04's first run): default session
+  posture `--dangerously-skip-permissions` (Han's call), overridable via `CLAUDE_FLAGS` or an
+  agentkernel sandbox via `CLAUDE_CMD`. Added a "Session invocation" section.
+- Specified prompt structure (POINTER + goal-file CONTENT + HANDOFF), closing the path-vs-content
+  ambiguity; AC4 updated.
+- Added an ADR-0027 carve-out vs ADR-0022's goal-ordering-chain fence (linear / single-mega-goal
+  / single-machine / halt-at-gate scope).
+- Noted (not built) the clean-working-tree guard as a future failure-mode check.

--- a/docs/implementation-notes/context-hygiene.md
+++ b/docs/implementation-notes/context-hygiene.md
@@ -3,6 +3,22 @@
 Delta-only notes for the design sub-goal (token-hygiene SG-03). The design itself is in
 SPEC-087 + ADR-0027; this records off-spec authoring decisions.
 
+## 2026-06-29 v2: design re-centered on a non-LLM orchestrator (operator review)
+
+- Context: Han reviewed the v1 design (distilled returns + operator checkpoint signal) and
+  rejected the operator-signal half: a human-performed `/clear` defeats the kit's unattended
+  automation premise.
+- Change: SPEC-087 + ADR-0027 rewritten to make a **non-LLM orchestrator** (Mechanism A) the
+  primary fix, with a **feed-forward grounded handoff** (Mechanism B) replacing the operator
+  signal, and distilled returns demoted to phase-2 Mechanism C. The load-bearing call
+  (DEC-004): the loop driver must be dumb code, not an LLM session, or it re-accumulates and
+  becomes the new marathon.
+- Impl choice: phase-1 implementation is bash `lib/orchestrate.sh` driving `claude -p`
+  (matches the existing lib/ drivers; Agent SDK is the upgrade path). The `claude` binary is
+  injected via `CLAUDE_CMD` so the test mocks it and the operator tunes the permission flags.
+- PR split: the spec/ADR revision rides the SG-03 design PR (#80); the orchestrator code is a
+  stacked SG-04 PR off this branch.
+
 ## 2026-06-29 Numbering: skipped SPEC-086 to avoid an in-flight collision
 - Context: master's highest SPEC is SPEC-085; next free is 086. But the active
   `feat/proof-visual-evidence` branch already claims `SPEC-086-stop-hook-scan-cost.md`

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -59,7 +59,9 @@ orchestrator (bash/SDK, NOT an LLM context)
 - **Completion is grounded, not self-claimed**: after a session returns, the orchestrator
   re-reads the ROADMAP; it advances only if the sub-goal's checkbox flipped to `[x]`. A
   session that returns without checking its box is a failure, and the orchestrator stops
-  rather than spinning.
+  rather than spinning. (Future guard, noted not yet built: also assert the working tree is
+  clean before advancing, so a session that died mid-edit halts the loop rather than handing a
+  dirty baseline to the next sub-goal.)
 
 ### Mechanism B: feed-forward handoff (kills the re-discovery tax)
 
@@ -78,6 +80,26 @@ HANDOFF.md (written by the sub-goal that just finished)
 Distinct from `POINTER_PROMPT.md`, which is static (it points at the ROADMAP). The handoff is
 dynamic, per-transition, and must be **grounded** (cite real files / PRs), so it cannot become
 an optimistic lie about the next step; the receiving session verifies before trusting.
+
+### Session invocation (the per-sub-goal `claude -p` call)
+
+Resolves the former OQ-001. Two things were under-specified: what goes into each session's
+prompt, and what permission posture it runs with.
+
+**Prompt structure.** For each sub-goal the orchestrator feeds, in order, the *content* (not
+just paths) of: (1) `POINTER_PROMPT.md`, (2) the sub-goal's goal file `goals/NN-*.md`, (3) the
+previous `HANDOFF.md` if present. Injecting the goal-file content (not a path hint) is what
+actually eliminates re-discovery, and is why a fresh run with no handoff still works (the goal
+file carries the contract). The HANDOFF's `goal file: goals/NN-*.md` line is a human pointer;
+the orchestrator injects the file's body.
+
+**Permission posture.** Default: `--dangerously-skip-permissions` (Han, 2026-06-29). An
+unattended sub-goal session must edit, commit, push, and open a PR, so it needs full tool
+access; a prompt-per-action permission wall would stall the loop. This is a deliberate
+blast-radius choice for the auto chain, mitigated by the gate-stop (shared-repo merges stay
+human) and by each sub-goal being a disposable session. The posture is **overridable** via the
+`CLAUDE_FLAGS` env var (e.g. a tight `--allowedTools` allowlist) or by running the session
+inside an agentkernel sandbox via `CLAUDE_CMD`; these are options, not the default.
 
 ### Mechanism C: distilled subagent returns (within-sub-goal; phase 2)
 
@@ -104,10 +126,13 @@ Phase 1 (SG-04, this cycle):
   the stop point) without invoking `claude`, so the control flow is testable and cheap.
 - AC3: The orchestrator stops at the first `gate` sub-goal and prints the held PR; it advances
   past an `auto` sub-goal only when the ROADMAP checkbox flipped to `[x]`.
-- AC4: The previous sub-goal's `HANDOFF.md` is injected into the next session's prompt; a
-  fresh run with no handoff still works.
+- AC4: The previous sub-goal's `HANDOFF.md` AND the goal-file content are injected into the
+  next session's prompt; a fresh run with no handoff still works (the goal file carries the
+  contract).
 - AC5: A `tests/test-orchestrate.sh` exercises the above with a mock `claude` (via `CLAUDE_CMD`),
-  including a negative control (a session that does not check its box halts the loop).
+  including a negative control (a session that does not check its box halts the loop) and a
+  check that the default permission posture (`--dangerously-skip-permissions` via `CLAUDE_FLAGS`)
+  is passed and is overridable.
 
 Phase 2 (follow-up): the distilled-return contract (Mechanism C) in the agent defs, measured by
 a before / after `token-forensic --loops` comparison of an equivalent run (lower `cache_read`/turn
@@ -146,6 +171,6 @@ bash lib/orchestrate.sh run <megagoal-dir> --dry-run   # ordered plan, no claude
 
 ## Open questions
 
-- OQ-001: `claude -p` permission mode + flag set for an unattended sub-goal session (resolved
-  at impl; kept configurable via `CLAUDE_CMD` so the test mocks it and the operator tunes it).
+- OQ-001: RESOLVED , see "Session invocation": default `--dangerously-skip-permissions`,
+  overridable via `CLAUDE_FLAGS`; prompt = POINTER + goal-file content + HANDOFF.
 - OQ-002: Exact distilled-return field set + length bound per role (phase 2).

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -1,125 +1,151 @@
-# SPEC-087: Inter-sub-goal context hygiene (distilled returns + checkpoint signal)
+# SPEC-087: Inter-sub-goal context hygiene (orchestrator + feed-forward handoff + distilled returns)
 
 Status: DRAFT
 Date: 2026-06-29
 Lane: normal (classified: normal)
-Type: design (design-only; implementation is a follow-up, token-hygiene SG-04)
-Board: token-hygiene mega-goal SG-03 (ops-toolkit `_meta/megagoals/token-hygiene/`); kit intake ID operator-assigned
+Type: design + impl (orchestrator built in token-hygiene SG-04; distilled-returns is phase 2)
+Board: token-hygiene mega-goal SG-03/SG-04 (ops-toolkit `_meta/megagoals/token-hygiene/`); kit intake ID operator-assigned
 
 ## Problem
 
 A mega-goal run under the kit is one un-cleared session whose context grows monotonically
-across 6-10h. Two structural drivers:
+across 6-10h. Cost is dominated by `cache_read`: the whole accumulated context is re-read
+every turn (~58.5% of spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). Three
+drivers:
 
-1. **Full subagent returns.** `/kit:execute` dispatches 5-9 subagents per sub-goal (workers,
-   task-verifiers, reviewers) and the lead absorbs each one's FULL output. The kit's own
-   state flow shows three stores with nothing distilled between phases
-   (`WORKFLOW.md:651-652`); the execute loop re-enters the lead after every increment
-   (`WORKFLOW.md:707-712`). A 16-25K-token return per subagent, multiplied across a sub-goal,
-   lands permanently in the lead context.
+1. **One marathon session.** The `/goal` loop runs every sub-goal in a single session whose
+   context only grows. The kit cannot fix this by self-`/clear`ing: a `/clear` inside the loop
+   kills the loop's own driving context.
 
-2. **No clear-able boundary.** The loop never signals a safe seam to `/clear`. Cost is
-   dominated by `cache_read`: the whole accumulated context is re-read every turn (~58.5% of
-   spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). The longer the
-   un-cleared marathon, the more each turn costs.
+2. **Full subagent returns.** Inside a sub-goal, `/kit:execute` dispatches 5-9 subagents
+   (workers, task-verifiers, reviewers) and the lead absorbs each one's FULL output. The state
+   flow distils nothing between phases (`WORKFLOW.md:651-652`); the execute loop re-enters the
+   lead after every increment (`WORKFLOW.md:707-712`). A 16-25K-token return per subagent,
+   multiplied across a sub-goal, lands permanently in the lead.
 
-The kit cannot fix (2) by self-clearing: a `/clear` inside the loop kills the loop's own
-driving context. So the design centers on (a) shrinking what the lead absorbs per subagent
-and (b) emitting an operator signal at each safe seam, leaving the actual `/clear` to the
-operator or an outer harness.
+3. **Re-discovery tax.** Reading a real run's log, each step spends many turns re-finding
+   context (which files, which interface) that an earlier step already knew, because nothing
+   is handed forward (operator observation, 2026-06-29).
+
+This SPEC supersedes its own v1 ("operator checkpoint signal"): an advisory "safe to /clear"
+that a human performs defeats the kit's automation premise (the kit exists to run without a
+human in the middle). The fix is to move the loop OUT of the LLM session.
 
 ## Design
 
-### Mechanism 1: distilled subagent returns (return contract)
+### Mechanism A: outer orchestrator (the structural fix)
 
-Subagent definitions and the dispatch convention gain a **return contract**: a subagent's
-final message (the value the lead absorbs) is a bounded, structured summary, not the full
-diff / log / transcript.
-
-- Structured fields: `verdict` (pass / fail / inconclusive), `key findings` (a few bullets),
-  `artifacts` (paths or refs where the full detail lives), `read-next` (the one slice the
-  lead should pull IF a finding needs more).
-- The full output is not lost: it stays in the subagent's own transcript
-  (`agent-<id>.jsonl` / the task output file), recoverable on demand. The lead absorbs the
-  summary and pulls detail only when a finding requires it.
-- Applies to the kit's dispatched roles: worker (execute), task-verifier,
-  integration-checker, reviewer / review-team, research-* (spec). Each role's agent
-  definition states its return-contract shape.
-
-Effect: the lead grows by a few hundred tokens per subagent instead of 16-25K.
-
-### Mechanism 2: post-sub-goal checkpoint signal
-
-At a sub-goal completion boundary (sub-goal merged-or-held AND its ROADMAP line updated), the
-loop emits an explicit operator signal:
+A **non-LLM** driver owns the loop; the LLM work happens only in disposable per-sub-goal
+sessions.
 
 ```
-Sub-goal NN complete (PR #N). Context checkpoint.
-  Safe to /clear now; resume by pasting POINTER_PROMPT.md into a fresh /goal.
-  POINTER_PROMPT freshness: <verified current | STALE: update before clearing>.
+orchestrator (bash/SDK, NOT an LLM context)
+   ├─ claude -p (fresh session, empty context) -> SG-01 -> ship PR -> write HANDOFF -> exit
+   ├─ claude -p (fresh session, empty context) -> SG-02 -> ship PR -> write HANDOFF -> exit
+   └─ ... stop at the first `gate` sub-goal (shared-repo review needs a human)
 ```
 
-- The signal is advisory: the kit prints it; the operator or an outer harness performs the
-  `/clear` + resume. The kit never self-clears.
-- Precondition guard: before advising `/clear`, the loop checks that POINTER_PROMPT.md +
-  ROADMAP.md encode enough to re-bootstrap losslessly (the resume contract). If
-  POINTER_PROMPT is stale, the signal says STALE and the loop refreshes it (or asks the
-  operator) instead of advising a lossy clear.
-- This makes each sub-goal a clear-able unit: `/clear` + POINTER_PROMPT resume between
-  sub-goals kills the monotonic growth (the #1 cost driver) without losing the thread.
+- Each `claude -p` invocation is a new session, so the `/clear` happens for free; no session
+  ever holds more than one sub-goal's context. The monotonic growth (driver 1) is removed
+  structurally, with no human and no kit self-clear.
+- **The driver must be non-LLM** (DEC-004). If the orchestrator were itself a persistent
+  Claude session spawning a subagent per sub-goal, that session would re-accumulate every
+  return and become the new marathon. A subagent reports back into a parent LLM context; only
+  a dumb driver avoids re-accumulation.
+- **Gate sub-goals stop the orchestrator** (DEC-005). A shared-repo (`gate`) sub-goal needs
+  team review before its dependents proceed; the orchestrator runs the `auto` chain
+  back-to-back and halts at the first `gate`, printing the held PR. "No human in the middle"
+  holds for the auto chain, not for shared-repo merges (which are intentionally human).
+- **Completion is grounded, not self-claimed**: after a session returns, the orchestrator
+  re-reads the ROADMAP; it advances only if the sub-goal's checkbox flipped to `[x]`. A
+  session that returns without checking its box is a failure, and the orchestrator stops
+  rather than spinning.
 
-### Where it lives (impl pointers for SG-04, not built here)
+### Mechanism B: feed-forward handoff (kills the re-discovery tax)
 
-- Return contract: the dispatched-role agent definitions (`agents/*.md`: worker,
-  task-verifier, integration-checker, reviewer) plus the dispatch prose in `/kit:execute` and
-  `WORKFLOW.md`.
-- Checkpoint signal: the sub-goal-boundary step of the mega-goal loop (`plan-for-mega-goal` /
-  the `/goal` loop's sub-goal-complete path) plus a POINTER_PROMPT freshness check.
+Each sub-goal session, on completion, writes a `HANDOFF.md` for the next one; the orchestrator
+injects the previous HANDOFF into the next session's prompt. This turns driver 3's
+re-discovery into a read.
 
-## Acceptance criteria (for the SG-04 implementation)
+```
+HANDOFF.md (written by the sub-goal that just finished)
+- Next sub-goal: SG-NN  (goal file: goals/NN-*.md)
+- Files / symbols it will touch: <paths, the ones already located>
+- Constraints already fixed: <e.g. SG-01 named the field `parent`; reuse it>
+- Open risks / gotchas: <...>
+```
 
-- AC1: Each kit-dispatched subagent role's definition carries a return-contract section
-  bounding its final message to a structured summary + artifact pointers, not full output.
-- AC2: `/kit:execute` and the dispatch prose instruct the lead to absorb the summary and pull
-  detail on demand only.
-- AC3: A sub-goal-boundary checkpoint signal is emitted (advisory, operator-performed
-  `/clear`), gated on a POINTER_PROMPT freshness check.
-- AC4: The kit never self-`/clear`s; verified by inspection (no `/clear` emitted as an
-  executed command in the loop).
-- AC5: A before / after `token-forensic --loops` comparison of an equivalent mega-goal run
-  shows lower `cache_read`/turn and lower total (the mega-goal's success metric).
+Distinct from `POINTER_PROMPT.md`, which is static (it points at the ROADMAP). The handoff is
+dynamic, per-transition, and must be **grounded** (cite real files / PRs), so it cannot become
+an optimistic lie about the next step; the receiving session verifies before trusting.
+
+### Mechanism C: distilled subagent returns (within-sub-goal; phase 2)
+
+Bounds growth INSIDE one sub-goal. Each kit-dispatched role returns a bounded structured
+summary (`verdict`, `key findings`, `artifacts`, `read-next`), not the full diff / log; the
+full output stays recoverable in the subagent transcript. The lead absorbs the summary and
+pulls detail on demand. Applies to worker, task-verifier, integration-checker, reviewer /
+review-team, research-*. This is additive to A+B and is built as a follow-up increment.
+
+### Where it lives
+
+- Orchestrator (A) + handoff (B): a new `lib/orchestrate.sh` (bash, matching the other lib
+  drivers) plus the handoff convention documented in `WORKFLOW.md` / `plan-for-mega-goal`.
+- Distilled returns (C): the dispatched-role agent definitions (`agents/*.md`) + the dispatch
+  prose in `/kit:execute`.
+
+## Acceptance criteria
+
+Phase 1 (SG-04, this cycle):
+- AC1: `lib/orchestrate.sh` parses a mega-goal ROADMAP, finds the next unchecked sub-goal +
+  its policy, and (real mode) runs it via a fresh `claude -p` session; the loop driver holds
+  no LLM context.
+- AC2: `--dry-run` prints the ordered plan (each sub-goal, its policy, the injected handoff,
+  the stop point) without invoking `claude`, so the control flow is testable and cheap.
+- AC3: The orchestrator stops at the first `gate` sub-goal and prints the held PR; it advances
+  past an `auto` sub-goal only when the ROADMAP checkbox flipped to `[x]`.
+- AC4: The previous sub-goal's `HANDOFF.md` is injected into the next session's prompt; a
+  fresh run with no handoff still works.
+- AC5: A `tests/test-orchestrate.sh` exercises the above with a mock `claude` (via `CLAUDE_CMD`),
+  including a negative control (a session that does not check its box halts the loop).
+
+Phase 2 (follow-up): the distilled-return contract (Mechanism C) in the agent defs, measured by
+a before / after `token-forensic --loops` comparison of an equivalent run (lower `cache_read`/turn
+and lower total, the mega-goal success metric).
 
 ## Verification
 
 ```
 # in the dwarves-kit checkout
-ls docs/specs/ | grep -i context-hygiene      # SPEC present
-ls docs/decisions/ | grep -i context-hygiene  # ADR present
+bash tests/test-orchestrate.sh            # phase-1 control flow + negative control
+bash lib/orchestrate.sh run <megagoal-dir> --dry-run   # ordered plan, no claude spawned
 ```
-
-Design-only; the behavioral verification (AC5) is owned by the SG-04 implementation PR.
 
 ## Out of scope
 
-- The implementation itself (token-hygiene SG-04).
-- Self-clearing inside the loop (rejected: kills the loop's own context; see ADR-0027).
-- Changing the three-store state model or the execute loop's control flow. This is additive
-  (what the lead absorbs + an advisory signal), not a re-architecture.
+- Replacing the interactive `/goal` loop; the orchestrator is an additive outer driver, the
+  in-session loop still works for hands-on runs.
+- A full Agent-SDK orchestrator (TypeScript/Python). Bash `claude -p` is phase 1; the SDK is
+  the upgrade path when structured handoffs / retries / inline distilled returns are wanted.
+- Self-clearing inside a session (rejected; kills the loop's own context).
 
 ## Decision log
 
-- DEC-001: Distill returns rather than route subagent output to a side file the lead must
-  re-read. Rationale: the cheapest token is the one never absorbed; a structured summary is
-  the absorption.
-- DEC-002: Checkpoint is an operator signal, not a self-`/clear`. Rationale: the kit cannot
-  clear its own driving context without killing the loop. The operator or outer harness owns
-  the clear; the kit owns the safe-seam signal + resume contract.
-- DEC-003: Full output stays recoverable in the subagent transcript, not discarded.
-  Rationale: honesty + debuggability; distillation must not destroy evidence.
+- DEC-001: Distill returns rather than route subagent output to a side file the lead re-reads.
+  The cheapest token is the one never absorbed.
+- DEC-002 (superseded by DEC-004): v1 made the checkpoint an operator signal. Replaced: a
+  human-performed clear defeats the automation premise.
+- DEC-003: Full subagent output stays recoverable in the transcript, not discarded.
+- DEC-004: The loop driver MUST be non-LLM. An LLM orchestrator spawning a subagent per
+  sub-goal re-accumulates every return and becomes the new marathon; only a dumb driver
+  running disposable fresh sessions removes the growth.
+- DEC-005: Gate sub-goals halt the orchestrator. The auto chain runs unattended; shared-repo
+  merges are an intentional human gate, not a flaw.
+- DEC-006: The handoff is feed-forward and grounded, distinct from the static POINTER_PROMPT;
+  it must cite real artifacts and the receiver verifies before trusting.
 
 ## Open questions
 
-- OQ-001: Does the checkpoint signal belong in `plan-for-mega-goal`, the built-in `/goal`
-  loop, or a kit hook? Resolved at SG-04 impl by where the sub-goal boundary is observable.
-- OQ-002: Exact return-contract field set + length bound per role. Tuned at impl; AC1 fixes
-  the shape, not the numbers.
+- OQ-001: `claude -p` permission mode + flag set for an unattended sub-goal session (resolved
+  at impl; kept configurable via `CLAUDE_CMD` so the test mocks it and the operator tunes it).
+- OQ-002: Exact distilled-return field set + length bound per role (phase 2).

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -1,0 +1,125 @@
+# SPEC-087: Inter-sub-goal context hygiene (distilled returns + checkpoint signal)
+
+Status: DRAFT
+Date: 2026-06-29
+Lane: normal (classified: normal)
+Type: design (design-only; implementation is a follow-up, token-hygiene SG-04)
+Board: token-hygiene mega-goal SG-03 (ops-toolkit `_meta/megagoals/token-hygiene/`); kit intake ID operator-assigned
+
+## Problem
+
+A mega-goal run under the kit is one un-cleared session whose context grows monotonically
+across 6-10h. Two structural drivers:
+
+1. **Full subagent returns.** `/kit:execute` dispatches 5-9 subagents per sub-goal (workers,
+   task-verifiers, reviewers) and the lead absorbs each one's FULL output. The kit's own
+   state flow shows three stores with nothing distilled between phases
+   (`WORKFLOW.md:651-652`); the execute loop re-enters the lead after every increment
+   (`WORKFLOW.md:707-712`). A 16-25K-token return per subagent, multiplied across a sub-goal,
+   lands permanently in the lead context.
+
+2. **No clear-able boundary.** The loop never signals a safe seam to `/clear`. Cost is
+   dominated by `cache_read`: the whole accumulated context is re-read every turn (~58.5% of
+   spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). The longer the
+   un-cleared marathon, the more each turn costs.
+
+The kit cannot fix (2) by self-clearing: a `/clear` inside the loop kills the loop's own
+driving context. So the design centers on (a) shrinking what the lead absorbs per subagent
+and (b) emitting an operator signal at each safe seam, leaving the actual `/clear` to the
+operator or an outer harness.
+
+## Design
+
+### Mechanism 1: distilled subagent returns (return contract)
+
+Subagent definitions and the dispatch convention gain a **return contract**: a subagent's
+final message (the value the lead absorbs) is a bounded, structured summary, not the full
+diff / log / transcript.
+
+- Structured fields: `verdict` (pass / fail / inconclusive), `key findings` (a few bullets),
+  `artifacts` (paths or refs where the full detail lives), `read-next` (the one slice the
+  lead should pull IF a finding needs more).
+- The full output is not lost: it stays in the subagent's own transcript
+  (`agent-<id>.jsonl` / the task output file), recoverable on demand. The lead absorbs the
+  summary and pulls detail only when a finding requires it.
+- Applies to the kit's dispatched roles: worker (execute), task-verifier,
+  integration-checker, reviewer / review-team, research-* (spec). Each role's agent
+  definition states its return-contract shape.
+
+Effect: the lead grows by a few hundred tokens per subagent instead of 16-25K.
+
+### Mechanism 2: post-sub-goal checkpoint signal
+
+At a sub-goal completion boundary (sub-goal merged-or-held AND its ROADMAP line updated), the
+loop emits an explicit operator signal:
+
+```
+Sub-goal NN complete (PR #N). Context checkpoint.
+  Safe to /clear now; resume by pasting POINTER_PROMPT.md into a fresh /goal.
+  POINTER_PROMPT freshness: <verified current | STALE: update before clearing>.
+```
+
+- The signal is advisory: the kit prints it; the operator or an outer harness performs the
+  `/clear` + resume. The kit never self-clears.
+- Precondition guard: before advising `/clear`, the loop checks that POINTER_PROMPT.md +
+  ROADMAP.md encode enough to re-bootstrap losslessly (the resume contract). If
+  POINTER_PROMPT is stale, the signal says STALE and the loop refreshes it (or asks the
+  operator) instead of advising a lossy clear.
+- This makes each sub-goal a clear-able unit: `/clear` + POINTER_PROMPT resume between
+  sub-goals kills the monotonic growth (the #1 cost driver) without losing the thread.
+
+### Where it lives (impl pointers for SG-04, not built here)
+
+- Return contract: the dispatched-role agent definitions (`agents/*.md`: worker,
+  task-verifier, integration-checker, reviewer) plus the dispatch prose in `/kit:execute` and
+  `WORKFLOW.md`.
+- Checkpoint signal: the sub-goal-boundary step of the mega-goal loop (`plan-for-mega-goal` /
+  the `/goal` loop's sub-goal-complete path) plus a POINTER_PROMPT freshness check.
+
+## Acceptance criteria (for the SG-04 implementation)
+
+- AC1: Each kit-dispatched subagent role's definition carries a return-contract section
+  bounding its final message to a structured summary + artifact pointers, not full output.
+- AC2: `/kit:execute` and the dispatch prose instruct the lead to absorb the summary and pull
+  detail on demand only.
+- AC3: A sub-goal-boundary checkpoint signal is emitted (advisory, operator-performed
+  `/clear`), gated on a POINTER_PROMPT freshness check.
+- AC4: The kit never self-`/clear`s; verified by inspection (no `/clear` emitted as an
+  executed command in the loop).
+- AC5: A before / after `token-forensic --loops` comparison of an equivalent mega-goal run
+  shows lower `cache_read`/turn and lower total (the mega-goal's success metric).
+
+## Verification
+
+```
+# in the dwarves-kit checkout
+ls docs/specs/ | grep -i context-hygiene      # SPEC present
+ls docs/decisions/ | grep -i context-hygiene  # ADR present
+```
+
+Design-only; the behavioral verification (AC5) is owned by the SG-04 implementation PR.
+
+## Out of scope
+
+- The implementation itself (token-hygiene SG-04).
+- Self-clearing inside the loop (rejected: kills the loop's own context; see ADR-0027).
+- Changing the three-store state model or the execute loop's control flow. This is additive
+  (what the lead absorbs + an advisory signal), not a re-architecture.
+
+## Decision log
+
+- DEC-001: Distill returns rather than route subagent output to a side file the lead must
+  re-read. Rationale: the cheapest token is the one never absorbed; a structured summary is
+  the absorption.
+- DEC-002: Checkpoint is an operator signal, not a self-`/clear`. Rationale: the kit cannot
+  clear its own driving context without killing the loop. The operator or outer harness owns
+  the clear; the kit owns the safe-seam signal + resume contract.
+- DEC-003: Full output stays recoverable in the subagent transcript, not discarded.
+  Rationale: honesty + debuggability; distillation must not destroy evidence.
+
+## Open questions
+
+- OQ-001: Does the checkpoint signal belong in `plan-for-mega-goal`, the built-in `/goal`
+  loop, or a kit hook? Resolved at SG-04 impl by where the sub-goal boundary is observable.
+- OQ-002: Exact return-contract field set + length bound per role. Tuned at impl; AC1 fixes
+  the shape, not the numbers.


### PR DESCRIPTION
Design-only SPEC + ADR (SG-03 of the ops-toolkit token-hygiene mega-goal). **Gate PR: held for team review, not auto-merged.**

## Problem
A mega-goal run is one un-cleared session whose context grows for 6-10h. Cost is dominated by `cache_read` (~58.5% of spend): the whole accumulated context is re-read every turn. Two kit behaviors feed the growth, cited from the audit (`WORKFLOW.md:651-652`, `707-712`): `/kit:execute` fans out 5-9 subagents per sub-goal and the lead absorbs each one's full output, and the loop never marks a safe `/clear` seam.

## Design (two additive mechanisms)
1. **Distilled subagent returns** , each dispatched role (worker, task-verifier, integration-checker, reviewer, research-*) returns a bounded structured summary (`verdict` / `key findings` / `artifacts` / `read-next`) the lead absorbs, not the full diff/log. Full detail stays recoverable in the subagent transcript.
2. **Post-sub-goal operator checkpoint signal** , at each sub-goal boundary the loop emits an advisory "safe to `/clear`, resume from POINTER_PROMPT", gated on a pointer-freshness check. The operator performs the clear.

**Hard boundary:** the kit never self-`/clear`s (would kill its own driving loop). The design centers on summarization + operator signals, not self-clearing.

## Scope
Design artifacts only (`docs/specs/SPEC-087-context-hygiene.md`, `docs/decisions/0027-context-hygiene.md`). No kit code. Implementation is the follow-up token-hygiene SG-04. SPEC-087 (skipped 086 to avoid colliding with the in-flight `feat/proof-visual-evidence` SPEC-086).

## Verification
```
ls docs/specs/ | grep -i context-hygiene      # SPEC present
ls docs/decisions/ | grep -i context-hygiene  # ADR present
```
Markdown-only diff; no em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
