### PR TITLE
feat(kit): orchestrator --step pause + live stream for observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ dwarves-kit/
   lib/goal-registry.sh          Cross-session running-goal registry: claim/list/log/release (multi-session moat + monitor)
   lib/goal-drafts.sh            Goal-draft lifecycle: archive shipped drafts to .claude/goals/done/
   lib/lane-telemetry.sh         Read-side lane-effectiveness aggregator over the run ledgers: report + misfires (reviewed at /kit:retro)
-  lib/orchestrate.sh            Non-LLM mega-goal driver: one fresh `claude -p` session per sub-goal so no session marathons (SPEC-087); linear + session-per-sub-goal, NOT a DAG scheduler or daemon
+  lib/orchestrate.sh            Non-LLM mega-goal driver: one fresh `claude -p` session per sub-goal so no session marathons (SPEC-087); linear + session-per-sub-goal, NOT a DAG scheduler or daemon. `run <dir>` flags: `--dry-run` (plan only), `--step` (pause for the operator between sub-goals), `--stream` (live stream-json tee'd to `.orchestrate/<id>.stream.jsonl`; gitignore that dir)
   skills/get-api-docs/          Context Hub integration
   rules/                        Path-scoped coding-standard templates
   examples/hello-spec/          Demo: small CLAUDE.md + SPEC.md walkthrough

--- a/docs/implementation-notes/orchestrator-run-modes.md
+++ b/docs/implementation-notes/orchestrator-run-modes.md
@@ -1,0 +1,32 @@
+# Implementation notes: orchestrator run-modes (SG-01)
+
+Delta from goal file `goals/01-run-modes.md` (token-optim-v2). The goal pins the contract;
+this records only off-spec decisions.
+
+## 2026-06-29 arg parsing rewrite
+- Context: `cmd_run` parsed `--dry-run` positionally (`[ "${2:-}" = "--dry-run" ]`). Adding two
+  more flags positionally would be brittle.
+- Decision: replaced with a flag loop that accepts `--dry-run`, `--step`, `--stream` in any
+  order, plus the megagoal dir as the one positional. Unknown `--flag` -> exit 64.
+- Why: three opt-in flags now; order-independence is the only sane shape.
+- Impact: existing call sites (`run <dir>`, `run <dir> --dry-run`) unchanged.
+
+## 2026-06-29 --step as a stdin gate, not a TTY keypress
+- Decision: `--step` pauses after each completed sub-goal and reads ONE line from the
+  orchestrator's stdin (free: the prompt goes to `claude` via `< "$pfile"`, not the driver's
+  stdin). Empty / `y` / `c` continues; `q` / `n` / `quit` stops cleanly (return 0). EOF (closed
+  stdin, no operator) stops cleanly too -- can't get consent, so don't march on.
+- Why over a raw keypress: testable without a PTY (pipe `"\n"` / `"q\n"`), and the pi-swarm
+  `confirmAction` borrow is a y/n line read, not a single-char raw read.
+- Impact: pausing only happens when there IS a next sub-goal (no trailing pause before the
+  gate-stop or done).
+
+## 2026-06-29 --stream wires stream-json + tee, opt-in
+- Decision: `--stream` invokes `claude -p --output-format stream-json --verbose ... | tee
+  <dir>/.orchestrate/<id>.stream.jsonl`. Off by default => byte-identical default invocation
+  (kept as a separate branch, not a built-up pipeline, so the no-stream path has no `tee`).
+- Why `--verbose`: `claude -p --output-format stream-json` requires it in non-interactive mode.
+- Why persist under `.orchestrate/`: the goal's proof wants a captured terminal slice; a file
+  next to the megagoal is the lazy durable capture + live tail in one (`tee`). Pipefail (already
+  set) keeps the `if ! ... | tee` failure check honest.
+- Note: `.orchestrate/` is runtime state; consumers should gitignore it (documented in README).

--- a/docs/verification/orchestrate.md
+++ b/docs/verification/orchestrate.md
@@ -79,3 +79,61 @@ Applied the review findings; the suite grew from 12 to 15 assertions, all green;
 New coverage: permission posture default + override (2 assertions); goal-file CONTENT injection
 into the prompt (1 assertion, closes the path-vs-content gap); policy parser hardened to
 exact-field match, unknown fail-safes to `gate`. NEGATIVE CONTROL still green. Verdict: PASS.
