### PR TITLE
feat(kit): stable `kit` CLI dispatcher (SPEC-090 Phase 1)

### DIFF
--- a/bin/kit
+++ b/bin/kit
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# kit: stable dispatcher to the dwarves-kit lib/ scripts.
+#
+# Purpose (SPEC-090): once dwarves-kit is plugin-only, docs can no longer call
+# `bash ~/.claude/dwarves-kit/lib/<x>.sh` (that install.sh path is gone), and the
+# plugin cache path is version-pinned while ${CLAUDE_PLUGIN_ROOT} is unset in a
+# doc-instructed bash call. This one small, rarely-changing script is the stable
+# PATH entrypoint; it resolves the *current* lib/ at runtime so callers never
+# hardcode a version or install location.
+#
+# Usage:
+#   kit <script> [args...]   ->   bash <resolved-lib>/<script>.sh [args...]
+#   kit --lib                ->   print the resolved lib dir (for debugging)
+#   kit --install            ->   symlink this dispatcher into ~/.local/bin/kit
+#   kit --help               ->   this help
+#
+# Resolution order (first hit wins):
+#   1. newest installed plugin cache:
+#      ~/.claude/plugins/cache/dwarves-marketplace/kit/*/lib   (version-sorted)
+#   2. the repo checkout this script ships in: <dir of bin/kit>/../lib
+#
+# ponytail: two sources is enough. A third (env override) gets added only if a
+# real deployment needs it.
+set -euo pipefail
+
+_kit_resolve_lib() {
+  local cache="$HOME/.claude/plugins/cache/dwarves-marketplace/kit"
+  if [ -d "$cache" ]; then
+    local newest
+    newest=$(find "$cache" -maxdepth 2 -type d -name lib 2>/dev/null | sort -V | tail -1)
+    if [ -n "$newest" ] && [ -d "$newest" ]; then
+      printf '%s\n' "$newest"
+      return 0
+    fi
+  fi
+  # Repo checkout fallback: this file is <repo>/bin/kit, so lib is ../lib.
+  local self_lib
+  self_lib="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/lib"
+  if [ -d "$self_lib" ]; then
+    printf '%s\n' "$self_lib"
+    return 0
+  fi
+  return 1
+}
+
+_kit_die() { printf 'kit: %s\n' "$1" >&2; exit 1; }
+
+_kit_help() {
+  sed -n '2,17p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+main() {
+  case "${1:-}" in
+    ""|-h|--help)
+      _kit_help
+      exit 0
+      ;;
+    --lib)
+      _kit_resolve_lib || _kit_die "no dwarves-kit lib/ found (is the kit plugin installed?)"
+      exit 0
+      ;;
+    --install)
+      local self
+      self="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/kit"
+      mkdir -p "$HOME/.local/bin"
+      ln -sf "$self" "$HOME/.local/bin/kit"
+      printf 'linked %s/.local/bin/kit -> %s\n' "$HOME" "$self"
+      exit 0
+      ;;
+  esac
+
+  local name="$1"; shift
+  local lib script
+  lib="$(_kit_resolve_lib)" || _kit_die "cannot locate dwarves-kit lib/ (is the kit plugin installed?)"
+  script="$lib/$name.sh"
+  [ -f "$script" ] || _kit_die "no such script '$name' in $lib"
+  exec bash "$script" "$@"
+}
+
+main "$@"

--- a/tests/test-kit-dispatcher.sh
+++ b/tests/test-kit-dispatcher.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# test-kit-dispatcher.sh -- SPEC-090 keystone: the `kit` dispatcher resolves the
+# current lib/ and dispatches to it, independent of install location/version.
+set -euo pipefail
+
+KIT="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/bin/kit"
+fail=0
+check() { # <desc> <actual-exit-already-run>  (call as: run; check "desc" $?)
+  if [ "$2" -eq 0 ]; then printf 'ok   %s\n' "$1"; else printf 'FAIL %s\n' "$1"; fail=1; fi
+}
+
+# 1. --lib resolves to a real dir containing the known scripts
+lib="$("$KIT" --lib)"; rc=$?
+check "--lib exits 0" $rc
+[ -d "$lib" ] && [ -f "$lib/lane-classify.sh" ]; check "--lib points at a lib/ with lane-classify.sh ($lib)" $?
+
+# 2. dispatch: `kit lane-classify classify ...` returns a non-empty lane
+lane="$("$KIT" lane-classify classify "add a config value")"; rc=$?
+check "dispatch lane-classify exits 0" $rc
+[ -n "$lane" ]; check "dispatch returns a non-empty lane ('$lane')" $?
+
+# 3. unknown script fails cleanly (non-zero, no exec)
+if "$KIT" no-such-script-xyz >/dev/null 2>&1; then bad=0; else bad=1; fi
+[ "$bad" -eq 1 ]; check "unknown script exits non-zero" $?
+
+# 4. --help prints usage
+"$KIT" --help 2>/dev/null | grep -q 'kit <script>'; check "--help prints usage" $?
+
+if [ "$fail" -eq 0 ]; then echo "PASS: kit dispatcher"; else echo "SOME TESTS FAILED"; exit 1; fi


### PR DESCRIPTION
Phase 1 of SPEC-090 (#96): the stable plugin-native entrypoint the doc migration depends on.

## What
`bin/kit` , a small dispatcher that resolves the current kit `lib/` at runtime (newest plugin cache -> repo checkout) and execs the named script:

```
kit lane-classify classify "<task>"    # was: bash ~/.claude/dwarves-kit/lib/lane-classify.sh classify "<task>"
kit proof-gate contract "<task>"
kit --lib        # print resolved lib dir
kit --install    # symlink onto PATH (~/.local/bin/kit)
```

Version- and install-location-independent, so docs stop hardcoding a removed path or a version-pinned cache path.

## Proof
`tests/test-kit-dispatcher.sh` (6 assertions) passes against the installed plugin cache:
- `--lib` resolves to a real `lib/` with `lane-classify.sh`
- `kit lane-classify classify …` dispatches, returns a lane ("normal")
- unknown script exits non-zero; `--help` prints usage

## Next (held for review)
Distribution (plugin SessionStart hook to ensure `~/.local/bin/kit`, vs manual `kit --install`) + the cross-repo doc rewrite are the following phases per SPEC-090. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
