### PR TITLE
docs(kit): backfill front docs for dynamic agent synthesis

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -151,6 +151,17 @@ schedules, sequences, or merges. Source: SPEC-036; ADR-0022.
 **When to invoke:** when you want hands-on control or the next task needs subtle judgment that the verification pipeline might over-correct on
 **Common gotcha:** picks the next unchecked task only. To skip a task or pick a specific one, edit SPEC.md task ordering first. This unchecked-only behavior is also why `/kit:next` (not a fresh `/kit:execute`) is the way to resume after a mid-flight amend: it runs the newly appended tasks and skips the done rows (SPEC-027).
 
+### `/kit:draft-agent`
+
+**Phase:** build (meta-tooling)
+**Reads:** a one-line role description (or a unit-of-work description) from `$ARGUMENTS`
+**Writes:** by default INSTALLS a new subagent , `agents/<name>.md` + the roster rows (MANUAL/architecture/README) + `~/.claude/agents/<name>.md` for runtime; `--draft` stops at a staged draft; `subgoal:` mode drafts a mega-goal sub-goal file (never installed)
+**Dispatches:** the `meta-agent` (drafts to staging; the command promotes/installs)
+**When to invoke:** when a task needs a specialist role no existing agent covers and you want it as a reusable, named kit agent. For a one-off same-run specialist during `/kit:execute`, you do NOT invoke this , 2b-0 role synthesis handles it inline (see below).
+**Common gotcha:** a freshly installed agent is dispatchable only NEXT session (Claude Code loads the agent registry at session start); the command prints the granted tools + an `rm` undo. Sharing an installed agent with the team still goes through a reviewed PR. Design: SPEC-089.
+
+Related , **2b-0 role synthesis** (inside `/kit:execute`): each task is classified by `lib/role-classify.sh`; a specialist-worthy task gets a role synthesized by the `meta-agent` (Mode C, open-ended , any role) and injected into the worker THIS run, cached to `~/.claude/agents/` for reuse. Plain tasks fall through to the generic worker. This is automatic; `/kit:draft-agent` is the manual, install-a-named-agent path. Both share the `meta-agent` + `role-classify.sh` primitives (SPEC-089).
+
 ### `/kit:debug`
 
 **Phase:** off-cycle (the `bug` lane: defect, regression, failing test, not a new feature)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ After install, open a Claude Code session in your project and run one full lap. 
 1. `/kit:start` orients you and suggests the next step.
 2. `/kit:think` and describe the change (e.g. "add a `--version` flag to the CLI"). It throws 6 forcing questions at the idea; answer them.
 3. `/kit:spec` writes the contract to `docs/specs/SPEC-NNN-<slug>.md`.
-4. `/kit:execute` runs the autonomous build: a worker implements the spec, a verifier checks it against the acceptance criteria, a fix-agent retries fixable failures (max 2).
+4. `/kit:execute` runs the autonomous build: a worker implements the spec (specialized on-demand per task , a security/migration/etc. role synthesized and injected when the task warrants it, SPEC-089), a verifier checks it against the acceptance criteria, a fix-agent retries fixable failures (max 2).
 5. `/kit:review` then `/kit:ship`: review gate, then version bump, changelog, conventional commit, PR.
 
 That is the whole loop. The spec is the unit of handoff: a contractor running `/kit:execute` reads the same `docs/specs/SPEC-NNN-<slug>.md` you wrote. To see the artifact set without running anything, browse [`examples/hello-spec/`](examples/hello-spec/).

--- a/docs/implementation-notes/docs-backfill-synthesis.md
+++ b/docs/implementation-notes/docs-backfill-synthesis.md
@@ -1,0 +1,29 @@
+# Implementation notes , front-doc backfill for dynamic agent synthesis
+
+Task: "apply SDD kit to backfill docs + update README/front docs" for the shipped meta-agent /
+dynamic-synthesis surface.
+
+## 2026-07-01 , the drift audit was stale; fact-checked before acting
+
+A subagent doc-drift audit reported 8 dwarves-kit gaps (README/MANUAL/architecture tables missing
+meta-agent / draft-agent / role-classify rows; execute.md missing the 2b-0 step). ALL were false: the
+audit read a stale local `master` (fa0e632, pre-merge) and concluded the features "aren't merged."
+They are , #90/#91/#92 merged to master (57efaff), and the tables + 2b-0 step were added during the
+wave (test-meta 508/508 verified the cross-refs). Fact-checked each claim against `origin/master` with
+`git show origin/master:<file> | grep` before touching anything (retro lesson: a fresh-context
+reviewer hallucinates scope from a stale base; verify first). Net: the 8 claimed gaps collapsed to ONE
+real one.
+
+## 2026-07-01 , the real gaps (convention-checked)
+
+- **MANUAL.md had a prose `### /kit:xxx` section for 22 commands but not `/kit:draft-agent`.** That is
+  the genuine gap (the tables already list it). Added the section + a "2b-0 role synthesis" cross-note.
+- README "What it does" is table-based (already lists meta-agent/draft-agent), and the README does NOT
+  enumerate individual SPECs by convention , so the audit's "add SPEC-089 to README" was NOT applied
+  (would break the convention). Instead added one clause to the closed-loop step 4 so a first-time
+  reader sees synthesis exists, pointing at SPEC-089.
+
+## 2026-07-01 , scope discipline
+
+Did not add prose the tables already cover, did not renumber, did not touch guarded counts. test-meta
+508/508 held after the MANUAL edit.


### PR DESCRIPTION
MANUAL.md gains the `/kit:draft-agent` prose section (the one real gap , every other command has one) + a 2b-0 role-synthesis cross-note; README step 4 gets a one-clause synthesis mention (SPEC-089).

A drift audit flagged 8 gaps but had read a stale pre-merge master; fact-checked each against origin/master , only the MANUAL section was genuinely missing (retro lesson applied). test-meta 508/508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)