### PR TITLE
feat(kit): orchestrator board-view / event-sourced kanban sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ dwarves-kit/
   lib/goal-registry.sh          Cross-session running-goal registry: claim/list/log/release (multi-session moat + monitor)
   lib/goal-drafts.sh            Goal-draft lifecycle: archive shipped drafts to .claude/goals/done/
   lib/lane-telemetry.sh         Read-side lane-effectiveness aggregator over the run ledgers: report + misfires (reviewed at /kit:retro)
-  lib/orchestrate.sh            Non-LLM mega-goal driver: one fresh `claude -p` session per sub-goal so no session marathons (SPEC-087); linear + session-per-sub-goal, NOT a DAG scheduler or daemon. `run <dir>` flags: `--dry-run` (plan only), `--step` (pause for the operator between sub-goals), `--stream` (live stream-json tee'd to `.orchestrate/<id>.stream.jsonl`; gitignore that dir)
+  lib/orchestrate.sh            Non-LLM mega-goal driver: one fresh `claude -p` session per sub-goal so no session marathons (SPEC-087); linear + session-per-sub-goal, NOT a DAG scheduler or daemon. `run <dir>` flags: `--dry-run` (plan only), `--step` (pause for the operator between sub-goals), `--stream` (live stream-json tee'd to `.orchestrate/<id>.stream.jsonl`), `--board=roadmap|kanban|both` (event-sourced per-mega-goal kanban derived to `<dir>/BOARD.md` via `lib/backlog.sh`; default detects, ROADMAP stays canonical). Gitignore `.orchestrate/` + `BOARD.md` (derived/runtime)
   skills/get-api-docs/          Context Hub integration
   rules/                        Path-scoped coding-standard templates
   examples/hello-spec/          Demo: small CLAUDE.md + SPEC.md walkthrough

--- a/docs/implementation-notes/orchestrator-board-sync.md
+++ b/docs/implementation-notes/orchestrator-board-sync.md
@@ -1,0 +1,39 @@
+# Implementation notes: orchestrator board-sync (SG-10)
+
+Delta from goal file `goals/10-board-sync.md` (token-optim-v2). Stacked on SG-01
+(`feat/orchestrator-run-modes`) because both edit `lib/orchestrate.sh`.
+
+## 2026-06-29 state-vocabulary mapping (the one real deviation)
+- Spec wants the board to extend the kanban with `ready` / `blocked(reason)` / `stalled`.
+- `lib/backlog.sh` (the reuse target) has a FIXED, non-env-overridable `STATES` vocabulary
+  (`queued claimed speccing validated executing shipped parked dropped`). Editing backlog.sh is
+  out of scope (scope = orchestrate.sh + its test + reuse backlog.sh).
+- Decision: map the orchestrator's derived lifecycle onto backlog.sh's standard keywords and
+  carry the extended nuance as STATUS PROSE (backlog.sh explicitly supports "prose after the
+  keyword"):
+  - box checked            -> `shipped`
+  - event log = executing  -> `executing`
+  - event log = stalled    -> `executing [stalled: <note>]`  (SG-11 emits this; SG-10 renders it)
+  - unchecked, deps met    -> `queued [ready]`                ("ready" = workable now)
+  - unchecked, deps NOT met -> `parked [blocked: needs <SG-..>]`
+- Why: keeps ONE renderer (backlog.sh) + the cockpit row format, no vocab fork. ready/blocked/
+  stalled stay visible (queued vs parked columns + the prose), which is the spec's intent
+  (distinguish workable-now from dep-blocked), just without forking backlog.sh's STATES.
+
+## 2026-06-29 dependency analysis source
+- "ready vs blocked" needs to know a sub-goal's deps. Read them from the ROADMAP line's
+  `depends ...` tail (e.g. `depends SG-02+SG-03`), NOT the goal file, so derivation needs only
+  the ROADMAP already in hand. A dep is blocking iff it names an UNCHECKED `SG-NN`. Non-SG deps
+  (`#81` = a prerequisite PR) are treated satisfied -- out of board scope, can't be read here.
+
+## 2026-06-29 event log = the progress signal SG-11 reuses
+- Event log at `<dir>/.orchestrate/events.log`, append-only `ISO\tSG\tstatus\tnote`. Emitted on
+  each transition in cmd_run (executing on launch, shipped on box-flip, blocked on gate-stop).
+- Board state is DERIVED by replay (last event per sub-goal wins); never mutated in place. A
+  crashed/concurrent session can't corrupt a checkbox. SG-11's stalled-watchdog reuses this
+  file's mtime + last-status as its progress signal (goal 11 "reuse SG-10's event log").
+
+## 2026-06-29 --board default = detect
+- Default (no `--board`): `both` when `lib/backlog.sh` resolves next to orchestrate.sh, else
+  `roadmap`. Fail-safe to `roadmap` so a kit without backlog.sh still runs. Never writes to the
+  repo-wide BACKLOG.md; the per-mega-goal board is `<dir>/BOARD.md` only.

--- a/docs/verification/orchestrate.md
+++ b/docs/verification/orchestrate.md
@@ -137,3 +137,87 @@ prompt appears while the auto chain still completes (SG-02 box flips). So the pa
 gated on the flag, not always-on; an unattended `run` cannot deadlock waiting on a keypress.
 
 Verdict: PASS (Exit: 0 on the suite; pause-gating proven by the default-mode negative control).
+
+## SG-10 addendum: board-view / event-sourced status (2026-06-29, token-optim-v2)
+
+Adds `--board=roadmap|kanban|both` (default detects: `backlog.sh` present -> `both`, else
+`roadmap`). In kanban/both the loop emits append-only status EVENTS to
+`<dir>/.orchestrate/events.log` and DERIVES a per-mega-goal `<dir>/BOARD.md` by replay (last
+event per sub-goal wins, never mutated in place). `BOARD.md` is a `backlog.sh`-format kanban
+table, rendered via `lib/backlog.sh`. ROADMAP.md + the goal files stay canonical; the repo-wide
+BACKLOG cockpit is never touched. Stacked on SG-01 (`feat/orchestrator-run-modes`).
+
+### Acceptance criteria (SG-10)
+
+| # | Criterion | Met |
+|---|---|---|
+| AC1 | `--board=roadmap\|kanban\|both`, default detects (backlog.sh -> both, else roadmap) | yes (tests 11a, 11b) |
+| AC2 | kanban/both derives `<dir>/BOARD.md` via `backlog.sh`; repo BACKLOG untouched | yes (11a, 11d) |
+| AC3 | Status is event-sourced: events appended, board derived by replay (never mutated) | yes (11e) |
+| AC4 | States distinguish shipped / ready / blocked(reason) [+ stalled, emitted by SG-11] | yes (11d) |
+| AC5 | roadmap-only fallback when no kanban tooling; explicit `--board=roadmap` suppresses | yes (11b, 11c) |
+| AC6 | ROADMAP.md stays canonical (no Done=/close-the-loop in board rows) | yes (board carries id/title/notes/status only) |
+
+### Confirmation run-table
+
+| Command | Exit | Result |
+|---|---|---|
+| `bash tests/test-orchestrate.sh` | 0 | 43/43 PASS (+9 for board-view) |
+| `shellcheck lib/orchestrate.sh` | 0 | CLEAN |
+| `bash tests/test-meta.sh` | 0 | 500/500 |
+| `bash lib/orchestrate.sh run <fixture> --board=both --dry-run` | 0 | both surfaces; no repo BACKLOG / events written |
+
+### Run detail: `--board=both --dry-run` (deps fixture, captured 2026-06-29)
+
+ROADMAP: SG-01 `[x]`; SG-02 `[ ]` (no deps); SG-03 `[ ]` depends SG-01+SG-02; SG-04 `[ ]`
+depends SG-09.
+
+```
+[plan] mega-goal: <fixture>
+  -> SG-02 (auto)  ...
+  -> SG-03 (gate)  ...
+  == STOP at SG-03 (gate: human review) ==
+
+[board mode: both]
+[board] derived per-mega-goal view -> <fixture>/BOARD.md (ROADMAP stays canonical)
+queued:
+  SG-02  second lever
+shipped:
+  SG-01  first lever
+parked:
+  SG-03  needs the first two
+  SG-04  blocked on missing
+```
+
+Derived `BOARD.md` (event-replay falls back to ROADMAP + dep-analysis when no events yet):
+```
+| ID | Item | Notes & source | Status |
+|----|------|----------------|--------|
+| SG-01 | first lever         | auto | shipped |
+| SG-02 | second lever        | auto | queued [ready] |
+| SG-03 | needs the first two | gate | parked [blocked: needs SG-02] |
+| SG-04 | blocked on missing  | auto | parked [blocked: needs SG-09] |
+```
+
+Note SG-03 blocks only on the ONE unchecked dep (SG-02), not the checked SG-01 -- dep-analysis
+reads the ROADMAP checkboxes. dry-run wrote NO `.orchestrate/events.log` (no execution).
+
+### Event-replay detail (real run via the good mock, `--board=both`)
+
+```
+$ cat <dir>/.orchestrate/events.log
+<ts>  SG-01  executing  model=inherit effort=inherit
+<ts>  SG-01  shipped    box checked
+<ts>  SG-02  blocked    gate: human review
+```
+The derived `BOARD.md` then shows `SG-01 ... shipped` by replay. The append-only log is the
+progress signal SG-11's watchdog reuses (goal 11 "reuse SG-10's event log").
+
+### NEGATIVE CONTROL (SG-10)
+
+Test 11b points `BACKLOG_LIB` at a non-existent path: detection fail-safes to `roadmap`, no
+`BOARD.md` is written, and no board output appears. So the board is genuinely gated on the
+tooling being present (a kit without `backlog.sh` still runs), and `--board=roadmap` (11c)
+suppresses it even when present. Unknown `--board=bogus` is rejected (exit 64, test 11f).
+
+Verdict: PASS (Exit: 0 on the suite; tooling-gating + ROADMAP-canonical proven by 11b/11c).

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -13,6 +13,9 @@
 #       --dry-run  print the plan only (no claude)
 #       --step     pause for the operator after each sub-goal (resume on Enter, q to stop)
 #       --stream   stream each session live (stream-json) + capture to .orchestrate/<id>.stream.jsonl
+#       --board=roadmap|kanban|both  surface progress as a per-mega-goal kanban (SG-10); default
+#                  detects (backlog.sh present -> both, else roadmap). Event-sourced + derived;
+#                  ROADMAP.md stays canonical, the repo-wide BACKLOG cockpit is never touched.
 #   --step/--stream are opt-in; default behavior is unchanged (SG-01, SPEC-087 Mechanism A).
 #
 # <megagoal-dir> holds: ROADMAP.md (sub-goal lines `- [ ] SG-NN ... , auto|gate , ...`),
@@ -38,6 +41,11 @@ CLAUDE_FLAGS="${CLAUDE_FLAGS:---dangerously-skip-permissions}"
 # point at the file. The WARM DECISIONS.md ledger is never injected in full (pointer only).
 HANDOFF_MAX_LINES="${HANDOFF_MAX_LINES:-80}"
 
+# Kanban renderer reused by the board-view (SG-10). Resolved next to this script; override in
+# tests. When absent, board mode fail-safes to roadmap-only so a kit without the tooling runs.
+ORCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKLOG_LIB="${BACKLOG_LIB:-$ORCH_DIR/backlog.sh}"
+
 _say() { printf '%s\n' "$*"; }
 
 # Emit "id<TAB>policy<TAB>checked(0|1)" per sub-goal line, in ROADMAP order.
@@ -61,6 +69,103 @@ _subgoals() {
 
 # Next unchecked sub-goal as "id<TAB>policy", or empty.
 _next() { _subgoals "$1" | awk -F'\t' '$3==0 {print $1"\t"$2; exit}'; }
+
+# ---- SG-10 board-view / event-sourced status -----------------------------------------------
+# Event-sourced status (pi-swarm borrow): the loop APPENDS status events; the board is DERIVED
+# by replay (last event per sub-goal wins), NEVER mutated in place -> a crashed/concurrent
+# session cannot corrupt a checkbox. ROADMAP.md + the goal files stay canonical; the board is a
+# regenerated view-sync. SG-11's watchdog reuses this file (mtime + last status) as its signal.
+_events_file() { printf '%s/.orchestrate/events.log\n' "$1"; }
+
+_emit_event() {  # dir id status [note]
+  local dir="$1" id="$2" status="$3" note="${4:-}" ef
+  ef=$(_events_file "$dir"); mkdir -p "$(dirname "$ef")"
+  printf '%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$id" "$status" "$note" >> "$ef"
+}
+
+# Last event for a sub-goal by replay, as "status<TAB>note" (empty if none).
+_event_status() {  # dir id
+  local ef; ef=$(_events_file "$1")
+  [ -f "$ef" ] || return 0
+  awk -F'\t' -v id="$2" '$2==id{s=$3; n=$4} END{ if(s!="") printf "%s\t%s", s, n }' "$ef"
+}
+
+# Raw ROADMAP line for a sub-goal id (or empty).
+_sg_line() { grep -E "^- \[[ xX]\] $2 " "$1" 2>/dev/null | head -1; }
+
+# Human title from a ROADMAP line: text after "SG-NN " up to the first " , " policy separator.
+_sg_title() {  # raw-line id
+  printf '%s' "$1" | sed -E "s/^- \[[ xX]\] $2 //; s/ , .*$//" | cut -c1-60
+}
+
+# Blocking deps: SG-NN tokens in the line's `depends ...` tail that are NOT yet checked (space-
+# separated, empty if none). Non-SG deps (e.g. #81 = a prerequisite PR) are out of board scope.
+_sg_deps_blocked() {  # roadmap raw-line
+  local roadmap="$1" line="$2" deps d blockers=""
+  deps=$(printf '%s' "$line" | grep -oE 'depends[^,]*' | grep -oE 'SG-[0-9]+' || true)
+  for d in $deps; do
+    _subgoals "$roadmap" | awk -F'\t' -v i="$d" '$1==i && $3==1{f=1} END{exit !f}' || blockers="$blockers $d"
+  done
+  printf '%s' "${blockers# }"
+}
+
+# Derive the per-mega-goal BOARD.md (kanban table in backlog.sh's row format, so backlog.sh
+# renders it and the cockpit format stays consistent). State = shipped if the box is checked,
+# else the replayed event status, else dep-analysis (queued=ready / parked=blocked). The
+# ready/blocked/stalled nuance rides as status PROSE (backlog.sh supports it). Prints the path.
+_derive_board() {  # dir roadmap
+  local dir="$1" roadmap="$2"
+  local board="$dir/BOARD.md"
+  {
+    printf '# Board (derived view): %s\n\n' "$(basename "$dir")"
+    printf '> DERIVED by "orchestrate.sh --board" from ROADMAP.md + .orchestrate/events.log. Do NOT\n'
+    printf '> hand-edit: ROADMAP.md + the goal files are canonical; this is a regenerated view-sync.\n'
+    printf '> Per-mega-goal only; the repo-wide BACKLOG cockpit is never touched.\n\n'
+    printf '## Active queue\n\n'
+    printf '| ID | Item | Notes & source | Status |\n'
+    printf '|----|------|----------------|--------|\n'
+    local id policy checked line title es estatus enote status blockers
+    while IFS=$'\t' read -r id policy checked; do
+      line=$(_sg_line "$roadmap" "$id"); title=$(_sg_title "$line" "$id")
+      es=$(_event_status "$dir" "$id")
+      estatus=$(printf '%s' "$es" | cut -f1); enote=$(printf '%s' "$es" | cut -f2)
+      if [ "$checked" = 1 ]; then
+        status="shipped"
+      elif [ "$estatus" = executing ] || [ "$estatus" = stalled ]; then
+        status="executing"
+        [ "$estatus" = stalled ] && status="executing [stalled${enote:+: $enote}]"
+      else
+        blockers=$(_sg_deps_blocked "$roadmap" "$line")
+        if [ -n "$blockers" ]; then status="parked [blocked: needs $blockers]"; else status="queued [ready]"; fi
+      fi
+      printf '| %s | %s | %s | %s |\n' "$id" "${title:-?}" "$policy" "$status"
+    done < <(_subgoals "$roadmap")
+  } > "$board"
+  printf '%s\n' "$board"
+}
+
+# Render the board surface to stdout for a mode. roadmap -> nothing (checkboxes ARE the view);
+# kanban|both -> derive BOARD.md then render its columns via backlog.sh (fallback: cat the file).
+_render_board() {  # dir roadmap mode
+  local dir="$1" roadmap="$2" mode="$3" board
+  case "$mode" in
+    roadmap|"") return 0 ;;
+    kanban|both)
+      board=$(_derive_board "$dir" "$roadmap")
+      _say "[board] derived per-mega-goal view -> $board (ROADMAP stays canonical)"
+      if [ -f "$BACKLOG_LIB" ]; then
+        BACKLOG_FILE="$board" bash "$BACKLOG_LIB" board 2>/dev/null || cat "$board"
+      else
+        cat "$board"
+      fi ;;
+    *) echo "unknown --board mode: '$mode' (want roadmap|kanban|both)" >&2; return 64 ;;
+  esac
+}
+
+# Resolve the board mode: explicit wins; empty -> detect (backlog.sh present -> both, else
+# roadmap so a kit without the kanban tooling still runs).
+_resolve_board_mode() { if [ -n "$1" ]; then printf '%s' "$1"; elif [ -f "$BACKLOG_LIB" ]; then printf 'both'; else printf 'roadmap'; fi; }
+# --------------------------------------------------------------------------------------------
 
 # Resolve a sub-goal's goal file path (goals/<NN>-*.md), or empty.
 _goalfile() {
@@ -139,20 +244,24 @@ _step_pause() {
 }
 
 cmd_run() {
-  local dir="" dry=0 step=0 stream=0
+  local dir="" dry=0 step=0 stream=0 board_arg=""
   while [ $# -gt 0 ]; do
     case "$1" in
-      --dry-run) dry=1 ;;
-      --step)    step=1 ;;
-      --stream)  stream=1 ;;
-      --*)       echo "unknown flag: $1" >&2; return 64 ;;
-      *)         if [ -z "$dir" ]; then dir="$1"; else echo "unexpected arg: $1" >&2; return 64; fi ;;
+      --dry-run)  dry=1 ;;
+      --step)     step=1 ;;
+      --stream)   stream=1 ;;
+      --board)    board_arg="both" ;;
+      --board=*)  board_arg="${1#--board=}" ;;
+      --*)        echo "unknown flag: $1" >&2; return 64 ;;
+      *)          if [ -z "$dir" ]; then dir="$1"; else echo "unexpected arg: $1" >&2; return 64; fi ;;
     esac
     shift
   done
   [ -d "$dir" ] || { echo "no such megagoal dir: '$dir'" >&2; return 64; }
   local roadmap="$dir/ROADMAP.md"
   [ -f "$roadmap" ] || { echo "no ROADMAP.md in '$dir'" >&2; return 64; }
