### PR TITLE
feat(kit): distilled subagent return contract (Mechanism C)

### DIFF
--- a/agents/doc-verifier.md
+++ b/agents/doc-verifier.md
@@ -81,3 +81,14 @@ Contradictions:
 - Keep output compact so `/docs` parses the verdict quickly.
 
 Source: GSD `agents/gsd-doc-verifier.md` (read-only adversarial doc fact-checker, "assume every claim is wrong until the filesystem proves it"); adapted to the kit's three-verdict shape. Reuses the verification-pipeline split (read-only verifier; the writer applies the fix), ADR-0005. Sibling of `integration-checker` (SPEC-021). See docs/specs/SPEC-022-doc-verifier.md and ADR-0016.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/fix-agent.md
+++ b/agents/fix-agent.md
@@ -65,3 +65,14 @@ Unfixed (if any):
 - Do NOT add defensive code "just in case." Fix what the verifier flagged.
 - Do NOT run the full build pipeline. Run tests only.
 - Do NOT create new files unless the verifier explicitly says a file is missing.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/integration-checker.md
+++ b/agents/integration-checker.md
@@ -104,3 +104,14 @@ Gaps:
 - Keep output compact so the orchestrator parses the verdict quickly.
 
 Source: GSD `agents/gsd-integration-checker.md` (read-only adversarial cross-phase verifier, "assume broken until grep proves the link"); adapted to the kit's three-verdict shape. Reuses the verification-pipeline split (read-only verifier + write-scoped fix-agent), ADR-0005. See docs/specs/SPEC-021-integration-checker.md and ADR-0015.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/research-architecture.md
+++ b/agents/research-architecture.md
@@ -65,3 +65,14 @@ File: [example file showing the pattern]
 - Max 60 lines. Patterns, not exhaustive listings.
 - Show concrete examples (actual file paths, actual function signatures) not abstract descriptions.
 - If the codebase has no consistent pattern (different features use different approaches), say so. That's useful information.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/research-features.md
+++ b/agents/research-features.md
@@ -58,3 +58,14 @@ Write to `docs/research/features.md`:
 - Max 80 lines. Focus on the 10-15 most relevant files, not exhaustive listing.
 - Use `git log` to find which files are actively maintained vs abandoned.
 - If the area doesn't exist yet (no related code found), say so explicitly. That means it's greenfield within a brownfield project.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/research-pitfalls.md
+++ b/agents/research-pitfalls.md
@@ -57,3 +57,14 @@ Write to `docs/research/pitfalls.md`:
 - Critical means "implementation will fail or produce bugs if this isn't addressed first."
 - If you find nothing, say "No significant pitfalls found." Don't pad the report.
 - Check `git blame` on suspicious code to see when it last changed. Code untouched for 6+ months in an active repo is a smell.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/research-stack.md
+++ b/agents/research-stack.md
@@ -54,3 +54,14 @@ Write to `docs/research/stack.md`:
 - Max 50 lines of output. Be concise.
 - Only report what you can verify from files. Don't guess.
 - If a config file doesn't exist, say "not found" instead of assuming.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/responding-to-review.md
