### PR TITLE
docs(kit): surface dynamic agent synthesis in the README front

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Agent workflows are shifting from `prompt -> output` to `goal -> loop -> evaluat
    +------------------ retro feeds the next cycle --------------------+
 ```
 
-Every build task runs a verification pipeline (worker → verifier → fix-agent retry), and hooks enforce safety automatically (`rm -rf`, push-to-main, force-push, and secret-file reads are blocked).
+Every build task runs a verification pipeline (worker → verifier → fix-agent retry), and hooks enforce safety automatically (`rm -rf`, push-to-main, force-push, and secret-file reads are blocked). The worker is also **specialized per task**: when a task needs a role no built-in agent covers (security, migration, a doc writer, ...), the kit synthesizes one on the fly and dispatches it, or `/kit:draft-agent` installs a reusable named agent ([SPEC-089](docs/specs/SPEC-089-dynamic-agent-synthesis.md)).
 
 **You drive it by intent, not by memorizing commands.** Say what you want; the kit reads your intent, runs the right step, and stops only at the real decisions:
 


### PR DESCRIPTION
Recent dwarves-kit change (dynamic agent synthesis) was only a table row + a buried parenthetical. Lifts it into the front prose (the 'every build task runs a verification pipeline' line): the worker is specialized per task, or /kit:draft-agent installs a reusable named agent, linked to SPEC-089. One sentence, no new section.

Checked the other recent changes too: data-driven routing (route-suggest) and deterministic handoff are internal/refinements , correctly NOT promoted to the README front. test-meta 508/508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)