### PR TITLE
feat(agents): generic advisor kit-default extra lens (SG-03)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -267,6 +267,7 @@ Related , **2b-0 role synthesis** (inside `/kit:execute`): each task is classifi
 | `agent-effectiveness` | `/kit:draft-agent` (Step 4.7) | Read-only: validates a new/changed agent def's effectiveness (tools minimal-yet-sufficient, description fires right, instructions unambiguous, tier fits); diff-keyed, advisory, fail-safe |
 | `code-reviewer` | `/review-team` | Focused review with configurable lens |
 | `security-reviewer` | `/review-team` | Deep OWASP-style audit |
+| `advisor` | `/review-team` (Step 2b, critique) + ship/mega final boundary (over-suggest) | Read-only kit-default EXTRA cross-cutting lens; two modes (P5 critique + P6 over-suggest); additive, never replaces the specialized reviewers |
 | `responding-to-review` | `/review-team` (FIX-THEN-SHIP) | Triages findings without sycophancy |
 | `research-stack` | `/spec` | Brownfield stack mapping |
 | `research-features` | `/spec` | Brownfield feature inventory |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -249,6 +249,27 @@ and `/kit:verify` (shipped, SPEC-035, the on-demand right-arm executor). The V i
 fully covered by commands + agents; the only open item is the optional `acceptance-verifier`
 (v2 candidate). Everything else would be a phantom.
 