+
+## SG-01 addendum: run-modes `--step` + `--stream` (2026-06-29, token-optim-v2)
+
+Adds two opt-in observability mechanisms (SPEC-087 Mechanism A): `--step` (pause for the operator
+after each completed auto sub-goal, resume on Enter / `q` to stop) and `--stream` (stream each
+session as stream-json, tee'd to `.orchestrate/<id>.stream.jsonl` for a live tail + capture).
+Both off by default => the default invocation is byte-identical.
+
+### Acceptance criteria (SG-01)
+
+| # | Criterion | Met |
+|---|---|---|
+| AC1 | `--step` pauses after each sub-goal, resumes on Enter, `q` stops cleanly (exit 0) | yes (tests 9b, 9c) |
+| AC2 | `--step --dry-run` plan shows the pause points, no claude invoked | yes (test 9a) |
+| AC3 | `--stream` streams live AND captures to `.orchestrate/<id>.stream.jsonl` | yes (test 10) |
+| AC4 | default (no `--step`/`--stream`) behavior unchanged; the `/goal` loop + Stop hook untouched | yes (test 9d, all prior tests green) |
+| AC5 | unknown `--flag` rejected (exit 64) | yes (test 10) |
+
+### Confirmation run-table
+
+| Command | Exit | Result |
+|---|---|---|
+| `bash tests/test-orchestrate.sh` | 0 | 34/34 PASS (`ALL PASS`; was 15, +19 for run-modes) |
+| `shellcheck lib/orchestrate.sh` | 0 | CLEAN |
+| `bash tests/test-meta.sh` | 0 | 500/500 (README lib row parity held) |
+| `bash lib/orchestrate.sh run <megagoal> --step --dry-run` | 0 | plan annotated with `(--step: pause ...)` |
+| (negative control) default run, stdin closed | 0 | no pause prompt; auto chain runs unchanged |
+
+### Run detail: captured `--step` + `--stream` terminal slice (2026-06-29)
+
+```
+[orchestrate] running SG-01 in a fresh session (... -p, model: inherit, effort: inherit) ...
+[orchestrate] streaming SG-01 -> .../.orchestrate/SG-01.stream.jsonl (live tail + captured)
+{"type":"assistant","text":"working on SG-01"}
+{"type":"result","sg":"SG-01"}
+[orchestrate] SG-01 complete (box checked); advancing.
+[orchestrate] --step: SG-01 done. [Enter]=continue  q=stop:        # <- PAUSED here; operator hits Enter
+[orchestrate] running SG-02 in a fresh session ...                 # <- RESUMED
+[orchestrate] streaming SG-02 -> .../.orchestrate/SG-02.stream.jsonl (live tail + captured)
+{"type":"assistant","text":"working on SG-02"}
+{"type":"result","sg":"SG-02"}
+[orchestrate] SG-02 complete (box checked); advancing.
+[orchestrate] STOP: SG-03 is a gate sub-goal; ...                  # <- gate-stop, no redundant pause
+```
+
+Captured `.orchestrate/SG-01.stream.jsonl`:
+```
+{"type":"assistant","text":"working on SG-01"}
+{"type":"result","sg":"SG-01"}
+```
+
+### NEGATIVE CONTROL (SG-01)
+
+Test 9d runs the default loop (no `--step`, stdin closed via `</dev/null`) and asserts NO `--step:`
+prompt appears while the auto chain still completes (SG-02 box flips). So the pause is genuinely
+gated on the flag, not always-on; an unattended `run` cannot deadlock waiting on a keypress.
+
+Verdict: PASS (Exit: 0 on the suite; pause-gating proven by the default-mode negative control).

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -9,7 +9,11 @@
 #
 # Usage:
 #   orchestrate.sh next <megagoal-dir>             print the next unchecked sub-goal + policy
-#   orchestrate.sh run  <megagoal-dir> [--dry-run] drive the loop (dry-run prints the plan only)
+#   orchestrate.sh run  <megagoal-dir> [--dry-run] [--step] [--stream]
+#       --dry-run  print the plan only (no claude)
+#       --step     pause for the operator after each sub-goal (resume on Enter, q to stop)
+#       --stream   stream each session live (stream-json) + capture to .orchestrate/<id>.stream.jsonl
+#   --step/--stream are opt-in; default behavior is unchanged (SG-01, SPEC-087 Mechanism A).
 #
 # <megagoal-dir> holds: ROADMAP.md (sub-goal lines `- [ ] SG-NN ... , auto|gate , ...`),
 # POINTER_PROMPT.md (static resume prompt), HANDOFF.md (feed-forward, written by each sub-goal).
@@ -118,15 +122,42 @@ cmd_next() {
   if [ -n "$nx" ]; then printf '%s\n' "$nx"; else _say "(none unchecked)"; fi
 }
 
+# Pause after a completed sub-goal in --step mode. Reads ONE line from the driver's stdin (free:
+# the prompt is fed to claude via a temp file, not here). Empty/y/c -> continue; q/n -> stop;
+# EOF (no operator attached) -> stop (can't get consent, so don't march on). pi-swarm confirmAction.
+_step_pause() {
+  local id="$1" ans
+  printf '[orchestrate] --step: %s done. [Enter]=continue  q=stop: ' "$id" >&2
+  if ! IFS= read -r ans; then
+    _say "[orchestrate] --step: stdin closed; stopping after $id."
+    return 1
+  fi
+  case "$ans" in
+    q|Q|n|N|quit|stop) _say "[orchestrate] --step: operator stopped after $id."; return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 cmd_run() {
-  local dir="${1:-}" dry=0
-  [ "${2:-}" = "--dry-run" ] && dry=1
+  local dir="" dry=0 step=0 stream=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run) dry=1 ;;
+      --step)    step=1 ;;
+      --stream)  stream=1 ;;
+      --*)       echo "unknown flag: $1" >&2; return 64 ;;
+      *)         if [ -z "$dir" ]; then dir="$1"; else echo "unexpected arg: $1" >&2; return 64; fi ;;
+    esac
+    shift
+  done
   [ -d "$dir" ] || { echo "no such megagoal dir: '$dir'" >&2; return 64; }
   local roadmap="$dir/ROADMAP.md"
   [ -f "$roadmap" ] || { echo "no ROADMAP.md in '$dir'" >&2; return 64; }
 
   if [ "$dry" = 1 ]; then
     _say "[plan] mega-goal: $dir"
