### PR TITLE
feat(kit): non-LLM mega-goal orchestrator + feed-forward handoff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Run review-team plant tests
         run: bash tests/test-review-team-plants.sh
+
+      - name: Run orchestrator tests
+        run: bash tests/test-orchestrate.sh

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ dwarves-kit/
   lib/goal-registry.sh          Cross-session running-goal registry: claim/list/log/release (multi-session moat + monitor)
   lib/goal-drafts.sh            Goal-draft lifecycle: archive shipped drafts to .claude/goals/done/
   lib/lane-telemetry.sh         Read-side lane-effectiveness aggregator over the run ledgers: report + misfires (reviewed at /kit:retro)
+  lib/orchestrate.sh            Non-LLM mega-goal driver: one fresh `claude -p` session per sub-goal so no session marathons (SPEC-087); linear + session-per-sub-goal, NOT a DAG scheduler or daemon
   skills/get-api-docs/          Context Hub integration
   rules/                        Path-scoped coding-standard templates
   examples/hello-spec/          Demo: small CLAUDE.md + SPEC.md walkthrough

--- a/docs/decisions/0027-context-hygiene.md
+++ b/docs/decisions/0027-context-hygiene.md
@@ -1,4 +1,4 @@
-# 0027. Inter-sub-goal context hygiene: distilled returns + operator checkpoint, never self-/clear
+# 0027. Inter-sub-goal context hygiene: move the loop out of the LLM session (non-LLM orchestrator)
 
 Date: 2026-06-29
 Status: Proposed
@@ -6,39 +6,42 @@ Relates-to: SPEC-087 (the design this records), ops-toolkit token-hygiene mega-g
 
 ## Decision (one line)
 
-The kit reduces a mega-goal run's marathon-context growth two ways, both additive: (1) dispatched subagents return a distilled summary the lead absorbs instead of full output, and (2) the loop emits an operator checkpoint signal at each sub-goal boundary so the operator can `/clear` and resume from POINTER_PROMPT. The kit never self-`/clear`s.
+A mega-goal run stops being one un-cleared marathon by moving the loop OUT of the LLM session: a non-LLM orchestrator runs each sub-goal in a fresh `claude -p` session (so the `/clear` is free), each session writes a feed-forward `HANDOFF.md` for the next (so the fresh start skips re-discovery), and inside a sub-goal the dispatched subagents return distilled summaries. The kit never self-`/clear`s, and the orchestrator halts at gate sub-goals.
 
 ## Context
 
-A mega-goal run is one un-cleared session whose context grows across 6-10h, and the cost of an LLM turn scales with the context re-read each turn (`cache_read`, ~58.5% of measured spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). Two kit behaviors feed that growth:
+A mega-goal run is one un-cleared session whose context grows across 6-10h, and the cost of an LLM turn scales with the context re-read each turn (`cache_read`, ~58.5% of measured spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). Three behaviors feed the growth:
 
-1. **Full subagent returns.** `/kit:execute` fans out 5-9 subagents per sub-goal and the lead absorbs each one's full output. The state flow distils nothing between phases (`WORKFLOW.md:651-652`), and the execute loop re-enters the lead after every increment (`WORKFLOW.md:707-712`), so each 16-25K-token return is permanent context for the rest of the run.
+1. **One marathon session.** The `/goal` loop runs every sub-goal in a single session whose context only grows.
+2. **Full subagent returns.** `/kit:execute` fans out 5-9 subagents per sub-goal and the lead absorbs each one's full output (`WORKFLOW.md:651-652`, `707-712`); each 16-25K-token return is permanent context for the rest of the run.
+3. **Re-discovery tax.** Each step re-finds context an earlier step already knew, because nothing is handed forward (operator observation, 2026-06-29).
 
-2. **No safe-seam signal.** The loop never marks a point where `/clear` is lossless, so the marathon never breaks into clear-able units.
-
-The obvious fix for (2), a `/clear` inside the loop, is unavailable: clearing the session that drives the loop kills the loop. Whatever the kit does about (2) must keep the loop alive, which means the actual clear is the operator's (or an outer harness's), not the kit's.
+This ADR's v1 proposed an advisory "safe to /clear" signal that a human performs. Rejected on review (Han, 2026-06-29): a human-in-the-middle clear defeats the kit's reason to exist (unattended automation). The clear that the kit cannot do to itself, an outer driver can do for free by simply starting a new session.
 
 ## Decision
 
-1. **Return contract (Mechanism 1).** Every kit-dispatched subagent role (worker, task-verifier, integration-checker, reviewer / review-team, research-*) gains a return contract: its final message, the thing the lead absorbs, is a bounded structured summary (`verdict`, `key findings`, `artifacts`, `read-next`), not the full diff / log / transcript. The full output remains recoverable in the subagent's own transcript; the lead pulls detail only when a finding demands it.
+1. **Non-LLM orchestrator (Mechanism A).** A dumb driver (`lib/orchestrate.sh`, bash; the Agent SDK is the upgrade path) owns the loop and runs each sub-goal in a fresh `claude -p` session. No session holds more than one sub-goal's context, so the marathon growth is gone. The driver MUST NOT be an LLM context: an LLM orchestrator spawning a subagent per sub-goal would re-accumulate every return and become the new marathon. This is the load-bearing call.
 
-2. **Operator checkpoint signal (Mechanism 2).** At a sub-goal boundary (merged-or-held + ROADMAP updated) the loop prints an advisory checkpoint: "safe to `/clear`, resume from POINTER_PROMPT", gated on a POINTER_PROMPT-freshness check so the advised clear is always lossless. The operator or an outer harness performs the clear.
+2. **Feed-forward handoff (Mechanism B).** Each sub-goal session writes a grounded `HANDOFF.md` (next sub-goal, files/symbols already located, fixed constraints, open risks); the orchestrator injects it into the next session's prompt, turning re-discovery into a read. It is dynamic and per-transition, distinct from the static `POINTER_PROMPT.md`, and the receiver verifies before trusting.
 
-3. **Never self-`/clear`.** The kit emits the signal but never executes the clear; doing so would destroy its own driving context. This is the hard boundary that shapes the whole design.
+3. **Distilled subagent returns (Mechanism C, phase 2).** Within a sub-goal, each dispatched role returns a bounded structured summary (`verdict`, `key findings`, `artifacts`, `read-next`) instead of full output; the full output stays recoverable in the transcript. Bounds the within-sub-goal growth that the orchestrator does not touch.
 
-4. **Strictly additive.** Both mechanisms are convention + prompt + advisory-output changes. No change to the three-store state model, the execute control flow, or any gate. The implementation (token-hygiene SG-04) realizes this; this ADR + SPEC-087 are design only.
+4. **Gate sub-goals halt the orchestrator; the kit never self-`/clear`s.** The auto chain runs unattended; a shared-repo (`gate`) sub-goal stops the loop for team review. The kit emits no `/clear` against its own session.
+
+5. **Additive.** No change to the three-store state model, the execute control flow, or any gate. The interactive `/goal` loop still works for hands-on runs; the orchestrator is an additional outer driver.
 
 ## Alternatives considered
 
