### PR TITLE
feat(kit): two-tier feed-forward handoff (hot HANDOFF + warm DECISIONS)

### DIFF
--- a/docs/implementation-notes/two-tier-handoff.md
+++ b/docs/implementation-notes/two-tier-handoff.md
@@ -1,0 +1,26 @@
+# Impl notes: two-tier feed-forward handoff (SG-02)
+
+Delta from SPEC-087 Mechanism B. Only off-spec calls live here.
+
+## 2026-06-29 hot/warm split: HANDOFF.md full-injected + capped, DECISIONS.md pointer-only
+- Decision: the orchestrator injects `HANDOFF.md` in full (hot, capped to `HANDOFF_MAX_LINES`,
+  default 80) and injects only a POINTER to `DECISIONS.md` (warm: path + line count), never its
+  body. The session reads the ledger on demand.
+- Why: injecting the whole append-only ledger every transition recreates the marathon the spec
+  is trying to kill. The cap bounds a runaway hot handoff too.
+- Roles: the sub-goal SESSION writes both files (overwrite HANDOFF, append DECISIONS); the
+  orchestrator only injects. Matches SPEC-087's "session writes HANDOFF" grounded-completion.
+
+## 2026-06-29 prompt injected via stdin (temp file), not an argv arg
+- Decision: build the prompt into a temp file and pipe it (`claude -p ... < "$tmp"`), instead of
+  passing it as the last positional arg. (pi-swarm borrow; verified `claude -p` reads the prompt
+  from stdin.)
+- Why: removes the backtick/`${}`/secret-guard bug class when the prompt body contains shell
+  metachars, and dodges ARG_MAX on a large injected handoff.
+- Consequence (test harness): the existing mocks read the prompt as `prompt="${!#}"` (last arg).
+  Switched every mock to `prompt=$(cat)`. This is the only reason the prior tests' mock bodies
+  changed; their assertions are unchanged.
+
+## 2026-06-29 cap is a head-truncate + notice, not a hard fail
+- Decision: if HANDOFF.md exceeds the cap, inject the first N lines + a `[... truncated, read
+  the file]` notice rather than erroring. Keeps the loop moving; the file path is still pointed at.

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -81,6 +81,25 @@ Distinct from `POINTER_PROMPT.md`, which is static (it points at the ROADMAP). T
 dynamic, per-transition, and must be **grounded** (cite real files / PRs), so it cannot become
 an optimistic lie about the next step; the receiving session verifies before trusting.
 
+**Two-tier feed-forward (the contract).** A single handoff file either bloats (carrying every
+decision forward) or forgets (carrying only "files located"). Split it by access pattern:
+
+| Tier | File | Lifecycle | Injection | Carries |
+|---|---|---|---|---|
+| HOT | `HANDOFF.md` | overwritten each transition | injected in FULL, capped to `HANDOFF_MAX_LINES` (default 80) | next sub-goal, the exact first action, read-pointers as `file:line` |
+| WARM | `DECISIONS.md` | append-only ledger | injected as a POINTER only (path + line count) | durable invariants + dead-ends, read on demand |
+
+The orchestrator inlines the hot handoff (head + a truncation notice if over the cap, so a
+runaway handoff cannot recreate the marathon) and inlines only a pointer to the warm ledger, so
+the append-only ledger never grows the prompt. The finishing session **reports IN the records,
+not in its response text** (the next session reads the files, not the transcript): it overwrites
+`HANDOFF.md` with the next action + read-pointers and appends durable invariants / dead-ends to
+`DECISIONS.md`. A committed sample pair lives at `tests/fixtures/handoff-sample/`.
+
+The prompt is injected via a **temp file on stdin** (`claude -p ... < tmp`), not a shell-
+interpolated argv arg, so a handoff body containing backticks / `${...}` / secret-shaped strings
+cannot trip shell evaluation or the secret-guard hook, and a large handoff cannot hit `ARG_MAX`.
+
 ### Session invocation (the per-sub-goal `claude -p` call)
 
 Resolves the former OQ-001. Two things were under-specified: what goes into each session's

