### PR TITLE
feat(kit): per-sub-goal model/effort routing in the orchestrator

### DIFF
--- a/docs/implementation-notes/orchestrate-model-effort-routing.md
+++ b/docs/implementation-notes/orchestrate-model-effort-routing.md
@@ -1,0 +1,17 @@
+# Impl notes: per-sub-goal model/effort routing (SG-03)
+
+Delta from SPEC-087. The spec adds a routing section (this PR); only off-spec calls live here.
+
+## 2026-06-29 effort flag exists on the CLI
+- Context: goal file said "pass `--model <tier>` + effort"; effort flag was unverified.
+- Decision: pass both `--model` and `--effort` to `claude -p`. Verified `claude --version`
+  2.1.195 exposes both `--model <model>` and `--effort <level>`. No custom plumbing needed.
+- Why: the goal warned effort tiering might not have a stable CLI flag yet; it does.
+
+## 2026-06-29 field read = grep, inherit-on-absent
+- Decision: read `Model:`/`Effort:` from the goal file with a case-insensitive `grep` on a
+  line-anchored `^Model:` / `^Effort:`, first match, value trimmed. Absent field or absent
+  goal file -> empty -> no flag emitted (session inherits parent tier).
+- Why: matches the existing goal-file `Key: value` convention; no frontmatter parser needed.
+- Alternative rejected: a full YAML frontmatter parse, the goal files are not YAML; the
+  fields are bare `Key: value` lines in the header.

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -101,6 +101,26 @@ human) and by each sub-goal being a disposable session. The posture is **overrid
 `CLAUDE_FLAGS` env var (e.g. a tight `--allowedTools` allowlist) or by running the session
 inside an agentkernel sandbox via `CLAUDE_CMD`; these are options, not the default.
 
+### Model / effort routing (the biggest $ lever)
+
+Forensic (2026-06-28): Opus = 86.5% of measured spend. Running every sub-goal on Opus is the
+single largest waste; most sub-goals (discovery, light edits, doc passes) do not need it. So
+each sub-goal declares its own tier and the orchestrator dispatches accordingly.
+
+Each goal file `goals/NN-*.md` MAY carry, as bare `Key: value` header lines (not YAML):
+
+```
+Model: <tier>     # e.g. haiku | sonnet | opus; omit to inherit the parent session's model
+Effort: <level>   # e.g. low | medium | high; omit to inherit
+```
+
+The orchestrator reads these and passes `--model <tier>` / `--effort <level>` to the
+per-sub-goal `claude -p` call (both flags exist on the CLI). An absent field emits no flag, so
+the session inherits its tier; a missing goal file means inherit for both. `run ... --dry-run`
+prints the resolved tier per sub-goal (`[model: X, effort: Y]`, or `inherit`) so the routing is
+auditable before any session spends a token. The GENERATOR that emits these fields into composed
+goal files is a separate increment (`plan-for-mega-goal`); the orchestrator only consumes them.
+
 ### Mechanism C: distilled subagent returns (within-sub-goal; phase 2)
 
 Bounds growth INSIDE one sub-goal. Each kit-dispatched role returns a bounded structured