+    [ "$step" = 1 ]   && _say "  (--step: pause for the operator after each sub-goal)"
+    [ "$stream" = 1 ] && _say "  (--stream: each session streamed live + captured to .orchestrate/<id>.stream.jsonl)"
     local any=0
     while IFS=$'\t' read -r sg ppolicy; do
       any=1
@@ -134,6 +165,7 @@ cmd_run() {
       IFS=$'\t' read -r rmodel reffort < <(_route "$(_goalfile "$dir" "$sg")")
       _say "  -> $sg ($ppolicy)  [model: ${rmodel:-inherit}, effort: ${reffort:-inherit}]  [prompt: POINTER_PROMPT + goal-file + $([ -s "$dir/HANDOFF.md" ] && echo HANDOFF || echo no-handoff)]"
       [ "$ppolicy" = gate ] && { _say "  == STOP at $sg (gate: human review) =="; break; }
+      [ "$step" = 1 ] && _say "     [--step] pause here for the operator before the next sub-goal"
     done < <(_subgoals "$roadmap" | awk -F'\t' '$3==0 {print $1"\t"$2}')
     [ "$any" = 1 ] || _say "  (no unchecked sub-goals)"
     return 0
@@ -164,13 +196,25 @@ cmd_run() {
     # stdin when no positional prompt is given.
     local pfile; pfile=$(mktemp)
     _build_prompt "$dir" "$id" > "$pfile"
-    # shellcheck disable=SC2086 # CLAUDE_FLAGS + route_flags are operator/goal config; word-splitting is intended.
-    if ! "$CLAUDE_CMD" -p $route_flags $CLAUDE_FLAGS < "$pfile"; then
-      rm -f "$pfile"
+    # --stream (opt-in observability): emit stream-json and tee it to a per-sub-goal capture so
+    # the operator sees a live tail AND the run is recorded. Off -> the default invocation is
+    # byte-identical (no pipe, no tee). pipefail (set at top) keeps the `if ! ... | tee` honest.
+    local rc=0
+    if [ "$stream" = 1 ]; then
+      local logdir="$dir/.orchestrate"; mkdir -p "$logdir"
+      local slog="$logdir/${id}.stream.jsonl"
+      _say "[orchestrate] streaming $id -> $slog (live tail + captured)"
+      # shellcheck disable=SC2086 # CLAUDE_FLAGS + route_flags are operator/goal config; word-splitting is intended.
+      "$CLAUDE_CMD" -p $route_flags --output-format stream-json --verbose $CLAUDE_FLAGS < "$pfile" | tee "$slog" || rc=$?
+    else
+      # shellcheck disable=SC2086 # CLAUDE_FLAGS + route_flags are operator/goal config; word-splitting is intended.
+      "$CLAUDE_CMD" -p $route_flags $CLAUDE_FLAGS < "$pfile" || rc=$?
+    fi
+    rm -f "$pfile"
+    if [ "$rc" != 0 ]; then
       echo "[orchestrate] session for $id exited nonzero; stopping." >&2
       return 1
     fi
-    rm -f "$pfile"
 
     # grounded completion: advance only if the box actually flipped.
     local checked; checked=$(_subgoals "$roadmap" | awk -F'\t' -v i="$id" '$1==i {print $3}')
@@ -179,6 +223,15 @@ cmd_run() {
       return 1
     fi
     _say "[orchestrate] $id complete (box checked); advancing."
+    # --step: pause for the operator between sub-goals, but only when the NEXT one is auto (the
+    # loop would actually run it). If next is a gate, the gate-stop below is the natural halt, so
+    # don't double up with a pause first.
+    if [ "$step" = 1 ]; then
+      local nxt; nxt=$(_next "$roadmap")
+      if [ -n "$nxt" ] && [ "$(printf '%s' "$nxt" | cut -f2)" = auto ]; then
+        _step_pause "$id" || return 0
+      fi
+    fi
   done
 }
 
@@ -187,7 +240,7 @@ main() {
   case "$cmd" in
     next) cmd_next "$@" ;;
     run)  cmd_run "$@" ;;
-    *) echo "usage: orchestrate.sh {next|run} <megagoal-dir> [--dry-run]" >&2; exit 64 ;;
+    *) echo "usage: orchestrate.sh {next|run} <megagoal-dir> [--dry-run] [--step] [--stream]" >&2; exit 64 ;;
   esac
 }
 

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -224,5 +224,66 @@ grep -q '^SG-01|.*--model sonnet --effort low' "$TMP/route.log" \
 { grep '^SG-02|' "$TMP/route.log" | grep -qv -- '--model'; } \
   && pass "run passes no --model for inherit SG-02" || { fail "SG-02 got an unexpected --model"; cat "$TMP/route.log"; }
 
