### PR TITLE
fix(install): plugin-aware bash installer (compat-only when plugin present)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to dwarves-kit are documented here.
 
 ## [Unreleased]
 
+> **Release hold:** the next version bump is deferred until the **kit-hardening
+> megagoal** completes. Keep accumulating changes under `[Unreleased]`; do not cut
+> a tagged release (or run `/kit:ship`'s version bump) until that megagoal ships.
+
+### Fixed
+- **install.sh is now plugin-aware, no more double-registered hooks.** When the
+  kit plugin (`kit@dwarves-marketplace`) is already installed, `install.sh`
+  detects it and does a COMPAT-ONLY install: it symlinks the legacy
+  `~/.claude/dwarves-kit/{lib,WORKFLOW.md,AGENTS.md}` paths (so docs that still
+  call `bash ~/.claude/dwarves-kit/lib/<x>.sh` in plain bash, where
+  `${CLAUDE_PLUGIN_ROOT}` is unset, keep resolving) and skips the settings.json
+  hook merge + flat-command symlinks the plugin already owns. This removes the
+  "don't run both paths" footgun: running both previously double-registered every
+  hook and could pin a drifting lib/ version. Force the full bash install with
+  `KIT_FORCE_FULL=1`. Covered by `tests/test-install-compat.sh`.
+
 ### Added
 - **spec-index: read-only registry view across co-located docs/specs namespaces
   (no numbering/discovery change).** New `lib/spec-index.sh` scans every

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ cd ~/.claude/dwarves-kit && bash install.sh
 
 Requires `jq` (for settings merge) and `git`. Cloning in place is simplest, but `install.sh` also runs from a checkout anywhere. To uninstall: `bash ~/.claude/dwarves-kit/install.sh --uninstall`.
 
-### Pick one
+### Pick one (the bash installer is plugin-aware)
 
-Don't run both paths on the same machine, hooks would register twice. The plugin install does not configure `statusLine` (not in the v1 plugin schema); use the bash install if you want the statusline HUD.
+The two paths no longer collide. If the plugin is already installed, `install.sh` detects it and does a **compat-only** install: it symlinks the legacy `~/.claude/dwarves-kit/{lib,WORKFLOW.md,AGENTS.md}` paths, so docs that still call `bash ~/.claude/dwarves-kit/lib/<x>.sh` (plain bash, where `${CLAUDE_PLUGIN_ROOT}` is unset) keep resolving, and skips the hook + command registration the plugin already owns. No double-registered hooks. Force the full bash install with `KIT_FORCE_FULL=1 bash install.sh` (e.g. for the `statusLine` HUD, which the v1 plugin schema does not configure).
 
 **Invocation differs by path:** installed as the plugin, commands are namespaced `/kit:<name>` (e.g. `/kit:spec`); via the bash installer they resolve bare `/<name>` (e.g. `/spec`). This README uses the plugin form.
 

--- a/install.sh
+++ b/install.sh
@@ -127,6 +127,36 @@ echo "=== dwarves-kit installer ==="
 echo "Kit location: $KIT_DIR"
 echo ""
 
+# --- Plugin-aware compat mode --------------------------------------------
+# If the kit is already installed as a Claude Code plugin, the plugin provides
+# the hooks, commands, agents, and lib/ at runtime via ${CLAUDE_PLUGIN_ROOT}.
+# Running the full bash install here would DOUBLE-register hooks (settings.json
+# AND the plugin) and could pin a different lib/ version, which is exactly the
+# "don't run both paths" hazard the README warns about.
+#
+# So on a plugin machine we do a COMPAT-ONLY install: symlink the legacy
+# ~/.claude/dwarves-kit paths (lib, WORKFLOW.md, AGENTS.md) that docs still call
+# as plain bash (`bash ~/.claude/dwarves-kit/lib/<x>.sh`, where CLAUDE_PLUGIN_ROOT
+# is not set). No settings.json hooks, no flat commands. The symlinks track this
+# checkout (KIT_DIR), which is also the marketplace source, so a `git pull`
+# updates them. Force the full bash install with KIT_FORCE_FULL=1.
+PLUGIN_LIB="$(ls -d "$CLAUDE_DIR"/plugins/cache/dwarves-marketplace/kit/*/lib 2>/dev/null | sort -V | tail -1 || true)"
+if [ -n "${PLUGIN_LIB:-}" ] && [ -z "${KIT_FORCE_FULL:-}" ]; then
+  echo "[plugin detected] kit@dwarves-marketplace is installed; runtime comes from the plugin."
+  echo "Doing a COMPAT-ONLY install (legacy path shims), not the full bash install,"
+  echo "to avoid double-registering hooks."
+  mkdir -p "$CLAUDE_DIR/dwarves-kit"
+  for f in lib WORKFLOW.md AGENTS.md; do
+    ln -sfn "$KIT_DIR/$f" "$CLAUDE_DIR/dwarves-kit/$f"
+    echo "[ok] compat symlink ~/.claude/dwarves-kit/$f -> $KIT_DIR/$f"
+  done
+  echo ""
+  echo "Legacy doc paths (bash ~/.claude/dwarves-kit/lib/*.sh) now resolve."
+  echo "Full bash install anyway: KIT_FORCE_FULL=1 bash install.sh"
+  exit 0
+fi
+# --- end plugin-aware compat mode ----------------------------------------
+
 # Ensure ~/.claude exists
 mkdir -p "$CLAUDE_DIR/commands" "$CLAUDE_DIR/skills"
 

--- a/tests/test-install-compat.sh
+++ b/tests/test-install-compat.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# test-install-compat.sh -- install.sh is plugin-aware: when the kit plugin is
+# installed, it does a COMPAT-ONLY install (legacy path symlinks) and must NOT
+# merge settings.json hooks or add flat commands (that would double-register).
+set -euo pipefail
+KIT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+fail=0
+chk() { if [ "$2" -eq 0 ]; then echo "ok   $1"; else echo "FAIL $1"; fail=1; fi; }
+
+# --- plugin present -> compat-only ---
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP" "${TMP2:-}"' EXIT
+mkdir -p "$TMP/plugins/cache/dwarves-marketplace/kit/1.0.0/lib"
+out="$(CLAUDE_DIR="$TMP" bash "$KIT_DIR/install.sh" 2>&1)"
+
+printf '%s' "$out" | grep -q 'COMPAT-ONLY'; chk "took the compat branch" $?
+[ -L "$TMP/dwarves-kit/lib" ];         chk "lib symlink created" $?
+[ -L "$TMP/dwarves-kit/WORKFLOW.md" ]; chk "WORKFLOW.md symlink created" $?
+[ -L "$TMP/dwarves-kit/AGENTS.md" ];   chk "AGENTS.md symlink created" $?
+[ ! -e "$TMP/settings.json" ];         chk "settings.json NOT written (no double hooks)" $?
+[ -e "$TMP/dwarves-kit/lib/lane-classify.sh" ]; chk "compat lib resolves to a real script" $?
+
+# --- KIT_FORCE_FULL bypasses compat even with the plugin present ---
+TMP2="$(mktemp -d)"
+mkdir -p "$TMP2/plugins/cache/dwarves-marketplace/kit/1.0.0/lib"
+out2="$(CLAUDE_DIR="$TMP2" KIT_FORCE_FULL=1 bash "$KIT_DIR/install.sh" 2>&1 || true)"
+if printf '%s' "$out2" | grep -q 'COMPAT-ONLY'; then echo "FAIL KIT_FORCE_FULL still compat"; fail=1; else echo "ok   KIT_FORCE_FULL bypasses compat"; fi
+
+[ "$fail" -eq 0 ] && echo "PASS: install compat" || { echo "SOME TESTS FAILED"; exit 1; }


### PR DESCRIPTION
Addresses the root cause behind this week's plugin-only migration mess: running `install.sh` on a machine that already has the plugin double-registered every hook (the "don't run both paths" footgun).

## 1. Fix install.sh (plugin-aware)
`install.sh` now detects `kit@dwarves-marketplace` and, if present, does a **COMPAT-ONLY** install:
- symlinks the legacy `~/.claude/dwarves-kit/{lib,WORKFLOW.md,AGENTS.md}` paths so docs calling `bash ~/.claude/dwarves-kit/lib/<x>.sh` (plain bash, no `${CLAUDE_PLUGIN_ROOT}`) keep resolving,
- **skips** the settings.json hook merge + flat commands the plugin already owns → no double registration.
- `KIT_FORCE_FULL=1` forces the old full install (e.g. for the statusLine HUD).
- Test: `tests/test-install-compat.sh` (7 assertions, pass).

## 2. README
"Pick one" section rewritten , the two paths no longer collide.

## 3. Version hold
CHANGELOG `[Unreleased]` gets a release-hold note: **no version bump until the kit-hardening megagoal completes.**

Note: I couldn't find an exact `kit-hardening` megagoal dir (saw `kit-north-star`, `kit-adopt-enforce`, and a `kit-hardening-plan` worktree in ops-toolkit) , the note references it by name; point me at the right one if you want a precise link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