+++ b/agents/responding-to-review.md
@@ -178,3 +178,14 @@ Implementation order:
 - External feedback is suggestions to evaluate, not orders to follow. Verify, question, then implement.
 
 Source: superpowers v5.0.7 `skills/receiving-code-review/SKILL.md` -- 6-step response pattern, forbidden-phrase list, YAGNI check, push-back-when-wrong framing. Adapted from a Skill (auto-discovered) to a custom subagent (dispatched on demand by `/review-team` or the user).
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -76,3 +76,14 @@ Severity: CRITICAL (blocks merge), HIGH (should fix), MEDIUM (fix soon), LOW (wh
 - Be specific. File paths and line numbers, not vague concerns.
 - If everything looks good through your lens, say so and give a high score. Don't invent problems.
 - Source: gstack /review paranoid reviewer pattern, split into focused lenses. Addy Osmani's parallel review pattern (security + performance + coverage as simultaneous subagents). Architecture lens "decomposed for independent testability" and "what this change contributed" framing borrowed from superpowers v5.0.7 `skills/subagent-driven-development/code-quality-reviewer-prompt.md`.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -102,3 +102,14 @@ Scope: [what was audited: diff hash, file list]
 - Only report real vulnerabilities, not style preferences. "Function could be named better" is not a security issue.
 - If you can't determine if something is vulnerable without more context, say so and recommend a specific follow-up (e.g., "check if this endpoint is behind auth middleware in router.ts:45").
 - Source: Trail of Bits security review patterns + OWASP Top 10 checklist.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/task-verifier.md
+++ b/agents/task-verifier.md
@@ -201,3 +201,14 @@ Issues:
 - Keep your output compact. The orchestrator needs to parse your verdict quickly.
 
 Source: superpowers v5.0.7 `skills/subagent-driven-development/spec-reviewer-prompt.md` -- "verify by reading code, not by trusting report" framing and the "extra / unneeded work" category (Section 3b above).
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -68,6 +68,11 @@ Tasks with no dependencies or whose dependencies are all complete can run in any
 
 #### 2b. Dispatch each task as a worker subagent
 
+> A subagent is NOT automatically cheaper: a subagent-heavy workflow can cost several times a
+> single thread. Dispatch one when isolating a task's noise (large reads, long tool chains) from
+> the lead's context is worth the setup overhead, NOT for one-prompt tasks, a single tool call,
+> or when near a rate/budget limit. (research/2026-06-28-token-efficient-design.md Part 1.)
+
 For each task, use the **Task tool** with this prompt structure:
 
 ```
@@ -117,11 +122,18 @@ Before writing any code, expand this task into **bite-sized steps** and present 
 ## Decision mode
 [lead: pause for human approval / autonomous: proceed with recommendation and log]
 
-## When done
-Report: what you implemented, what tests you wrote, what files you changed, decisions made
-(with protocol format), whether all acceptance criteria are met, and the path
-+ count of entries appended to `docs/implementation-notes/<spec-slug>.md` (or
-`no deviations logged` if you appended the no-deviations line).
+## When done (distilled return contract, SPEC-087 Mechanism C)
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+- **verdict** -- one line: all acceptance criteria met? + the commit hash.
+- **key findings** -- decisions made (protocol format) + any blocker; the few things that
+  change what the lead does next.
+- **artifacts** -- files you changed, the tests you wrote, and the path + count of entries
+  appended to `docs/implementation-notes/<spec-slug>.md` (or `no deviations logged`).
+- **read-next** -- `file:line` pointers if the lead wants detail.
+
+Report findings IN this summary, not as a re-paste of full diffs or test logs; the full output
+stays recoverable in your subagent transcript. The lead absorbs the summary and pulls detail on
+demand (and passes it to the task-verifier).
 ```
 
 #### 2c. Verify worker output (THE VERIFICATION PIPELINE)

--- a/docs/implementation-notes/distilled-returns.md
+++ b/docs/implementation-notes/distilled-returns.md
@@ -1,0 +1,28 @@
+# Impl notes: distilled subagent returns (SG-04)
+
+Delta from SPEC-087 Mechanism C. Only off-spec calls live here.
+
+## 2026-06-29 contract appended to ALL agents/*.md, not only the 4 named
+- Context: the goal's verification grep names worker/task-verifier/integration-checker/reviewer;
+  the scope line says "across dispatched roles".
+- Decision: append the `## Return contract` block to every `agents/*.md` (all are dispatched
+  subagent defs), so the lead's growth is bounded no matter which role it spawns. Worker has no
+  agent file -> its contract goes in `commands/execute.md` dispatch prose.
+- Why: a partial rollout leaves the high-volume roles (research-*, security-auditor) dumping.
+
+## 2026-06-29 block APPENDED at end, not inserted before ## Rules
+- Decision: append the section at the end of each file rather than splicing before `## Rules`.
+- Why: 11 files with different internal structure; a uniform append is mechanical and low-risk.
+  Cost: the existing `Source:` footer is no longer the literal last line in files that had one.
+  Accepted as cosmetic; the contract reads fine as the closing section.
+- Alternative rejected: 11 bespoke "insert before X" edits, higher chance of a mis-splice for
+  no real gain.
+
+## 2026-06-29 "subagent is not automatically cheaper" decision rule
+- Placed in SPEC-087 Mechanism C (design rationale) + a one-liner in execute.md, not in every
+  agent def (it governs WHEN the lead dispatches, not how a role returns). Source:
+  research/2026-06-28-token-efficient-design.md Part 1.
+
+## 2026-06-29 verification grep adapted
+- The goal's grep lists `agents/worker.md`, which does not exist. Proof uses the real file set
+  + an explicit check that execute.md carries the worker return contract.

--- a/docs/specs/SPEC-087-context-hygiene.md
+++ b/docs/specs/SPEC-087-context-hygiene.md
@@ -106,8 +106,21 @@ inside an agentkernel sandbox via `CLAUDE_CMD`; these are options, not the defau
 Bounds growth INSIDE one sub-goal. Each kit-dispatched role returns a bounded structured
 summary (`verdict`, `key findings`, `artifacts`, `read-next`), not the full diff / log; the
 full output stays recoverable in the subagent transcript. The lead absorbs the summary and
-pulls detail on demand. Applies to worker, task-verifier, integration-checker, reviewer /
-review-team, research-*. This is additive to A+B and is built as a follow-up increment.
+pulls detail on demand. Implemented as a `## Return contract` section appended to every
+`agents/*.md` (the worker has no agent file, so its contract lives in the `/kit:execute`
+dispatch prose). The wording is grounded in pi-swarm (`spawn.ts:180`, "report findings IN the
+record, not your response text"); the verdict is a "concrete outcome with evidence". This bounds
+the lead's growth to hundreds of tokens per dispatch instead of the 16-25K a full dump costs.
+
+**Decision rule (when to dispatch at all).** A subagent is NOT automatically cheaper: a
+subagent-heavy workflow can cost several times a single thread (setup + the return still lands in
+the lead). Dispatch one only when isolating a task's noise (large reads, long tool chains) from
+the lead's context is worth that overhead, NOT for one-prompt tasks, a single tool call, or when
+near a rate/budget limit (research/2026-06-28-token-efficient-design.md Part 1). The return
+contract makes the dispatch-and-absorb path cheap; the decision rule keeps it from being overused.
+
+Applies to worker, task-verifier, integration-checker, reviewer / review-team, research-*. This
+is additive to A+B.
 
 ### Where it lives
 

--- a/docs/verification/distilled-returns.md
+++ b/docs/verification/distilled-returns.md
@@ -1,0 +1,64 @@
+# Proof of done: distilled subagent return contract (SG-04)
+
+| | |
+|---|---|
+| **Profile** | feature (behavioral/structural) |
+| **Proof class** | structural verification (every dispatched role carries the contract) + meta-test regression |
+| **Spec** | SPEC-087 Mechanism C |
+| **Canonical** | this file |
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| AC1 | Every dispatched-role agent def carries a return contract (`verdict`/`key findings`/`artifacts`/`read-next`) | PASS | R1 |
+| AC2 | The worker (no agent file) carries the contract in `/kit:execute` dispatch prose | PASS | R2 |
+| AC3 | Contract says report IN the summary; full output stays recoverable in the transcript | PASS | code, R1 |
+| AC4 | The "subagent is not automatically cheaper" decision rule is baked in | PASS | execute.md + SPEC-087 Mechanism C |
+| AC5 | No tool grants changed; no role's structure broken | PASS | R3 (500/500 meta) |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | `## Return contract` section appended to every `agents/*.md`; worker contract in execute.md `## When done`; decision rule at the dispatch boundary + in the spec |
+| Where | `agents/*.md` (11 files), `commands/execute.md`, `docs/specs/SPEC-087-context-hygiene.md` |
+| How it runs | injected into each subagent's prompt by the existing dispatch machinery; no code path change |
+| Reversibility | pure doc/prose addition; revert restores the prior return shape |
+
+## 3. Confirmation (recorded runs)
+
+| Run | When | Command | Exit | Verdict |
+|---|---|---|---|---|
+| R1 | 2026-06-29 | `grep -L 'read-next' agents/*.md` | 0 | empty -> all 11 roles carry the contract |
+| R2 | 2026-06-29 | `grep -c 'distilled return contract' commands/execute.md` | 0 | 1 -> worker contract present |
+| R3 | 2026-06-29 | `bash tests/test-meta.sh` | 0 | PASS 500/500 (no agent/command structure regressed) |
+
+## 4. Run detail
+
+### R1 structural: every dispatched role carries the contract
+- Command: `grep -L 'read-next' agents/*.md`
+- Output: (empty) -> no agent file is missing the contract. 11 files updated.
+
+### R2 worker contract in the dispatch prose
+- The worker has no `agents/worker.md`; its return contract lives in `commands/execute.md`
+  Section 2b `## When done`, reshaped to verdict / key findings / artifacts / read-next.
+
+### R3 regression: kit structure intact
+- Command: `bash tests/test-meta.sh`
+- Output: `Passed: 500 / 500. All meta tests passed.`
+- Confirms frontmatter, source citations, and command/agent wiring still validate after the edits.
+
+## 5. Note on token-delta
+A live before/after token capture needs a real dispatch (non-deterministic, model-dependent), so
+the recorded proof is the structural guarantee that every role now returns a bounded summary +
+points at its transcript. The mechanism (bounded summary vs full dump) is what cuts the per-
+dispatch cost from ~16-25K to hundreds of tokens; SG-09's ablation measures the aggregate effect.
+
+## 6. Reproduce
+```
+git switch feat/distilled-returns
+grep -L 'read-next' agents/*.md          # empty
+grep -c 'distilled return contract' commands/execute.md   # 1
+bash tests/test-meta.sh                   # 500/500
+```


### PR DESCRIPTION
## What

Distilled subagent return contract across the kit's dispatched roles (SPEC-087 Mechanism C). Bounds context growth INSIDE a single sub-goal: a dispatched subagent returns a bounded structured summary instead of dumping a full diff/log, so the lead grows by hundreds of tokens per dispatch instead of 16-25K.

## How

- Appended a `## Return contract` section (verdict / key findings / artifacts / read-next) to every `agents/*.md` (11 files).
- The worker has no agent file -> its contract lives in `commands/execute.md` `## When done`.
- "Subagent is NOT automatically cheaper" decision rule at the dispatch boundary + in the spec, so the cheap dispatch path is not overused.
- Full output stays recoverable in the subagent transcript (point at it, never discard).

## Proof

`docs/verification/distilled-returns.md` (table-first):
- `grep -L 'read-next' agents/*.md` -> empty (all 11 carry the contract)
- `grep -c 'distilled return contract' commands/execute.md` -> 1 (worker)
- `bash tests/test-meta.sh` -> 500/500 (no agent/command structure regressed)

No tool grants changed. Wording grounded in pi-swarm `spawn.ts:180`. A live token-delta needs a non-deterministic real dispatch; SG-09's ablation measures the aggregate effect.

## Scope

`agents/*.md` + `/kit:execute` prose only. Part of the token-optim-v2 wave (SG-04); independent of SG-01/02/03 (touches different files).

**Gated for team review** (shared repo): open-only, do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