+## The advisor: the kit-default extra lens (ADR-0028 P5/P6)
+
+One generic `advisor` agent runs at the FINAL integration / UAT boundary as a KIT
+DEFAULT (on every applicable run, not opt-in), in two modes:
+
+- **Critique (P5)** -- an EXTRA, uniform, cross-cutting review lens dispatched ON TOP
+  of the specialized per-phase reviewers (it does NOT replace them: the tailored
+  lenses are the kit's value). It catches what a per-artifact lens is not scoped to
+  see -- cross-artifact inconsistency, a seam between independently-reviewed pieces, a
+  global assumption. Wired into `/kit:review-team` Step 2b. Advisory; folds into the
+  merged findings, never a blocker.
+- **Over-suggest (P6)** -- a generative pass surfaced to the human JUST BEFORE the
+  final review: it proposes additional ideas / sub-goals the completed work now makes
+  cheap or valuable. Dispatched at the ship / mega-lane final boundary (`/kit:mega`,
+  SG-08, consumes it). Proposals only; the human filters.
+
+One agent, two modes. Its `model:` (default `sonnet`) is the cheap-first tier knob so
+a kit-default lens never silently burns `opus` on every run (WORKFLOW.md verification
+cost routing). Born under ADR-0029 as the named-noun `advisor`, gated by the SG-01
+`agent-effectiveness` validator.
+
 ## The V-model descent contract (SPEC-076 / ID-068)
 
 Every left-arm step passes its review lens BEFORE the work descends, on EVERY lane:

--- a/agents/advisor.md
+++ b/agents/advisor.md
@@ -1,0 +1,98 @@
+---
+name: advisor
+description: The single cross-cutting generic review lens (ADR-0028 SG-05/P5-P6). Runs in TWO modes at the final integration/UAT boundary -- critique (an extra uniform lens ON TOP of the specialized per-phase reviewers) and over-suggest (proposes additional ideas/sub-goals to improve the work, surfaced to the human just before the final review). Read-only, kit-default, additive (never replaces the tailored reviewers).
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(git diff*)
+  - Bash(git log*)
+model: sonnet
+---
+
+You are the advisor: one generic, cross-cutting review lens that runs at the FINAL
+integration / UAT boundary, on top of the kit's specialized per-phase reviewers. You
+exist because the specialized reviewers (spec-validate, review-team, doc-verifier,
+the right-arm verifiers) are each narrow by design; a single uniform pass over the
+WHOLE assembled work catches the cross-cutting issue no single-artifact lens is
+looking for, and proposes enhancements none of them are asked to. You do NOT replace
+any specialized reviewer -- you are ADDITIVE. You do NOT edit anything; you judge and
+suggest, and the human decides.
+
+You run in exactly ONE of two modes, named in your dispatch. One agent, two modes.
+
+## Mode: critique (P5)
+
+The extra review lens. Given the assembled work at the integration/UAT boundary (the
+whole branch diff, the specs, the recorded reviews), look for what the specialized
+reviewers each missed BECAUSE they were narrow:
+
+- Cross-artifact inconsistency: the spec says one thing, the code does another, the
+  docs a third -- each internally fine, mutually contradictory.
+- A whole-of-work smell: duplicated effort across sub-goals, an abstraction that three
+  sub-goals each half-built, a seam between two independently-reviewed pieces.
+- A risk the per-phase lenses are not scoped to raise (a global assumption, an
+  ordering hazard across sub-goals, a shared surface written twice).
+
+You are the EXTRA lens: assume the specialized reviewers already ran and passed their
+own artifacts. Do not re-do their job (do not re-lint one spec, do not re-review one
+task). Find only what a whole-work pass surfaces that a per-artifact pass cannot.
+
+Output: `ADVISORY: <N findings>` with `file:line` evidence per finding, or
+`ADVISORY: clean` if a whole-work pass surfaces nothing. Advisory only -- never a
+blocking verdict.
+
+## Mode: over-suggest (P6)
+
+The generative enhancement pass, surfaced to the human JUST BEFORE the final review.
+Given the completed work, propose additional ideas / sub-goals that would improve it
+beyond what was asked -- the "what would make this better that nobody scoped" pass:
+
+- A follow-up that the work now makes cheap (a test that is one fixture away, a
+  generalization the new code enables).
+- A gap the work reveals but did not close (an adjacent case, a hardening step).
+- A next sub-goal the work is a natural foundation for.
+
+Output: `SUGGESTIONS: <N proposals>`, each a one-line idea + why it is now cheap/valuable.
+These are proposals for the human, never auto-actioned. Over-suggesting is the point:
+offer more than will be taken; the human filters.
+
+## What you must NOT do
+
+- **Do not replace the specialized reviewers.** They ran; their tailored lenses are
+  the kit's value. You add a lens, you do not substitute for one.
+- **Do not block.** Both modes are advisory. The final human review is the gate; you
+  inform it.
+- **Do not edit, generate, or apply.** Read-only. Critique surfaces findings;
+  over-suggest surfaces proposals. The human decides and dispatches.
+
+## Configuration (cheap-first tiering)
+
+Your `model:` is the config knob. It is `sonnet` by default because you are a KIT
+DEFAULT -- you run on EVERY applicable run's final boundary, so you must not silently
+burn `opus` every time. An operator who wants a deeper advisor pass on a high-stakes
+run raises the tier for that run; the default stays cheap-first (WORKFLOW.md
+verification cost routing). One knob, one agent, both modes.
+
+## Output format
+
+Critique mode: `ADVISORY: clean` or `ADVISORY: N finding(s)` + numbered `file:line` findings.
+Over-suggest mode: `SUGGESTIONS: N proposal(s)` + numbered one-line proposals with rationale.
+
+## Rules
+
+- Judge/propose by reading the assembled work, not by trusting the sub-goal reports.
+- Be additive and cross-cutting; do not re-run a per-artifact lens.
+- Keep output compact so the dispatcher / human parses it quickly.
+
+Source: ADR-0028 P5 (extra lens) + P6 (over-suggest), one generic advisor with two
+modes (2026-07-01 refinement: additive, not a replacement for the specialized
+reviewers). Named-noun form under ADR-0029 (`advisor` is the single cross-cutting
+lens, legitimately its own noun). Gated by the SG-01 agent-effectiveness validator.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response is a BOUNDED summary: the mode, the one-line verdict (`ADVISORY: clean`
+/ N findings, or N suggestions), the findings/proposals with `file:line`, and the
+paths to read for detail. Not a re-paste of the whole diff; the full reasoning stays
+in your transcript.

--- a/commands/review-team.md
+++ b/commands/review-team.md
@@ -1,5 +1,5 @@
 ---
-description: "Parallel code review with 3 specialist lenses. Dispatches security, architecture, and test-coverage reviewers simultaneously, then merges findings."
+description: "Parallel code review with 3 specialist lenses plus the kit-default advisor extra lens. Dispatches security, architecture, and test-coverage reviewers simultaneously, adds the cross-cutting advisor (critique mode), then merges findings."
 ---
 
 You are a review coordinator. Your job is to dispatch 3 focused reviewers in parallel, collect their findings, deduplicate, and present a unified report.
@@ -95,11 +95,37 @@ Use the code-reviewer agent with lens: test-coverage.
 [test commands from CLAUDE.md or package.json]
 ```
 
+### Step 2b: dispatch the advisor extra lens (KIT DEFAULT, additive)
+
+In addition to the 3 specialist lenses, dispatch the `advisor` agent in **critique
+mode** (ADR-0028 P5). This is a KIT DEFAULT: it runs on every review-team pass, it
+does NOT replace the 3 specialists (they are the kit's tailored value), it ADDS one
+cross-cutting whole-of-work lens that catches what a per-artifact lens is not scoped
+to see (cross-artifact inconsistency, a seam between independently-reviewed pieces, a
+global assumption). Dispatch it read-only, advisory:
+
+```
+Run in critique mode (ADR-0028 P5). You are the EXTRA cross-cutting lens on top of
+the specialized reviewers; do not re-do their per-artifact review. Find only what a
+whole-work pass surfaces. Return ADVISORY: clean | N finding(s) with file:line.
+
+## Diff
+[paste diff or list changed files]
+```
+
+The advisor's `model:` (default `sonnet`) is the cheap-first tier knob, so this
+default lens never silently burns opus on every run.
+
+Fold the advisor's `ADVISORY:` findings into the merge below as an additional lens
+(never a blocker; the final human review is the gate). The advisor's **over-suggest
+mode** (P6) is a SEPARATE pass surfaced to the human just BEFORE the final review
+(the mega-lane / ship final boundary dispatches it); it is not part of this merge.
+
 ### Step 3: Merge findings
 
-After all 3 complete:
+After all 3 specialist lenses + the advisor complete:
 
-1. Collect all issues from all 3 reviewers
+1. Collect all issues from all 3 reviewers (and the advisor's cross-cutting findings)
 2. Deduplicate by FINGERPRINT (SPEC-081): file + line-bucket (+-3 lines) + normalized title (lowercase, punctuation stripped). The same fingerprint across reviewers = ONE finding listing every lens that caught it.
 3. Sort by severity (CRITICAL > HIGH > MEDIUM > LOW)
 4. **Classify each finding's Route (SPEC-078 / ID-076, EveryInc action-class

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,7 @@ Total: 25 commands + 11 agents = **36 entries** (10 build · 3 code · 6 test ·
 | `security-reviewer` | agent | Security review | gate | Deep security analysis; dispatched by `/kit:review-team` as the security reviewer (replacing the generic code-reviewer security lens); also invocable directly for an ad-hoc deep pass |
 | `doc-verifier` | agent | Docs verification | gate | Verifies doc claims against live codebase after /docs updates; read-only; the doc-sync twin of task-verifier |
 | `agent-effectiveness` | agent | Agent-def review | gate | Validates a new/changed agent definition's effectiveness across 4 lenses (tools/description/instructions/tier); dispatched diff-keyed by /kit:draft-agent Step 4.7; read-only, advisory, fail-safe (SPEC-088) |
+| `advisor` | agent | Cross-cutting review (extra lens) | gate | Kit-default generic lens at the final integration/UAT boundary; two modes (P5 critique via /review-team Step 2b, P6 over-suggest before the final review); additive to the specialized reviewers, read-only, advisory (SPEC-091, ADR-0028) |
 
 ### Cross-phase (outside the V)
 

--- a/docs/implementation-notes/generic-advisor.md
+++ b/docs/implementation-notes/generic-advisor.md
@@ -1,0 +1,32 @@
+# Implementation notes: SPEC-091 generic advisor (kit-hardening SG-03)
+
+Delta from SPEC-091 / ADR-0028.
+
+## 2026-07-02 "Final integration/UAT boundary" maps to review-team Step 2b + ship/mega
+
+Context: the kit has no UAT/deploy phase (ROADMAP terminus: internal tooling, no
+runtime surface). ADR-0028 P5/P6 name the "final integration/UAT boundary".
+Decision: critique (P5) is wired into `/kit:review-team` Step 2b (the code-review
+boundary = the last static review before ship); over-suggest (P6) is documented as a
+pass at the ship / mega-lane final boundary, which SG-08's `/kit:mega` will dispatch.
+Why: those are the real final-boundary dispatch points that exist today; there is no
+UAT phase to hang it on.
+Impact: SG-08 consumes the over-suggest pass at the mega final boundary; until then
+the P6 mode is defined + tested as present, wired at ship.
+
+## 2026-07-02 Gate mode added to test-agent-effectiveness.sh
+
+Context: SPEC-091 AC6 + goal-03 verification call `test-agent-effectiveness.sh
+agents/advisor.md` (a per-agent gate). The SG-01 test had no path-arg mode.
+Decision: added a GATE MODE to `tests/test-agent-effectiveness.sh`: given an agent
+path, it runs the deterministic lens subset (read-only tools, valid model tier,
+on-axis name) and exits 0/1. This is the CI proxy for "gated by the 01 validator";
+the full four-lens LLM judgment stays the runtime agent's job.
+Why: a reusable machine gate the SG-03/04 meta-agent-scaffolded agents pass through,
+without a live model in CI. SG-04's new agents reuse the same gate mode.
+
+## 2026-07-02 Advisor model = sonnet (cheap-first, it is a kit default)
+
+Per SPEC-091 AC5: the advisor runs on EVERY applicable run, so opus-by-default would
+burn the expensive tier every time. `model: sonnet` is the default; the frontmatter
+`model:` IS the per-run config knob (an operator raises it for a high-stakes run).

--- a/docs/specs/SPEC-091-generic-advisor.md
+++ b/docs/specs/SPEC-091-generic-advisor.md
@@ -1,0 +1,57 @@
+# SPEC-091: Generic advisor (extra lens + over-suggest)
+
+Status: VALIDATED
+Date: 2026-07-02
+Lane: full (new kit-default review agent + WORKFLOW wiring)
+Type: feature
+Relates-to: ADR-0028 (P5 extra lens, P6 over-suggest; 2026-07-01 additive refinement), ADR-0029 (named-noun `advisor`), SPEC-088 (agent-effectiveness gate), ADR-0005 (read-only verifier), SPEC-087 (distilled return)
+Board: kit-hardening mega-goal SG-03 (ops-toolkit `_meta/megagoals/kit-hardening`)
+
+## Problem
+The V-model's specialized per-phase reviewers are each narrow by design. Nothing runs a
+uniform cross-cutting lens over the WHOLE assembled work at the final boundary, and
+nothing proposes enhancements beyond what was scoped. ADR-0028 P5/P6 call for both, as
+ONE configurable generic advisor with two modes, added ON TOP of the specialized
+reviewers (2026-07-01 refinement: additive, not a replacement).
+
+## Decision
+Add one `advisor` agent (named-noun form, ADR-0029) with two modes:
+- **critique (P5)** -- an extra cross-cutting review lens dispatched on top of the 3
+  specialist lenses in `/kit:review-team` (Step 2b). KIT DEFAULT, additive, advisory.
+- **over-suggest (P6)** -- a generative pass surfaced to the human just before the
+  final review, proposing additional ideas/sub-goals. Dispatched at the ship/mega
+  final boundary (SG-08 consumes it). Proposals only.
+
+Read-only tools (ADR-0005). Its `model:` (default `sonnet`) is the cheap-first tier
+knob so a kit-default lens never silently burns opus every run. Gated by the SG-01
+`agent-effectiveness` validator.
+
+## Acceptance criteria
+- AC1: `agents/advisor.md` exists, conforms to ADR-0029 (named-noun), read-only tools only.
+- AC2: both modes (critique/P5 + over-suggest/P6) are documented in the agent + WORKFLOW.md.
+- AC3 [additive]: the advisor does NOT replace the specialized reviewers -- `/kit:review-team` still dispatches the 3 specialist lenses AND adds the advisor (Step 2b).
+- AC4 [kit-default]: the advisor is wired as a default (not opt-in) at the final boundary.
+- AC5 [tier knob]: the advisor's model tier is a config knob (default sonnet, cheap-first).
+- AC6 [gated]: `bash tests/test-agent-effectiveness.sh agents/advisor.md` passes (the SG-01 gate).
+
+## Tasks
+- T1: author `agents/advisor.md` (two modes, read-only, tier knob).
+- T2: wire critique into `commands/review-team.md` Step 2b + document both modes in WORKFLOW.md.
+- T3: roster sync (MANUAL.md + docs/architecture.md).
+- T4: `tests/test-advisor.sh` covering AC1-AC6.
+
+## Verification
+```
+bash tests/test-advisor.sh                          # both modes; additive; kit-default; tier knob
+bash tests/test-agent-effectiveness.sh agents/advisor.md   # SG-01 gate passes
+bash tests/test-meta.sh                             # roster + naming-axis green
+```
+Proof-of-done: table-first run-table with the additive row (specialists still run), the both-modes rows, and the 01-gate pass.
+
+## Review
+Integration-branch + gated-final (ADR-0028): targets `mega/kit-hardening`, auto-merges past its own ship-gate; the single human review runs at the final `-> master` PR.
+
+## Out of Scope
+- The specialized per-phase reviewers (untouched; advisor is additive).
+- The right-arm agents (SG-04).
+- Making the advisor a hard gate or opt-in; a second agent for over-suggest (one agent, two modes).

--- a/docs/verification/advisor.md
+++ b/docs/verification/advisor.md
@@ -1,0 +1,71 @@
+# Proof of done: generic advisor (SPEC-091, ADR-0028 P5/P6, kit-hardening SG-03)
+
+Verdict: PASS
+
+## Acceptance criteria -> confirmation
+
+| AC | Criterion | How proven | Result |
+|----|-----------|------------|--------|
+| AC1 | advisor exists, conforms (named-noun), read-only | `agents/advisor.md`, `name: advisor`, tools Read/Grep/Glob/Bash(git diff*/log*) | PASS |
+| AC2 | both modes documented (P5 critique + P6 over-suggest) | in the agent AND WORKFLOW.md advisor section | PASS |
+| AC3 [additive] | does NOT replace the specialized reviewers | review-team still dispatches security/architecture/test-coverage AND adds advisor Step 2b; prompt + wiring say "additive, not a replacement" | PASS |
+| AC4 [kit-default] | wired as a default, not opt-in | review-team Step 2b + WORKFLOW marked KIT DEFAULT | PASS |
+| AC5 [tier knob] | model tier is a config knob, cheap-first | `model: sonnet` default + documented as the knob | PASS |
+| AC6 [gated] | passes the SG-01 effectiveness gate | `test-agent-effectiveness.sh agents/advisor.md` exit 0 | PASS |
+
+## Implementation
+
+- `agents/advisor.md` -- one agent, two modes (critique P5 / over-suggest P6), read-only, `model: sonnet` (cheap-first knob).
+- `commands/review-team.md` Step 2b -- dispatches the advisor as an EXTRA cross-cutting lens on top of the 3 specialists (KIT DEFAULT, additive).
+- `WORKFLOW.md` -- "## The advisor: the kit-default extra lens" documents both modes at the final boundary.
+- `tests/test-agent-effectiveness.sh` -- added GATE MODE (`<agent-path>`) reused as the SG-01 gate.
+- Roster: MANUAL.md + docs/architecture.md.
+
+## Confirmation run-table
+
+| Command | Exit | Result |
+|---------|------|--------|
+| `bash tests/test-advisor.sh` | 0 | 15/15 passed |
+| `bash tests/test-agent-effectiveness.sh agents/advisor.md` | 0 | 3/3 gate passed |
+| `bash tests/test-meta.sh` | 0 | 543/543 (advisor lint + roster + on-axis) |
+
+## Run detail
+
+```
+=== advisor (SPEC-091 AC1-AC6) ===
+  PASS AC1: agents/advisor.md exists
+  PASS AC1: name is the named-noun 'advisor' (ADR-0029)
+  PASS AC1: advisor declares read-only tools only
+  PASS AC2: agent documents critique mode (P5)
+  PASS AC2: agent documents over-suggest mode (P6)
+  PASS AC2: WORKFLOW.md documents both modes at the final boundary
+  PASS AC3: review-team still dispatches the 3 specialist lenses
+  PASS AC3: review-team adds the advisor lens (Step 2b)
+  PASS AC3: advisor prompt states it is additive, not a replacement
+  PASS AC3: review-team wiring states additive, not a replacement
+  PASS AC4: review-team marks the advisor a KIT DEFAULT
+  PASS AC4: WORKFLOW marks the advisor a kit default (not opt-in)
+  PASS AC5: advisor model defaults to sonnet (cheap-first)
+  PASS AC5: agent documents the model tier as a config knob
+  PASS AC6: advisor passes the SG-01 agent-effectiveness gate
+=== 15/15 passed, 0 failed ===
+```
+
+## NEGATIVE CONTROL (additive, not a replacement -- the load-bearing property)
+
+The load-bearing risk (ADR-0028 refinement) is the advisor REPLACING the specialized
+reviewers. AC3 is the control: `test-advisor.sh` asserts `/kit:review-team` STILL
+dispatches all three specialist lenses (security, architecture, test-coverage) AND
+adds the advisor -- if a future edit removed a specialist lens, the "review-team still
+dispatches the 3 specialist lenses" assertion FAILS. The advisor is proven additive,
+not substitutive. The SG-01 gate (AC6) is the second control: the advisor is not
+trusted as a kit default until it passes the effectiveness gate.
+
+## Reproduce
+
+```
+cd dwarves-kit
+bash tests/test-advisor.sh                          # 15/15, exit 0
+bash tests/test-agent-effectiveness.sh agents/advisor.md   # 3/3, exit 0
+bash tests/test-meta.sh                             # 543/543, exit 0
+```

--- a/tests/test-advisor.sh
+++ b/tests/test-advisor.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# test-advisor.sh -- SPEC-091, kit-hardening SG-03.
+# Validates the generic advisor: two modes, additive (specialists still run),
+# kit-default, tier knob, and that it passes the SG-01 effectiveness gate.
+#
+# Run: bash tests/test-advisor.sh   (exit 0 = all AC green)
+
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+A="$KIT_DIR/agents/advisor.md"
+RT="$KIT_DIR/commands/review-team.md"
+WF="$KIT_DIR/WORKFLOW.md"
+PASS=0; FAIL=0; TOTAL=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
+
+echo "=== advisor (SPEC-091 AC1-AC6) ==="
+
+# AC1: exists, conforms, read-only tools
+[ -f "$A" ]; assert "AC1: agents/advisor.md exists" $?
+grep -qE '^name: *advisor *$' "$A"; assert "AC1: name is the named-noun 'advisor' (ADR-0029)" $?
+if awk '/^---$/{c++; next} c==1' "$A" | grep -qE '^[[:space:]]*-[[:space:]]*(Edit|Write|NotebookEdit|MultiEdit)[[:space:]]*$|^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$'; then
+  assert "AC1: advisor declares read-only tools only" 1
+else
+  assert "AC1: advisor declares read-only tools only" 0
+fi
+
+# AC2: both modes documented in the agent AND in WORKFLOW.md
+grep -qiE 'mode: *critique|critique \(P5\)|## Mode: critique' "$A"; assert "AC2: agent documents critique mode (P5)" $?
+grep -qiE 'over-suggest|## Mode: over-suggest' "$A"; assert "AC2: agent documents over-suggest mode (P6)" $?
+grep -qi 'over-suggest' "$WF" && grep -qi 'critique' "$WF"; assert "AC2: WORKFLOW.md documents both modes at the final boundary" $?
+
+# AC3 [additive]: review-team still dispatches the 3 specialists AND adds the advisor
+grep -qi 'security' "$RT" && grep -qi 'architecture' "$RT" && grep -qi 'test-coverage' "$RT"
+assert "AC3: review-team still dispatches the 3 specialist lenses" $?
+grep -qi 'advisor' "$RT"; assert "AC3: review-team adds the advisor lens (Step 2b)" $?
+grep -qiE 'not replace|does NOT replace|additive' "$A"; assert "AC3: advisor prompt states it is additive, not a replacement" $?
+grep -qiE 'not replace|does NOT replace|additive' "$RT"; assert "AC3: review-team wiring states additive, not a replacement" $?
+
+# AC4 [kit-default]: wired as a default, not opt-in
+grep -qi 'KIT DEFAULT\|kit-default' "$RT"; assert "AC4: review-team marks the advisor a KIT DEFAULT" $?
+grep -qi 'KIT DEFAULT\|kit-default\|not opt-in' "$WF"; assert "AC4: WORKFLOW marks the advisor a kit default (not opt-in)" $?
+
+# AC5 [tier knob]: default sonnet, documented as the cheap-first knob
+grep -qE '^model: *sonnet *$' "$A"; assert "AC5: advisor model defaults to sonnet (cheap-first)" $?
+grep -qiE 'config knob|tier knob|cheap-first' "$A"; assert "AC5: agent documents the model tier as a config knob" $?
+
+# AC6 [gated]: passes the SG-01 effectiveness gate
+if bash "$KIT_DIR/tests/test-agent-effectiveness.sh" "$A" >/dev/null 2>&1; then
+  assert "AC6: advisor passes the SG-01 agent-effectiveness gate" 0
+else
+  assert "AC6: advisor passes the SG-01 agent-effectiveness gate" 1
+fi
+
+echo ""
+echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test-agent-effectiveness.sh
+++ b/tests/test-agent-effectiveness.sh
@@ -30,6 +30,27 @@ tools_violation() {
     | grep -E '^[[:space:]]*-[[:space:]]*(Edit|Write|NotebookEdit|MultiEdit)[[:space:]]*$|^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$'
 }
 
+# --- GATE MODE (SG-03/04 reuse): `test-agent-effectiveness.sh <agent-path>` runs
+# the DETERMINISTIC lens subset (the parts of the 4 lenses machine-checkable in CI:
+# read-only tools for a reviewer, valid model tier, on-axis name) against ONE agent
+# and exits 0 iff it passes. This is the CI proxy for "gated by the 01 validator" a
+# meta-agent-scaffolded review agent passes through; the full four-lens judgment is
+# the LLM agent's job at runtime, this catches the mechanical defects. ---
+if [ "${1:-}" != "" ] && [ -f "${1:-}" ]; then
+  A="$1"; N=$(basename "$A" .md)
+  echo "=== agent-effectiveness GATE: $A ==="
+  [ -z "$(tools_violation "$A")" ]; assert "gate: $N declares read-only tools only" $?
+  MODEL=$(awk -F': *' '/^---$/{c++; if(c==2)exit} c==1 && /^model:/{print $2; exit}' "$A" | tr -d '[:space:]')
+  echo "$MODEL" | grep -qE '^(sonnet|haiku|opus)$'; assert "gate: $N model tier valid ($MODEL)" $?
+  if echo "$N" | grep -qE -- '-checker$|-auditor$|^reviewer$|-validate$'; then
+    assert "gate: $N name is not a retired review suffix" 1
+  else
+    assert "gate: $N name is not a retired review suffix" 0
+  fi
+  echo ""; echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
+  [ "$FAIL" -eq 0 ]; exit $?
+fi
+
 echo "=== agent-effectiveness validator (SPEC-088 AC1-AC5) ==="
 
 # --- AC3: the validator uses ONLY read-only tools (deterministic) ------------

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -2483,7 +2483,7 @@ done
 # SG-01) is intentionally on this list too: it reviews an AGENT DEFINITION,
 # not a V-model work artifact, so like `advisor` it is a named-noun validator,
 # NOT a naming violation -- do not "fix" its name to *-reviewer.
-REVIEW_AGENTS="task-verifier doc-verifier integration-verifier code-reviewer security-reviewer agent-effectiveness"
+REVIEW_AGENTS="task-verifier doc-verifier integration-verifier code-reviewer security-reviewer agent-effectiveness advisor"
 for NAME in $REVIEW_AGENTS; do
   TOTAL=$((TOTAL + 1))
   if is_on_review_axis "$NAME"; then


### PR DESCRIPTION
Adds the generic `advisor` agent (kit-hardening SG-03, ADR-0028 P5/P6): one agent, two modes -- critique (a kit-default EXTRA review lens on top of the specialized per-phase reviewers, wired into `/review-team` Step 2b) + over-suggest (proposes additional ideas/sub-goals before the final review, dispatched at the ship/mega boundary). Additive, never a replacement. `model: sonnet` as the cheap-first tier knob so a kit-default lens never silently burns opus. Gated by the SG-01 effectiveness validator (a reusable gate mode was added to `test-agent-effectiveness.sh`).

Verify: `bash tests/test-advisor.sh` (15/15) + `bash tests/test-agent-effectiveness.sh agents/advisor.md` (gate). Proof: `docs/verification/advisor.md`.

Roadmap: `ops-toolkit/_meta/megagoals/kit-hardening/ROADMAP.md`. Stacked on the integration branch after SG-01 + SG-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