--- a/docs/verification/two-tier-handoff.md
+++ b/docs/verification/two-tier-handoff.md
@@ -1,0 +1,60 @@
+# Proof of done: two-tier feed-forward handoff (SG-02)
+
+| | |
+|---|---|
+| **Profile** | feature (behavioral) |
+| **Proof class** | behavioral: real orchestrator injection flow + tests + negative control |
+| **Spec** | SPEC-087 Mechanism B (two-tier contract) |
+| **Canonical** | this file |
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| AC1 | HOT `HANDOFF.md` injected in full (overwritten each transition) | PASS | R1 (6a), R2 |
+| AC2 | HOT handoff is size-capped (head + notice over `HANDOFF_MAX_LINES`) | PASS | R1 (6d) |
+| AC3 | WARM `DECISIONS.md` injected as a POINTER only, body not inlined | PASS | R1 (6b) |
+| AC4 | "report IN the records, not your response" wording injected | PASS | R1 (6c) |
+| AC5 | prompt injected via temp file on stdin, not an argv arg | PASS | R2, code |
+| AC6 | contract documented + sample pair committed | PASS | SPEC-087 Mechanism B, `tests/fixtures/handoff-sample/` |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | hot/warm split in `_build_prompt` (full+capped vs pointer-only) + stdin temp-file injection |
+| Where | `lib/orchestrate.sh` (`_build_prompt`, run path), `tests/test-orchestrate.sh` (TEST 6a-6d), `tests/fixtures/handoff-sample/`, SPEC-087 Mechanism B |
+| How it runs | orchestrator inlines HANDOFF.md (capped), points at DECISIONS.md, pipes the prompt via `< tmp` |
+| Reversibility | additive: no HANDOFF/DECISIONS -> prior behavior; cap default 80 lines |
+
+## 3. Confirmation (recorded runs)
+
+| Run | When | Command | Exit | Verdict |
+|---|---|---|---|---|
+| R1 | 2026-06-29 | `bash tests/test-orchestrate.sh` | 0 | PASS (19/19, incl. 4 two-tier + box-not-flipped negative control) |
+| R2 | 2026-06-29 | capture-mock run: prompt received on stdin, hot body present, warm body absent | 0 | PASS |
+
+## 4. Run detail
+
+### R1 GREEN, full suite incl. negative control
+- Command: `bash tests/test-orchestrate.sh`
+- Output (tail): `... PASS hot HANDOFF capped at HANDOFF_MAX_LINES with a truncation notice / ---- / ALL PASS`
+- Negative control (pre-existing, still green): a session that does not flip its ROADMAP box
+  halts the loop nonzero. Confirms the harness can go RED.
+- Mock-injection change: all mocks now read the prompt from stdin (`prompt=$(cat)`), proving the
+  stdin injection path end-to-end; assertions unchanged from phase 1.
+
+### R2 two-tier injection shape (TEST 6a-6d)
+- 6a: a deep HANDOFF body line (`Read-pointers (verified this run)`) is present, no truncation
+  notice -> full injection under cap.
+- 6b: `WARM LEDGER` + `DECISIONS.md` present, but the ledger's body line (`append-only:
+  invariants + dead-ends, read on demand`) is absent -> pointer-only.
+- 6c: `report findings IN the records` present.
+- 6d: with `HANDOFF_MAX_LINES=5` over a 20-line handoff, `LINE-5` present, `LINE-20` absent,
+  `truncated at 5/20 lines` present.
+
+## 5. Reproduce
+```
+git switch feat/two-tier-handoff
+bash tests/test-orchestrate.sh        # 19/19 ALL PASS
+```

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -29,6 +29,11 @@ CLAUDE_CMD="${CLAUDE_CMD:-claude}"
 # so the mock's prompt stays the last arg.
 CLAUDE_FLAGS="${CLAUDE_FLAGS:---dangerously-skip-permissions}"
 
+# Hot-handoff size cap (SPEC-087 Mechanism B, two-tier). The HOT HANDOFF.md is injected in full,
+# so it must stay small or it recreates the marathon. Over the cap -> inject head + a notice and
+# point at the file. The WARM DECISIONS.md ledger is never injected in full (pointer only).
+HANDOFF_MAX_LINES="${HANDOFF_MAX_LINES:-80}"
+
 _say() { printf '%s\n' "$*"; }
 
 # Emit "id<TAB>policy<TAB>checked(0|1)" per sub-goal line, in ROADMAP order.
@@ -65,10 +70,27 @@ _build_prompt() {
     printf '\nGOAL FILE (%s, the contract for this sub-goal):\n' "$(basename "$gf")"
     cat "$gf"
   fi
+  # Two-tier feed-forward (SPEC-087 Mechanism B):
+  #   HOT  HANDOFF.md  -- overwritten each transition; injected in FULL but capped. Carries the
+  #                      next action + read-pointers so re-discovery becomes a read.
+  #   WARM DECISIONS.md -- append-only ledger of invariants + dead-ends; injected as a POINTER
+  #                      only (path + size), read on demand, so it never bloats the prompt.
   if [ -s "$dir/HANDOFF.md" ]; then
-    printf '\nHANDOFF from the previous sub-goal (verify before trusting):\n'
-    cat "$dir/HANDOFF.md"
+    local lines; lines=$(wc -l < "$dir/HANDOFF.md" | tr -d ' ')
+    printf '\nHOT HANDOFF from the previous sub-goal (verify before trusting):\n'
+    if [ "$lines" -gt "$HANDOFF_MAX_LINES" ]; then
+      head -n "$HANDOFF_MAX_LINES" "$dir/HANDOFF.md"
+      printf '[... HANDOFF.md truncated at %s/%s lines; read the file for the rest]\n' "$HANDOFF_MAX_LINES" "$lines"
+    else
+      cat "$dir/HANDOFF.md"
+    fi
   fi
+  if [ -s "$dir/DECISIONS.md" ]; then
+    local dlines; dlines=$(wc -l < "$dir/DECISIONS.md" | tr -d ' ')
+    printf '\nWARM LEDGER: %s exists (%s lines) -- invariants + dead-ends. Read it on demand before re-deciding; it is NOT inlined here to keep this prompt lean.\n' "$dir/DECISIONS.md" "$dlines"
+  fi
+  # pi-swarm wording: the next session reads these records, not your transcript.
+  printf '\nWhen you finish: report findings IN the records (overwrite HANDOFF.md with the next action + read-pointers as file:line; append durable invariants/dead-ends to DECISIONS.md), NOT only in your response text. The next sub-goal reads the files, not this transcript.\n'
 }
 
 cmd_next() {
@@ -109,12 +131,19 @@ cmd_run() {
     fi
 
     _say "[orchestrate] running $id in a fresh session ($CLAUDE_CMD -p) ..."
-    local prompt; prompt=$(_build_prompt "$dir" "$id")
+    # Inject the prompt via a TEMP FILE on stdin, not a shell-interpolated argv arg (pi-swarm
+    # borrow). Removes the backtick/${}/secret-guard bug class when the handoff body carries shell
+    # metachars, and dodges ARG_MAX on a large injected handoff. `claude -p` reads the prompt from
+    # stdin when no positional prompt is given.
+    local pfile; pfile=$(mktemp)
+    _build_prompt "$dir" "$id" > "$pfile"
     # shellcheck disable=SC2086 # CLAUDE_FLAGS is operator config; word-splitting is intended.
-    if ! "$CLAUDE_CMD" -p $CLAUDE_FLAGS "$prompt"; then
+    if ! "$CLAUDE_CMD" -p $CLAUDE_FLAGS < "$pfile"; then
+      rm -f "$pfile"
       echo "[orchestrate] session for $id exited nonzero; stopping." >&2
       return 1
     fi
+    rm -f "$pfile"
 
     # grounded completion: advance only if the box actually flipped.
     local checked; checked=$(_subgoals "$roadmap" | awk -F'\t' -v i="$id" '$1==i {print $3}')

--- a/tests/fixtures/handoff-sample/DECISIONS.md
+++ b/tests/fixtures/handoff-sample/DECISIONS.md
@@ -1,0 +1,13 @@
+# WARM LEDGER (append-only: invariants + dead-ends, read on demand)
+
+Never inlined into the prompt; the orchestrator injects only a pointer to this file.
+
+## Invariants
+- The driver stays non-LLM (DEC-004). Do not add an LLM coordinator.
+- A sub-goal advances ONLY when it flips its own ROADMAP box (grounded completion).
+
+## Dead-ends
+- 2026-06-29: tried capping subagent returns in `/kit:execute` prose -> every dispatcher would
+  need the same edit. Belongs in `agents/*.md` instead.
+- 2026-06-29: passing the prompt as an argv arg tripped secret-guard on `${}` in a handoff body.
+  Fixed by stdin temp-file injection.

--- a/tests/fixtures/handoff-sample/HANDOFF.md
+++ b/tests/fixtures/handoff-sample/HANDOFF.md
@@ -1,0 +1,12 @@
+# HOT HANDOFF (overwritten each sub-goal transition)
+
+Next sub-goal: SG-04 distilled subagent returns.
+First action: add the return-contract block to `agents/worker.md` and `agents/reviewer.md`.
+
+Read-pointers (verified this run):
+- `lib/orchestrate.sh:56` -- `_build_prompt`, where injection happens
+- `docs/specs/SPEC-087-context-hygiene.md:104` -- Mechanism C (the contract to implement)
+- `agents/worker.md:1` -- the agent def to extend
+
+Dead-end hit this run: do NOT try to cap returns in `/kit:execute` prose; the cap belongs in
+the agent def so every dispatcher inherits it. See DECISIONS.md.

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -34,8 +34,8 @@ EOF
 mk_mock_good() {
   cat > "$TMP/claude-good" <<'EOF'
 #!/usr/bin/env bash
-# args: -p "<prompt>"  ; env: MOCK_ROADMAP, MOCK_DIR
-prompt="${!#}"   # last arg = the prompt, robust to any leading flags (e.g. --dangerously-skip-permissions)
+# the prompt now arrives on STDIN (orchestrator pipes a temp file); env: MOCK_ROADMAP, MOCK_DIR
+prompt=$(cat)
 id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
 awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' \
   "$MOCK_ROADMAP" > "$MOCK_ROADMAP.tmp" && mv "$MOCK_ROADMAP.tmp" "$MOCK_ROADMAP"
@@ -85,7 +85,7 @@ grep -q 'STOP: SG-03 is a gate' "$TMP/run.out" && pass "stopped at gate with mes
 D3="$TMP/mg3"; mk_megagoal "$D3"
 cat > "$TMP/claude-probe" <<EOF
 #!/usr/bin/env bash
-prompt="\${!#}"
+prompt=\$(cat)
 id=\$(printf '%s' "\$prompt" | grep -oE 'SG-[0-9]+' | head -1)
 # record whether this turn's prompt carried a HANDOFF section
 printf '%s handoff=%s goal=%s\n' "\$id" "\$(printf '%s' "\$prompt" | grep -c 'HANDOFF from the previous')" "\$(printf '%s' "\$prompt" | grep -c 'GOALFILE-MARKER-01')" >> "$TMP/probe.log"
@@ -115,7 +115,7 @@ grep -q '^- \[ \] SG-01' "$D4/ROADMAP.md" && pass "negative control: SG-01 stays
 cat > "$TMP/claude-args" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$@" >> "$ARGS_LOG"
-prompt="${!#}"
+prompt=$(cat)
 id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
 awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' "$ARGS_RM" > "$ARGS_RM.tmp" && mv "$ARGS_RM.tmp" "$ARGS_RM"
 EOF
@@ -133,6 +133,55 @@ ARGS_LOG="$TMP/args.log" ARGS_RM="$D6/ROADMAP.md" CLAUDE_FLAGS="--allowedTools R
 { grep -q -- '--allowedTools' "$TMP/args.log" && ! grep -q -- '--dangerously-skip-permissions' "$TMP/args.log"; } \
   && pass "CLAUDE_FLAGS overrides the default posture" \
   || { fail "CLAUDE_FLAGS override wrong"; cat "$TMP/args.log"; }
+
+# ============================ TEST 6: two-tier handoff injection ============================
+# Probe mock dumps the received prompt (stdin) to a capture file, then flips the box.
+cat > "$TMP/claude-cap" <<'EOF'
+#!/usr/bin/env bash
+prompt=$(cat)
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+printf '%s' "$prompt" > "$CAP_FILE"
+awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' "$CAP_RM" > "$CAP_RM.tmp" && mv "$CAP_RM.tmp" "$CAP_RM"
+EOF
+chmod +x "$TMP/claude-cap"
+
+# Fixture: single auto sub-goal, pre-seeded with the committed HOT/WARM pair.
+D7="$TMP/mg7"; mk_megagoal "$D7"
+# make SG-01 the only runnable (gate at SG-02 so the loop stops right after SG-01)
+cat > "$D7/ROADMAP.md" <<'EOF'
+# Mega-goal: fixture
+## Sub-goals
+- [ ] SG-01 only auto , auto , PR #__
+- [ ] SG-02 gate , gate , PR #__
+EOF
+cp "$KIT/tests/fixtures/handoff-sample/HANDOFF.md" "$D7/HANDOFF.md"
+cp "$KIT/tests/fixtures/handoff-sample/DECISIONS.md" "$D7/DECISIONS.md"
+CAP_FILE="$TMP/cap.txt" CAP_RM="$D7/ROADMAP.md" CLAUDE_CMD="$TMP/claude-cap" bash "$ORCH" run "$D7" >/dev/null 2>&1
+
+# 6a: HOT handoff injected in full (small file -> a deep body line present, no truncation notice)
+{ grep -q 'Read-pointers (verified this run)' "$TMP/cap.txt" && ! grep -q 'truncated at' "$TMP/cap.txt"; } \
+  && pass "hot HANDOFF injected in full (under cap)" || { fail "hot handoff not fully injected"; }
+# 6b: WARM ledger injected as a POINTER only (path present, body NOT inlined)
+{ grep -q 'WARM LEDGER' "$TMP/cap.txt" && grep -q 'DECISIONS.md' "$TMP/cap.txt" && ! grep -q 'append-only: invariants + dead-ends, read on demand' "$TMP/cap.txt"; } \
+  && pass "warm DECISIONS injected as pointer, body not inlined" || { fail "warm ledger leaked its body or missing pointer"; }
+# 6c: the "report IN the records" wording is present
+grep -q 'report findings IN the records' "$TMP/cap.txt" \
+  && pass "report-in-the-records wording injected" || fail "missing report-in-records wording"
+
+# 6d: hot handoff CAP -> head + truncation notice when over HANDOFF_MAX_LINES
+D8="$TMP/mg8"; mk_megagoal "$D8"
+cat > "$D8/ROADMAP.md" <<'EOF'
+# Mega-goal: fixture
+## Sub-goals
+- [ ] SG-01 only auto , auto , PR #__
+- [ ] SG-02 gate , gate , PR #__
+EOF
+seq 1 20 | sed 's/^/LINE-/' > "$D8/HANDOFF.md"   # 20 lines: LINE-1 .. LINE-20
+CAP_FILE="$TMP/cap2.txt" CAP_RM="$D8/ROADMAP.md" HANDOFF_MAX_LINES=5 \
+  CLAUDE_CMD="$TMP/claude-cap" bash "$ORCH" run "$D8" >/dev/null 2>&1
+{ grep -q 'LINE-5' "$TMP/cap2.txt" && ! grep -q 'LINE-20' "$TMP/cap2.txt" && grep -q 'truncated at 5/20 lines' "$TMP/cap2.txt"; } \
+  && pass "hot HANDOFF capped at HANDOFF_MAX_LINES with a truncation notice" \
+  || { fail "handoff cap wrong"; }
 
 echo "----"
 [ "$fails" = 0 ] && { echo "ALL PASS"; exit 0; } || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## What

Two-tier feed-forward handoff in `lib/orchestrate.sh` (SPEC-087 Mechanism B). A single handoff file either bloats (carries every decision forward) or forgets (carries only "files located"). Split it by access pattern.

| Tier | File | Lifecycle | Injection | Carries |
|---|---|---|---|---|
| HOT | `HANDOFF.md` | overwritten each transition | FULL, capped to `HANDOFF_MAX_LINES` (default 80) | next sub-goal + first action + read-pointers (`file:line`) |
| WARM | `DECISIONS.md` | append-only | POINTER only (path + line count) | invariants + dead-ends, read on demand |

## How

- `_build_prompt` inlines the hot handoff (head + truncation notice over the cap) and inlines only a pointer to the warm ledger, so the append-only ledger never grows the prompt.
- pi-swarm borrow: prompt injected via a **temp file on stdin** (`claude -p ... < tmp`), not a shell-interpolated argv arg, killing the backtick/`${}`/secret-guard bug class and `ARG_MAX` risk.
- "report findings IN the records, not your response text" wording injected (next session reads files, not the transcript).

## Proof

`docs/verification/two-tier-handoff.md` (table-first). `bash tests/test-orchestrate.sh` = 19/19 (TEST 6a-6d: full inject, pointer-only, wording, cap + the pre-existing box-not-flipped negative control). All mocks switched to read the prompt from stdin, proving the injection path end-to-end. Committed sample pair at `tests/fixtures/handoff-sample/`.

## Scope

Off master, independent of the other SG-01..04 orchestrator changes (they touch the same file; merge-order is the reviewer's call). Part of the token-optim-v2 wave (SG-02); pairs with SG-03 to unlock the composer-emits-fields work (SG-08).

**Gated for team review** (shared repo): open-only, do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