-- **Self-`/clear` inside the loop.** Rejected: kills the loop's own context. This is the constraint, not an option.
-- **Route full subagent output to a side file the lead re-reads on demand.** Rejected (SPEC-087 DEC-001): re-reading is still absorption; distilling at the source is the cheaper token.
-- **Rely on the operator runbook (token-hygiene SG-02) alone.** Rejected: the runbook is the manual practice; the structural win needs the kit to shrink returns by default, not by operator vigilance.
+- **Operator checkpoint signal (this ADR's v1).** Rejected: needs a human to perform the clear; defeats the automation premise.
+- **LLM orchestrator that spawns a subagent per sub-goal.** Rejected (DEC-004): the orchestrating session re-accumulates every return and becomes the new marathon. The driver must be dumb.
+- **Self-`/clear` inside the loop.** Rejected: kills the loop's own driving context.
+- **Route full subagent output to a side file the lead re-reads.** Rejected: re-reading is still absorption; distilling at the source is cheaper.
 - **A hard token budget that aborts the loop.** Rejected: blunt; the goal is lower cost per equivalent run, not a truncated run.
 
 ## Consequences
 
-- The lead grows by hundreds of tokens per subagent instead of tens of thousands; each sub-goal becomes a clear-able unit, so `/clear` + resume between sub-goals removes the dominant `cache_read` growth.
-- Evidence is preserved: distillation points at the full transcript rather than discarding it.
-- Reversible: the change is docs + prompts + one advisory output; reverting the SG-04 diff restores prior behavior with no state migration.
-- Success is measurable: a before / after `token-forensic --loops` comparison of an equivalent run (lower `cache_read`/turn and lower total) is the mega-goal's acceptance metric (SPEC-087 AC5).
-- Slightly more prose in each dispatched-role definition (the return contract); mitigated by a shared contract shape reused across roles.
+- The dominant cost driver (a context that grows for hours and is re-read every turn) is removed structurally, not trimmed: each sub-goal runs in a near-fresh session.
+- A bounded cold-start tax replaces it (each fresh session reloads CLAUDE.md + pointer + handoff, a few K tokens); the grounded handoff keeps it small. Net win is large and measurable via `token-forensic --loops` (before / after an equivalent run).
+- Reversible: the orchestrator is additive bash + a doc convention; removing it restores the in-session loop with no state migration.
+- The orchestrator is harder to watch live than one session, but yields one clean transcript per sub-goal (better post-hoc forensics).
+- Evidence preserved throughout: handoffs and distilled returns point at full artifacts rather than discarding them.

--- a/docs/decisions/0027-context-hygiene.md
+++ b/docs/decisions/0027-context-hygiene.md
@@ -30,6 +30,8 @@ This ADR's v1 proposed an advisory "safe to /clear" signal that a human performs
 
 5. **Additive.** No change to the three-store state model, the execute control flow, or any gate. The interactive `/goal` loop still works for hands-on runs; the orchestrator is an additional outer driver.
 
+6. **Carve-out from ADR-0022's goal-ordering-chain fence.** ADR-0022 keeps goal-ordering chains (B waits for A to merge) at L5, and the README says the kit stops short of a DAG scheduler / coordinating daemon / cross-machine orchestration. This orchestrator runs sub-goals in order and advances on a checkbox flip, which is a *linear* ordering chain, so the boundary must be argued, not assumed. It is in scope because it is narrowly bounded: ONE mega-goal, ONE machine, a one-shot script (not a daemon), strictly LINEAR (not a DAG, no parallel fan-out), and it HALTS at the first gate (it never auto-crosses a shared-repo merge). What stays fenced at L5 / out of scope is unchanged: cross-repo or cross-machine coordination, 3+ concurrent operators, parallel DAG fan-out, and any always-on supervising daemon. The orchestrator is the linear-single-mega-goal slice of that space, deliberately the smallest thing that removes the marathon.
+
 ## Alternatives considered
 
 - **Operator checkpoint signal (this ADR's v1).** Rejected: needs a human to perform the clear; defeats the automation premise.

--- a/docs/decisions/0027-context-hygiene.md
+++ b/docs/decisions/0027-context-hygiene.md
@@ -1,0 +1,44 @@
+# 0027. Inter-sub-goal context hygiene: distilled returns + operator checkpoint, never self-/clear
+
+Date: 2026-06-29
+Status: Proposed
+Relates-to: SPEC-087 (the design this records), ops-toolkit token-hygiene mega-goal (the driver), ops-toolkit `research/2026-06-28-token-spend-forensic.md` (the evidence), WORKFLOW.md `## State model` + the execute loop (the accumulation surface), ADR-0022 (multi-session boundary, the prior art on session limits)
+
+## Decision (one line)
+
+The kit reduces a mega-goal run's marathon-context growth two ways, both additive: (1) dispatched subagents return a distilled summary the lead absorbs instead of full output, and (2) the loop emits an operator checkpoint signal at each sub-goal boundary so the operator can `/clear` and resume from POINTER_PROMPT. The kit never self-`/clear`s.
+
+## Context
+
+A mega-goal run is one un-cleared session whose context grows across 6-10h, and the cost of an LLM turn scales with the context re-read each turn (`cache_read`, ~58.5% of measured spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). Two kit behaviors feed that growth:
+
+1. **Full subagent returns.** `/kit:execute` fans out 5-9 subagents per sub-goal and the lead absorbs each one's full output. The state flow distils nothing between phases (`WORKFLOW.md:651-652`), and the execute loop re-enters the lead after every increment (`WORKFLOW.md:707-712`), so each 16-25K-token return is permanent context for the rest of the run.
+
+2. **No safe-seam signal.** The loop never marks a point where `/clear` is lossless, so the marathon never breaks into clear-able units.
+
+The obvious fix for (2), a `/clear` inside the loop, is unavailable: clearing the session that drives the loop kills the loop. Whatever the kit does about (2) must keep the loop alive, which means the actual clear is the operator's (or an outer harness's), not the kit's.
+
+## Decision
+
+1. **Return contract (Mechanism 1).** Every kit-dispatched subagent role (worker, task-verifier, integration-checker, reviewer / review-team, research-*) gains a return contract: its final message, the thing the lead absorbs, is a bounded structured summary (`verdict`, `key findings`, `artifacts`, `read-next`), not the full diff / log / transcript. The full output remains recoverable in the subagent's own transcript; the lead pulls detail only when a finding demands it.
+
+2. **Operator checkpoint signal (Mechanism 2).** At a sub-goal boundary (merged-or-held + ROADMAP updated) the loop prints an advisory checkpoint: "safe to `/clear`, resume from POINTER_PROMPT", gated on a POINTER_PROMPT-freshness check so the advised clear is always lossless. The operator or an outer harness performs the clear.
+
+3. **Never self-`/clear`.** The kit emits the signal but never executes the clear; doing so would destroy its own driving context. This is the hard boundary that shapes the whole design.
+
+4. **Strictly additive.** Both mechanisms are convention + prompt + advisory-output changes. No change to the three-store state model, the execute control flow, or any gate. The implementation (token-hygiene SG-04) realizes this; this ADR + SPEC-087 are design only.
+
+## Alternatives considered
+
+- **Self-`/clear` inside the loop.** Rejected: kills the loop's own context. This is the constraint, not an option.
+- **Route full subagent output to a side file the lead re-reads on demand.** Rejected (SPEC-087 DEC-001): re-reading is still absorption; distilling at the source is the cheaper token.
+- **Rely on the operator runbook (token-hygiene SG-02) alone.** Rejected: the runbook is the manual practice; the structural win needs the kit to shrink returns by default, not by operator vigilance.
+- **A hard token budget that aborts the loop.** Rejected: blunt; the goal is lower cost per equivalent run, not a truncated run.
+
+## Consequences
+
+- The lead grows by hundreds of tokens per subagent instead of tens of thousands; each sub-goal becomes a clear-able unit, so `/clear` + resume between sub-goals removes the dominant `cache_read` growth.
+- Evidence is preserved: distillation points at the full transcript rather than discarding it.
+- Reversible: the change is docs + prompts + one advisory output; reverting the SG-04 diff restores prior behavior with no state migration.
+- Success is measurable: a before / after `token-forensic --loops` comparison of an equivalent run (lower `cache_read`/turn and lower total) is the mega-goal's acceptance metric (SPEC-087 AC5).
+- Slightly more prose in each dispatched-role definition (the return contract); mitigated by a shared contract shape reused across roles.

--- a/docs/implementation-notes/context-hygiene.md
+++ b/docs/implementation-notes/context-hygiene.md
@@ -1,0 +1,24 @@
+# Implementation notes: SPEC-087 inter-sub-goal context hygiene (design)
+
+Delta-only notes for the design sub-goal (token-hygiene SG-03). The design itself is in
+SPEC-087 + ADR-0027; this records off-spec authoring decisions.
+
+## 2026-06-29 Numbering: skipped SPEC-086 to avoid an in-flight collision
+- Context: master's highest SPEC is SPEC-085; next free is 086. But the active
+  `feat/proof-visual-evidence` branch already claims `SPEC-086-stop-hook-scan-cost.md`
+  (uncommitted on that branch).
+- Decision: used **SPEC-087** so this design does not collide when that branch merges.
+  ADR-0027 has no such conflict (master highest is 0026, the feature branch adds no ADR).
+- Impact: a one-number gap on master until 086 lands; harmless.
+
+## 2026-06-29 Isolated worktree created off origin/master by hand
+- Context: the native EnterWorktree tool operates on the session's current repo (ops-toolkit);
+  it cannot create a worktree in a second repo. The kit checkout had 9 uncommitted files on
+  `feat/proof-visual-evidence` that must not be disturbed.
+- Decision: created `.claude/worktrees/context-hygiene` off `origin/master` via `git worktree
+  add` at the sanctioned path. Reversible; cleaned up after the gate PR is opened.
+
+## 2026-06-29 Lane = normal; design-only, no kit code
+- Decision: SPEC declares `Lane: normal`. The diff is markdown-only (SPEC + ADR), which the
+  proof-gate classifies inert, so no proof-of-done is owed. Gate-ledger recorded for the
+  normal lane so the kit ship-gate does not block the push.

--- a/docs/implementation-notes/context-hygiene.md
+++ b/docs/implementation-notes/context-hygiene.md
@@ -38,3 +38,13 @@ SPEC-087 + ADR-0027; this records off-spec authoring decisions.
 - Decision: SPEC declares `Lane: normal`. The diff is markdown-only (SPEC + ADR), which the
   proof-gate classifies inert, so no proof-of-done is owed. Gate-ledger recorded for the
   normal lane so the kit ship-gate does not block the push.
+
+## 2026-06-29 v3: review fixes (PR #80 review)
+- Resolved OQ-001 (a HIGH review gap that would block SG-04's first run): default session
+  posture `--dangerously-skip-permissions` (Han's call), overridable via `CLAUDE_FLAGS` or an
+  agentkernel sandbox via `CLAUDE_CMD`. Added a "Session invocation" section.
+- Specified prompt structure (POINTER + goal-file CONTENT + HANDOFF), closing the path-vs-content
+  ambiguity; AC4 updated.
+- Added an ADR-0027 carve-out vs ADR-0022's goal-ordering-chain fence (linear / single-mega-goal
+  / single-machine / halt-at-gate scope).
+- Noted (not built) the clean-working-tree guard as a future failure-mode check.

--- a/docs/implementation-notes/context-hygiene.md
+++ b/docs/implementation-notes/context-hygiene.md
@@ -3,6 +3,22 @@
 Delta-only notes for the design sub-goal (token-hygiene SG-03). The design itself is in
 SPEC-087 + ADR-0027; this records off-spec authoring decisions.
 
+## 2026-06-29 v2: design re-centered on a non-LLM orchestrator (operator review)
+
+- Context: Han reviewed the v1 design (distilled returns + operator checkpoint signal) and
+  rejected the operator-signal half: a human-performed `/clear` defeats the kit's unattended
+  automation premise.
+- Change: SPEC-087 + ADR-0027 rewritten to make a **non-LLM orchestrator** (Mechanism A) the
+  primary fix, with a **feed-forward grounded handoff** (Mechanism B) replacing the operator
+  signal, and distilled returns demoted to phase-2 Mechanism C. The load-bearing call
+  (DEC-004): the loop driver must be dumb code, not an LLM session, or it re-accumulates and
+  becomes the new marathon.
+- Impl choice: phase-1 implementation is bash `lib/orchestrate.sh` driving `claude -p`
+  (matches the existing lib/ drivers; Agent SDK is the upgrade path). The `claude` binary is
+  injected via `CLAUDE_CMD` so the test mocks it and the operator tunes the permission flags.
+- PR split: the spec/ADR revision rides the SG-03 design PR (#80); the orchestrator code is a
+  stacked SG-04 PR off this branch.
+
 ## 2026-06-29 Numbering: skipped SPEC-086 to avoid an in-flight collision
 - Context: master's highest SPEC is SPEC-085; next free is 086. But the active
   `feat/proof-visual-evidence` branch already claims `SPEC-086-stop-hook-scan-cost.md`

--- a/docs/implementation-notes/orchestrate.md
+++ b/docs/implementation-notes/orchestrate.md
@@ -29,3 +29,12 @@ Delta-only. Design is in SPEC-087 + ADR-0027; this records impl decisions not in
 - README line ~151 says the kit stops short of a DAG scheduler / daemon / cross-machine
   orchestration. The orchestrator is a LINEAR, single-machine, session-per-sub-goal mega-goal
   driver, not any of those; the README row says so explicitly to avoid the apparent tension.
+
+## 2026-06-29 Review fixes (PR #81 review, 7/10)
+- Policy parser: exact comma-field match in awk (was a regex that false-matched "(gate review)");
+  unknown policy fail-safes to `gate` not `auto`.
+- pipefail `|| true` on the `_subgoals` grep|while (no-match no longer escapes `set -o pipefail`).
+- Permission posture (OQ-001): `CLAUDE_FLAGS` (default `--dangerously-skip-permissions`) word-split
+  into `claude -p`; mocks read prompt as LAST arg. Two tests (default + override).
+- `_build_prompt` injects the goal-file CONTENT (glob, shellcheck-clean), matching AC4; one test.
+- Cosmetic: `pid` -> `sg`.

--- a/docs/implementation-notes/orchestrate.md
+++ b/docs/implementation-notes/orchestrate.md
@@ -1,0 +1,31 @@
+# Implementation notes: lib/orchestrate.sh (SPEC-087 phase 1, SG-04)
+
+Delta-only. Design is in SPEC-087 + ADR-0027; this records impl decisions not in the spec.
+
+## 2026-06-29 Scope: phase 1 = orchestrator + handoff (Mechanism A + B); C deferred
+- The spec's Mechanism C (distilled subagent-return contract in `agents/*.md`) is phase 2,
+  not in this PR. This PR ships the structural fix (the non-LLM driver + feed-forward handoff)
+  + its test, keeping the diff focused/reviewable. The before/after `token-forensic --loops`
+  measurement (SPEC-087 phase-2 metric) lands with C.
+
+## 2026-06-29 `CLAUDE_CMD` injection for mockability
+- The real session spawn is `$CLAUDE_CMD -p "<prompt>"` (default `claude`). The test injects a
+  mock so the suite never spawns a real (expensive) session. The real `claude -p` permission
+  flags are SPEC-087 OQ-001, left to the operator (not hardcoded), so the kit does not bake in
+  a permission posture.
+
+## 2026-06-29 Grounded completion via ROADMAP box-flip
+- The orchestrator advances only when the just-run sub-goal's ROADMAP checkbox is `[x]`. This
+  is the anti-self-claim guard (mirrors the kit's "done means the check ran, not asserted"
+  doctrine): a session that no-ops cannot make the loop march. The negative-control test pins it.
+
+## 2026-06-29 ROADMAP parsing
+- Sub-goal lines matched as `^- \[[ xX]\] SG-[0-9]+`; policy extracted as the first
+  `auto|gate` after a `,` or `(`. Tolerant of the trailing `, PR #N (merged)` / `depends ...`
+  noise in real ROADMAP lines (verified against the live token-hygiene ROADMAP). `--dry-run`
+  prints the full planned sequence up to and including the first gate, without executing.
+
+## 2026-06-29 README lib-index row, framed against the "no DAG scheduler" stance
+- README line ~151 says the kit stops short of a DAG scheduler / daemon / cross-machine
+  orchestration. The orchestrator is a LINEAR, single-machine, session-per-sub-goal mega-goal
+  driver, not any of those; the README row says so explicitly to avoid the apparent tension.

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -59,7 +59,9 @@ orchestrator (bash/SDK, NOT an LLM context)
 - **Completion is grounded, not self-claimed**: after a session returns, the orchestrator
   re-reads the ROADMAP; it advances only if the sub-goal's checkbox flipped to `[x]`. A
   session that returns without checking its box is a failure, and the orchestrator stops
-  rather than spinning.
+  rather than spinning. (Future guard, noted not yet built: also assert the working tree is
+  clean before advancing, so a session that died mid-edit halts the loop rather than handing a
+  dirty baseline to the next sub-goal.)
 
 ### Mechanism B: feed-forward handoff (kills the re-discovery tax)
 
@@ -78,6 +80,26 @@ HANDOFF.md (written by the sub-goal that just finished)
 Distinct from `POINTER_PROMPT.md`, which is static (it points at the ROADMAP). The handoff is
 dynamic, per-transition, and must be **grounded** (cite real files / PRs), so it cannot become
 an optimistic lie about the next step; the receiving session verifies before trusting.
+
+### Session invocation (the per-sub-goal `claude -p` call)
+
+Resolves the former OQ-001. Two things were under-specified: what goes into each session's
+prompt, and what permission posture it runs with.
+
+**Prompt structure.** For each sub-goal the orchestrator feeds, in order, the *content* (not
+just paths) of: (1) `POINTER_PROMPT.md`, (2) the sub-goal's goal file `goals/NN-*.md`, (3) the
+previous `HANDOFF.md` if present. Injecting the goal-file content (not a path hint) is what
+actually eliminates re-discovery, and is why a fresh run with no handoff still works (the goal
+file carries the contract). The HANDOFF's `goal file: goals/NN-*.md` line is a human pointer;
+the orchestrator injects the file's body.
+
+**Permission posture.** Default: `--dangerously-skip-permissions` (Han, 2026-06-29). An
+unattended sub-goal session must edit, commit, push, and open a PR, so it needs full tool
+access; a prompt-per-action permission wall would stall the loop. This is a deliberate
+blast-radius choice for the auto chain, mitigated by the gate-stop (shared-repo merges stay
+human) and by each sub-goal being a disposable session. The posture is **overridable** via the
+`CLAUDE_FLAGS` env var (e.g. a tight `--allowedTools` allowlist) or by running the session
+inside an agentkernel sandbox via `CLAUDE_CMD`; these are options, not the default.
 
 ### Mechanism C: distilled subagent returns (within-sub-goal; phase 2)
 
@@ -104,10 +126,13 @@ Phase 1 (SG-04, this cycle):
   the stop point) without invoking `claude`, so the control flow is testable and cheap.
 - AC3: The orchestrator stops at the first `gate` sub-goal and prints the held PR; it advances
   past an `auto` sub-goal only when the ROADMAP checkbox flipped to `[x]`.
-- AC4: The previous sub-goal's `HANDOFF.md` is injected into the next session's prompt; a
-  fresh run with no handoff still works.
+- AC4: The previous sub-goal's `HANDOFF.md` AND the goal-file content are injected into the
+  next session's prompt; a fresh run with no handoff still works (the goal file carries the
+  contract).
 - AC5: A `tests/test-orchestrate.sh` exercises the above with a mock `claude` (via `CLAUDE_CMD`),
-  including a negative control (a session that does not check its box halts the loop).
+  including a negative control (a session that does not check its box halts the loop) and a
+  check that the default permission posture (`--dangerously-skip-permissions` via `CLAUDE_FLAGS`)
+  is passed and is overridable.
 
 Phase 2 (follow-up): the distilled-return contract (Mechanism C) in the agent defs, measured by
 a before / after `token-forensic --loops` comparison of an equivalent run (lower `cache_read`/turn
@@ -146,6 +171,6 @@ bash lib/orchestrate.sh run <megagoal-dir> --dry-run   # ordered plan, no claude
 
 ## Open questions
 
-- OQ-001: `claude -p` permission mode + flag set for an unattended sub-goal session (resolved
-  at impl; kept configurable via `CLAUDE_CMD` so the test mocks it and the operator tunes it).
+- OQ-001: RESOLVED , see "Session invocation": default `--dangerously-skip-permissions`,
+  overridable via `CLAUDE_FLAGS`; prompt = POINTER + goal-file content + HANDOFF.
 - OQ-002: Exact distilled-return field set + length bound per role (phase 2).

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -1,125 +1,151 @@
-# SPEC-087: Inter-sub-goal context hygiene (distilled returns + checkpoint signal)
+# SPEC-087: Inter-sub-goal context hygiene (orchestrator + feed-forward handoff + distilled returns)
 
 Status: DRAFT
 Date: 2026-06-29
 Lane: normal (classified: normal)
-Type: design (design-only; implementation is a follow-up, token-hygiene SG-04)
-Board: token-hygiene mega-goal SG-03 (ops-toolkit `_meta/megagoals/token-hygiene/`); kit intake ID operator-assigned
+Type: design + impl (orchestrator built in token-hygiene SG-04; distilled-returns is phase 2)
+Board: token-hygiene mega-goal SG-03/SG-04 (ops-toolkit `_meta/megagoals/token-hygiene/`); kit intake ID operator-assigned
 
 ## Problem
 
 A mega-goal run under the kit is one un-cleared session whose context grows monotonically
-across 6-10h. Two structural drivers:
+across 6-10h. Cost is dominated by `cache_read`: the whole accumulated context is re-read
+every turn (~58.5% of spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). Three
+drivers:
 
-1. **Full subagent returns.** `/kit:execute` dispatches 5-9 subagents per sub-goal (workers,
-   task-verifiers, reviewers) and the lead absorbs each one's FULL output. The kit's own
-   state flow shows three stores with nothing distilled between phases
-   (`WORKFLOW.md:651-652`); the execute loop re-enters the lead after every increment
-   (`WORKFLOW.md:707-712`). A 16-25K-token return per subagent, multiplied across a sub-goal,
-   lands permanently in the lead context.
+1. **One marathon session.** The `/goal` loop runs every sub-goal in a single session whose
+   context only grows. The kit cannot fix this by self-`/clear`ing: a `/clear` inside the loop
+   kills the loop's own driving context.
 
-2. **No clear-able boundary.** The loop never signals a safe seam to `/clear`. Cost is
-   dominated by `cache_read`: the whole accumulated context is re-read every turn (~58.5% of
-   spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). The longer the
-   un-cleared marathon, the more each turn costs.
+2. **Full subagent returns.** Inside a sub-goal, `/kit:execute` dispatches 5-9 subagents
+   (workers, task-verifiers, reviewers) and the lead absorbs each one's FULL output. The state
+   flow distils nothing between phases (`WORKFLOW.md:651-652`); the execute loop re-enters the
+   lead after every increment (`WORKFLOW.md:707-712`). A 16-25K-token return per subagent,
+   multiplied across a sub-goal, lands permanently in the lead.
 
-The kit cannot fix (2) by self-clearing: a `/clear` inside the loop kills the loop's own
-driving context. So the design centers on (a) shrinking what the lead absorbs per subagent
-and (b) emitting an operator signal at each safe seam, leaving the actual `/clear` to the
-operator or an outer harness.
+3. **Re-discovery tax.** Reading a real run's log, each step spends many turns re-finding
+   context (which files, which interface) that an earlier step already knew, because nothing
+   is handed forward (operator observation, 2026-06-29).
+
+This SPEC supersedes its own v1 ("operator checkpoint signal"): an advisory "safe to /clear"
+that a human performs defeats the kit's automation premise (the kit exists to run without a
+human in the middle). The fix is to move the loop OUT of the LLM session.
 
 ## Design
 
-### Mechanism 1: distilled subagent returns (return contract)
+### Mechanism A: outer orchestrator (the structural fix)
 
-Subagent definitions and the dispatch convention gain a **return contract**: a subagent's
-final message (the value the lead absorbs) is a bounded, structured summary, not the full
-diff / log / transcript.
-
-- Structured fields: `verdict` (pass / fail / inconclusive), `key findings` (a few bullets),
-  `artifacts` (paths or refs where the full detail lives), `read-next` (the one slice the
-  lead should pull IF a finding needs more).
-- The full output is not lost: it stays in the subagent's own transcript
-  (`agent-<id>.jsonl` / the task output file), recoverable on demand. The lead absorbs the
-  summary and pulls detail only when a finding requires it.
-- Applies to the kit's dispatched roles: worker (execute), task-verifier,
-  integration-checker, reviewer / review-team, research-* (spec). Each role's agent
-  definition states its return-contract shape.
-
-Effect: the lead grows by a few hundred tokens per subagent instead of 16-25K.
-
-### Mechanism 2: post-sub-goal checkpoint signal
-
-At a sub-goal completion boundary (sub-goal merged-or-held AND its ROADMAP line updated), the
-loop emits an explicit operator signal:
+A **non-LLM** driver owns the loop; the LLM work happens only in disposable per-sub-goal
+sessions.
 
 ```
-Sub-goal NN complete (PR #N). Context checkpoint.
-  Safe to /clear now; resume by pasting POINTER_PROMPT.md into a fresh /goal.
-  POINTER_PROMPT freshness: <verified current | STALE: update before clearing>.
+orchestrator (bash/SDK, NOT an LLM context)
+   ├─ claude -p (fresh session, empty context) -> SG-01 -> ship PR -> write HANDOFF -> exit
+   ├─ claude -p (fresh session, empty context) -> SG-02 -> ship PR -> write HANDOFF -> exit
+   └─ ... stop at the first `gate` sub-goal (shared-repo review needs a human)
 ```
 
-- The signal is advisory: the kit prints it; the operator or an outer harness performs the
-  `/clear` + resume. The kit never self-clears.
-- Precondition guard: before advising `/clear`, the loop checks that POINTER_PROMPT.md +
-  ROADMAP.md encode enough to re-bootstrap losslessly (the resume contract). If
-  POINTER_PROMPT is stale, the signal says STALE and the loop refreshes it (or asks the
-  operator) instead of advising a lossy clear.
-- This makes each sub-goal a clear-able unit: `/clear` + POINTER_PROMPT resume between
-  sub-goals kills the monotonic growth (the #1 cost driver) without losing the thread.
+- Each `claude -p` invocation is a new session, so the `/clear` happens for free; no session
+  ever holds more than one sub-goal's context. The monotonic growth (driver 1) is removed
+  structurally, with no human and no kit self-clear.
+- **The driver must be non-LLM** (DEC-004). If the orchestrator were itself a persistent
+  Claude session spawning a subagent per sub-goal, that session would re-accumulate every
+  return and become the new marathon. A subagent reports back into a parent LLM context; only
+  a dumb driver avoids re-accumulation.
+- **Gate sub-goals stop the orchestrator** (DEC-005). A shared-repo (`gate`) sub-goal needs
+  team review before its dependents proceed; the orchestrator runs the `auto` chain
+  back-to-back and halts at the first `gate`, printing the held PR. "No human in the middle"
+  holds for the auto chain, not for shared-repo merges (which are intentionally human).
+- **Completion is grounded, not self-claimed**: after a session returns, the orchestrator
+  re-reads the ROADMAP; it advances only if the sub-goal's checkbox flipped to `[x]`. A
+  session that returns without checking its box is a failure, and the orchestrator stops
+  rather than spinning.
 
-### Where it lives (impl pointers for SG-04, not built here)
+### Mechanism B: feed-forward handoff (kills the re-discovery tax)
 
-- Return contract: the dispatched-role agent definitions (`agents/*.md`: worker,
-  task-verifier, integration-checker, reviewer) plus the dispatch prose in `/kit:execute` and
-  `WORKFLOW.md`.
-- Checkpoint signal: the sub-goal-boundary step of the mega-goal loop (`plan-for-mega-goal` /
-  the `/goal` loop's sub-goal-complete path) plus a POINTER_PROMPT freshness check.
+Each sub-goal session, on completion, writes a `HANDOFF.md` for the next one; the orchestrator
+injects the previous HANDOFF into the next session's prompt. This turns driver 3's
+re-discovery into a read.
 
-## Acceptance criteria (for the SG-04 implementation)
+```
+HANDOFF.md (written by the sub-goal that just finished)
+- Next sub-goal: SG-NN  (goal file: goals/NN-*.md)
+- Files / symbols it will touch: <paths, the ones already located>
+- Constraints already fixed: <e.g. SG-01 named the field `parent`; reuse it>
+- Open risks / gotchas: <...>
+```
 
-- AC1: Each kit-dispatched subagent role's definition carries a return-contract section
-  bounding its final message to a structured summary + artifact pointers, not full output.
-- AC2: `/kit:execute` and the dispatch prose instruct the lead to absorb the summary and pull
-  detail on demand only.
-- AC3: A sub-goal-boundary checkpoint signal is emitted (advisory, operator-performed
-  `/clear`), gated on a POINTER_PROMPT freshness check.
-- AC4: The kit never self-`/clear`s; verified by inspection (no `/clear` emitted as an
-  executed command in the loop).
-- AC5: A before / after `token-forensic --loops` comparison of an equivalent mega-goal run
-  shows lower `cache_read`/turn and lower total (the mega-goal's success metric).
+Distinct from `POINTER_PROMPT.md`, which is static (it points at the ROADMAP). The handoff is
+dynamic, per-transition, and must be **grounded** (cite real files / PRs), so it cannot become
+an optimistic lie about the next step; the receiving session verifies before trusting.
+
+### Mechanism C: distilled subagent returns (within-sub-goal; phase 2)
+
+Bounds growth INSIDE one sub-goal. Each kit-dispatched role returns a bounded structured
+summary (`verdict`, `key findings`, `artifacts`, `read-next`), not the full diff / log; the
+full output stays recoverable in the subagent transcript. The lead absorbs the summary and
+pulls detail on demand. Applies to worker, task-verifier, integration-checker, reviewer /
+review-team, research-*. This is additive to A+B and is built as a follow-up increment.
+
+### Where it lives
+
+- Orchestrator (A) + handoff (B): a new `lib/orchestrate.sh` (bash, matching the other lib
+  drivers) plus the handoff convention documented in `WORKFLOW.md` / `plan-for-mega-goal`.
+- Distilled returns (C): the dispatched-role agent definitions (`agents/*.md`) + the dispatch
+  prose in `/kit:execute`.
+
+## Acceptance criteria
+
+Phase 1 (SG-04, this cycle):
+- AC1: `lib/orchestrate.sh` parses a mega-goal ROADMAP, finds the next unchecked sub-goal +
+  its policy, and (real mode) runs it via a fresh `claude -p` session; the loop driver holds
+  no LLM context.
+- AC2: `--dry-run` prints the ordered plan (each sub-goal, its policy, the injected handoff,
+  the stop point) without invoking `claude`, so the control flow is testable and cheap.
+- AC3: The orchestrator stops at the first `gate` sub-goal and prints the held PR; it advances
+  past an `auto` sub-goal only when the ROADMAP checkbox flipped to `[x]`.
+- AC4: The previous sub-goal's `HANDOFF.md` is injected into the next session's prompt; a
+  fresh run with no handoff still works.
+- AC5: A `tests/test-orchestrate.sh` exercises the above with a mock `claude` (via `CLAUDE_CMD`),
+  including a negative control (a session that does not check its box halts the loop).
+
+Phase 2 (follow-up): the distilled-return contract (Mechanism C) in the agent defs, measured by
+a before / after `token-forensic --loops` comparison of an equivalent run (lower `cache_read`/turn
+and lower total, the mega-goal success metric).
 
 ## Verification
 
 ```
 # in the dwarves-kit checkout
-ls docs/specs/ | grep -i context-hygiene      # SPEC present
-ls docs/decisions/ | grep -i context-hygiene  # ADR present
+bash tests/test-orchestrate.sh            # phase-1 control flow + negative control
+bash lib/orchestrate.sh run <megagoal-dir> --dry-run   # ordered plan, no claude spawned
 ```
-
-Design-only; the behavioral verification (AC5) is owned by the SG-04 implementation PR.
 
 ## Out of scope
 
-- The implementation itself (token-hygiene SG-04).
-- Self-clearing inside the loop (rejected: kills the loop's own context; see ADR-0027).
-- Changing the three-store state model or the execute loop's control flow. This is additive
-  (what the lead absorbs + an advisory signal), not a re-architecture.
+- Replacing the interactive `/goal` loop; the orchestrator is an additive outer driver, the
+  in-session loop still works for hands-on runs.
+- A full Agent-SDK orchestrator (TypeScript/Python). Bash `claude -p` is phase 1; the SDK is
+  the upgrade path when structured handoffs / retries / inline distilled returns are wanted.
+- Self-clearing inside a session (rejected; kills the loop's own context).
 
 ## Decision log
 
-- DEC-001: Distill returns rather than route subagent output to a side file the lead must
-  re-read. Rationale: the cheapest token is the one never absorbed; a structured summary is
-  the absorption.
-- DEC-002: Checkpoint is an operator signal, not a self-`/clear`. Rationale: the kit cannot
-  clear its own driving context without killing the loop. The operator or outer harness owns
-  the clear; the kit owns the safe-seam signal + resume contract.
-- DEC-003: Full output stays recoverable in the subagent transcript, not discarded.
-  Rationale: honesty + debuggability; distillation must not destroy evidence.
+- DEC-001: Distill returns rather than route subagent output to a side file the lead re-reads.
+  The cheapest token is the one never absorbed.
+- DEC-002 (superseded by DEC-004): v1 made the checkpoint an operator signal. Replaced: a
+  human-performed clear defeats the automation premise.
+- DEC-003: Full subagent output stays recoverable in the transcript, not discarded.
+- DEC-004: The loop driver MUST be non-LLM. An LLM orchestrator spawning a subagent per
+  sub-goal re-accumulates every return and becomes the new marathon; only a dumb driver
+  running disposable fresh sessions removes the growth.
+- DEC-005: Gate sub-goals halt the orchestrator. The auto chain runs unattended; shared-repo
+  merges are an intentional human gate, not a flaw.
+- DEC-006: The handoff is feed-forward and grounded, distinct from the static POINTER_PROMPT;
+  it must cite real artifacts and the receiver verifies before trusting.
 
 ## Open questions
 
-- OQ-001: Does the checkpoint signal belong in `plan-for-mega-goal`, the built-in `/goal`
-  loop, or a kit hook? Resolved at SG-04 impl by where the sub-goal boundary is observable.
-- OQ-002: Exact return-contract field set + length bound per role. Tuned at impl; AC1 fixes
-  the shape, not the numbers.
+- OQ-001: `claude -p` permission mode + flag set for an unattended sub-goal session (resolved
+  at impl; kept configurable via `CLAUDE_CMD` so the test mocks it and the operator tunes it).
+- OQ-002: Exact distilled-return field set + length bound per role (phase 2).

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -1,0 +1,125 @@
+# SPEC-087: Inter-sub-goal context hygiene (distilled returns + checkpoint signal)
+
+Status: DRAFT
+Date: 2026-06-29
+Lane: normal (classified: normal)
+Type: design (design-only; implementation is a follow-up, token-hygiene SG-04)
+Board: token-hygiene mega-goal SG-03 (ops-toolkit `_meta/megagoals/token-hygiene/`); kit intake ID operator-assigned
+
+## Problem
+
+A mega-goal run under the kit is one un-cleared session whose context grows monotonically
+across 6-10h. Two structural drivers:
+
+1. **Full subagent returns.** `/kit:execute` dispatches 5-9 subagents per sub-goal (workers,
+   task-verifiers, reviewers) and the lead absorbs each one's FULL output. The kit's own
+   state flow shows three stores with nothing distilled between phases
+   (`WORKFLOW.md:651-652`); the execute loop re-enters the lead after every increment
+   (`WORKFLOW.md:707-712`). A 16-25K-token return per subagent, multiplied across a sub-goal,
+   lands permanently in the lead context.
+
+2. **No clear-able boundary.** The loop never signals a safe seam to `/clear`. Cost is
+   dominated by `cache_read`: the whole accumulated context is re-read every turn (~58.5% of
+   spend; ops-toolkit `research/2026-06-28-token-spend-forensic.md`). The longer the
+   un-cleared marathon, the more each turn costs.
+
+The kit cannot fix (2) by self-clearing: a `/clear` inside the loop kills the loop's own
+driving context. So the design centers on (a) shrinking what the lead absorbs per subagent
+and (b) emitting an operator signal at each safe seam, leaving the actual `/clear` to the
+operator or an outer harness.
+
+## Design
+
+### Mechanism 1: distilled subagent returns (return contract)
+
+Subagent definitions and the dispatch convention gain a **return contract**: a subagent's
+final message (the value the lead absorbs) is a bounded, structured summary, not the full
+diff / log / transcript.
+
+- Structured fields: `verdict` (pass / fail / inconclusive), `key findings` (a few bullets),
+  `artifacts` (paths or refs where the full detail lives), `read-next` (the one slice the
+  lead should pull IF a finding needs more).
+- The full output is not lost: it stays in the subagent's own transcript
+  (`agent-<id>.jsonl` / the task output file), recoverable on demand. The lead absorbs the
+  summary and pulls detail only when a finding requires it.
+- Applies to the kit's dispatched roles: worker (execute), task-verifier,
+  integration-checker, reviewer / review-team, research-* (spec). Each role's agent
+  definition states its return-contract shape.
+
+Effect: the lead grows by a few hundred tokens per subagent instead of 16-25K.
+
+### Mechanism 2: post-sub-goal checkpoint signal
+
+At a sub-goal completion boundary (sub-goal merged-or-held AND its ROADMAP line updated), the
+loop emits an explicit operator signal:
+
+```
+Sub-goal NN complete (PR #N). Context checkpoint.
+  Safe to /clear now; resume by pasting POINTER_PROMPT.md into a fresh /goal.
+  POINTER_PROMPT freshness: <verified current | STALE: update before clearing>.
+```
+
+- The signal is advisory: the kit prints it; the operator or an outer harness performs the
+  `/clear` + resume. The kit never self-clears.
+- Precondition guard: before advising `/clear`, the loop checks that POINTER_PROMPT.md +
+  ROADMAP.md encode enough to re-bootstrap losslessly (the resume contract). If
+  POINTER_PROMPT is stale, the signal says STALE and the loop refreshes it (or asks the
+  operator) instead of advising a lossy clear.
+- This makes each sub-goal a clear-able unit: `/clear` + POINTER_PROMPT resume between
+  sub-goals kills the monotonic growth (the #1 cost driver) without losing the thread.
+
+### Where it lives (impl pointers for SG-04, not built here)
+
+- Return contract: the dispatched-role agent definitions (`agents/*.md`: worker,
+  task-verifier, integration-checker, reviewer) plus the dispatch prose in `/kit:execute` and
+  `WORKFLOW.md`.
+- Checkpoint signal: the sub-goal-boundary step of the mega-goal loop (`plan-for-mega-goal` /
+  the `/goal` loop's sub-goal-complete path) plus a POINTER_PROMPT freshness check.
+
+## Acceptance criteria (for the SG-04 implementation)
+
+- AC1: Each kit-dispatched subagent role's definition carries a return-contract section
+  bounding its final message to a structured summary + artifact pointers, not full output.
+- AC2: `/kit:execute` and the dispatch prose instruct the lead to absorb the summary and pull
+  detail on demand only.
+- AC3: A sub-goal-boundary checkpoint signal is emitted (advisory, operator-performed
+  `/clear`), gated on a POINTER_PROMPT freshness check.
+- AC4: The kit never self-`/clear`s; verified by inspection (no `/clear` emitted as an
+  executed command in the loop).
+- AC5: A before / after `token-forensic --loops` comparison of an equivalent mega-goal run
+  shows lower `cache_read`/turn and lower total (the mega-goal's success metric).
+
+## Verification
+
+```
+# in the dwarves-kit checkout
+ls docs/specs/ | grep -i context-hygiene      # SPEC present
+ls docs/decisions/ | grep -i context-hygiene  # ADR present
+```
+
+Design-only; the behavioral verification (AC5) is owned by the SG-04 implementation PR.
+
+## Out of scope
+
+- The implementation itself (token-hygiene SG-04).
+- Self-clearing inside the loop (rejected: kills the loop's own context; see ADR-0027).
+- Changing the three-store state model or the execute loop's control flow. This is additive
+  (what the lead absorbs + an advisory signal), not a re-architecture.
+
+## Decision log
+
+- DEC-001: Distill returns rather than route subagent output to a side file the lead must
+  re-read. Rationale: the cheapest token is the one never absorbed; a structured summary is
+  the absorption.
+- DEC-002: Checkpoint is an operator signal, not a self-`/clear`. Rationale: the kit cannot
+  clear its own driving context without killing the loop. The operator or outer harness owns
+  the clear; the kit owns the safe-seam signal + resume contract.
+- DEC-003: Full output stays recoverable in the subagent transcript, not discarded.
+  Rationale: honesty + debuggability; distillation must not destroy evidence.
+
+## Open questions
+
+- OQ-001: Does the checkpoint signal belong in `plan-for-mega-goal`, the built-in `/goal`
+  loop, or a kit hook? Resolved at SG-04 impl by where the sub-goal boundary is observable.
+- OQ-002: Exact return-contract field set + length bound per role. Tuned at impl; AC1 fixes
+  the shape, not the numbers.

--- a/docs/verification/orchestrate.md
+++ b/docs/verification/orchestrate.md
@@ -1,0 +1,68 @@
+# Proof of done: lib/orchestrate.sh (SPEC-087 phase 1)
+
+## Acceptance criteria (SPEC-087 phase 1)
+
+| # | Criterion | Met |
+|---|---|---|
+| AC1 | Parses a mega-goal ROADMAP, finds next unchecked sub-goal + policy; real mode runs it via a fresh `claude -p`; driver holds no LLM context | yes (`lib/orchestrate.sh`; driver is bash, never an LLM) |
+| AC2 | `--dry-run` prints the ordered plan + stop point without invoking `claude` | yes (test 2; no side effects) |
+| AC3 | Stops at the first `gate` sub-goal; advances past `auto` only when the box flipped to `[x]` | yes (tests 3, 4) |
+| AC4 | Previous `HANDOFF.md` injected into the next session's prompt; fresh run with no handoff works | yes (test 3b) |
+| AC5 | `tests/test-orchestrate.sh` exercises the above incl. a negative control | yes (12 assertions) |
+
+## Implementation
+
+`lib/orchestrate.sh` (bash, matching the other `lib/` drivers): subcommands `next` and
+`run <megagoal-dir> [--dry-run]`. It reads `ROADMAP.md` sub-goal lines
+(`- [ ] SG-NN ... , auto|gate , ...`), runs each `auto` sub-goal in a fresh
+`$CLAUDE_CMD -p` session (the `/clear` is free), injects the prior `HANDOFF.md`, and stops at
+the first `gate`. Completion is grounded: it advances only when the sub-goal flipped its
+ROADMAP checkbox. `CLAUDE_CMD` is injected so the test mocks `claude` (no real sessions).
+
+## Confirmation run-table
+
+| Command | Exit | Result |
+|---|---|---|
+| `bash tests/test-orchestrate.sh` | 0 | 12/12 PASS (`ALL PASS`) |
+| `bash lib/orchestrate.sh next <real-megagoal>` | 0 | `SG-04	gate` (the real token-hygiene state) |
+| `bash lib/orchestrate.sh run <real-megagoal> --dry-run` | 0 | plan: `SG-04 (gate)` then `STOP at SG-04` |
+| `bash tests/test-meta.sh` | 0 | 500/500 (README lib row did not break parity) |
+| (negative control) mock session that does NOT check its box | 1 | loop halts: "did not check its ROADMAP box" |
+
+Verdict: PASS (Exit: 0 on the suite; the negative control is RED-by-design at Exit: 1).
+
+## Run detail (captured 2026-06-29)
+
+```
+$ bash tests/test-orchestrate.sh
+PASS next -> SG-01 auto
+PASS dry-run lists SG-01, SG-02, STOP at gate SG-03
+PASS dry-run did not execute anything
+PASS run exited 0
+PASS auto SG-01 + SG-02 boxes flipped
+PASS gate SG-03 left unchecked (stopped)
+PASS stopped at gate with message
+PASS HANDOFF.md written for the next sub-goal
+PASS handoff injected into SG-02's prompt but not SG-01's
+PASS negative control: run halts nonzero when box not flipped
+PASS negative control: explains the halt
+PASS negative control: SG-01 stays unchecked
+----
+ALL PASS                                         # Exit: 0
+```
+
+## NEGATIVE CONTROL
+
+Test 4 injects a mock `claude` that does work but does NOT flip the sub-goal's ROADMAP box.
+The orchestrator detects the unflipped box and halts with Exit: 1
+("did not check its ROADMAP box; halting (no self-claim)"), leaving SG-01 unchecked. So the
+grounded-completion check actually gates advancement rather than trusting a session's word; a
+session that silently no-ops cannot make the loop march on.
+
+## Reproduce
+
+```
+cd <dwarves-kit>
+bash tests/test-orchestrate.sh
+bash lib/orchestrate.sh run ~/workspace/tieubao/ops-toolkit/_meta/megagoals/token-hygiene --dry-run
+```

--- a/docs/verification/orchestrate.md
+++ b/docs/verification/orchestrate.md
@@ -66,3 +66,16 @@ cd <dwarves-kit>
 bash tests/test-orchestrate.sh
 bash lib/orchestrate.sh run ~/workspace/tieubao/ops-toolkit/_meta/megagoals/token-hygiene --dry-run
 ```
+
+## Review-fix addendum (2026-06-29, PR #81 review)
+
+Applied the review findings; the suite grew from 12 to 15 assertions, all green; shellcheck clean.
+
+| Command | Exit | Result |
+|---|---|---|
+| `bash tests/test-orchestrate.sh` | 0 | 15/15 PASS (`ALL PASS`) |
+| `shellcheck lib/orchestrate.sh` | 0 | CLEAN |
+
+New coverage: permission posture default + override (2 assertions); goal-file CONTENT injection
+into the prompt (1 assertion, closes the path-vs-content gap); policy parser hardened to
+exact-field match, unknown fail-safes to `gate`. NEGATIVE CONTROL still green. Verdict: PASS.

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -22,22 +22,32 @@
 set -uo pipefail
 
 CLAUDE_CMD="${CLAUDE_CMD:-claude}"
+# Permission posture for the unattended sub-goal session (SPEC-087 "Session invocation"). Default
+# is full access so the session can edit/commit/push/open-PR without a permission wall stalling
+# the loop; override with a tighter `--allowedTools` allowlist or an agentkernel sandbox via
+# CLAUDE_CMD. Word-split intentionally (operator config, not user data). Tests set CLAUDE_FLAGS=""
+# so the mock's prompt stays the last arg.
+CLAUDE_FLAGS="${CLAUDE_FLAGS:---dangerously-skip-permissions}"
 
 _say() { printf '%s\n' "$*"; }
 
 # Emit "id<TAB>policy<TAB>checked(0|1)" per sub-goal line, in ROADMAP order.
+# Policy is the comma-separated field that EQUALS auto|gate after trim (not a regex hit on the
+# description, so "(gate review)" or "gate-aware" do not false-match). Unknown -> gate (fail-safe:
+# a malformed line stops the loop for a human rather than silently auto-running). The trailing
+# `|| true` keeps a no-match grep from escaping under `set -o pipefail`.
 _subgoals() {
   local roadmap="$1"
   grep -E '^- \[[ xX]\] SG-[0-9]+' "$roadmap" 2>/dev/null | while IFS= read -r line; do
     local id policy checked=0
     id=$(printf '%s' "$line" | grep -oE 'SG-[0-9]+' | head -1)
     [ -n "$id" ] || continue
-    policy=$(printf '%s' "$line" | grep -oiE '[,(] *(auto|gate)\b' | grep -oiE '(auto|gate)' | head -1 | tr '[:upper:]' '[:lower:]')
+    policy=$(printf '%s' "$line" | awk -F',' '{for(i=1;i<=NF;i++){f=$i; gsub(/^[ \t]+|[ \t]+$/,"",f); lf=tolower(f); if(lf=="auto"||lf=="gate"){print lf; exit}}}')
     case "$line" in
       '- ['[xX]']'*) checked=1 ;;
     esac
-    printf '%s\t%s\t%s\n' "$id" "${policy:-auto}" "$checked"
-  done
+    printf '%s\t%s\t%s\n' "$id" "${policy:-gate}" "$checked"
+  done || true
 }
 
 # Next unchecked sub-goal as "id<TAB>policy", or empty.
@@ -47,6 +57,14 @@ _build_prompt() {
   local dir="$1" id="$2"
   cat "$dir/POINTER_PROMPT.md" 2>/dev/null
   printf '\n\nNEXT SUB-GOAL: %s\n' "$id"
+  # Inject the goal file's CONTENT (not just a path), so the session has the contract and
+  # re-discovery is actually eliminated (SPEC-087 "Session invocation").
+  local gf="" f
+  for f in "$dir/goals/${id#SG-}-"*.md; do [ -f "$f" ] && { gf="$f"; break; }; done
+  if [ -n "$gf" ]; then
+    printf '\nGOAL FILE (%s, the contract for this sub-goal):\n' "$(basename "$gf")"
+    cat "$gf"
+  fi
   if [ -s "$dir/HANDOFF.md" ]; then
     printf '\nHANDOFF from the previous sub-goal (verify before trusting):\n'
     cat "$dir/HANDOFF.md"
@@ -70,10 +88,10 @@ cmd_run() {
   if [ "$dry" = 1 ]; then
     _say "[plan] mega-goal: $dir"
     local any=0
-    while IFS=$'\t' read -r pid ppolicy; do
+    while IFS=$'\t' read -r sg ppolicy; do
       any=1
-      _say "  -> $pid ($ppolicy)  [prompt: POINTER_PROMPT + $pid + $([ -s "$dir/HANDOFF.md" ] && echo HANDOFF || echo no-handoff)]"
-      [ "$ppolicy" = gate ] && { _say "  == STOP at $pid (gate: human review) =="; break; }
+      _say "  -> $sg ($ppolicy)  [prompt: POINTER_PROMPT + goal-file + $([ -s "$dir/HANDOFF.md" ] && echo HANDOFF || echo no-handoff)]"
+      [ "$ppolicy" = gate ] && { _say "  == STOP at $sg (gate: human review) =="; break; }
     done < <(_subgoals "$roadmap" | awk -F'\t' '$3==0 {print $1"\t"$2}')
     [ "$any" = 1 ] || _say "  (no unchecked sub-goals)"
     return 0
@@ -92,7 +110,8 @@ cmd_run() {
 
     _say "[orchestrate] running $id in a fresh session ($CLAUDE_CMD -p) ..."
     local prompt; prompt=$(_build_prompt "$dir" "$id")
-    if ! "$CLAUDE_CMD" -p "$prompt"; then
+    # shellcheck disable=SC2086 # CLAUDE_FLAGS is operator config; word-splitting is intended.
+    if ! "$CLAUDE_CMD" -p $CLAUDE_FLAGS "$prompt"; then
       echo "[orchestrate] session for $id exited nonzero; stopping." >&2
       return 1
     fi

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# orchestrate.sh -- drive a mega-goal as ONE fresh `claude -p` session per sub-goal, so the
+# loop lives in this dumb (non-LLM) driver and no session accumulates more than one sub-goal's
+# context (SPEC-087, ADR-0027). Each `claude -p` is a new session, so the `/clear` between
+# sub-goals is free; the kit never self-`/clear`s. Each sub-goal session writes HANDOFF.md for
+# the next, and the orchestrator injects it (re-discovery becomes a read). The driver MUST stay
+# non-LLM: an LLM orchestrator spawning a subagent per sub-goal would re-accumulate every return
+# and become the new marathon (DEC-004).
+#
+# Usage:
+#   orchestrate.sh next <megagoal-dir>             print the next unchecked sub-goal + policy
+#   orchestrate.sh run  <megagoal-dir> [--dry-run] drive the loop (dry-run prints the plan only)
+#
+# <megagoal-dir> holds: ROADMAP.md (sub-goal lines `- [ ] SG-NN ... , auto|gate , ...`),
+# POINTER_PROMPT.md (static resume prompt), HANDOFF.md (feed-forward, written by each sub-goal).
+# Grounded completion: a sub-goal session MUST flip its ROADMAP checkbox to [x]; the
+# orchestrator advances only then (no self-claim). It STOPS at the first `gate` sub-goal
+# (shared-repo review needs a human).
+#
+# The `claude` invocation is `$CLAUDE_CMD` (default: claude), so tests mock it and operators
+# tune the permission flags.
+set -uo pipefail
+
+CLAUDE_CMD="${CLAUDE_CMD:-claude}"
+
+_say() { printf '%s\n' "$*"; }
+
+# Emit "id<TAB>policy<TAB>checked(0|1)" per sub-goal line, in ROADMAP order.
+_subgoals() {
+  local roadmap="$1"
+  grep -E '^- \[[ xX]\] SG-[0-9]+' "$roadmap" 2>/dev/null | while IFS= read -r line; do
+    local id policy checked=0
+    id=$(printf '%s' "$line" | grep -oE 'SG-[0-9]+' | head -1)
+    [ -n "$id" ] || continue
+    policy=$(printf '%s' "$line" | grep -oiE '[,(] *(auto|gate)\b' | grep -oiE '(auto|gate)' | head -1 | tr '[:upper:]' '[:lower:]')
+    case "$line" in
+      '- ['[xX]']'*) checked=1 ;;
+    esac
+    printf '%s\t%s\t%s\n' "$id" "${policy:-auto}" "$checked"
+  done
+}
+
+# Next unchecked sub-goal as "id<TAB>policy", or empty.
+_next() { _subgoals "$1" | awk -F'\t' '$3==0 {print $1"\t"$2; exit}'; }
+
+_build_prompt() {
+  local dir="$1" id="$2"
+  cat "$dir/POINTER_PROMPT.md" 2>/dev/null
+  printf '\n\nNEXT SUB-GOAL: %s\n' "$id"
+  if [ -s "$dir/HANDOFF.md" ]; then
+    printf '\nHANDOFF from the previous sub-goal (verify before trusting):\n'
+    cat "$dir/HANDOFF.md"
+  fi
+}
+
+cmd_next() {
+  local dir="${1:-}"
+  [ -f "$dir/ROADMAP.md" ] || { echo "no ROADMAP.md in '$dir'" >&2; return 64; }
+  local nx; nx=$(_next "$dir/ROADMAP.md")
+  if [ -n "$nx" ]; then printf '%s\n' "$nx"; else _say "(none unchecked)"; fi
+}
+
+cmd_run() {
+  local dir="${1:-}" dry=0
+  [ "${2:-}" = "--dry-run" ] && dry=1
+  [ -d "$dir" ] || { echo "no such megagoal dir: '$dir'" >&2; return 64; }
+  local roadmap="$dir/ROADMAP.md"
+  [ -f "$roadmap" ] || { echo "no ROADMAP.md in '$dir'" >&2; return 64; }
+
+  if [ "$dry" = 1 ]; then
+    _say "[plan] mega-goal: $dir"
+    local any=0
+    while IFS=$'\t' read -r pid ppolicy; do
+      any=1
+      _say "  -> $pid ($ppolicy)  [prompt: POINTER_PROMPT + $pid + $([ -s "$dir/HANDOFF.md" ] && echo HANDOFF || echo no-handoff)]"
+      [ "$ppolicy" = gate ] && { _say "  == STOP at $pid (gate: human review) =="; break; }
+    done < <(_subgoals "$roadmap" | awk -F'\t' '$3==0 {print $1"\t"$2}')
+    [ "$any" = 1 ] || _say "  (no unchecked sub-goals)"
+    return 0
+  fi
+
+  while :; do
+    local nx id policy
+    nx=$(_next "$roadmap")
+    [ -n "$nx" ] || { _say "[orchestrate] all sub-goals checked; done."; return 0; }
+    id=$(printf '%s' "$nx" | cut -f1); policy=$(printf '%s' "$nx" | cut -f2)
+
+    if [ "$policy" = gate ]; then
+      _say "[orchestrate] STOP: $id is a gate sub-goal; open/await its PR for review, then re-run."
+      return 0
+    fi
+
+    _say "[orchestrate] running $id in a fresh session ($CLAUDE_CMD -p) ..."
+    local prompt; prompt=$(_build_prompt "$dir" "$id")
+    if ! "$CLAUDE_CMD" -p "$prompt"; then
+      echo "[orchestrate] session for $id exited nonzero; stopping." >&2
+      return 1
+    fi
+
+    # grounded completion: advance only if the box actually flipped.
+    local checked; checked=$(_subgoals "$roadmap" | awk -F'\t' -v i="$id" '$1==i {print $3}')
+    if [ "$checked" != 1 ]; then
+      echo "[orchestrate] $id did not check its ROADMAP box; halting (no self-claim)." >&2
+      return 1
+    fi
+    _say "[orchestrate] $id complete (box checked); advancing."
+  done
+}
+
+main() {
+  local cmd="${1:-}"; shift 2>/dev/null || true
+  case "$cmd" in
+    next) cmd_next "$@" ;;
+    run)  cmd_run "$@" ;;
+    *) echo "usage: orchestrate.sh {next|run} <megagoal-dir> [--dry-run]" >&2; exit 64 ;;
+  esac
+}
+
+main "$@"

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# test-orchestrate.sh
+# Pins lib/orchestrate.sh (SPEC-087 phase 1): the non-LLM driver finds the next unchecked
+# sub-goal, runs the auto chain via a MOCK `claude` (CLAUDE_CMD), injects the previous
+# HANDOFF, stops at the first gate, and advances only when a sub-goal flips its ROADMAP box.
+# Negative control: a session that does NOT flip its box halts the loop (no self-claim).
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORCH="$KIT/lib/orchestrate.sh"
+fails=0
+pass() { echo "PASS $*"; }
+fail() { echo "FAIL $*"; fails=$((fails + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- fixture: a mega-goal dir with 2 auto sub-goals then a gate ---
+mk_megagoal() {
+  local d="$1"
+  mkdir -p "$d"
+  cat > "$d/ROADMAP.md" <<'EOF'
+# Mega-goal: fixture
+## Sub-goals
+- [ ] SG-01 first thing (x) , auto , PR #__
+- [ ] SG-02 second thing , auto , PR #__
+- [ ] SG-03 third thing , gate , PR #__
+EOF
+  echo "POINTER: resume from ROADMAP" > "$d/POINTER_PROMPT.md"
+}
+
+# --- mock claude: flips the named sub-goal's box + writes a handoff (the "good" session) ---
+mk_mock_good() {
+  cat > "$TMP/claude-good" <<'EOF'
+#!/usr/bin/env bash
+# args: -p "<prompt>"  ; env: MOCK_ROADMAP, MOCK_DIR
+prompt="${2:-}"
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' \
+  "$MOCK_ROADMAP" > "$MOCK_ROADMAP.tmp" && mv "$MOCK_ROADMAP.tmp" "$MOCK_ROADMAP"
+printf 'Next: continue. Files already located: lib/orchestrate.sh\n' > "$MOCK_DIR/HANDOFF.md"
+EOF
+  chmod +x "$TMP/claude-good"
+}
+
+# --- mock claude: does NOT flip the box (the "lying" session, negative control) ---
+mk_mock_bad() {
+  cat > "$TMP/claude-bad" <<'EOF'
+#!/usr/bin/env bash
+echo "did work but forgot to check the box"
+EOF
+  chmod +x "$TMP/claude-bad"
+}
+
+# ============================ TEST 1: next ============================
+D="$TMP/mg1"; mk_megagoal "$D"
+out=$(bash "$ORCH" next "$D")
+[ "$out" = "$(printf 'SG-01\tauto')" ] && pass "next -> SG-01 auto" || fail "next: got '$out'"
+
+# ============================ TEST 2: dry-run plan ============================
+out=$(bash "$ORCH" run "$D" --dry-run)
+echo "$out" | grep -q 'SG-01 (auto)' && echo "$out" | grep -q 'SG-02 (auto)' \
+  && echo "$out" | grep -q 'STOP at SG-03 (gate' \
+  && pass "dry-run lists SG-01, SG-02, STOP at gate SG-03" || { fail "dry-run plan wrong"; echo "$out"; }
+# dry-run must NOT invoke claude (no box flipped, no handoff written)
+grep -q '^- \[ \] SG-01' "$D/ROADMAP.md" && [ ! -f "$D/HANDOFF.md" ] \
+  && pass "dry-run did not execute anything" || fail "dry-run had side effects"
+
+# ============================ TEST 3: real run via good mock ============================
+D2="$TMP/mg2"; mk_megagoal "$D2"; mk_mock_good
+export MOCK_ROADMAP="$D2/ROADMAP.md" MOCK_DIR="$D2"
+CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$D2" > "$TMP/run.out" 2>&1
+rc=$?
+[ "$rc" = 0 ] && pass "run exited 0" || { fail "run exited $rc"; cat "$TMP/run.out"; }
+grep -q '^- \[x\] SG-01' "$D2/ROADMAP.md" && grep -q '^- \[x\] SG-02' "$D2/ROADMAP.md" \
+  && pass "auto SG-01 + SG-02 boxes flipped" || fail "auto boxes not flipped"
+grep -q '^- \[ \] SG-03' "$D2/ROADMAP.md" && pass "gate SG-03 left unchecked (stopped)" || fail "gate SG-03 touched"
+grep -q 'STOP: SG-03 is a gate' "$TMP/run.out" && pass "stopped at gate with message" || fail "no gate-stop message"
+[ -s "$D2/HANDOFF.md" ] && pass "HANDOFF.md written for the next sub-goal" || fail "no HANDOFF.md"
+
+# TEST 3b: handoff is injected into the next session's prompt
+# (re-run next step's prompt build by checking the good mock saw a handoff on SG-02's turn:
+#  after SG-01 wrote HANDOFF, the orchestrator should have injected it for SG-02.)
+D3="$TMP/mg3"; mk_megagoal "$D3"
+cat > "$TMP/claude-probe" <<EOF
+#!/usr/bin/env bash
+prompt="\${2:-}"
+id=\$(printf '%s' "\$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+# record whether this turn's prompt carried a HANDOFF section
+printf '%s handoff=%s\n' "\$id" "\$(printf '%s' "\$prompt" | grep -c 'HANDOFF from the previous')" >> "$TMP/probe.log"
+awk -v id="\$id" '{ if (\$0 ~ ("^- \\\\[ \\\\] " id " ")) sub(/\\[ \\]/, "[x]"); print }' "$D3/ROADMAP.md" > "$D3/ROADMAP.md.tmp" && mv "$D3/ROADMAP.md.tmp" "$D3/ROADMAP.md"
+echo "h" > "$D3/HANDOFF.md"
+EOF
+chmod +x "$TMP/claude-probe"
+: > "$TMP/probe.log"
+CLAUDE_CMD="$TMP/claude-probe" bash "$ORCH" run "$D3" >/dev/null 2>&1
+# SG-01: no handoff yet (0); SG-02: handoff injected (1)
+grep -q 'SG-01 handoff=0' "$TMP/probe.log" && grep -q 'SG-02 handoff=1' "$TMP/probe.log" \
+  && pass "handoff injected into SG-02's prompt but not SG-01's" || { fail "handoff injection wrong"; cat "$TMP/probe.log"; }
+
+# ============================ TEST 4: negative control ============================
+D4="$TMP/mg4"; mk_megagoal "$D4"; mk_mock_bad
+CLAUDE_CMD="$TMP/claude-bad" bash "$ORCH" run "$D4" > "$TMP/neg.out" 2>&1
+rc=$?
+[ "$rc" != 0 ] && pass "negative control: run halts nonzero when box not flipped" || fail "neg control did not halt (rc=$rc)"
+grep -q 'did not check its ROADMAP box' "$TMP/neg.out" && pass "negative control: explains the halt" || fail "no halt message"
+grep -q '^- \[ \] SG-01' "$D4/ROADMAP.md" && pass "negative control: SG-01 stays unchecked" || fail "SG-01 wrongly checked"
+
+echo "----"
+[ "$fails" = 0 ] && { echo "ALL PASS"; exit 0; } || { echo "$fails FAILED"; exit 1; }

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -26,6 +26,8 @@ mk_megagoal() {
 - [ ] SG-03 third thing , gate , PR #__
 EOF
   echo "POINTER: resume from ROADMAP" > "$d/POINTER_PROMPT.md"
+  mkdir -p "$d/goals"
+  echo "GOALFILE-MARKER-01 contract for SG-01" > "$d/goals/01-first.md"
 }
 
 # --- mock claude: flips the named sub-goal's box + writes a handoff (the "good" session) ---
@@ -33,7 +35,7 @@ mk_mock_good() {
   cat > "$TMP/claude-good" <<'EOF'
 #!/usr/bin/env bash
 # args: -p "<prompt>"  ; env: MOCK_ROADMAP, MOCK_DIR
-prompt="${2:-}"
+prompt="${!#}"   # last arg = the prompt, robust to any leading flags (e.g. --dangerously-skip-permissions)
 id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
 awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' \
   "$MOCK_ROADMAP" > "$MOCK_ROADMAP.tmp" && mv "$MOCK_ROADMAP.tmp" "$MOCK_ROADMAP"
@@ -83,10 +85,10 @@ grep -q 'STOP: SG-03 is a gate' "$TMP/run.out" && pass "stopped at gate with mes
 D3="$TMP/mg3"; mk_megagoal "$D3"
 cat > "$TMP/claude-probe" <<EOF
 #!/usr/bin/env bash
-prompt="\${2:-}"
+prompt="\${!#}"
 id=\$(printf '%s' "\$prompt" | grep -oE 'SG-[0-9]+' | head -1)
 # record whether this turn's prompt carried a HANDOFF section
-printf '%s handoff=%s\n' "\$id" "\$(printf '%s' "\$prompt" | grep -c 'HANDOFF from the previous')" >> "$TMP/probe.log"
+printf '%s handoff=%s goal=%s\n' "\$id" "\$(printf '%s' "\$prompt" | grep -c 'HANDOFF from the previous')" "\$(printf '%s' "\$prompt" | grep -c 'GOALFILE-MARKER-01')" >> "$TMP/probe.log"
 awk -v id="\$id" '{ if (\$0 ~ ("^- \\\\[ \\\\] " id " ")) sub(/\\[ \\]/, "[x]"); print }' "$D3/ROADMAP.md" > "$D3/ROADMAP.md.tmp" && mv "$D3/ROADMAP.md.tmp" "$D3/ROADMAP.md"
 echo "h" > "$D3/HANDOFF.md"
 EOF
@@ -96,6 +98,8 @@ CLAUDE_CMD="$TMP/claude-probe" bash "$ORCH" run "$D3" >/dev/null 2>&1
 # SG-01: no handoff yet (0); SG-02: handoff injected (1)
 grep -q 'SG-01 handoff=0' "$TMP/probe.log" && grep -q 'SG-02 handoff=1' "$TMP/probe.log" \
   && pass "handoff injected into SG-02's prompt but not SG-01's" || { fail "handoff injection wrong"; cat "$TMP/probe.log"; }
+grep -q 'SG-01 .*goal=1' "$TMP/probe.log" \
+  && pass "goal-file content injected into the prompt (not just a path)" || { fail "goal-file not injected"; cat "$TMP/probe.log"; }
 
 # ============================ TEST 4: negative control ============================
 D4="$TMP/mg4"; mk_megagoal "$D4"; mk_mock_bad
@@ -104,6 +108,31 @@ rc=$?
 [ "$rc" != 0 ] && pass "negative control: run halts nonzero when box not flipped" || fail "neg control did not halt (rc=$rc)"
 grep -q 'did not check its ROADMAP box' "$TMP/neg.out" && pass "negative control: explains the halt" || fail "no halt message"
 grep -q '^- \[ \] SG-01' "$D4/ROADMAP.md" && pass "negative control: SG-01 stays unchecked" || fail "SG-01 wrongly checked"
+
+# ============================ TEST 5: permission posture flag ============================
+# A mock that records its args + flips the box (so the auto chain completes). ARGS_LOG/ARGS_RM
+# are set per-run so one mock serves multiple fixtures.
+cat > "$TMP/claude-args" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >> "$ARGS_LOG"
+prompt="${!#}"
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' "$ARGS_RM" > "$ARGS_RM.tmp" && mv "$ARGS_RM.tmp" "$ARGS_RM"
+EOF
+chmod +x "$TMP/claude-args"
+
+D5="$TMP/mg5"; mk_megagoal "$D5"; : > "$TMP/args.log"
+ARGS_LOG="$TMP/args.log" ARGS_RM="$D5/ROADMAP.md" CLAUDE_CMD="$TMP/claude-args" bash "$ORCH" run "$D5" >/dev/null 2>&1
+grep -q -- '--dangerously-skip-permissions' "$TMP/args.log" \
+  && pass "default posture flag (--dangerously-skip-permissions) passed to claude" \
+  || { fail "default posture flag missing"; cat "$TMP/args.log"; }
+
+D6="$TMP/mg6"; mk_megagoal "$D6"; : > "$TMP/args.log"
+ARGS_LOG="$TMP/args.log" ARGS_RM="$D6/ROADMAP.md" CLAUDE_FLAGS="--allowedTools Read" \
+  CLAUDE_CMD="$TMP/claude-args" bash "$ORCH" run "$D6" >/dev/null 2>&1
+{ grep -q -- '--allowedTools' "$TMP/args.log" && ! grep -q -- '--dangerously-skip-permissions' "$TMP/args.log"; } \
+  && pass "CLAUDE_FLAGS overrides the default posture" \
+  || { fail "CLAUDE_FLAGS override wrong"; cat "$TMP/args.log"; }
 
 echo "----"
 [ "$fails" = 0 ] && { echo "ALL PASS"; exit 0; } || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
Implements **SPEC-087 phase 1** (stacked on the design PR #80). **Gate PR: held for team review.** This is the structural fix Han asked for: move the mega-goal loop OUT of the LLM session.

## What
`lib/orchestrate.sh` , a **non-LLM** driver that owns the loop and runs each sub-goal in a **fresh `claude -p` session**:
- No session holds more than one sub-goal's context, so the marathon `cache_read` growth (the dominant token-waste class) is removed structurally. The `/clear` between sub-goals is free; the kit never self-`/clear`s.
- The driver must stay dumb (DEC-004): an LLM orchestrator spawning a subagent per sub-goal would re-accumulate every return and become the new marathon.
- **Feed-forward handoff:** each session writes `HANDOFF.md`; the orchestrator injects the previous one into the next prompt, so a fresh start skips re-discovery (Han's second point).
- **Grounded completion:** advances only when a sub-goal flips its ROADMAP checkbox; a no-op session halts the loop (no self-claim).
- **Stops at the first `gate` sub-goal** (shared-repo review is the one intentional human point).

## Verification (captured)
| Command | Exit | Result |
|---|---|---|
| `bash tests/test-orchestrate.sh` | 0 | 12/12 PASS (incl. negative control) |
| `bash lib/orchestrate.sh run <real-megagoal> --dry-run` | 0 | plan: `SG-04 (gate)` then `STOP` |
| `bash tests/test-meta.sh` | 0 | 500/500 (README parity intact) |

`CLAUDE_CMD` injects a mock `claude` in tests (no real sessions spawned). Proof: `docs/verification/orchestrate.md`. Delta notes: `docs/implementation-notes/orchestrate.md`.

## Scope
Phase 1 = orchestrator + handoff (Mechanism A + B). Distilled subagent returns (Mechanism C) + the before/after `token-forensic --loops` measurement are phase 2. The interactive `/goal` loop is untouched; this is an additive outer driver. Bash `claude -p` now; the Agent SDK is the documented upgrade path.

Base: #80 (SPEC-087 + ADR-0027 revision). Review #80 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