+# ============================ TEST 9: --step run-modes (SG-01) ============================
+# 9a: --step --dry-run annotates the plan with pause points (no claude invoked).
+DS="$TMP/mgs"; mk_megagoal "$DS"
+out=$(bash "$ORCH" run "$DS" --step --dry-run)
+{ echo "$out" | grep -q 'pause for the operator after each sub-goal' \
+  && echo "$out" | grep -q '\[--step\] pause here'; } \
+  && pass "--step --dry-run shows pause points" || { fail "--step dry-run missing pauses"; echo "$out"; }
+grep -q '^- \[ \] SG-01' "$DS/ROADMAP.md" && pass "--step --dry-run did not execute" || fail "--step dry-run had side effects"
+
+# 9b: --step real run, operator resumes (Enter) -> chain completes, stops at gate.
+D9="$TMP/mg9"; mk_megagoal "$D9"; mk_mock_good
+export MOCK_ROADMAP="$D9/ROADMAP.md" MOCK_DIR="$D9"
+printf '\n\n' | CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$D9" --step > "$TMP/step.out" 2>&1
+{ grep -q '^- \[x\] SG-01' "$D9/ROADMAP.md" && grep -q '^- \[x\] SG-02' "$D9/ROADMAP.md" \
+  && grep -q '^- \[ \] SG-03' "$D9/ROADMAP.md"; } \
+  && pass "--step resume: SG-01+SG-02 ran, gate SG-03 untouched" || { fail "--step resume wrong"; cat "$TMP/step.out"; }
+grep -q '\-\-step: SG-01 done' "$TMP/step.out" && pass "--step paused after SG-01" || { fail "no pause prompt"; cat "$TMP/step.out"; }
+
+# 9c: --step real run, operator quits (q) after SG-01 -> SG-02 NOT run, exit 0.
+D10="$TMP/mg10"; mk_megagoal "$D10"
+export MOCK_ROADMAP="$D10/ROADMAP.md" MOCK_DIR="$D10"
+printf 'q\n' | CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$D10" --step > "$TMP/quit.out" 2>&1
+rc=$?
+{ [ "$rc" = 0 ] && grep -q '^- \[x\] SG-01' "$D10/ROADMAP.md" && grep -q '^- \[ \] SG-02' "$D10/ROADMAP.md"; } \
+  && pass "--step quit: SG-01 ran, SG-02 stopped, exit 0" || { fail "--step quit wrong (rc=$rc)"; cat "$TMP/quit.out"; }
+grep -q 'operator stopped after SG-01' "$TMP/quit.out" && pass "--step quit: explains the stop" || fail "no quit message"
+
+# Negative control for SG-01: default (no --step) run does NOT pause (unchanged behavior).
+D11="$TMP/mg11"; mk_megagoal "$D11"
+export MOCK_ROADMAP="$D11/ROADMAP.md" MOCK_DIR="$D11"
+CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$D11" > "$TMP/nostep.out" 2>&1 < /dev/null
+{ ! grep -q -- '--step:' "$TMP/nostep.out" && grep -q '^- \[x\] SG-02' "$D11/ROADMAP.md"; } \
+  && pass "default (no --step) does not pause; chain runs unchanged" || { fail "default mode changed"; cat "$TMP/nostep.out"; }
+
+# ============================ TEST 10: --stream capture (SG-01) ============================
+# Mock emits two lines (simulated stream-json) and flips the box; orchestrator tee's to capture.
+cat > "$TMP/claude-stream" <<'EOF'
+#!/usr/bin/env bash
+prompt=$(cat)
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+printf '{"type":"assistant","sg":"%s"}\n{"type":"result"}\n' "$id"
+awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' "$STREAM_RM" > "$STREAM_RM.tmp" && mv "$STREAM_RM.tmp" "$STREAM_RM"
+EOF
+chmod +x "$TMP/claude-stream"
+D12="$TMP/mg12"; mk_megagoal "$D12"
+cat > "$D12/ROADMAP.md" <<'EOF'
+# Mega-goal: fixture
+## Sub-goals
+- [ ] SG-01 only auto , auto , PR #__
+- [ ] SG-02 gate , gate , PR #__
+EOF
+STREAM_RM="$D12/ROADMAP.md" CLAUDE_CMD="$TMP/claude-stream" bash "$ORCH" run "$D12" --stream > "$TMP/stream.out" 2>&1 < /dev/null
+{ [ -f "$D12/.orchestrate/SG-01.stream.jsonl" ] && grep -q '"type":"result"' "$D12/.orchestrate/SG-01.stream.jsonl"; } \
+  && pass "--stream captured the session output to .orchestrate/SG-01.stream.jsonl" || { fail "--stream capture missing"; cat "$TMP/stream.out"; }
+grep -q '"type":"result"' "$TMP/stream.out" && pass "--stream tee'd output live to stdout" || fail "--stream not teed live"
+grep -q '^- \[x\] SG-01' "$D12/ROADMAP.md" && pass "--stream run still advances on box flip" || fail "--stream did not advance"
+
+# Unknown flag is rejected.
+bash "$ORCH" run "$DS" --bogus > "$TMP/bogus.out" 2>&1; rc=$?
+{ [ "$rc" = 64 ] && grep -q 'unknown flag' "$TMP/bogus.out"; } && pass "unknown flag -> exit 64" || fail "unknown flag not rejected (rc=$rc)"
+
 echo "----"
 [ "$fails" = 0 ] && { echo "ALL PASS"; exit 0; } || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
