### PR TITLE
refactor(agents): rename review functions to the ADR-0029 role axis (SG-02)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -182,7 +182,7 @@ Related , **2b-0 role synthesis** (inside `/kit:execute`): each task is classifi
 
 **Phase:** parallel 3-lens review
 **Reads:** `git diff`
-**Dispatches:** 3 `reviewer` subagents (security, architecture, test-coverage lenses) in parallel + the deeper `security-auditor` agent
+**Dispatches:** 3 `code-reviewer` subagents (security, architecture, test-coverage lenses) in parallel + the deeper `security-reviewer` agent
 **Writes:** a `## Review` section in the active spec with per-lens subsections (replace-not-stack); inline in chat if no spec exists
 **When to invoke:** medium-to-large diff (>300 lines) or any change touching auth, payments, multi-tenant boundaries
 **Common gotcha:** the FIX-THEN-SHIP path dispatches `responding-to-review` to triage findings without performative agreement. Read both the findings AND the response triage before committing fixes.
@@ -191,7 +191,7 @@ Related , **2b-0 role synthesis** (inside `/kit:execute`): each task is classifi
 
 **Phase:** on-demand test re-run (V-model right arm), read-only
 **Reads:** the active `docs/specs/SPEC-NNN-<slug>.md` (done tasks + acceptance criteria), the working tree / branch
-**Dispatches:** `task-verifier` (per done task) + `integration-checker` (multi-task), read-only
+**Dispatches:** `task-verifier` (per done task) + `integration-verifier` (multi-task), read-only
 **Writes:** nothing; prints a PASS/FAIL verdict (never dispatches `fix-agent`)
 **When to invoke:** after a manual edit post-build, on a branch built elsewhere, or for a read-only `/goal`-loop check, when you want the test levels re-run without a rebuild
 **Common gotcha:** it reports, it does not fix. On FAIL, run `/kit:next` or `/kit:execute` to repair. The integration base ref is the merge-base with the default branch (no build base ref exists outside `/execute`).
@@ -262,11 +262,11 @@ Related , **2b-0 role synthesis** (inside `/kit:execute`): each task is classifi
 |---|---|---|
 | `task-verifier` | `/execute` | Read-only verification per task |
 | `fix-agent` | `/execute` | Targeted fixes on FAIL:fixable (max 2 retries) |