--- a/docs/verification/model-effort-routing.md
+++ b/docs/verification/model-effort-routing.md
@@ -1,0 +1,69 @@
+# Proof of done: per-sub-goal model/effort routing (SG-03)
+
+| | |
+|---|---|
+| **Profile** | feature (behavioral) |
+| **Proof class** | behavioral: real orchestrator flow + tests + negative control |
+| **Spec** | SPEC-087 "Model / effort routing" section |
+| **Canonical** | this file |
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| AC1 | `orchestrate.sh` reads `Model:`/`Effort:` from each sub-goal's goal file | PASS | R1, R2 |
+| AC2 | Reads pass to the session as `claude -p --model <tier> --effort <level>` | PASS | R2 |
+| AC3 | Default-when-absent: no flag emitted, session inherits its tier | PASS | R1, R2 |
+| AC4 | `--dry-run` prints the chosen tier per sub-goal | PASS | R1, R3 |
+| AC5 | `tests/test-orchestrate.sh` covers parse, dry-run display, default-when-absent | PASS | R1 |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | `_route()` reads `Model:`/`Effort:` from a goal file; the run path passes `--model`/`--effort`; `--dry-run` shows the resolved tier; absent -> inherit (no flag) |
+| Where | `lib/orchestrate.sh` (`_goalfile`, `_route`, `cmd_run`), `tests/test-orchestrate.sh` (TEST 6-7), `docs/specs/SPEC-087-context-hygiene.md` (routing section) |
+| How it runs | `bash lib/orchestrate.sh run <dir> [--dry-run]`; CLI flags `--model`/`--effort` verified present (`claude` 2.1.195) |
+| Reversibility | pure additive; absent fields reproduce the prior inherit-everything behavior |
+
+## 3. Confirmation (recorded runs)
+
+| Run | When | Command | Exit | Verdict |
+|---|---|---|---|---|
+| R1 | 2026-06-29 | `bash tests/test-orchestrate.sh` | 0 | PASS (19/19, incl. 4 new routing + the box-not-flipped negative control) |
+| R2 | 2026-06-29 | real run via arg-logging mock (`CLAUDE_CMD`) | 0 | hinted SG-01 got `--model sonnet --effort low`; inherit SG-02 got no `--model` |
+| R3 | 2026-06-29 | `bash lib/orchestrate.sh run <mixed-tiers> --dry-run` | 0 | distinct tiers per sub-goal + inherit |
+
+## 4. Run detail
+
+### R1 GREEN, full suite incl. negative control
+- Command: `bash tests/test-orchestrate.sh`
+- Exit: 0
+- Output (tail): `... PASS run passes no --model for inherit SG-02 / ---- / ALL PASS`
+- Negative control (pre-existing, still green): a session that does not flip its ROADMAP box
+  halts the loop nonzero ("did not check its ROADMAP box"). Confirms the harness can go RED.
+
+### R2 real flow, routing flags reach the session
+- The run path dispatches `claude -p $route_flags $CLAUDE_FLAGS "$prompt"`. A mock `claude`
+  logged `<id>|<flags>` per call. Hinted SG-01 line: `SG-01|... --model sonnet --effort low`.
+  Inherit SG-02 line carried no `--model`. (TEST 7.)
+
+### R3 dry-run tier display
+- Command: `bash lib/orchestrate.sh run <mixed-tiers fixture> --dry-run`
+- Output:
+  ```
+    -> SG-01 (auto)  [model: haiku, effort: low]   ...
+    -> SG-02 (auto)  [model: sonnet, effort: medium] ...
+    -> SG-03 (auto)  [model: opus, effort: high]   ...
+    -> SG-04 (gate)  [model: inherit, effort: inherit] ...
+    == STOP at SG-04 (gate: human review) ==
+  ```
+- Verdict: PASS. Routing is auditable before any token is spent.
+
+## 5. Reproduce
+```
+git switch feat/model-effort-routing
+bash tests/test-orchestrate.sh        # 19/19 ALL PASS
+# dry-run on any megagoal dir with Model:/Effort: goal files:
+bash lib/orchestrate.sh run <megagoal-dir> --dry-run
+```

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -53,14 +53,32 @@ _subgoals() {
 # Next unchecked sub-goal as "id<TAB>policy", or empty.
 _next() { _subgoals "$1" | awk -F'\t' '$3==0 {print $1"\t"$2; exit}'; }
 
+# Resolve a sub-goal's goal file path (goals/<NN>-*.md), or empty.
+_goalfile() {
+  local dir="$1" id="$2" f
+  for f in "$dir/goals/${id#SG-}-"*.md; do [ -f "$f" ] && { printf '%s\n' "$f"; return; }; done
+}
+
+# Emit "model<TAB>effort" read from a goal file's `Model:`/`Effort:` lines (empty when absent).
+# Bare `Key: value` header lines, not YAML; first match each, value trimmed. Absent field or
+# absent file -> empty -> the orchestrator emits no flag and the session inherits its tier
+# (SPEC-087 "Model / Effort routing"). The biggest $ lever: Opus only on the hard sub-goals.
+_route() {
+  local gf="${1:-}" model="" effort=""
+  if [ -f "$gf" ]; then
+    model=$(grep -iE '^Model:[[:space:]]*' "$gf" | head -1 | sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]+$//')
+    effort=$(grep -iE '^Effort:[[:space:]]*' "$gf" | head -1 | sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]+$//')
+  fi
+  printf '%s\t%s\n' "$model" "$effort"
+}
+
 _build_prompt() {
   local dir="$1" id="$2"
   cat "$dir/POINTER_PROMPT.md" 2>/dev/null
   printf '\n\nNEXT SUB-GOAL: %s\n' "$id"
   # Inject the goal file's CONTENT (not just a path), so the session has the contract and
   # re-discovery is actually eliminated (SPEC-087 "Session invocation").
-  local gf="" f
-  for f in "$dir/goals/${id#SG-}-"*.md; do [ -f "$f" ] && { gf="$f"; break; }; done
+  local gf; gf=$(_goalfile "$dir" "$id")
   if [ -n "$gf" ]; then
     printf '\nGOAL FILE (%s, the contract for this sub-goal):\n' "$(basename "$gf")"
     cat "$gf"
@@ -90,7 +108,9 @@ cmd_run() {
     local any=0
     while IFS=$'\t' read -r sg ppolicy; do
       any=1
-      _say "  -> $sg ($ppolicy)  [prompt: POINTER_PROMPT + goal-file + $([ -s "$dir/HANDOFF.md" ] && echo HANDOFF || echo no-handoff)]"
+      local rmodel reffort
+      IFS=$'\t' read -r rmodel reffort < <(_route "$(_goalfile "$dir" "$sg")")
+      _say "  -> $sg ($ppolicy)  [model: ${rmodel:-inherit}, effort: ${reffort:-inherit}]  [prompt: POINTER_PROMPT + goal-file + $([ -s "$dir/HANDOFF.md" ] && echo HANDOFF || echo no-handoff)]"
       [ "$ppolicy" = gate ] && { _say "  == STOP at $sg (gate: human review) =="; break; }
     done < <(_subgoals "$roadmap" | awk -F'\t' '$3==0 {print $1"\t"$2}')
     [ "$any" = 1 ] || _say "  (no unchecked sub-goals)"
@@ -108,10 +128,17 @@ cmd_run() {
       return 0
     fi
 
-    _say "[orchestrate] running $id in a fresh session ($CLAUDE_CMD -p) ..."
+    # Per-sub-goal model/effort routing (SPEC-087): read the goal file's hints and pass them as
+    # flags, so this sub-goal runs on its own tier instead of inheriting Opus-for-everything.
+    # Absent hint -> no flag -> inherit.
+    local rmodel reffort route_flags=""
+    IFS=$'\t' read -r rmodel reffort < <(_route "$(_goalfile "$dir" "$id")")
+    [ -n "$rmodel" ] && route_flags="$route_flags --model $rmodel"
+    [ -n "$reffort" ] && route_flags="$route_flags --effort $reffort"
+    _say "[orchestrate] running $id in a fresh session ($CLAUDE_CMD -p, model: ${rmodel:-inherit}, effort: ${reffort:-inherit}) ..."
     local prompt; prompt=$(_build_prompt "$dir" "$id")
-    # shellcheck disable=SC2086 # CLAUDE_FLAGS is operator config; word-splitting is intended.
-    if ! "$CLAUDE_CMD" -p $CLAUDE_FLAGS "$prompt"; then
+    # shellcheck disable=SC2086 # CLAUDE_FLAGS + route_flags are operator/goal config; word-splitting is intended.
+    if ! "$CLAUDE_CMD" -p $route_flags $CLAUDE_FLAGS "$prompt"; then
       echo "[orchestrate] session for $id exited nonzero; stopping." >&2
       return 1
     fi

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -134,5 +134,47 @@ ARGS_LOG="$TMP/args.log" ARGS_RM="$D6/ROADMAP.md" CLAUDE_FLAGS="--allowedTools R
   && pass "CLAUDE_FLAGS overrides the default posture" \
   || { fail "CLAUDE_FLAGS override wrong"; cat "$TMP/args.log"; }
 
+# ============================ TEST 6 + 7: model/effort routing ============================
+# Mixed-tier fixture: SG-01 carries Model:/Effort: hints, SG-02 carries none (inherit).
+mk_routed() {
+  local d="$1"; mk_megagoal "$d"
+  cat > "$d/goals/01-first.md" <<'EOF'
+# SG-01
+Model: sonnet
+Effort: low
+
+GOALFILE-MARKER-01 contract for SG-01
+EOF
+  # SG-02 deliberately has NO goal file -> no hints -> inherit.
+}
+
+# TEST 6: --dry-run prints the chosen tier per sub-goal (and "inherit" when absent).
+DR="$TMP/mgr"; mk_routed "$DR"
+out=$(bash "$ORCH" run "$DR" --dry-run)
+echo "$out" | grep -qE 'SG-01 \(auto\).*model: sonnet, effort: low' \
+  && pass "dry-run shows SG-01 routed model/effort" || { fail "dry-run SG-01 tier wrong"; echo "$out"; }
+echo "$out" | grep -qE 'SG-02 \(auto\).*model: inherit, effort: inherit' \
+  && pass "dry-run shows SG-02 inherit (no hints)" || { fail "dry-run SG-02 inherit wrong"; echo "$out"; }
+
+# TEST 7: real run passes --model/--effort for the hinted sub-goal, none for the inherit one.
+# Mock logs "<id>|<flags>" per call (drops the last arg, the prompt, which has newlines).
+cat > "$TMP/claude-route" <<'EOF'
+#!/usr/bin/env bash
+prompt="${!#}"
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+args=("$@"); [ "${#args[@]}" -gt 0 ] && unset 'args[${#args[@]}-1]'
+printf '%s|%s\n' "$id" "${args[*]}" >> "$ROUTE_LOG"
+awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' "$ROUTE_RM" > "$ROUTE_RM.tmp" && mv "$ROUTE_RM.tmp" "$ROUTE_RM"
+EOF
+chmod +x "$TMP/claude-route"
+
+DR2="$TMP/mgr2"; mk_routed "$DR2"; : > "$TMP/route.log"
+ROUTE_LOG="$TMP/route.log" ROUTE_RM="$DR2/ROADMAP.md" CLAUDE_FLAGS="" \
+  CLAUDE_CMD="$TMP/claude-route" bash "$ORCH" run "$DR2" >/dev/null 2>&1
+grep -q '^SG-01|.*--model sonnet --effort low' "$TMP/route.log" \
+  && pass "run passes --model/--effort for hinted SG-01" || { fail "SG-01 routing flags missing"; cat "$TMP/route.log"; }
+{ grep '^SG-02|' "$TMP/route.log" | grep -qv -- '--model'; } \
+  && pass "run passes no --model for inherit SG-02" || { fail "SG-02 got an unexpected --model"; cat "$TMP/route.log"; }
+
 echo "----"
 [ "$fails" = 0 ] && { echo "ALL PASS"; exit 0; } || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## What

Per-sub-goal **model/effort routing** in `lib/orchestrate.sh`. The single biggest $ lever: Opus = 86.5% of measured spend (forensic 2026-06-28). Each sub-goal now declares its tier in its goal file and the orchestrator dispatches accordingly, instead of running Opus-for-everything.

## How

- `_goalfile()` + `_route()` read `Model:`/`Effort:` (bare `Key: value` header lines) from each `goals/NN-*.md`.
- Run path passes `claude -p --model <tier> --effort <level>` (both flags verified on `claude` 2.1.195).
- Absent field -> no flag -> the session inherits its tier. Missing goal file -> inherit both.
- `--dry-run` prints the resolved tier per sub-goal (`[model: X, effort: Y]` or `inherit`), so routing is auditable before any token is spent.

## Proof

`docs/verification/model-effort-routing.md` (table-first). `bash tests/test-orchestrate.sh` = 19/19 (4 new routing tests + the pre-existing box-not-flipped negative control). Spec section added to SPEC-087.

```
-> SG-01 (auto)  [model: haiku, effort: low]
-> SG-02 (auto)  [model: sonnet, effort: medium]
-> SG-03 (auto)  [model: opus, effort: high]
-> SG-04 (gate)  [model: inherit, effort: inherit]
```

## Scope

Orchestrator consume-side only. The generator that *emits* these fields into composed goal files is a separate increment (`plan-for-mega-goal`, SG-08). Part of the token-optim-v2 wave (SG-03).

**Gated for team review** (shared repo): open-only, do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