Implements SPEC-087 Mechanism A observability for `lib/orchestrate.sh` (token-optim-v2 SG-01). Gated for team review.

## What

Two opt-in run-modes on `orchestrate.sh run <dir>`:

- `--step` — pause for the operator after each completed **auto** sub-goal. Resume on Enter; `q` stops cleanly (exit 0). No pause before a gate-stop (that's the natural halt) or before the loop finishes.
- `--stream` — stream each session as `stream-json` and `tee` it to `.orchestrate/<id>.stream.jsonl`, so the operator gets a live tail AND a captured slice.

Both are **off by default** → the default invocation is byte-identical. The in-session `/goal` loop and the Stop hook are untouched. Arg parsing rewritten to a flag loop (any order; unknown flag → exit 64).

## Why

Closes the "background black box" concern from the 2026-06-29 design session without giving up per-sub-goal context isolation. `--step` (pi-swarm `confirmAction` borrow) lets a human watch and step in between sub-goals; `--stream` (pi-swarm live-progress borrow) gives a live tail + a durable capture for review.

## Proof

`docs/verification/orchestrate.md` (SG-01 addendum): acceptance table, run-table, a captured `--step`+`--stream` terminal slice, and a **default-mode negative control** proving the pause is flag-gated (an unattended `run` cannot deadlock on a keypress).

| Command | Exit | Result |
|---|---|---|
| `bash tests/test-orchestrate.sh` | 0 | 34/34 PASS (+19 for run-modes) |
| `shellcheck lib/orchestrate.sh` | 0 | CLEAN |
| `bash tests/test-meta.sh` | 0 | 500/500 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