+  local board_mode; board_mode=$(_resolve_board_mode "$board_arg")
+  case "$board_mode" in roadmap|kanban|both) ;; *) echo "unknown --board mode: '$board_mode' (want roadmap|kanban|both)" >&2; return 64 ;; esac
 
   if [ "$dry" = 1 ]; then
     _say "[plan] mega-goal: $dir"
@@ -168,6 +277,10 @@ cmd_run() {
       [ "$step" = 1 ] && _say "     [--step] pause here for the operator before the next sub-goal"
     done < <(_subgoals "$roadmap" | awk -F'\t' '$3==0 {print $1"\t"$2}')
     [ "$any" = 1 ] || _say "  (no unchecked sub-goals)"
+    if [ "$board_mode" != roadmap ]; then
+      _say ""; _say "[board mode: $board_mode]"
+      _render_board "$dir" "$roadmap" "$board_mode"
+    fi
     return 0
   fi
 
@@ -178,6 +291,8 @@ cmd_run() {
     id=$(printf '%s' "$nx" | cut -f1); policy=$(printf '%s' "$nx" | cut -f2)
 
     if [ "$policy" = gate ]; then
+      _emit_event "$dir" "$id" blocked "gate: human review"
+      [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
       _say "[orchestrate] STOP: $id is a gate sub-goal; open/await its PR for review, then re-run."
       return 0
     fi
@@ -189,6 +304,8 @@ cmd_run() {
     IFS=$'\t' read -r rmodel reffort < <(_route "$(_goalfile "$dir" "$id")")
     [ -n "$rmodel" ] && route_flags="$route_flags --model $rmodel"
     [ -n "$reffort" ] && route_flags="$route_flags --effort $reffort"
+    _emit_event "$dir" "$id" executing "model=${rmodel:-inherit} effort=${reffort:-inherit}"
+    [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
     _say "[orchestrate] running $id in a fresh session ($CLAUDE_CMD -p, model: ${rmodel:-inherit}, effort: ${reffort:-inherit}) ..."
     # Inject the prompt via a TEMP FILE on stdin, not a shell-interpolated argv arg (pi-swarm
     # borrow). Removes the backtick/${}/secret-guard bug class when the handoff body carries shell
@@ -212,6 +329,8 @@ cmd_run() {
     fi
     rm -f "$pfile"
     if [ "$rc" != 0 ]; then
+      _emit_event "$dir" "$id" blocked "session exited nonzero ($rc)"
+      [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
       echo "[orchestrate] session for $id exited nonzero; stopping." >&2
       return 1
     fi
@@ -219,9 +338,13 @@ cmd_run() {
     # grounded completion: advance only if the box actually flipped.
     local checked; checked=$(_subgoals "$roadmap" | awk -F'\t' -v i="$id" '$1==i {print $3}')
     if [ "$checked" != 1 ]; then
+      _emit_event "$dir" "$id" blocked "box not flipped (no self-claim)"
+      [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
       echo "[orchestrate] $id did not check its ROADMAP box; halting (no self-claim)." >&2
       return 1
     fi
+    _emit_event "$dir" "$id" shipped "box checked"
+    [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
     _say "[orchestrate] $id complete (box checked); advancing."
     # --step: pause for the operator between sub-goals, but only when the NEXT one is auto (the
     # loop would actually run it). If next is a gate, the gate-stop below is the natural halt, so
@@ -240,7 +363,7 @@ main() {
   case "$cmd" in
     next) cmd_next "$@" ;;
     run)  cmd_run "$@" ;;
-    *) echo "usage: orchestrate.sh {next|run} <megagoal-dir> [--dry-run] [--step] [--stream]" >&2; exit 64 ;;
+    *) echo "usage: orchestrate.sh {next|run} <megagoal-dir> [--dry-run] [--step] [--stream] [--board=roadmap|kanban|both]" >&2; exit 64 ;;
   esac
 }
 

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -285,5 +285,63 @@ grep -q '^- \[x\] SG-01' "$D12/ROADMAP.md" && pass "--stream run still advances 
 bash "$ORCH" run "$DS" --bogus > "$TMP/bogus.out" 2>&1; rc=$?
 { [ "$rc" = 64 ] && grep -q 'unknown flag' "$TMP/bogus.out"; } && pass "unknown flag -> exit 64" || fail "unknown flag not rejected (rc=$rc)"
 
+# ============================ TEST 11: board-view / event-sourced status (SG-10) ============
+# 11a: detect default -> backlog.sh present => both; dry-run renders the board + derives BOARD.md.
+DB="$TMP/mgb"; mk_megagoal "$DB"
+out=$(bash "$ORCH" run "$DB" --dry-run)
+{ echo "$out" | grep -q 'board mode: both' && [ -f "$DB/BOARD.md" ] && grep -q '| SG-01 |' "$DB/BOARD.md"; } \
+  && pass "detect default -> both; dry-run derives BOARD.md" || { fail "board detect/derive wrong"; echo "$out"; }
+# dry-run must NOT write an events.log (board derived from ROADMAP only, no execution)
+[ ! -f "$DB/.orchestrate/events.log" ] && pass "dry-run board writes no events.log (no execution)" || fail "dry-run wrote events"
+
+# 11b: roadmap fallback -> no kanban tooling => roadmap mode, no board rendered.
+DBF="$TMP/mgbf"; mk_megagoal "$DBF"
+out=$(BACKLOG_LIB="$TMP/nope.sh" bash "$ORCH" run "$DBF" --dry-run)
+{ ! echo "$out" | grep -q 'board mode' && [ ! -f "$DBF/BOARD.md" ]; } \
+  && pass "no backlog.sh -> detect fail-safes to roadmap (no board)" || { fail "roadmap fallback wrong"; echo "$out"; }
+
+# 11c: explicit --board=roadmap suppresses the board even when backlog.sh is present.
+DBR="$TMP/mgbr"; mk_megagoal "$DBR"
+out=$(bash "$ORCH" run "$DBR" --board=roadmap --dry-run)
+{ ! echo "$out" | grep -q 'board mode' && [ ! -f "$DBR/BOARD.md" ]; } \
+  && pass "--board=roadmap suppresses the board" || { fail "--board=roadmap wrong"; echo "$out"; }
+
+# 11d: ready/blocked derivation from deps. SG-03 depends on unchecked SG-02 => blocked; SG-02 has
+# no deps => ready; SG-01 checked => shipped.
+DBD="$TMP/mgbd"; mk_megagoal "$DBD"
+cat > "$DBD/ROADMAP.md" <<'EOF'
+# Mega-goal: fixture
+## Sub-goals
+- [x] SG-01 done thing , auto , PR #1
+- [ ] SG-02 ready thing , auto , PR #__
+- [ ] SG-03 blocked thing , gate , PR #__ , depends SG-02
+EOF
+bash "$ORCH" run "$DBD" --board=kanban --dry-run >/dev/null
+{ grep -q '| SG-01 | .* | shipped |' "$DBD/BOARD.md" \
+  && grep -q '| SG-02 | .* | queued \[ready\] |' "$DBD/BOARD.md" \
+  && grep -q '| SG-03 | .* | parked \[blocked: needs SG-02\] |' "$DBD/BOARD.md"; } \
+  && pass "board derives shipped / ready / blocked-on-dep from ROADMAP" || { fail "board state derivation wrong"; cat "$DBD/BOARD.md"; }
+
+# 11e: event-sourced replay. A real run emits executing then shipped for SG-01; BOARD.md (derived
+# by replay, last event wins) shows SG-01 shipped. SG-02 gate => a blocked event.
+DBE="$TMP/mgbe"; mk_megagoal "$DBE"
+cat > "$DBE/ROADMAP.md" <<'EOF'
+# Mega-goal: fixture
+## Sub-goals
+- [ ] SG-01 only auto , auto , PR #__
+- [ ] SG-02 the gate , gate , PR #__
+EOF
+export MOCK_ROADMAP="$DBE/ROADMAP.md" MOCK_DIR="$DBE"
+CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$DBE" --board=both >/dev/null 2>&1 < /dev/null
+ev_has() { awk -F'\t' -v id="$1" -v st="$2" '$2==id && $3==st{f=1} END{exit !f}' "$DBE/.orchestrate/events.log"; }
+{ ev_has SG-01 executing && ev_has SG-01 shipped; } \
+  && pass "event log records executing then shipped for SG-01" || { fail "event log wrong"; cat "$DBE/.orchestrate/events.log" 2>&1; }
+ev_has SG-02 blocked && pass "gate sub-goal emits a blocked event" || fail "no gate blocked event"
+grep -q '| SG-01 | .* | shipped |' "$DBE/BOARD.md" && pass "board derived by replay shows SG-01 shipped" || { fail "board replay wrong"; cat "$DBE/BOARD.md"; }
+
+# 11f: unknown --board mode rejected.
+bash "$ORCH" run "$DB" --board=bogus --dry-run > "$TMP/bm.out" 2>&1; rc=$?
+{ [ "$rc" != 0 ] && grep -q "unknown --board mode" "$TMP/bm.out"; } && pass "unknown --board mode rejected" || fail "bad --board mode not rejected (rc=$rc)"
+
 echo "----"
 [ "$fails" = 0 ] && { echo "ALL PASS"; exit 0; } || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
Implements token-optim-v2 SG-10. **Stacked on #86** (`feat/orchestrator-run-modes`); both edit `lib/orchestrate.sh`. Review/merge #86 first. Gated for team review.

## What

`orchestrate.sh run <dir> --board=roadmap|kanban|both` (default **detects**: `backlog.sh` present → `both`, else `roadmap`):

- The loop appends **append-only status events** to `<dir>/.orchestrate/events.log`.
- `<dir>/BOARD.md` is **derived by replay** (last event per sub-goal wins) — never mutated in place, so a crashed/concurrent session can't corrupt a checkbox (pi-swarm event-sourcing borrow).
- `BOARD.md` is a `backlog.sh`-format kanban; rendered via `lib/backlog.sh` (single renderer, cockpit-consistent).
- State: `shipped` (box checked) / `executing` (event) / `queued [ready]` (deps met) / `parked [blocked: needs SG-..]` (dep unchecked). Dep-analysis reads the ROADMAP's `depends …` tail.

ROADMAP.md + the goal files stay **canonical**; the repo-wide BACKLOG cockpit is **never** touched (per-mega-goal `BOARD.md` only).

## Design note (one deviation)

`backlog.sh`'s `STATES` vocabulary is fixed and not env-overridable, and editing it is out of scope. So the `ready`/`blocked`/`stalled` nuance rides as **status prose** on the standard keywords (`queued [ready]`, `parked [blocked: …]`) rather than forking the vocabulary — keeps one renderer. Full rationale in `docs/implementation-notes/orchestrator-board-sync.md`.

## Synergy with SG-11

The event log is the progress signal SG-11's stalled-watchdog will reuse (goal 11 "reuse SG-10's event log").

## Proof

`docs/verification/orchestrate.md` (SG-10 addendum): acceptance table, a `--board=both --dry-run` capture, a derived `BOARD.md`, an event-replay log, and a **negative control** (tooling-gating: `BACKLOG_LIB` missing → roadmap fallback, no board).

| Command | Exit | Result |
|---|---|---|
| `bash tests/test-orchestrate.sh` | 0 | 43/43 PASS (+9) |
| `shellcheck lib/orchestrate.sh` | 0 | CLEAN |
| `bash tests/test-meta.sh` | 0 | 500/500 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
