### PR TITLE
feat(kit): spec-index, read-only registry view across co-located docs/specs namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to dwarves-kit are documented here.
 
 ## [Unreleased]
 
+### Added
+- **spec-index: read-only registry view across co-located docs/specs namespaces
+  (no numbering/discovery change).** New `lib/spec-index.sh` scans every
+  `*/docs/specs/SPEC-*.md` in the repo and lists them grouped by namespace
+  (`central docs/specs` and co-located ones like `tools/<name>`), each group
+  sorted by local number. Numbering stays deliberately per-namespace and local;
+  this view is NOT wired into `spec-next` / `goal-drafts` / `precedent`, which
+  remain namespace-scoped. Covered by `tests/test-spec-index.sh`.
+
 ## [1.7.0] - 2026-06-11
 
 ### Added

--- a/lib/spec-index.sh
+++ b/lib/spec-index.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# spec-index.sh -- read-only SPEC registry view across every docs/specs namespace.
+#
+# Specs can live co-located under any `*/docs/specs/` (the central docs/specs/ AND
+# co-located ones like tools/<name>/docs/specs/, experiments/<slug>/docs/specs/,
+# _meta/megagoals/<prog>/docs/specs/). Numbering is deliberately PER-NAMESPACE and
+# LOCAL: each namespace owns its own SPEC-001.. sequence, so the same number can
+# (and does) recur across namespaces. This command does NOT change that, and is NOT
+# wired into spec-next / goal-drafts / precedent -- those stay namespace-scoped.
+#
+# This is purely the "show me every spec in one place" READ view: it scans every
+# `*/docs/specs/SPEC-*.md` in the repo and prints them grouped by namespace, each
+# group sorted by local number:
+#
+#   <namespace>
+#     SPEC-NNN | <title> | <Status>
+#
+# namespace = "central docs/specs" for the central tree, else the co-located prefix
+#             (e.g. "tools/bar" for tools/bar/docs/specs/)
+# title     = the first `# ` heading (leading "# " / "Spec: " stripped), else the filename
+# Status    = the first `Status:` header value if present, else "(none)"
+#
+# Stdlib/bash only -- no deps, no index, no daemon. Re-run to regenerate.
+#
+# Usage:
+#   spec-index.sh          -> the grouped table (default; same as `list`)
+#   spec-index.sh list     -> the grouped table
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Pull the title cheaply from a spec file (first `# ` heading wins).
+_title() {
+  local f="$1" t
+  t="$(grep -m1 -E '^# ' "$f" 2>/dev/null || true)"
+  if [ -n "$t" ]; then
+    t="${t#\# }"          # drop leading "# "
+    t="${t#Spec: }"       # drop a leading "Spec: " (kit idiom), if present
+    printf '%s\n' "$t"
+    return 0
+  fi
+  basename "$f" .md       # fall back to the filename
+}
+
+_status() {
+  local f="$1" s
+  s="$(grep -m1 -iE '^Status:[[:space:]]*' "$f" 2>/dev/null || true)"
+  s="${s#*[Ss]tatus:}"
+  # trim surrounding whitespace
+  s="$(printf '%s' "$s" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  printf '%s\n' "${s:-(none)}"
+}
+
+# Namespace label for a spec dir (e.g. "$ROOT/tools/bar/docs/specs").
+_namespace() {
+  local rel="${1#"$ROOT"/}"
+  if [ "$rel" = "docs/specs" ]; then
+    printf 'central docs/specs\n'
+  else
+    printf '%s\n' "${rel%/docs/specs}"   # strip trailing /docs/specs
+  fi
+}
+
+list_specs() {
+  local f num ns title status
+  # Emit "namespace<TAB>NNN<TAB>row" per spec, sort by namespace then local number,
+  # then walk the sorted stream printing a header per new namespace.
+  find "$ROOT" -type f -path '*/docs/specs/SPEC-*.md' -not -path '*/.git/*' 2>/dev/null \
+    | while IFS= read -r f; do
+        num="$(basename "$f" | grep -oE 'SPEC-[0-9]+' | head -1)"
+        [ -n "$num" ] || continue
+        ns="$(_namespace "$(dirname "$f")")"
+        title="$(_title "$f")"
+        status="$(_status "$f")"
+        printf '%s\t%s\t%s | %s | %s\n' \
+          "$ns" "$(printf '%s' "$num" | grep -oE '[0-9]+')" \
+          "$num" "$title" "$status"
+      done \
+    | sort -t$'\t' -k1,1 -k2,2n \
+    | { last_ns=""
+        while IFS=$'\t' read -r ns _num row; do
+          if [ "$ns" != "$last_ns" ]; then
+            [ -n "$last_ns" ] && printf '\n'
+            printf '%s\n' "$ns"
+            last_ns="$ns"
+          fi
+          printf '  %s\n' "$row"
+        done; }
+}
+
+main() {
+  local sub="${1:-list}"; shift 2>/dev/null || true
+  case "$sub" in
+    list) list_specs ;;
+    *) echo "usage: spec-index.sh [list]" >&2; return 64 ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/tests/test-spec-index.sh
+++ b/tests/test-spec-index.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# test-spec-index.sh -- the read-only SPEC registry view (lib/spec-index.sh).
+#
+# spec-index is purely a "list every SPEC across all */docs/specs/ namespaces,
+# grouped by namespace" READ view. Numbering stays per-namespace local; this lib
+# is NOT wired into spec-next / goal-drafts / precedent. This pins that the view
+# lists a central spec AND a co-located spec under the correct namespace labels.
+#
+# Run: bash tests/test-spec-index.sh
+# Exit 0 = all pass. Exit 1 = failures.
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+PASS=0; FAIL=0; TOTAL=0
+
+ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
+bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
+expect()  { if printf '%s' "$3" | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+refute()  { if printf '%s' "$3" | grep -q "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
+
+SPEC_INDEX="$KIT_DIR/lib/spec-index.sh"
+
+mk_repo() {
+  local r; r="$(mktemp -d "${TMPDIR:-/tmp}/kit-spec-index.XXXXXX")"
+  git -C "$r" init -q
+  git -C "$r" config user.email t@t.t
+  git -C "$r" config user.name t
+  printf '%s\n' "$r"
+}
+
+write_spec() {  # <repo> <relpath> <heading> <status>
+  local full="$1/$2"
+  mkdir -p "$(dirname "$full")"
+  {
+    printf '# Spec: %s\n' "$3"
+    printf 'Status: %s\n\n' "$4"
+    printf '## Problem\n\nbody\n'
+  } > "$full"
+}
+
+# ============================================================
+echo "=== spec-index: central + co-located, grouped by namespace ==="
+# ============================================================
+REPO="$(mk_repo)"
+trap 'rm -rf "$REPO" "${REPO2:-}"' EXIT
+# Two namespaces, each with its OWN local SPEC-001 (per-namespace numbering).
+write_spec "$REPO" "docs/specs/SPEC-001-foo.md"           "foo central" "DRAFT"
+write_spec "$REPO" "tools/bar/docs/specs/SPEC-001-bar.md" "bar tool"    "SHIPPED"
+git -C "$REPO" add -A; git -C "$REPO" commit -qm "specs"
+
+INDEX="$(cd "$REPO" && bash "$SPEC_INDEX" list)"
+
+expect "spec-index: central namespace header present" "^central docs/specs$"        "$INDEX"
+expect "spec-index: co-located namespace header present" "^tools/bar$"              "$INDEX"
+expect "spec-index: central SPEC-001 row + title"     "SPEC-001 | foo central"      "$INDEX"
+expect "spec-index: co-located SPEC-001 row + title"  "SPEC-001 | bar tool"         "$INDEX"
+expect "spec-index: co-located row carries its SHIPPED status" "bar tool | SHIPPED" "$INDEX"
+# both local SPEC-001s coexist (per-namespace numbering) -> two SPEC-001 rows total
+ROWS="$(printf '%s\n' "$INDEX" | grep -c 'SPEC-001 ')"
+expect "spec-index: both local SPEC-001s listed (2 rows)" "^2$" "$ROWS"
+
+# ============================================================
+echo ""
+echo "=== spec-index: central-only repo ==="
+# ============================================================
+REPO2="$(mk_repo)"
+write_spec "$REPO2" "docs/specs/SPEC-001-foo.md" "foo central only" "SHIPPED"
+git -C "$REPO2" add -A; git -C "$REPO2" commit -qm "central spec"
+
+INDEX2="$(cd "$REPO2" && bash "$SPEC_INDEX" list)"
+expect "spec-index: central-only lists SPEC-001"         "SPEC-001 | foo central only" "$INDEX2"
+expect "spec-index: central-only has the central header" "^central docs/specs$"        "$INDEX2"
+refute "spec-index: central-only has no co-located namespace" "tools/"                 "$INDEX2"
+
+echo ""
+echo "=== Results ==="
+echo -e "Passed: ${GREEN}$PASS${NC} / $TOTAL"
+if [ "$FAIL" -gt 0 ]; then echo -e "${RED}$FAIL assertions failed.${NC}"; exit 1; fi
+echo -e "${GREEN}spec-index green.${NC}"


### PR DESCRIPTION
## What

Adds `lib/spec-index.sh`: a **read-only** registry view that lists every `SPEC-*.md` across all `*/docs/specs/` namespaces in a repo (central `docs/specs/` plus co-located `tools/<x>/docs/specs/`, `experiments/<slug>/docs/specs/`, etc.), grouped by namespace and sorted by local number.

## Why

Repos that co-locate specs per tool/experiment lose the single "see every spec at once" view that a flat `docs/specs/` gave. This restores that view without changing how specs are numbered or discovered.

## Explicitly NOT changed

SPEC **numbering, is-shipped, and precedent stay namespace-scoped** (flat-per-`docs/specs/`). An earlier draft made these recursive/union, but that is wrong: real repos use **per-namespace local numbering** (one observed repo has 47 `docs/specs/` namespaces and 28 distinct `SPEC-001`s), so a union makes `check 001` always TAKEN and `is-shipped 001` ambiguous. `spec-index.sh` is therefore read-only and is **not** wired into `spec-next` / `goal-drafts` / `precedent` (those three libs are untouched vs master).

## Diff

`lib/spec-index.sh` (new) + `tests/test-spec-index.sh` (new) + a `CHANGELOG` line. Nothing else.

## Tests

Full kit suite green (12/12), including the new `test-spec-index.sh` (9/9: lists central + co-located specs under correct namespace labels; confirms two local `SPEC-001`s coexist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