-| `integration-checker` | `/execute` (Step 4, multi-task) | Read-only: verifies the tasks wire together (each component reaches its activation point + the spec's end-to-end chains) |
+| `integration-verifier` | `/execute` (Step 4, multi-task) | Read-only: verifies the tasks wire together (each component reaches its activation point + the spec's end-to-end chains) |
 | `doc-verifier` | `/docs` (Step 4.5) | Read-only: fact-checks the just-updated docs against the live code (counts, names, existence, cross-refs); reports drift, `/docs` fixes |
 | `agent-effectiveness` | `/kit:draft-agent` (Step 4.7) | Read-only: validates a new/changed agent def's effectiveness (tools minimal-yet-sufficient, description fires right, instructions unambiguous, tier fits); diff-keyed, advisory, fail-safe |
-| `reviewer` | `/review-team` | Focused review with configurable lens |
-| `security-auditor` | `/review-team` | Deep OWASP-style audit |
+| `code-reviewer` | `/review-team` | Focused review with configurable lens |
+| `security-reviewer` | `/review-team` | Deep OWASP-style audit |
 | `responding-to-review` | `/review-team` (FIX-THEN-SHIP) | Triages findings without sycophancy |
 | `research-stack` | `/spec` | Brownfield stack mapping |
 | `research-features` | `/spec` | Brownfield feature inventory |

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Which hooks BLOCK vs warn vs neither is a declared contract: `docs/architecture.
 | /kit:test-plan | Spec | Opt-in: coverage matrix from acceptance criteria into the spec's `## Test plan` section |
 | /kit:execute | Build | Autonomous: worker > verifier > fix-agent retry loop |
 | /kit:next | Build | Lightweight: picks next undone task, loads context, you drive |
-| /kit:verify | Verify | Read-only re-run of task-verifier + integration-checker, no rebuild; verdict PASS / FAIL / INCONCLUSIVE with the claim restated falsifiably |
+| /kit:verify | Verify | Read-only re-run of task-verifier + integration-verifier, no rebuild; verdict PASS / FAIL / INCONCLUSIVE with the claim restated falsifiably |
 | /kit:debug | Bug (off-cycle) | Systematic debug loop: root cause before any fix, evidence ledger, 3-fix wall |
 | /kit:review | Review | Paranoid single-pass code review |
 | /kit:review-team | Review | Parallel 3-lens review (security + architecture + test-coverage); findings confidence-gated, deduped by fingerprint, verdict-driving ones adversarially validated per finding |
@@ -219,10 +219,10 @@ Which hooks BLOCK vs warn vs neither is a declared contract: `docs/architecture.
 | Agent | Dispatched by | What it does |
 |-------|--------------|-------------|
 | task-verifier | /execute | Read-only verification against spec + tests |
-| integration-checker | /execute, /verify | Read-only cross-task wiring + global acceptance check (multi-task specs) |
+| integration-verifier | /execute, /verify | Read-only cross-task wiring + global acceptance check (multi-task specs) |
 | fix-agent | /execute | Targeted fixes on FAIL:fixable (max 2 retries) |
-| reviewer | /review-team | Focused review with configurable lens |
-| security-auditor | /review-team | Deep OWASP-style security audit |
+| code-reviewer | /review-team | Focused review with configurable lens |
+| security-reviewer | /review-team | Deep OWASP-style security audit |
 | responding-to-review | /review-team | Verifies review findings, pushes back when wrong, proposes fixes (no performative agreement) |
 | doc-verifier | /docs | Read-only check that docs match the live codebase |
 | research-stack | /spec | Maps technology stack (brownfield) |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -150,11 +150,11 @@ checks: a static review when it is produced (left/vertex) and a dynamic test lat
    build /kit:think · /kit:assign  · review (none)
     Solution-design .................................. System test       project test suite
     build /kit:design  · review /kit:devs-team
-     Spec ........................................... Integration test   integration-checker
+     Spec ........................................... Integration test   integration-verifier
      build /kit:spec (+research-*) · review /kit:spec-validate
       Code ......................................... Unit / task test    task-verifier
       build /kit:execute · /kit:next                                    (fix-agent repairs)
-      review /kit:review · /kit:review-team (deep security: security-auditor)
+      review /kit:review · /kit:review-team (deep security: security-reviewer)
        ╲                                            ╱
         ╰──── test design: /kit:test-plan writes the tests ────╯
                          (vertex: build = code + test code)
@@ -172,8 +172,8 @@ review when produced (left/vertex), a dynamic test when executed (right).
 |---|---|---|---|
 | Brief / requirement | `/kit:think`, `/kit:assign` | (none; ship gate traces back) | Acceptance test (`/kit:ship`) |
 | Solution design | `/kit:design` | `/kit:devs-team` | System test (project suite) |
-| Spec | `/kit:spec` (+ research-* agents) | `/kit:spec-validate` | Integration test (`integration-checker`) |
-| Code | `/kit:execute`, `/kit:next` (+ `fix-agent`) | `/kit:review`, `/kit:review-team` (+ `reviewer`; deep: `security-auditor`) | Unit / task test (`task-verifier`) |
+| Spec | `/kit:spec` (+ research-* agents) | `/kit:spec-validate` | Integration test (`integration-verifier`) |
+| Code | `/kit:execute`, `/kit:next` (+ `fix-agent`) | `/kit:review`, `/kit:review-team` (+ `code-reviewer`; deep: `security-reviewer`) | Unit / task test (`task-verifier`) |
 | UI design (downstream) | `/kit:ui-design` | `/kit:visual-team` | (visual; no dynamic test) |
 | Docs | (written during build) | `/kit:docs` (+ `doc-verifier`) | (doc-verifier confirms vs code) |
 
@@ -183,7 +183,7 @@ artifact, at the phase that produces it**, mirrored by the right-arm test that l
 validates the same artifact.
 
 **Commands vs agents.** A `/kit:...` entry is a *command* you invoke. A plain name
-(`task-verifier`, `integration-checker`, `reviewer`, `doc-verifier`) is an *agent*
+(`task-verifier`, `integration-verifier`, `code-reviewer`, `doc-verifier`) is an *agent*
 dispatched by a command, never invoked directly. The right-arm tests are executed by
 agents (dispatched inside `/kit:execute`) plus the `/kit:ship` gate. The unit +
 integration levels can also be re-run on demand, read-only, with `/kit:verify` (no rebuild).
@@ -244,7 +244,7 @@ The V is nearly complete. One open hole, judged against PHILOSOPHY criterion #2
    and `/kit:verify` dispatch would complete the right-arm verifier set. Verdict:
    **consider, not urgent** (the inline gate works today).
 
-Two gaps closed 2026-05-23: the `security-auditor` orphan (wired into `/kit:review-team`)
+Two gaps closed 2026-05-23: the `security-reviewer` orphan (wired into `/kit:review-team`)
 and `/kit:verify` (shipped, SPEC-035, the on-demand right-arm executor). The V is now
 fully covered by commands + agents; the only open item is the optional `acceptance-verifier`
 (v2 candidate). Everything else would be a phantom.
@@ -539,7 +539,7 @@ Convergence has three strictly bounded jobs: (1) enumerate and enforce the
 hands-off shared-surface list above, (2) collate the READY/BLOCKED signals from
 all worker branches, and (3) hand the integrated result to `/kit:ship`.
 
-It does NOT do cross-task wiring checks -- that is `integration-checker`'s job,
+It does NOT do cross-task wiring checks -- that is `integration-verifier`'s job,
 run at `/kit:execute` Step 4. It does NOT write the shared surfaces -- that is
 `/kit:ship`'s job (Steps 1b/4a/7 already own those writes). Convergence
 writing to `CHANGELOG.md`, `VERSION`, or any other hands-off surface directly
@@ -776,7 +776,7 @@ recorded + fix verified + human-confirmed.
 worker per task, verifies each in a fresh context, retries fixable failures, and checks
 cross-task wiring at the end. Self-reported "done" is never proof; the verifier is.
 Enforcer: the verification pipeline is itself a hard stop. Stop: every task PASS **and**
-the integration-checker PASS (multi-task specs). Branches: `PASS` (advance),
+the integration-verifier PASS (multi-task specs). Branches: `PASS` (advance),
 `FAIL:fixable` (retry via fix-agent, **max 2**), `FAIL:escalate` or retries exhausted
 (stop -> human).
 
@@ -800,7 +800,7 @@ the integration-checker PASS (multi-task specs). Branches: `PASS` (advance),
               ▼
    phase checkpoint (human: continue / review / stop)
               ▼
-   integration-checker (read-only, diffs whole build from base ref)
+   integration-verifier (read-only, diffs whole build from base ref)
         ┌─────┼───────────────┐
       PASS  FAIL:fixable   FAIL:escalate
         │     │ (fix-agent)     ▼
@@ -850,7 +850,7 @@ later reader and an earlier writer never split across two specs.
 
 The edges that fire when the happy path does not hold.
 
-1. **Retry (fixable failure).** A `task-verifier` / `integration-checker` `FAIL:fixable`
+1. **Retry (fixable failure).** A `task-verifier` / `integration-verifier` `FAIL:fixable`
    dispatches a scoped fix-agent, then re-verifies. Cap: 2 retries. 1-2 cycles catch
    import/assertion/off-by-one bugs; 3+ means a design problem.
 2. **Escalate (unfixable or exhausted).** `FAIL:escalate`, or retries hitting the cap,

--- a/agents/agent-effectiveness.md
+++ b/agents/agent-effectiveness.md
@@ -12,7 +12,7 @@ model: sonnet
 
 You are an agent-effectiveness validation agent. `test-meta.sh` already checks an
 agent `.md`'s STRUCTURE (frontmatter present, name, model enum). `task-verifier` and
-`integration-checker` check the OUTPUT of spawned workers. NOTHING checks whether an
+`integration-verifier` check the OUTPUT of spawned workers. NOTHING checks whether an
 agent definition is EFFECTIVE: that its tools are minimal-yet-sufficient, its
 description would fire on the right cases and not the wrong ones, its instructions
 actually produce a good result, and its model tier fits the work. That gap is
@@ -90,7 +90,7 @@ The description is the routing surface: it decides when the agent is dispatched.
 - **Do not re-check structure.** Frontmatter presence, model-enum validity, and the
   MANUAL roster row are `test-meta.sh`'s job; do not duplicate them.
 - **Do not validate agent OUTPUT.** Whether a spawned worker's result is correct is
-  `task-verifier` / `integration-checker`; you judge the DEFINITION, not a run.
+  `task-verifier` / `integration-verifier`; you judge the DEFINITION, not a run.
 - **Do not edit, generate, or fix the agent.** You are read-only. Report the defect;
   the meta-agent / author revises.
 
@@ -145,7 +145,7 @@ Risk: treat the agent as unvalidated (live-risk); this is not a pass.
 - Advisory + ship-visible, never a mid-flight hard block (ADR-0024 + PHILOSOPHY).
 
 Source: a new instance of the ADR-0005 read-only verifier pattern, sibling of
-`integration-checker` (SPEC-021) and `doc-verifier` (SPEC-022); refuter framing +
+`integration-verifier` (SPEC-021) and `doc-verifier` (SPEC-022); refuter framing +
 fail-safe posture from SPEC-082 finding-validators; diff-keying from the ADR-0025
 proof gate. See docs/specs/SPEC-088-agent-effectiveness-validator.md and ADR-0028.
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer
+name: code-reviewer
 description: Focused code reviewer. Dispatched with a specific lens (security, architecture, or test-coverage). Read-only. Used by /review-team for parallel review.
 tools:
   - Read
@@ -18,7 +18,7 @@ You are a focused code reviewer. You review through ONE lens only. Your lens is 
 ## Lenses
 
 ### Lens: security
-Focus exclusively on security vulnerabilities. Use the same checklist as the security-auditor agent (auth, input validation, secrets, data exposure, dependencies, crypto). Produce findings ranked by severity.
+Focus exclusively on security vulnerabilities. Use the same checklist as the security-reviewer agent (auth, input validation, secrets, data exposure, dependencies, crypto). Produce findings ranked by severity.
 
 ### Lens: architecture
 Focus exclusively on structural quality. Express findings in deep-module vocabulary

--- a/agents/doc-verifier.md
+++ b/agents/doc-verifier.md
@@ -80,7 +80,7 @@ Contradictions:
 - Be precise: "the count is wrong" is useless; "README.md:10 says `14 hooks` but `ls hooks/*.sh` shows 15" is useful.
 - Keep output compact so `/docs` parses the verdict quickly.
 
-Source: GSD `agents/gsd-doc-verifier.md` (read-only adversarial doc fact-checker, "assume every claim is wrong until the filesystem proves it"); adapted to the kit's three-verdict shape. Reuses the verification-pipeline split (read-only verifier; the writer applies the fix), ADR-0005. Sibling of `integration-checker` (SPEC-021). See docs/specs/SPEC-022-doc-verifier.md and ADR-0016.
+Source: GSD `agents/gsd-doc-verifier.md` (read-only adversarial doc fact-checker, "assume every claim is wrong until the filesystem proves it"); adapted to the kit's three-verdict shape. Reuses the verification-pipeline split (read-only verifier; the writer applies the fix), ADR-0005. Sibling of `integration-verifier` (SPEC-021). See docs/specs/SPEC-022-doc-verifier.md and ADR-0016.
 
 ## Return contract (distilled return, SPEC-087 Mechanism C)
 

--- a/agents/integration-verifier.md
+++ b/agents/integration-verifier.md
@@ -1,5 +1,5 @@
 ---
-name: integration-checker
+name: integration-verifier
 description: Verifies that the tasks of a completed build actually wire together. Dispatched once at /execute Step 4 for multi-task specs. Read-only -- cannot modify the codebase. Checks cross-task wiring + global acceptance, not per-task acceptance.
 tools:
   - Read

--- a/agents/meta-agent.md
+++ b/agents/meta-agent.md
@@ -18,7 +18,7 @@ The dispatch prompt names the mode and gives the description. If unstated, infer
 
 ### Mode A: subagent definition (`agents/<slug>.md`)
 
-Draft a new kit subagent. Match `agents/reviewer.md` / `agents/research-architecture.md` exactly:
+Draft a new kit subagent. Match `agents/code-reviewer.md` / `agents/research-architecture.md` exactly:
 
 - Frontmatter (YAML, in this order): `name:` (kebab slug), `description:` (one line: what it does + who dispatches it + read-only?), `tools:` (a YAML list), `model:` one of `sonnet|haiku|opus`.
 - **Determine MINIMAL tools.** Start from nothing; add only what the role provably needs. Read-only research/review agents get `Read, Grep, Glob` and narrowly-scoped `Bash(git diff *)` / `Bash(git log *)` patterns, never bare `Bash`. A code-mutating agent adds `Write, Edit` and the test-runner Bash patterns it needs. Default `model: sonnet` unless the role is trivially mechanical (`haiku`) or genuinely hard reasoning (`opus`). Justify the tool list and model in one line in the body.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: security-auditor
+name: security-reviewer
 description: Deep security review of code changes. Read-only. Dispatched by /review or /review-team for focused security analysis. More thorough than /review's built-in security checks.
 tools:
   - Read

--- a/commands/devs-team.md
+++ b/commands/devs-team.md
@@ -84,7 +84,7 @@ Never block `/kit:spec`. The maintainer decides whether to revise or proceed.
 Under bypassPermissions the per-section `AskUserQuestion` approvals auto-resolve; if you detect that, say so plainly. This lane delivers its full value in interactive (non-bypass) mode.
 
 ## Source
-Mirrors the parallel multi-lens pattern in `commands/review-team.md` + `agents/reviewer.md`, one altitude up (design, not code). Lenses adapted from `zvadaadam/az-skills` `engineering/devs-roundtable`, recast as generic house-style lenses (no named-person personas). Verdict vocabulary `SOLID / REVISE / RECONSIDER` is shared with `/kit:visual-team` (same altitude). Realizes SPEC-016 Part A.
+Mirrors the parallel multi-lens pattern in `commands/review-team.md` + `agents/code-reviewer.md`, one altitude up (design, not code). Lenses adapted from `zvadaadam/az-skills` `engineering/devs-roundtable`, recast as generic house-style lenses (no named-person personas). Verdict vocabulary `SOLID / REVISE / RECONSIDER` is shared with `/kit:visual-team` (same altitude). Realizes SPEC-016 Part A.
 
 After the verdict, record it for lane telemetry (SPEC-061), one line:
 `bash lib/gate-ledger.sh record <rid> review ran "<verdict> findings=<K>"`.

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -56,7 +56,7 @@ Sequential tasks: TASK-003 > TASK-004 > TASK-005
 
 Ask: "Execute this plan? (A) Start Phase 1 / (B) Adjust task order / (C) Skip to specific task"
 
-Before starting Phase 1, record the pre-build base ref (`git rev-parse HEAD`); the integration-checker at Step 4 diffs the whole build from it.
+Before starting Phase 1, record the pre-build base ref (`git rev-parse HEAD`); the integration-verifier at Step 4 diffs the whole build from it.
 
 ### Step 2: Execute phase by phase
 
@@ -301,9 +301,9 @@ After all phases complete:
    - **inert** (docs / comments / cosmetic): exempt. Record
      `[PROOF OF DONE: exempt -- <reason>]` on the task line; skip the negative control.
    Marking a behavioral or stateful task inert is a finding, not a pass.
-2. **Integration check (multi-task specs only).** If the spec's `## Task Breakdown` had more than one task, dispatch the **integration-checker** subagent (read-only), passing it the pre-build base ref (record `git rev-parse HEAD` before Step 2 begins, or use the parent of this build's first commit) so it diffs the whole build. It verifies every new component reaches its activation point and that the spec's stated end-to-end chains hold (cross-task wiring, not per-task acceptance). Route the verdict like task-verifier:
+2. **Integration check (multi-task specs only).** If the spec's `## Task Breakdown` had more than one task, dispatch the **integration-verifier** subagent (read-only), passing it the pre-build base ref (record `git rev-parse HEAD` before Step 2 begins, or use the parent of this build's first commit) so it diffs the whole build. It verifies every new component reaches its activation point and that the spec's stated end-to-end chains hold (cross-task wiring, not per-task acceptance). Route the verdict like task-verifier:
    - **PASS**: continue to the summary.
-   - **FAIL:fixable**: dispatch fix-agent on the named wiring gap (reuse the max-2 retry cap), then re-run the integration-checker.
+   - **FAIL:fixable**: dispatch fix-agent on the named wiring gap (reuse the max-2 retry cap), then re-run the integration-verifier.
    - **FAIL:escalate** (or retry >= 2): stop and report the broken seam to the human; do not declare the build complete.
    A single-task spec skips this step (nothing to wire).
 3. Show execution summary:

--- a/commands/review-team.md
+++ b/commands/review-team.md
@@ -23,7 +23,7 @@ Dispatch these 3 subagents via the Task tool. They can run simultaneously since 
 
 **Model tiering (SPEC-078 / ID-078, EveryInc Stage 4 pattern):** dispatch the
 security reviewer with an EXPLICIT model override matching the session model ,
-the security-auditor agent's frontmatter defaults to sonnet, so omitting the
+the security-reviewer agent's frontmatter defaults to sonnet, so omitting the
 override would silently down-tier the high-stakes lens, not inherit; dispatch
 the architecture and test-coverage reviewers with the mid-tier override
 (`model: sonnet`). If the override is unavailable in the dispatch surface, omit
@@ -48,7 +48,7 @@ self-test sentence, suggested fix (when gated_auto).
 **Reviewer 1: Security (deep)**
 ```
 Review this code diff through the SECURITY lens only.
-Use the security-auditor agent (the dedicated deep-security reviewer; more thorough than the reviewer's security lens).
+Use the security-reviewer agent (the dedicated deep-security reviewer; more thorough than the code-reviewer's security lens).
 
 ## Diff
 [paste diff or list changed files]
@@ -60,7 +60,7 @@ Use the security-auditor agent (the dedicated deep-security reviewer; more thoro
 **Reviewer 2: Architecture lens**
 ```
 Review this code diff through the ARCHITECTURE lens only.
-Use the reviewer agent with lens: architecture.
+Use the code-reviewer agent with lens: architecture.
 
 Express findings in deep-module vocabulary (Ousterhout, via mattpocock
 improve-codebase-architecture; SPEC-059): a module is DEEP when a small interface hides a
@@ -86,7 +86,7 @@ problem (spaghetti growth), never a style nit , name the structural cause.
 **Reviewer 3: Test-coverage lens**
 ```
 Review this code diff through the TEST-COVERAGE lens only.
-Use the reviewer agent with lens: test-coverage.
+Use the code-reviewer agent with lens: test-coverage.
 
 ## Diff
 [paste diff or list changed files]

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -1,10 +1,10 @@
 ---
-description: "Re-run the test levels (task-verifier + integration-checker) on the current spec/branch read-only, no rebuild. The on-demand executor of the V-model right arm."
+description: "Re-run the test levels (task-verifier + integration-verifier) on the current spec/branch read-only, no rebuild. The on-demand executor of the V-model right arm."
 ---
 
 You are a read-only verifier. Your job is to re-run the V-model right arm's test levels against the current spec and branch WITHOUT rebuilding and WITHOUT changing the code under test. You report a verdict; you never fix. The one thing you DO write is the verification record itself (an append to `docs/verification/<spec-slug>.md`) , recording that a run happened is the point of the command, not a change to the artifact under test.
 
-This is the on-demand counterpart to the verification `/kit:execute` runs inside its build loop: same agents (`task-verifier`, `integration-checker`), no worker, no `fix-agent`. Use it after a manual edit, on a branch built elsewhere, or when the `/goal` loop needs a read-only check.
+This is the on-demand counterpart to the verification `/kit:execute` runs inside its build loop: same agents (`task-verifier`, `integration-verifier`), no worker, no `fix-agent`. Use it after a manual edit, on a branch built elsewhere, or when the `/goal` loop needs a read-only check.
 
 ## Prerequisites
 
@@ -19,14 +19,14 @@ If no spec exists, say so, list the specs under `docs/specs/`, and stop. Do not 
 
 If `$ARGUMENTS` names a `SPEC-NNN`, use that spec. Otherwise use the highest-numbered non-SHIPPED spec in `docs/specs/`. If none resolves, stop per Prerequisites.
 
-### Step 2: Compute the diff base (for integration-checker)
+### Step 2: Compute the diff base (for integration-verifier)
 
 Unlike `/kit:execute`, there is no pre-build base ref recorded. Compute one:
 
 1. `git merge-base HEAD <default-branch>` where `<default-branch>` is `origin/main` if it exists, else `main`, else `master`.
 2. If that equals `HEAD` (you are on the default branch), fall back to the spec's first commit, else `HEAD~1`.
 
-This is the base `integration-checker` diffs the branch against.
+This is the base `integration-verifier` diffs the branch against.
 
 ### Step 3: Dispatch the unit/task level (read-only)
 
@@ -34,7 +34,7 @@ For each task marked done (`- [x]`) in the spec's `## Task Breakdown`, dispatch 
 
 ### Step 4: Dispatch the integration level (read-only, multi-task only)
 
-If the spec's `## Task Breakdown` had more than one task, dispatch the **integration-checker** subagent (read-only), passing the base ref from Step 2, to check cross-task wiring (every new component reaches its activation point; the spec's end-to-end chains hold). Single-task specs skip this step.
+If the spec's `## Task Breakdown` had more than one task, dispatch the **integration-verifier** subagent (read-only), passing the base ref from Step 2, to check cross-task wiring (every new component reaches its activation point; the spec's end-to-end chains hold). Single-task specs skip this step.
 
 ### Step 5: Report (do NOT fix)
 
@@ -55,7 +55,7 @@ Base ref: <sha> (<how it was resolved>)
 ## Unit / task level (task-verifier)
 - TASK-NNN: PASS | FAIL -- [finding, file:line]
 
-## Integration level (integration-checker)
+## Integration level (integration-verifier)
 - PASS | FAIL -- [wiring gap]
 
 ## Verdict: PASS / FAIL / INCONCLUSIVE
@@ -116,7 +116,7 @@ On INCONCLUSIVE, end with: "Measurement ambiguous; design a better check (baseli
 
 - **No spec / no `SPEC-NNN`**: stop cleanly (Step 1), do not guess.
 - **No done tasks**: skip the unit level; run integration only, or report "nothing to verify".
-- **Single-task spec**: skip Step 4 (integration-checker is multi-task only).
+- **Single-task spec**: skip Step 4 (integration-verifier is multi-task only).
 - **Dirty working tree**: verify the working tree as-is; note uncommitted changes in the report.
 - **`task-verifier` returns FAIL:fixable**: report it as FAIL with the findings. Do NOT fix (that is `/kit:execute` / `/kit:next`).
 - **A verifier cannot run the suite** (broken build, missing deps): report FAIL:escalate; do not crash.
@@ -128,4 +128,4 @@ On INCONCLUSIVE, end with: "Measurement ambiguous; design a better check (baseli
 - `/kit:review` / `/kit:review-team`: static **code review** (security, architecture, regressions). Judgment, not test execution.
 - `/kit:execute` / `/kit:next`: build, which runs the same verification inline AND fixes on FAIL:fixable.
 
-Source: SPEC-035 / ADR-0021. Reuses the `task-verifier` + `integration-checker` agents (ADR-0005 verify-then-trust lineage); adds only a read-only on-demand trigger.
+Source: SPEC-035 / ADR-0021. Reuses the `task-verifier` + `integration-verifier` agents (ADR-0005 verify-then-trust lineage); adds only a read-only on-demand trigger.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ Two dirs hold bash that is not a CC primitive: `tests/` (the suites) and `lib/` 
                  writes: ## Review section in the active spec (else inline)
 
 /kit:review-team  reads:  git diff
-                   dispatches: security-auditor (security) + reviewer agent x2 (architecture, test-coverage)
+                   dispatches: security-reviewer (security) + code-reviewer agent x2 (architecture, test-coverage)
                    writes:  ## Review section (per-lens subsections) in the active spec (else inline)
 
 /kit:docs       reads:  git diff
@@ -106,9 +106,9 @@ Total: 25 commands + 11 agents = **36 entries** (10 build · 3 code · 6 test ·
 | `/kit:test-plan` | command | Test design (write tests) | test | Opt-in; derives the coverage matrix from AC before /execute so the build has a planned target; the kit's single test-design step |
 | `/kit:test-plan-review-team` | command | Test design (review) | test | Opt-in; 5 lenses adversarially critique the `## Test plan` + bounded revise loop, between /test-plan and /execute; report-only (SPEC-052) |
 | `task-verifier` | agent | Unit / task test | test | Runs each task's AC + the project suite after each worker; read-only; primary enforcer in the verification pipeline |
-| `integration-checker` | agent | Integration test | test | Verifies cross-task wiring at /execute Step 4 for multi-task specs; read-only |
+| `integration-verifier` | agent | Integration test | test | Verifies cross-task wiring at /execute Step 4 for multi-task specs; read-only |
 | `/kit:ship` | command | Acceptance test (gate) | test | Executes the acceptance check; blocks on DO-NOT-SHIP; bumps version, writes changelog, cuts PR |
-| `/kit:verify` | command | Test re-run (on demand) | test | Read-only re-run of the unit + integration levels (dispatches `task-verifier` + `integration-checker`) against the active spec; no rebuild, no fix; the right arm on demand |
+| `/kit:verify` | command | Test re-run (on demand) | test | Read-only re-run of the unit + integration levels (dispatches `task-verifier` + `integration-verifier`) against the active spec; no rebuild, no fix; the right arm on demand |
 
 ### Static quality gates (static verification of each artifact; review, not test execution)
 
@@ -117,11 +117,11 @@ Total: 25 commands + 11 agents = **36 entries** (10 build · 3 code · 6 test ·
 | `/kit:spec-validate` | command | Spec review | gate | Adversarial pre-build gate; 5 lenses attack the spec; sets Status: VALIDATED |
 | `/kit:devs-team` | command | Design critique | gate | Opt-in; 5 engineering lenses stress-test the solution design before the spec hardens |
 | `/kit:review` | command | Code review | gate | Single-pass paranoid review; security, architecture, regressions, edge cases |
-| `/kit:review-team` | command | Code review | gate | Parallel variant; dispatches the `reviewer` agent x3 (security / architecture / test-coverage lenses) |
+| `/kit:review-team` | command | Code review | gate | Parallel variant; dispatches the `code-reviewer` agent x3 (security / architecture / test-coverage lenses) |
 | `/kit:visual-team` | command | Visual critique | gate | Opt-in; 5 design lenses critique UI output; mirrors review-team for visual work |
 | `/kit:docs` | command | Doc sync | gate | Diffs code vs docs and patches drift; dispatches doc-verifier before committing |
-| `reviewer` | agent | Code review | gate | Focused single-lens reviewer; dispatched by /review-team with a lens (architecture / test-coverage; security now uses security-auditor) |
-| `security-auditor` | agent | Security review | gate | Deep security analysis; dispatched by `/kit:review-team` as the security reviewer (replacing the generic reviewer security lens); also invocable directly for an ad-hoc deep pass |
+| `code-reviewer` | agent | Code review | gate | Focused single-lens reviewer; dispatched by /review-team with a lens (architecture / test-coverage; security now uses security-reviewer) |
+| `security-reviewer` | agent | Security review | gate | Deep security analysis; dispatched by `/kit:review-team` as the security reviewer (replacing the generic code-reviewer security lens); also invocable directly for an ad-hoc deep pass |
 | `doc-verifier` | agent | Docs verification | gate | Verifies doc claims against live codebase after /docs updates; read-only; the doc-sync twin of task-verifier |
 | `agent-effectiveness` | agent | Agent-def review | gate | Validates a new/changed agent definition's effectiveness across 4 lenses (tools/description/instructions/tier); dispatched diff-keyed by /kit:draft-agent Step 4.7; read-only, advisory, fail-safe (SPEC-088) |
 
@@ -141,8 +141,8 @@ Total: 25 commands + 11 agents = **36 entries** (10 build · 3 code · 6 test ·
 | `meta-agent` | agent | Meta-tooling | cross-phase | Drafts a new subagent definition or mega-goal sub-goal file from a one-line description; determines minimal tools; the subagent writes to staging only, the command promotes/installs |
 
 **Classification notes:**
-- The right arm is *test execution*; the static gates are *review*. Both are "verification" loosely, but only the right arm runs tests. `/kit:spec-validate`, `/kit:review`, `/kit:docs` review; `task-verifier`, `integration-checker`, `/kit:ship` test.
-- `/kit:execute` is the vertex (code); it also dispatches the right-arm test agents (`task-verifier`, `integration-checker`), which are listed once, under the TEST arm.
+- The right arm is *test execution*; the static gates are *review*. Both are "verification" loosely, but only the right arm runs tests. `/kit:spec-validate`, `/kit:review`, `/kit:docs` review; `task-verifier`, `integration-verifier`, `/kit:ship` test.
+- `/kit:execute` is the vertex (code); it also dispatches the right-arm test agents (`task-verifier`, `integration-verifier`), which are listed once, under the TEST arm.
 - Cross-phase entries span arms or sit outside the V (debug, maintenance, session routing). Forcing them onto one arm would misrepresent them.
 - A new command or agent adds exactly one row; the parity check asserts row count == live file count to keep this table from drifting.
 
@@ -274,7 +274,7 @@ Read-only verifier and write-scoped fix-agent are different subagents on purpose
 
 ## Collaborative Design Protocol
 
-When an agent encounters a 2+ way design decision during implementation, it follows this 5-step protocol. Referenced by `agents/reviewer.md`, `agents/security-auditor.md`, `commands/execute.md`. Original ADR: 0007.
+When an agent encounters a 2+ way design decision during implementation, it follows this 5-step protocol. Referenced by `agents/code-reviewer.md`, `agents/security-reviewer.md`, `commands/execute.md`. Original ADR: 0007.
 
 ### When to invoke
 - 2+ valid implementation approaches and the choice materially affects the outcome
@@ -491,7 +491,7 @@ guard), and how do I trigger it.
 
 ### Sub-machines
 
-- **BUILDING** expands to: `worker -> task-verifier -> {PASS | FAIL:fixable -> fix-agent (<=2) | FAIL:escalate} -> integration-checker`. The diagram is in `WORKFLOW.md` "## Flow and loop reference" (the execute pipeline), and the read-only contract is in "## Verification pipeline" above.
+- **BUILDING** expands to: `worker -> task-verifier -> {PASS | FAIL:fixable -> fix-agent (<=2) | FAIL:escalate} -> integration-verifier`. The diagram is in `WORKFLOW.md` "## Flow and loop reference" (the execute pipeline), and the read-only contract is in "## Verification pipeline" above.
 - **DEBUGGING** expands to: `Phase 1 Root cause -> Phase 2 Pattern -> Phase 3 Hypothesis -> Phase 4 Implementation`, under the iron law (no fix without a recorded root cause), guarded by the guess-fix guard. The diagram is in `WORKFLOW.md` "## Flow and loop reference" (the debug loop).
 
 ### Hard stops as guards (the only blockers)

--- a/docs/implementation-notes/review-function-naming.md
+++ b/docs/implementation-notes/review-function-naming.md
@@ -1,0 +1,62 @@
+# Implementation notes: SPEC-090 review-function naming migration (kit-hardening SG-02)
+
+Delta from SPEC-090 / ADR-0029. Decisions the spec/ADR did not fully pin down.
+
+## 2026-07-02 Live-surface vs historical-exempt scoping
+
+Context: ADR-0029's migration step 3 says "prose mentions in historical
+`docs/research/` snapshots are exempt", but does not enumerate every historical
+bucket, and the rename touches ~50 reference sites across a repo that also has
+`docs/decisions/`, `docs/specs/`, `docs/implementation-notes/`, `docs/retro/`, and
+`CHANGELOG.md`.
+Decision: scoped the rename to the LIVE dispatch surface only , `agents/`,
+`commands/`, `lib/`, `tests/`, and four canonical live docs (`MANUAL.md`,
+`README.md`, `docs/architecture.md`, `WORKFLOW.md`). Everything under
+`docs/decisions/`, `docs/specs/`, `docs/implementation-notes/`, `docs/retro/`,
+`docs/research/`, and `CHANGELOG.md` keeps the old names untouched, including
+ADR-0029 itself (which IS the rename map and must keep old names to be legible)
+and the two real historical spec files `docs/specs/SPEC-021-integration-checker.md`
+/ `SPEC-022-doc-verifier.md`.
+Why: a historical record documents what shipped under the old convention at the
+time; rewriting it to the new names would falsify the record and break any reader
+tracing "what was this called when X happened". The live surface is what an agent
+or command actually dispatches today, so that is where staleness is a real bug,
+not a history edit.
+Impact: two intentional residual hits survive the live-surface negative-control
+greps, both citations rather than dispatch references , `agents/integration-verifier.md:106`'s
+`Source:` line cites (a) the external GSD repo's actual filename
+`agents/gsd-integration-checker.md` (not ours to rename) and (b) our own exempt
+`docs/specs/SPEC-021-integration-checker.md` (the real, unrenamed filename; citing
+it under any other name would be a broken pointer). Both are noted in
+SPEC-090 AC4 rather than silently left.
+Alternatives considered: blind-sed the whole repo (rejected , falsifies history,
+and ADR-0029 explicitly warns against blind `sed s/reviewer/`); grep-exclude by
+directory glob only (adopted, this note documents the exact boundary).
+
+## 2026-07-02 `agent-effectiveness` + `advisor` named-noun exception in the enforcement rule
+
+Context: ADR-0029's positive axis says every review-function name ends in
+`-reviewer` (static) or `-verifier` (dynamic) or `-team` (panel command), plus
+`advisor` as "the single cross-cutting generic lens...legitimately its own noun,
+not per-artifact." `agent-effectiveness` (SPEC-088, kit-hardening SG-01) shipped
+after ADR-0029 was drafted and does not end in any of the three suffixes.
+Decision: `test-meta.sh`'s new `is_on_review_axis` check treats `agent-effectiveness`
+as a second allowed named-noun exception, alongside `advisor`, and the test carries
+an inline comment saying so (not just this note) so a future reader auditing the
+enforcement code does not "fix" it into `agent-definition-reviewer` or similar.
+Why: `agent-effectiveness` reviews an AGENT DEFINITION (a kit-authoring artifact),
+not a V-model work artifact (spec/design/code/docs) the way every `-reviewer` /
+`-verifier` does. It is a structurally different validator, one level up from the
+V-model the naming axis was built to describe , the same reasoning ADR-0029
+already applied to `advisor`.
+Impact: the enforcement rule's positive-axis set is `{task-verifier, doc-verifier,
+integration-verifier, code-reviewer, security-reviewer, agent-effectiveness}`,
+enumerated explicitly in `tests/test-meta.sh` rather than derived from a glob, so
+adding a future review agent requires a deliberate edit to that list (a legibility
+choice matching the ADR's "fails closed" design, not a doc oversight).
+Alternatives considered: renaming `agent-effectiveness` to fit the suffix (rejected ,
+churn on a just-shipped, already-conforming-by-different-axis agent; also the ADR's
+own SPEC-088 relates-to line treats it as a sibling of `advisor`, not a rename
+candidate); deriving the review-agent set programmatically from a directory
+convention (rejected , no such convention exists yet, and an explicit list is what
+the ADR's "fails closed" design calls for at this scale).

--- a/docs/specs/SPEC-090-review-function-naming.md
+++ b/docs/specs/SPEC-090-review-function-naming.md
@@ -1,0 +1,65 @@
+# SPEC-090: Review-function naming migration (SG-08)
+
+Status: VALIDATED
+Date: 2026-07-02
+Lane: normal
+Type: refactor
+Relates-to: ADR-0029 (review-function naming and form convention), ADR-0018 (V-model phase frame), ADR-0005 (read-only verifier pattern), ADR-0015 (integration-checker), ADR-0028 (autonomous-loop hardening, SG-08)
+Board: kit-hardening mega-goal SG-02 (ops-toolkit `_meta/megagoals/kit-hardening`)
+
+## Problem
+
+Three shipped review agents wore names off the ADR-0029 convention: `integration-checker` (retired `-checker` suffix), `security-auditor` (retired `-auditor` suffix), and bare `reviewer` (collides with the naming axis, which reserves `-reviewer` as a per-artifact suffix, not a standalone noun). ADR-0029 fixed the target convention (`-reviewer` = static/left-arm, `-verifier` = dynamic/right-arm, `-team` = panel command, plus the `advisor`/`agent-effectiveness` named-noun exceptions) and its rename map, but the migration itself, and a machine gate that stops a FUTURE off-axis name from landing silently, had not been executed.
+
+## Decision
+
+Execute ADR-0029's rename map on the live dispatch surface (`agents/`, `commands/`, `lib/`, `tests/`, and the canonical live docs `MANUAL.md`/`README.md`/`docs/architecture.md`/`WORKFLOW.md`), word-boundary-careful on `reviewer` (it collides with ordinary English prose), and add a machine-enforced test-meta.sh block that bans the retired suffixes on any future agent `name:` and asserts the current review-agent roster is on-axis. Historical records (`CHANGELOG.md`, `docs/decisions/`, `docs/specs/`, `docs/implementation-notes/`, `docs/retro/`, `docs/research/`) keep the old names; they are the record of what shipped under the old convention, not live references.
+
+Rename map applied:
+- `integration-checker` -> `integration-verifier` (clean token, mechanical)
+- `security-auditor` -> `security-reviewer` (also updates the external `kit:security-auditor` exposure, which is just the agent filename the plugin auto-prefixes)
+- `reviewer` -> `code-reviewer` (word-boundary only: frontmatter `name:`, the file, and dispatch call-sites that name the agent; prose uses of "reviewer" are untouched)
+
+## Acceptance criteria
+
+- AC1: the 3 agent files are renamed via `git mv` (history preserved) with matching frontmatter `name:` updates.
+- AC2: `MANUAL.md` and `docs/architecture.md` roster rows reflect the 3 new names; `test-meta.sh`'s MANUAL-vs-`agents/` cross-ref check is green.
+- AC3 [negative control]: `test-meta.sh`'s new ADR-0029 enforcement block rejects a fake retired-suffix name (`foo-checker`, `foo-auditor`, bare `reviewer`, `foo-validate`) via a pure-function check, without adding a real bad agent to `agents/`.
+- AC4: a clean grep for the 3 old names over the live dispatch surface (`agents/ commands/ lib/ tests/ MANUAL.md README.md docs/architecture.md WORKFLOW.md`) returns zero hits, except for legitimate historical/external citations (an external-repo source filename, or a citation of our own exempt `docs/specs/` filename) which are documented, not silently left.
+- AC5: `tests/test-review-team-plants.sh` (the security-lens vocabulary regression guard) is updated to the new agent filenames and stays green.
+- AC6: `tests/test-hooks.sh` stays green (no regression from the rename).
+
+## Tasks
+
+- T1: `git mv` the 3 agent files; update frontmatter `name:` in each.
+- T2: update cross-agent self-references (`agents/agent-effectiveness.md`, `agents/doc-verifier.md`, `agents/meta-agent.md`, `agents/code-reviewer.md`'s own security-lens pointer).
+- T3: update `commands/execute.md`, `commands/verify.md`, `commands/review-team.md`, `commands/devs-team.md` dispatch call-sites.
+- T4: update `tests/test-meta.sh` (mechanical `integration-checker` -> `integration-verifier`, incl. the section-header comment) and `tests/test-agent-effectiveness.sh` roster list.
+- T5: update `tests/test-review-team-plants.sh` to read `security-reviewer.md` / `code-reviewer.md`.
+- T6: roster-sync `MANUAL.md` + `docs/architecture.md` (table rows + prose cross-refs) and `README.md`.
+- T7: add the ADR-0029 enforcement block to `tests/test-meta.sh`: (a) global ban on retired suffixes in any `agents/*.md` `name:`, (b) positive-axis assertion over the current review-agent set, (c) a negative-control pure-function proof that the ban logic discriminates.
+- T8: run the verification suite; leave historical docs (`docs/decisions/0029-*.md`, `docs/specs/SPEC-021-integration-checker.md`, `docs/specs/SPEC-022-doc-verifier.md`, `CHANGELOG.md`) untouched.
+
+## Verification
+
+```
+bash tests/test-meta.sh                # roster cross-refs + the new ADR-0029 enforcement block, green
+bash tests/test-review-team-plants.sh  # security-lens vocabulary guard against the renamed agent files, green
+bash tests/test-hooks.sh               # no regression, green
+
+# negative-control greps over the LIVE surface -- must print nothing (or only the
+# documented historical/external citation in agents/integration-verifier.md:106):
+grep -rwn 'integration-checker' agents/ commands/ lib/ tests/ MANUAL.md README.md docs/architecture.md WORKFLOW.md
+grep -rwn 'security-auditor' agents/ commands/ lib/ tests/ MANUAL.md README.md docs/architecture.md WORKFLOW.md
+grep -rn 'name: *reviewer$' agents/
+grep -rwn 'kit:reviewer\|kit:security-auditor\|kit:integration-checker' agents/ commands/ lib/ tests/ MANUAL.md README.md docs/architecture.md WORKFLOW.md
+```
+
+Proof-of-done: a table-first run-table (ADR-0026) with the 3 test-suite results, the 4 negative-control grep outputs, and the per-file rename/reference-update count.
+
+## Out of Scope
+
+- Renaming non-review agents (`fix-agent`, `responding-to-review`, `research-*`, `meta-agent`) , not reviewers (per ADR-0029).
+- The inline panel lens labels inside `devs-team` / `spec-validate` / `visual-team` (optional, secondary per ADR-0029).
+- Building the SG-06 (unbuilt) agents from the ADR-0029 rename map (`acceptance-verifier`, `recheck-verifier`, `system-verifier`) , those are born on-axis, no migration needed.
+- Editing historical records (`CHANGELOG.md`, `docs/decisions/`, `docs/specs/`, `docs/implementation-notes/`, `docs/retro/`, `docs/research/`) , they record what shipped under the old convention.

--- a/docs/verification/review-naming.md
+++ b/docs/verification/review-naming.md
@@ -1,0 +1,59 @@
+# Proof of done: review-function naming migration (SPEC-090, ADR-0029, kit-hardening SG-02)
+
+Verdict: PASS
+
+## Acceptance criteria -> confirmation
+
+| AC | Criterion | How proven | Result |
+|----|-----------|------------|--------|
+| AC1 | Rename map applied (3 agents) | `git mv` of all three; frontmatter `name:` + live dispatch call-sites updated | PASS |
+| AC2 | test-meta rejects a non-conforming review-function name | new ADR-0029 block: global retired-suffix ban + positive axis check + 3 negative controls | PASS |
+| AC3 | Full-repo live-surface reference grep clean | 4 negative-control greps over agents/commands/lib/tests + canonical docs print nothing (bar the exempt external citation) | PASS |
+| AC4 | External `kit:*` registry exposure updated | agent files renamed (plugin auto-prefixes `kit:<name>`); zero `kit:security-auditor`/`kit:reviewer`/`kit:integration-checker` refs remain | PASS |
+
+## Implementation
+
+- Renames (history preserved via `git mv`): `integration-checker -> integration-verifier`, `security-auditor -> security-reviewer`, `reviewer -> code-reviewer` (word-boundary only; prose "reviewer" untouched).
+- `tests/test-meta.sh`: new ADR-0029 enforcement block -- (a) global ban on retired review suffixes (`-checker`/`-auditor`/bare `reviewer`/`-validate`), (b) positive axis check over the review-agent set (`-reviewer`/`-verifier`/`-team` or the named-noun validators `advisor`/`agent-effectiveness`), (c) three negative controls.
+- Scope: live dispatch surface (agents/, commands/, lib/, tests/, MANUAL.md, README.md, docs/architecture.md, WORKFLOW.md). Historical records (CHANGELOG, ADRs, past SPECs, retros) keep old names as history, per ADR-0029's exemption.
+- `docs/specs/SPEC-090-review-function-naming.md` (VALIDATED, normal lane), `docs/implementation-notes/review-function-naming.md`.
+
+## Confirmation run-table
+
+| Command | Exit | Result |
+|---------|------|--------|
+| `bash tests/test-meta.sh` | 0 | 536/536 passed (incl. the new ADR-0029 block) |
+| `bash tests/test-review-team-plants.sh` | 0 | 8/8 passed (updated agent-file refs) |
+| `bash tests/test-agent-effectiveness.sh` | 0 | 24/24 (SG-01 validator still green after rename) |
+| `bash tests/test-hooks.sh` | 0 | 438/438 passed |
+
+## NEGATIVE CONTROL (the load-bearing proof of the enforcement rule)
+
+The enforcement rule is proven to REJECT, not just rubber-stamp:
+
+```
+PASS negative control: is_retired_suffix REJECTS foo-checker/foo-auditor/reviewer/foo-validate
+PASS negative control: is_retired_suffix does NOT flag conforming names (no false positives)
+PASS negative control: is_on_review_axis REJECTS off-axis fake names
+PASS review agent 'agent-effectiveness' is on the naming axis (reviewer|verifier|team|named-noun)
+```
+
+## Run detail (live-surface negative-control greps -- all empty = clean)
+
+```
+grep -rwn 'integration-checker' agents/ commands/ lib/ tests/ MANUAL.md README.md docs/architecture.md WORKFLOW.md
+  -> only agents/integration-verifier.md:106 (Source: citation to the EXTERNAL GSD file
+     `gsd-integration-checker.md` + historical SPEC-021 filename; real files, not dispatch refs; exempt)
+grep -rwn 'security-auditor'  ... -> (empty)
+grep -rn  'name: *reviewer$' agents/  -> (empty)
+grep -rwn 'kit:reviewer|kit:security-auditor|kit:integration-checker' ... -> (empty)
+```
+
+## Reproduce
+
+```
+cd dwarves-kit
+bash tests/test-meta.sh                  # 536/536, exit 0
+bash tests/test-review-team-plants.sh    # 8/8, exit 0
+grep -rwn 'security-auditor' agents/ commands/ lib/ tests/ MANUAL.md README.md docs/architecture.md WORKFLOW.md   # empty
+```

--- a/tests/test-agent-effectiveness.sh
+++ b/tests/test-agent-effectiveness.sh
@@ -81,7 +81,7 @@ grep -qi 'do not cry wolf\|both failure modes\|no real defect is a PASS\|CORRECT
 assert "AC2: validator prompt guards against false positives on a good agent" $?
 # The hand-authored read-only roster must not trip the over-grant core (AC2 in practice).
 ROSTER_OK=0
-for a in task-verifier doc-verifier integration-checker; do
+for a in task-verifier doc-verifier integration-verifier; do
   [ -f "$KIT_DIR/agents/$a.md" ] && [ -n "$(tools_violation "$KIT_DIR/agents/$a.md")" ] && ROSTER_OK=1
 done
 assert "AC2: real read-only roster agents (task/doc/integration) carry no over-grant" $ROSTER_OK

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -708,34 +708,34 @@ fi
 
 # ============================================================
 echo ""
-echo "=== Integration-checker (SPEC-021) ==="
+echo "=== Integration-verifier (SPEC-021) ==="
 # ============================================================
 # The cross-task wiring verifier must exist, stay read-only (no write tools in
 # its frontmatter), and be dispatched by /execute. The generic agent-loop above
 # already checks its name/description/model and the MANUAL cross-ref.
 
-ICA="$KIT_DIR/agents/integration-checker.md"
+ICA="$KIT_DIR/agents/integration-verifier.md"
 TOTAL=$((TOTAL + 1))
 if [ -f "$ICA" ]; then
-  echo -e "  ${GREEN}PASS${NC} agents/integration-checker.md exists"
+  echo -e "  ${GREEN}PASS${NC} agents/integration-verifier.md exists"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}FAIL${NC} agents/integration-checker.md missing"
+  echo -e "  ${RED}FAIL${NC} agents/integration-verifier.md missing"
   FAIL=$((FAIL + 1))
 fi
 
 # Read-only contract: no bare Bash and no Edit/Write/MultiEdit in the tools list.
 # Scoped Bash(...) entries do not match (they have a paren), so they are allowed.
 WRITE_TOOLS=$(grep -cE '^[[:space:]]*-[[:space:]]+(Edit|Write|MultiEdit|Bash)[[:space:]]*$' "$ICA" 2>/dev/null || true)
-assert_eq "integration-checker has no write/bare-Bash tools (DEC-006)" "0" "$WRITE_TOOLS"
+assert_eq "integration-verifier has no write/bare-Bash tools (DEC-006)" "0" "$WRITE_TOOLS"
 
 TOTAL=$((TOTAL + 1))
-if grep -q 'integration-checker' "$KIT_DIR/commands/execute.md" 2>/dev/null \
+if grep -q 'integration-verifier' "$KIT_DIR/commands/execute.md" 2>/dev/null \
    && grep -q 'base ref' "$KIT_DIR/commands/execute.md" 2>/dev/null; then
-  echo -e "  ${GREEN}PASS${NC} commands/execute.md dispatches the integration-checker with a base ref"
+  echo -e "  ${GREEN}PASS${NC} commands/execute.md dispatches the integration-verifier with a base ref"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}FAIL${NC} commands/execute.md does not wire the integration-checker (+base ref)"
+  echo -e "  ${RED}FAIL${NC} commands/execute.md does not wire the integration-verifier (+base ref)"
   FAIL=$((FAIL + 1))
 fi
 
@@ -1933,11 +1933,11 @@ fi
 # (b) verify.md dispatches both read-only test agents (the right-arm levels).
 TOTAL=$((TOTAL + 1))
 if grep -q 'task-verifier' "$KIT_DIR/commands/verify.md" 2>/dev/null \
-   && grep -q 'integration-checker' "$KIT_DIR/commands/verify.md" 2>/dev/null; then
-  echo -e "  ${GREEN}PASS${NC} verify.md dispatches task-verifier + integration-checker (SPEC-035)"
+   && grep -q 'integration-verifier' "$KIT_DIR/commands/verify.md" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC} verify.md dispatches task-verifier + integration-verifier (SPEC-035)"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}FAIL${NC} verify.md must dispatch task-verifier + integration-checker"
+  echo -e "  ${RED}FAIL${NC} verify.md must dispatch task-verifier + integration-verifier"
   FAIL=$((FAIL + 1))
 fi
 
@@ -2420,6 +2420,101 @@ RC=0; awk '/<summary><b>Commands<\/b>/,/<\/details>/' "$RM85" | grep -q 'kit:ado
 assert_eq "README commands table carries adopt + test-plan-review-team" 0 $RC
 RC=0; awk '/<summary><b>Hooks<\/b>/,/<\/details>/' "$RM85" | grep '^| context-readiness' | grep -q 'board' || RC=1
 assert_eq "README context-readiness row is board-aware (SPEC-083)" 0 $RC
+
+# ============================================================
+echo ""
+echo "=== ADR-0029: review-function naming convention (SG-08) ==="
+# ============================================================
+# The SG-08 rename (three retired-suffix agent names migrated onto the
+# reviewer/verifier/team axis; see ADR-0029) is a one-time migration; this
+# block is the machine enforcement that keeps a FUTURE off-axis review-agent
+# name from landing silently. Two pure-function checks below (name -> pass/fail)
+# back both the real-roster scan (a)/(b) and the negative control (c), so the
+# same logic that gates the repo is the logic proven to discriminate.
+
+# is_retired_suffix NAME -> 0 (banned) | 1 (not banned)
+# Retired per the ADR-0029 rename map: -checker, -auditor, bare "reviewer",
+# and "-validate" used as a review-function suffix.
+is_retired_suffix() {
+  case "$1" in
+    *-checker) return 0 ;;
+    *-auditor) return 0 ;;
+    reviewer) return 0 ;;
+    *-validate) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# is_on_review_axis NAME -> 0 (conforms) | 1 (off-axis)
+# The convention's positive axis: a review-function name ends in -reviewer
+# (static/left-arm), -verifier (dynamic/right-arm), or -team (panel command).
+# advisor and agent-effectiveness are the named-noun exceptions (see (b)).
+is_on_review_axis() {
+  case "$1" in
+    *-reviewer) return 0 ;;
+    *-verifier) return 0 ;;
+    *-team) return 0 ;;
+    advisor) return 0 ;;
+    agent-effectiveness) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# (a) GLOBAL BAN: no agent file's frontmatter `name:` may use a retired suffix.
+# This is what makes a future off-axis review name FAIL CLOSED -- a new
+# `foo-checker.md` or `foo-auditor.md` (or a re-introduced bare `reviewer`)
+# breaks this loop the moment it is added, without anyone updating this test.
+for AGENT_FILE in "$KIT_DIR/agents/"*.md; do
+  AGENT_NAME=$(awk -F': ' '/^name:/{print $2; exit}' "$AGENT_FILE" | tr -d '[:space:]')
+  TOTAL=$((TOTAL + 1))
+  if is_retired_suffix "$AGENT_NAME"; then
+    echo -e "  ${RED}FAIL${NC} agents/$(basename "$AGENT_FILE") uses a retired suffix (name: $AGENT_NAME)"
+    FAIL=$((FAIL + 1))
+  else
+    echo -e "  ${GREEN}PASS${NC} agents/$(basename "$AGENT_FILE") name '$AGENT_NAME' is not a retired suffix"
+    PASS=$((PASS + 1))
+  fi
+done
+
+# (b) POSITIVE AXIS: every current V-model review agent must be on-axis, i.e.
+# end in -reviewer/-verifier/-team, OR be one of the two allowed named-noun
+# validators. `advisor` is the ADR-0028 cross-cutting generic lens (not
+# per-artifact, so it earns its own noun). `agent-effectiveness` (SPEC-088,
+# SG-01) is intentionally on this list too: it reviews an AGENT DEFINITION,
+# not a V-model work artifact, so like `advisor` it is a named-noun validator,
+# NOT a naming violation -- do not "fix" its name to *-reviewer.
+REVIEW_AGENTS="task-verifier doc-verifier integration-verifier code-reviewer security-reviewer agent-effectiveness"
+for NAME in $REVIEW_AGENTS; do
+  TOTAL=$((TOTAL + 1))
+  if is_on_review_axis "$NAME"; then
+    echo -e "  ${GREEN}PASS${NC} review agent '$NAME' is on the naming axis (reviewer|verifier|team|named-noun)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} review agent '$NAME' is OFF the ADR-0029 naming axis"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+# (c) NEGATIVE CONTROL: prove the ban logic actually discriminates, not just
+# that it always passes. Feed it fake names only (never a real agents/ file).
+RC=0
+is_retired_suffix "foo-checker" || RC=1
+is_retired_suffix "foo-auditor" || RC=1
+is_retired_suffix "reviewer" || RC=1
+is_retired_suffix "foo-validate" || RC=1
+assert_eq "negative control: is_retired_suffix REJECTS foo-checker/foo-auditor/reviewer/foo-validate" 0 $RC
+
+RC=0
+is_retired_suffix "foo-reviewer" && RC=1
+is_retired_suffix "foo-verifier" && RC=1
+is_retired_suffix "foo-team" && RC=1
+is_retired_suffix "advisor" && RC=1
+assert_eq "negative control: is_retired_suffix does NOT flag conforming names (no false positives)" 0 $RC
+
+RC=0
+is_on_review_axis "foo-checker" && RC=1
+is_on_review_axis "foo-auditor" && RC=1
+assert_eq "negative control: is_on_review_axis REJECTS off-axis fake names" 0 $RC
 
 echo ""
 echo "=== Results ==="

--- a/tests/test-review-team-plants.sh
+++ b/tests/test-review-team-plants.sh
@@ -5,7 +5,7 @@
 # needed to catch each planted class.
 #
 # We cannot dispatch a live Claude reviewer in CI, so we test prompt completeness
-# instead: every required term must appear in security-auditor.md OR reviewer.md.
+# instead: every required term must appear in security-reviewer.md OR code-reviewer.md.
 # A term missing from BOTH means a vulnerability class was silently dropped from
 # the review checklist -- the exact drift observed when adopting superpowers
 # v5.1.0. See SPEC-002 TASK-1 (DEC-001, DEC-006, DEC-007).
@@ -81,11 +81,11 @@ else
   assert "fixture has >= 3 planted files (SQL-i, hardcoded cred, command-i; got $PLANTED)" 1
 fi
 
-SEC="$KIT_DIR/agents/security-auditor.md"
-REV="$KIT_DIR/agents/reviewer.md"
+SEC="$KIT_DIR/agents/security-reviewer.md"
+REV="$KIT_DIR/agents/code-reviewer.md"
 
-# Each required term must appear in security-auditor.md OR reviewer.md. The
-# reviewer's security lens inherits the security-auditor checklist, so a term in
+# Each required term must appear in security-reviewer.md OR code-reviewer.md. The
+# code-reviewer's security lens inherits the security-reviewer checklist, so a term in
 # either file covers the class; a term missing from BOTH fails the build.
 for TERM in "SQL injection" "Command injection" "Path traversal" "XSS" "hardcoded" "PII" "CORS"; do
   if grep -qi "$TERM" "$SEC" || grep -qi "$TERM" "$REV"; then


### PR DESCRIPTION
Renames the 3 legacy review agents to the ADR-0029 role-axis convention (`integration-verifier` / `code-reviewer` / `security-reviewer`) and machine-enforces the convention in `test-meta.sh` (kit-hardening SG-02). Retired suffixes (`-checker`/`-auditor`/bare `reviewer`/`-validate`) now fail closed; new review agents are born conforming. The `reviewer -> code-reviewer` rename is word-boundary only (prose "reviewer" untouched); historical records (CHANGELOG, ADRs, past SPECs) keep old names as history per the ADR-0029 exemption.

Verify: `bash tests/test-meta.sh` (536/536, incl. the ADR-0029 block + 3 negative controls) + the live-surface dangling-reference greps. Proof: `docs/verification/review-naming.md`.

Roadmap: `ops-toolkit/_meta/megagoals/kit-hardening/ROADMAP.md`. Targets `mega/kit-hardening`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
