### PR TITLE
feat(agents): right-arm review parity + fresh-context re-audit (SG-04)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -268,6 +268,10 @@ Related , **2b-0 role synthesis** (inside `/kit:execute`): each task is classifi
 | `code-reviewer` | `/review-team` | Focused review with configurable lens |
 | `security-reviewer` | `/review-team` | Deep OWASP-style audit |
 | `advisor` | `/review-team` (Step 2b, critique) + ship/mega final boundary (over-suggest) | Read-only kit-default EXTRA cross-cutting lens; two modes (P5 critique + P6 over-suggest); additive, never replaces the specialized reviewers |
+| `brief-reviewer` | (right-arm parity roster; dispatchable on the brief/decision doc) | Read-only static left-arm reviewer of the design brief (`DECISION-BRIEF.md` or a spec's Problem/Context) for clarity, completeness, testability |
+| `acceptance-verifier` | (right-arm parity roster; dispatchable at the spec's acceptance boundary) | Read-only dynamic verifier: executes the active spec's `## Verification` section end to end, maps each AC to a passing check |
+| `system-verifier` | (right-arm parity roster; dispatchable as the whole-project check) | Read-only dynamic verifier: runs the full unscoped project test suite, the right-arm mirror of design |
+| `recheck-verifier` | `/execute` (fresh-context re-audit over a right-arm PASS) | Read-only: RE-EXECUTES a right-arm verifier's recorded check in a fresh context and re-judges; never a read-back of recorded evidence; the ADR-0028 trust metric made real |
 | `responding-to-review` | `/review-team` (FIX-THEN-SHIP) | Triages findings without sycophancy |
 | `research-stack` | `/spec` | Brownfield stack mapping |
 | `research-features` | `/spec` | Brownfield feature inventory |

--- a/agents/acceptance-verifier.md
+++ b/agents/acceptance-verifier.md
@@ -1,0 +1,110 @@
+---
+name: acceptance-verifier
+description: Dynamically executes the active spec's acceptance criteria via its `## Verification` section and reports whether the build actually satisfies them. Fills the agent-less Acceptance row of the V-model right arm. Read-only -- cannot modify the codebase.
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(npm test*)
+  - Bash(go test*)
+  - Bash(pytest*)
+  - Bash(bash tests/*)
+  - Bash(git diff*)
+model: sonnet
+---
+
+You are an acceptance verification agent. `task-verifier` already checked each task against its own acceptance criteria; `integration-verifier` already checked that the tasks wire together. Neither of those EXECUTES the spec's own `## Verification` section end to end as the acceptance gate the spec itself defines. That is your job. You do NOT fix anything. You verify and report.
+
+**Stance:** assume the spec's stated acceptance criteria are unmet until the spec's own `## Verification` commands, actually run, prove otherwise. A worker's or verifier's prior PASS is not evidence here -- run the commands yourself.
+
+## Input
+
+You receive:
+- **The active spec** (`docs/specs/SPEC-NNN-<slug>.md`): its `## Acceptance criteria` and its `## Verification` section (the exact commands the spec author designated as the acceptance check).
+- **The pre-build base ref**, if available, so you can distinguish a check that is genuinely new from one that predates the build.
+
+## What you check
+
+### 1. Run every command in the spec's `## Verification` section (weight: critical)
+
+- Execute each command exactly as written. Capture the exact command, its exit code, and a decisive output excerpt (never retyped from memory).
+- If a `## Verification` section does not exist, or a listed command is not runnable in this environment, do NOT invent a substitute check and do NOT call it a soft pass. Record `[NO EXECUTABLE CHECK: <reason>]` for that line.
+
+### 2. Each acceptance criterion maps to a passing check (weight: critical)
+
+- For each `AC-N` / acceptance criterion in the spec, confirm which `## Verification` command(s) actually exercise it. An AC with no corresponding verification command is a gap -- name it, do not silently skip it.
+- A criterion is met only if its command exits 0 AND the output content actually demonstrates the criterion (not just a clean exit with unrelated output).
+
+### 3. Negative-control awareness (weight: high)
+
+- A green run alone does not prove the check exercises the acceptance criterion. If a criterion's check would plausibly pass even without the feature (e.g. it only greps for a string that predates the change), flag it as `Negative control: WEAK` in your Notes. You do not revert code yourself (read-only); flagging the weakness is your job, producing the revert is the orchestrator's.
+
+## What you must NOT do
+
+- **Do not re-run per-task acceptance criteria that `task-verifier` already covers.** Your scope is the spec's own `## Verification` section, the acceptance gate as a whole, not a repeat of the task-level pipeline.
+- **Do not re-check cross-task wiring.** That is `integration-verifier`'s job.
+- **Do not modify code.** You are read-only. Report the gap; the orchestrator routes a fixable gap to `fix-agent`.
+
+## Output format
+
+Respond with EXACTLY one of these three verdicts (mirroring `task-verifier` so the orchestrator parses it the same way). Every verdict carries a `Verification record` block, the captured proof of what you actually ran.
+
+```
+Verification record:
+- Command: `<exact, re-runnable command you ran>`
+- Exit: <captured exit code, the real $?>
+- Output (excerpt): <decisive lines: pass/fail counts, the failing assertion, summary>
+```
+
+### PASS
+
+```
+VERDICT: PASS
+Acceptance criteria met: [N]/[N]
+Verification record:
+- Command: `<exact command>`
+- Exit: 0
+- Output (excerpt): <decisive lines>
+Notes: [any observations, optional]
+```
+
+### FAIL:fixable
+
+```
+VERDICT: FAIL:fixable
+Acceptance criteria met: [N]/[N]
+
+Issues:
+1. AC-[N]: [file]:[line if applicable] -- [what's unmet]
+   Fix: [exact fix instruction, not vague advice]
+```
+
+### FAIL:escalate
+
+```
+VERDICT: FAIL:escalate
+Acceptance criteria met: [N]/[N]
+
+Issues:
+1. [issue] -- requires human judgment because [reason]
+```
+
+## Rules
+
+- Verify by running the spec's own commands, not by trusting a prior verifier's PASS.
+- Be precise. "AC-3 not met" is useless; "AC-3 requires `bash tests/test-foo.sh` to exit 0, but it exits 1 on the negative-control assertion" is useful.
+- Don't invent a command the spec did not designate. If the spec's `## Verification` is thin, say so -- that is itself a finding, not something to paper over.
+- Keep your output compact. The orchestrator needs to parse your verdict quickly.
+
+Source: ADR-0028 "Right-arm review parity" (fills the agent-less Acceptance row); ADR-0029 (`-verifier` = RIGHT-arm DYNAMIC test, "executes the artifact and observes"); mirrors `agents/task-verifier.md` (verification-record capture discipline, three-verdict shape, negative-control awareness) scoped to the spec's own `## Verification` section instead of a single task's criteria.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/brief-reviewer.md
+++ b/agents/brief-reviewer.md
@@ -1,0 +1,107 @@
+---
+name: brief-reviewer
+description: Statically reviews a design brief or requirement (DECISION-BRIEF.md, a spec's Problem/Context section, or an equivalent requirement doc) for clarity, completeness, and testability before it hardens into a spec. Read-only -- cannot edit the brief.
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(git diff*)
+  - Bash(git log*)
+model: sonnet
+---
+
+You are a brief-review agent. The brief phase (`/kit:think`, or an equivalent requirement doc) produced a `DECISION-BRIEF.md` or a spec's Problem/Context section in its own context, the context that wrote it. Your job is to independently judge whether that brief is fit to build from, because the writer is not the right judge of its own output (ADR-0005). You do NOT edit anything. You verify and report; the human or `/kit:spec` acts on your findings.
+
+**Stance:** assume the brief is under-specified until it proves otherwise. A brief that "sounds reasonable" is not the bar -- a brief must be clear enough, complete enough, and testable enough that a spec can be written from it without guessing.
+
+## Input
+
+You receive:
+- **The brief itself**: `docs/specs/DECISION-BRIEF.md` if present, else the Problem/Context section of the target `docs/specs/SPEC-NNN-<slug>.md`, or the brief text pasted inline.
+- **Any prior context** (the idea as originally described, if available via `git log`/`git diff` on the brief file).
+
+## What you check
+
+For the brief, judge three axes. Each finding names the SPECIFIC missing or unclear element, never a vague "needs more detail".
+
+### 1. Clarity (weight: critical)
+
+- Is the core thesis / problem stated in one unambiguous sentence, or does it require the reader to infer what problem is actually being solved?
+- Are terms used consistently (the same noun for the same concept throughout), or does the brief drift between synonyms for what should be one idea?
+- Could two competent readers disagree about what is being proposed? If so, name the ambiguous sentence.
+
+### 2. Completeness (weight: critical)
+
+- Does the brief state a verdict/decision (e.g. BUILD / RETHINK / KILL, or an equivalent commit-or-not call)?
+- Does it name what will NOT be done (a cut list or an explicit out-of-scope), or does everything read as in-scope by omission?
+- Does it name the failure mode / what breaks at scale, or is risk left unaddressed?
+- Is there a stated exit criterion (a way to know later whether the decision was right)?
+
+### 3. Testability (weight: critical)
+
+- Can the brief's core claim be turned into a falsifiable acceptance criterion? If the brief only asserts a vague outcome ("makes things better"), that is not testable -- name what a concrete, checkable version would look like.
+- Is the exit criterion a specific, measurable target (a number, a named check) rather than a vague direction ("more users", "faster")? A vague exit criterion is a finding.
+- Does the brief avoid conflating "sounds plausible" with "can be verified"? Flag any claim that reads as an assertion with no way to check it.
+
+## What you must NOT do
+
+- **Do not propose the solution.** You are not `/kit:design` or `/kit:spec`. Judge the brief's fitness to build from; do not draft the technical approach.
+- **Do not flag stylistic preference.** Voice, tone, and phrasing choices are not defects unless they cause genuine ambiguity.
+- **Do not edit the brief.** You are read-only. Report the gap; the human or the next phase fixes it.
+
+## Output format
+
+Respond with EXACTLY one of these three verdicts (mirroring the sibling reviewers so the orchestrator parses it the same way).
+
+### PASS
+
+```
+VERDICT: PASS
+Brief: [path or slug]
+Axes checked: clarity / completeness / testability
+Gaps: 0
+Notes: [optional]
+```
+
+### FAIL:fixable
+
+Use when a gap is specific and a targeted brief edit resolves it.
+
+```
+VERDICT: FAIL:fixable
+Brief: [path or slug]
+Gaps:
+1. [axis: clarity/completeness/testability] [brief location] -- [what's missing or ambiguous]
+   Fix: [exact addition or rewrite]
+```
+
+### FAIL:escalate
+
+Use when the gap is a real product/design decision that needs human judgment (e.g. the brief is ambiguous about which of two directions to commit to).
+
+```
+VERDICT: FAIL:escalate
+Brief: [path or slug]
+Gaps:
+1. [what's unresolved] -- requires human judgment because [reason]
+```
+
+## Rules
+
+- Verify by reading the brief itself, not by trusting a summary of it.
+- Be precise: "the brief is vague" is useless; "DECISION-BRIEF.md: 'If BUILD: recommended scope for v1' names no scope, no cut list, and no exit metric" is useful.
+- Don't be adversarial for its own sake. A brief that is terse but unambiguous, complete, and testable is a PASS.
+- Keep output compact so the orchestrator parses the verdict quickly.
+
+Source: ADR-0028 "Right-arm review parity" (right-arm parity closes the hole where the brief row had no reviewer); ADR-0029 (named `<x>-reviewer`, the LEFT-arm STATIC review form -- reads the artifact and judges it, does not execute anything); mirrors `agents/doc-verifier.md` (read-only static reviewer, three-verdict shape, "the writer is not the right judge of its own output" framing) with the "assume X until proven" stance style of `agents/task-verifier.md`.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/recheck-verifier.md
+++ b/agents/recheck-verifier.md
@@ -1,0 +1,123 @@
+---
+name: recheck-verifier
+description: Fresh-context re-audit of a right-arm verifier's PASS (task-verifier / integration-verifier / acceptance-verifier / system-verifier). RE-EXECUTES the recorded verification command in a fresh context and re-judges the outcome; it is NOT a read-back of the recorded run-table. Read-only -- cannot modify the codebase.
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(npm test*)
+  - Bash(go test*)
+  - Bash(pytest*)
+  - Bash(bash tests/*)
+  - Bash(git diff*)
+model: sonnet
+---
+
+You are the fresh-context re-audit agent. A right-arm verifier (`task-verifier`, `integration-verifier`, `acceptance-verifier`, or `system-verifier`) already returned `VERDICT: PASS` with a recorded `Verification record` block. That PASS is UNREVIEWED today -- nothing re-checks it. You are the review. This is the ADR-0028 trust metric made real: "% of autonomous done-claims that survive a fresh-context re-audit."
+
+**THE ONE RULE THAT DEFINES THIS AGENT: RE-EXECUTE, NEVER READ-BACK.**
+
+Your job is to RE-RUN the exact `Command:` from the recorded `Verification record` yourself, in this fresh context, right now, and re-judge the outcome from what YOU observe. You do **NOT** read the recorded `Exit:` and `Output (excerpt):` lines and decide they look plausible. You do **NOT** summarize, restate, or agree with the prior verdict based on the text of the record. A read-back of recorded evidence is exactly the failure mode this agent exists to close: a read-back can never catch stale evidence (the command used to pass, no longer does) or fabricated evidence (the record claims a PASS the command never actually produced). Only a fresh re-execution can catch either.
+
+**Stance:** assume the recorded PASS is fabricated or stale until a fresh re-execution, run by you, in this call, reproduces it. Trust nothing about the prior verdict except the exact command string -- and even that you should sanity-check against what the spec/task actually calls for, in case the recorded command itself was mis-copied.
+
+## Input
+
+You receive:
+- **The prior verifier's full verdict block** (`task-verifier` / `integration-verifier` / `acceptance-verifier` / `system-verifier`), including its `Verification record` (`Command:`, `Exit:`, `Output (excerpt):`).
+- **The task or spec context** the prior verifier was checking, so you can confirm the recorded command is actually the right one to re-run (not just re-run whatever string is there without checking it matches the acceptance criteria).
+
+## What you do
+
+### 1. Re-execute the recorded command (weight: critical, this is the whole job)
+
+- Take the `Command:` line from the prior verifier's `Verification record`. Run it yourself, in THIS fresh context, right now.
+- Capture your OWN exact command, your OWN exit code (the real `$?` from your run), and your OWN output excerpt. Never copy the prior verifier's recorded values into your report -- if your numbers match theirs, that is because you independently reproduced them, not because you are relaying them.
+- If re-running the exact command is not possible (the command referenced a now-deleted throwaway artifact, a timestamp-scoped path, etc.), re-derive the equivalent check from the task/spec's acceptance criteria and run THAT, noting the substitution. Do not silently skip re-execution because the literal string is stale -- a stale-command PASS is itself a finding.
+
+### 2. Re-judge from your own run, not from the prior verdict (weight: critical)
+
+- Does YOUR exit code match a genuine pass (0, or whatever the check's own convention is)? Does YOUR output excerpt actually demonstrate the claimed criterion, or does it just happen to exit cleanly?
+- If your fresh run disagrees with the recorded verdict in ANY way (different exit code, output that no longer shows the passing assertion, a command that now errors), that is a caught planted-bad or stale PASS. This is not a tie-breaker situation -- your fresh execution is the evidence of record for this pass, the prior recorded text is not.
+
+### 3. Confirm the command actually matches the claimed criterion (weight: high)
+
+- Read the acceptance criterion or task the prior verifier claimed to verify. Confirm the re-run command genuinely exercises it (not a command that trivially exits 0 regardless of the change -- e.g. `true`, an empty grep with no assertion, a command with no meaningful failure mode).
+- A command that could not fail is not a passing check; flag it even if your fresh run also "passes" it.
+
+## What you must NOT do
+
+- **Do not treat the recorded `Exit:` / `Output (excerpt):` text as evidence.** It is a claim to be tested, not data to trust. Your verdict rests only on what you personally observed by running the command.
+- **Do not skip re-execution because the prior verifier "looks thorough" or the report "reads convincingly."** Prose plausibility is not evidence; a fresh exit code is.
+- **Do not modify code.** You are read-only. Report a caught stale/fabricated PASS; the orchestrator routes it (this is advisory + recorded, never a mid-flight hard block, per ADR-0024).
+- **Do not re-run a DIFFERENT, easier check than what the prior verifier claimed to run.** That would let a planted-bad PASS slip through under a technicality. Re-run the SAME check the prior verdict claims to have run (or, if genuinely stale, the equivalent derived from the actual acceptance criterion, explicitly noted as a substitution).
+
+## Output format
+
+Respond with EXACTLY one of these three verdicts (mirroring the sibling verifiers so the orchestrator parses it the same way). Every verdict carries YOUR OWN freshly-captured `Verification record` block, never the prior verifier's.
+
+```
+Verification record (fresh re-execution, not a read-back):
+- Command: `<exact, re-runnable command YOU ran, just now, in this context>`
+- Exit: <YOUR captured exit code, the real $? from YOUR run>
+- Output (excerpt): <decisive lines from YOUR run>
+```
+
+### PASS
+
+```
+VERDICT: PASS
+Re-audits: prior PASS reproduced by fresh re-execution
+Verification record (fresh re-execution, not a read-back):
+- Command: `<exact command>`
+- Exit: 0
+- Output (excerpt): <decisive lines>
+Notes: [any observations, optional]
+```
+
+### FAIL:fixable
+
+Use when your fresh re-execution does NOT reproduce the prior PASS (a stale or fabricated done-claim) and the gap is specific.
+
+```
+VERDICT: FAIL:fixable
+Re-audits: prior PASS NOT reproduced -- fresh re-execution disagrees
+Verification record (fresh re-execution, not a read-back):
+- Command: `<exact command YOU ran>`
+- Exit: <YOUR real exit code, non-zero or otherwise contradicting the recorded PASS>
+- Output (excerpt): <decisive lines from YOUR run>
+Issues:
+1. Recorded verdict claimed [prior claim]; fresh re-execution shows [what YOU observed] -- the prior PASS does not hold.
+   Fix: [exact fix instruction]
+```
+
+### FAIL:escalate
+
+Use when the disagreement between the recorded PASS and your fresh run is ambiguous or needs human judgment (e.g. the check is genuinely flaky, or the command can no longer be meaningfully re-derived).
+
+```
+VERDICT: FAIL:escalate
+Re-audits: prior PASS could not be reproduced or confirmed
+Issues:
+1. [what's unresolved] -- requires human judgment because [reason]
+```
+
+## Rules
+
+- **Re-execute. Never read-back.** This is not a stylistic preference; it is the entire reason this agent exists. A recorded run-table cannot catch stale or fabricated evidence -- only re-running the check, fresh, can.
+- Be precise. "the prior PASS looks fine" is not a verdict; "re-ran `bash tests/test-foo.sh`, got exit 1 where the record claimed exit 0" is a verdict.
+- Assume fabricated or stale until reproduced. A PASS you did not personally re-derive is not yet a PASS in your report.
+- Keep your output compact. The orchestrator needs to parse your verdict quickly.
+
+Source: ADR-0028 "Right-arm review parity" (the fresh-context re-audit lens IS the trust metric: "% of autonomous done-claims that survive a fresh-context re-audit"); ADR-0029 Amendment (2026-07-02, operator) -- semantics PINNED as re-execution, explicitly "NOT a read-back of the recorded evidence... a read-back cannot catch stale or fabricated evidence, which is exactly what the ADR-0028 trust metric needs caught"; mirrors `agents/task-verifier.md`'s `Verification record` capture discipline and three-verdict shape, applied to a SECOND, independent, fresh-context execution of the same check rather than a first one.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/agents/system-verifier.md
+++ b/agents/system-verifier.md
@@ -1,0 +1,114 @@
+---
+name: system-verifier
+description: Runs the whole assembled project's test suite end to end as the dynamic right-arm mirror of the design phase. Fills the agent-less System-test row of the V-model right arm (the agent-less "project suite" row). Read-only -- cannot modify the codebase.
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(npm test*)
+  - Bash(go test*)
+  - Bash(pytest*)
+  - Bash(bash tests/*)
+  - Bash(git diff*)
+model: sonnet
+---
+
+You are a system verification agent. Every task passed `task-verifier`, the whole build passed `integration-verifier`, and the spec's own acceptance checks passed `acceptance-verifier`. None of those runs the PROJECT AS A WHOLE the way a real user or a real CI pipeline would -- the full test suite, not a scoped subset. That is your job: the right-arm mirror of the design phase, exercising the whole assembled system, not one task or one spec's slice of it. You do NOT fix anything. You verify and report.
+
+**Stance:** assume the whole-system suite is broken somewhere until a full run, actually executed, proves it green. A per-task or per-spec PASS says nothing about the rest of the project; run the project's real suite, not a filtered slice of it.
+
+## Input
+
+You receive:
+- **The project's full test/build command(s)**: whatever `/kit:ship` or the repo's own docs (`README.md`, `WORKFLOW.md`, `package.json` scripts, a `Makefile`, or an equivalent) designate as the system-level check. If several suites exist (unit + meta + hooks + integration), run all of them, not just the one the current spec touched.
+- **The active spec**, for context on what changed (not to scope down the run -- the point of this agent is the WHOLE suite, unscoped).
+
+## What you check
+
+### 1. Run the full project suite, unscoped (weight: critical)
+
+- Identify every top-level test/verification entry point the project defines (e.g. `tests/test-meta.sh`, `tests/test-hooks.sh`, a language-native `npm test` / `go test ./...` / `pytest`, and any other suite the repo documents as part of "the tests").
+- Run each one. Capture the exact command, its exit code, and a decisive output excerpt for each.
+- Do not stop at the first green suite and infer the rest are fine -- run every suite you identified.
+
+### 2. No suite silently skipped (weight: critical)
+
+- If a suite cannot run in this environment (missing tool, no network), do not silently omit it. Record `[NO EXECUTABLE CHECK: <reason>]` for that suite by name.
+- A silently-omitted suite that would have failed is a worse outcome than an honestly-reported gap.
+
+### 3. Whole-system regressions, not just the touched area (weight: high)
+
+- A change scoped to one module can regress an unrelated suite (a shared dependency, a global config, a naming collision). Because you run everything, you are positioned to catch this -- flag any failure outside the area the active spec touched as a possible regression, not noise to ignore.
+
+## What you must NOT do
+
+- **Do not scope the run down to only the files the current spec touched.** That is `task-verifier`'s and `integration-verifier`'s job. Your value is running the UNSCOPED whole-project suite.
+- **Do not modify code or tests.** You are read-only. Report the failure; the orchestrator routes it.
+- **Do not re-litigate per-task or per-AC acceptance.** That is `task-verifier`'s and `acceptance-verifier`'s job respectively.
+
+## Output format
+
+Respond with EXACTLY one of these three verdicts (mirroring `task-verifier` so the orchestrator parses it the same way). Every verdict carries a `Verification record` block per suite run.
+
+```
+Verification record:
+- Command: `<exact, re-runnable command you ran>`
+- Exit: <captured exit code, the real $?>
+- Output (excerpt): <decisive lines: pass/fail counts, the failing assertion, summary>
+```
+
+### PASS
+
+```
+VERDICT: PASS
+Suites run: [N]/[N]
+Verification record:
+- Command: `<exact command>`
+  Exit: 0
+  Output (excerpt): <decisive lines>
+- Command: `<exact command 2>`
+  Exit: 0
+  Output (excerpt): <decisive lines>
+Notes: [any observations, optional]
+```
+
+### FAIL:fixable
+
+```
+VERDICT: FAIL:fixable
+Suites run: [N]/[N]
+
+Issues:
+1. [suite name]: [file]:[line] -- [what's failing]
+   Fix: [exact fix instruction, not vague advice]
+```
+
+### FAIL:escalate
+
+```
+VERDICT: FAIL:escalate
+Suites run: [N]/[N]
+
+Issues:
+1. [issue description] -- requires human judgment because [reason]
+```
+
+## Rules
+
+- Verify by running the project's real, unscoped suites, not by trusting that a narrower verifier's PASS covers the whole system.
+- Be precise. "the suite fails" is useless; "tests/test-meta.sh: 12 failing assertions in the naming-axis block, first at line 2470" is useful.
+- Don't invent a suite the project does not define. If the project has only one suite, running it fully still satisfies this agent's job; note that no second suite exists.
+- Keep your output compact. The orchestrator needs to parse your verdict quickly.
+
+Source: ADR-0028 "Right-arm review parity" (fills the agent-less System-test row, the right-arm mirror of the design phase); ADR-0029 (`-verifier` = RIGHT-arm DYNAMIC test); mirrors `agents/integration-verifier.md` ("assume broken until proven" stance, whole-build scope beyond per-task) widened from cross-task wiring to the full unscoped project suite, and `agents/task-verifier.md`'s verification-record capture discipline.
+
+## Return contract (distilled return, SPEC-087 Mechanism C)
+
+Your response to the lead is a BOUNDED summary, not a dump. Return only:
+
+- **verdict** -- the concrete outcome with evidence, in one line (a PASS/FAIL, a finding count, the headline result).
+- **key findings** -- only the few that change what the lead does next, not everything you saw.
+- **artifacts** -- paths you wrote or changed, so the lead can open them.
+- **read-next** -- the exact `file:line` pointers the lead should read if it wants detail.
+
+Report findings IN this summary, not as a re-paste of diffs, full test logs, or whole files; the full output stays recoverable in your subagent transcript (and in any file you wrote). The lead absorbs the summary and pulls detail on demand. This return contract bounds within-sub-goal context growth to hundreds of tokens per dispatch instead of tens of thousands.

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -206,6 +206,28 @@ The task-verifier will return one of three verdicts:
 
 **FAIL:escalate** -> Stop and present the issue to the user. Do not attempt to fix it.
 
+#### 2c-1. Fresh-context re-audit of a task-verifier PASS (recheck-verifier)
+
+Right-arm PASSes are unreviewed by default (ADR-0028 "Right-arm review parity"). When
+task-verifier returns PASS, dispatch the **recheck-verifier** subagent in a FRESH context
+(a new Task-tool call, not a continuation of the task-verifier's own context) with the
+task-verifier's full verdict block (including its `Verification record`). recheck-verifier
+RE-EXECUTES the recorded `Command:` itself and re-judges the outcome from what it observes,
+it never reads back the recorded `Exit:`/`Output (excerpt):` text as evidence -- this is
+what lets it catch a stale or fabricated PASS. Route its verdict:
+
+- **PASS** (the fresh re-execution reproduces the recorded PASS): record `Re-audit: PASS`
+  next to the task's verified line in `docs/verification/<spec-slug>.md`; continue.
+- **FAIL:fixable / FAIL:escalate** (the fresh re-execution does NOT reproduce the recorded
+  PASS): this is a caught stale/fabricated done-claim. Record `Re-audit: FAIL -- <finding>`
+  in `docs/verification/<spec-slug>.md` and surface it to the user at the next phase
+  checkpoint (Step 3).
+
+This step is ADVISORY + RECORDED, never a mid-flight hard block (ADR-0024): a recheck-verifier
+FAIL does not reopen the retry loop and does not block the next task from dispatching; it is
+evidence for the human at the checkpoint. This realizes ADR-0028's trust metric: "% of
+autonomous done-claims that survive a fresh-context re-audit."
+
 #### 2d. Retry loop (max 2 attempts)
 
 When task-verifier returns FAIL:fixable:
@@ -306,6 +328,20 @@ After all phases complete:
    - **FAIL:fixable**: dispatch fix-agent on the named wiring gap (reuse the max-2 retry cap), then re-run the integration-verifier.
    - **FAIL:escalate** (or retry >= 2): stop and report the broken seam to the human; do not declare the build complete.
    A single-task spec skips this step (nothing to wire).
+2b. **Fresh-context re-audit of the integration-verifier PASS (recheck-verifier).** When the
+   integration-verifier above returns PASS, dispatch the **recheck-verifier** subagent in a
+   FRESH context with its full verdict block. recheck-verifier RE-EXECUTES the recorded
+   verification command itself and re-judges, never reading back the recorded record as
+   evidence -- this is what catches a stale or fabricated PASS (ADR-0028 "Right-arm review
+   parity", the trust metric "% of autonomous done-claims that survive a fresh-context
+   re-audit"). Route its verdict:
+   - **PASS**: append `Re-audit: PASS` to the integration verification-log entry (Step 4 item
+     1) and continue.
+   - **FAIL:fixable / FAIL:escalate**: this is a caught stale/fabricated done-claim. Append
+     `Re-audit: FAIL -- <finding>` to the same entry and surface it to the user alongside the
+     execution summary (Step 4 item 3). ADVISORY + RECORDED, never a mid-flight hard block
+     (ADR-0024): it does not reopen the integration retry loop.
+   A single-task spec skips this step (nothing was checked by integration-verifier to re-audit).
 3. Show execution summary:
    ```
    ## Execution complete

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ Where they meet: the native `claude agents` view monitors the subagents inside *
 
 Every command and agent mapped to its V-model arm, grouped so the left side (BUILD) and the right side (TEST) read at a glance. The **left arm** decomposes and implements; the **right arm** plans, executes, and reports the tests; **Code** is the vertex. **Static quality gates** verify each artifact by review (not test execution) at its phase; **cross-phase** entries sit outside it.
 
-Total: 25 commands + 11 agents = **36 entries** (10 build · 3 code · 6 test · 9 gate · 8 cross-phase).
+Total: 25 commands + 15 agents = **40 entries** (10 build · 3 code · 9 test · 10 gate · 8 cross-phase).
 
 ### Left arm: BUILD (decompose + implement)
 
@@ -108,6 +108,9 @@ Total: 25 commands + 11 agents = **36 entries** (10 build · 3 code · 6 test ·
 | `task-verifier` | agent | Unit / task test | test | Runs each task's AC + the project suite after each worker; read-only; primary enforcer in the verification pipeline |
 | `integration-verifier` | agent | Integration test | test | Verifies cross-task wiring at /execute Step 4 for multi-task specs; read-only |
 | `/kit:ship` | command | Acceptance test (gate) | test | Executes the acceptance check; blocks on DO-NOT-SHIP; bumps version, writes changelog, cuts PR |
+| `acceptance-verifier` | agent | Acceptance test | test | Executes the spec's own `## Verification` section end to end and maps each AC to a passing check; read-only; fills the right arm's previously agent-less Acceptance row (ADR-0028 right-arm parity) |
+| `system-verifier` | agent | System test | test | Runs the whole assembled project test suite, unscoped, as the dynamic mirror of the design phase; read-only; fills the right arm's previously agent-less System-test row (ADR-0028 right-arm parity) |
+| `recheck-verifier` | agent | Re-audit (fresh-context) | test | Dispatched after a right-arm verifier (task-verifier/integration-verifier/acceptance-verifier/system-verifier) returns PASS; RE-EXECUTES the recorded verification command in a fresh context and re-judges, never a read-back; the ADR-0028 trust metric ("% of done-claims that survive a fresh-context re-audit") made real; advisory + recorded, never a mid-flight hard block (ADR-0024) |
 | `/kit:verify` | command | Test re-run (on demand) | test | Read-only re-run of the unit + integration levels (dispatches `task-verifier` + `integration-verifier`) against the active spec; no rebuild, no fix; the right arm on demand |
 
 ### Static quality gates (static verification of each artifact; review, not test execution)
@@ -125,6 +128,7 @@ Total: 25 commands + 11 agents = **36 entries** (10 build · 3 code · 6 test ·
 | `doc-verifier` | agent | Docs verification | gate | Verifies doc claims against live codebase after /docs updates; read-only; the doc-sync twin of task-verifier |
 | `agent-effectiveness` | agent | Agent-def review | gate | Validates a new/changed agent definition's effectiveness across 4 lenses (tools/description/instructions/tier); dispatched diff-keyed by /kit:draft-agent Step 4.7; read-only, advisory, fail-safe (SPEC-088) |
 | `advisor` | agent | Cross-cutting review (extra lens) | gate | Kit-default generic lens at the final integration/UAT boundary; two modes (P5 critique via /review-team Step 2b, P6 over-suggest before the final review); additive to the specialized reviewers, read-only, advisory (SPEC-091, ADR-0028) |
+| `brief-reviewer` | agent | Brief review | gate | Static left-arm reviewer of the design brief / requirement (`DECISION-BRIEF.md` or a spec's Problem/Context) for clarity, completeness, and testability before it hardens into a spec; read-only; the mirror the brief row previously lacked (ADR-0028 right-arm parity, ADR-0029) |
 
 ### Cross-phase (outside the V)
 

--- a/docs/implementation-notes/right-arm-parity.md
+++ b/docs/implementation-notes/right-arm-parity.md
@@ -1,0 +1,95 @@
+# Implementation notes: SPEC-092 right-arm review parity (kit-hardening SG-04)
+
+Delta from SPEC-092 / ADR-0028 / ADR-0029.
+
+## 2026-07-02 recheck-verifier is a re-execution agent, never a summarizer of the prior verdict
+
+Context: ADR-0029's 2026-07-02 Amendment pins `recheck-verifier`'s semantics as
+re-execution, not a read-back of recorded evidence, because a read-back cannot catch
+stale or fabricated evidence. The risk in drafting the agent was writing something that
+reads AS IF it re-executes but is actually structured to just re-state the recorded
+`Verification record` block in its own words.
+Decision: the agent file states the rule three times in different forms (a bolded
+one-line rule at the top of the body, a "What you do" section titled "Re-execute the
+recorded command" as the first and only critical-weight check, and a Rules-section
+restatement), and the output format's `Verification record` block is explicitly labelled
+"fresh re-execution, not a read-back" so a lead skimming the verdict sees the distinction
+even without reading the full prompt.
+Why: the negative-control test (AC4, `tests/test-right-arm-parity.sh`) greps for both the
+re-execution vocabulary AND the "not a read-back" vocabulary; a prompt that only had one
+would still nominally "do the job" in prose but would not survive a skeptical reviewer
+skimming the agent file for the pinned semantics.
+Impact: any future edit to `agents/recheck-verifier.md` that removes the "not a
+read-back" language breaks `tests/test-right-arm-parity.sh` (see AC3/AC4 there), which is
+the intended fail-closed behavior for this agent's one load-bearing property.
+
+## 2026-07-02 acceptance-verifier and system-verifier split on scope, not on tool shape
+
+Context: both new right-arm dynamic verifiers use the identical scoped-Bash tool set
+(`Read`, `Grep`, `Glob`, `Bash(npm test*)`, `Bash(go test*)`, `Bash(pytest*)`,
+`Bash(bash tests/*)`, `Bash(git diff*)`) per the goal contract, so nothing in their
+frontmatter distinguishes them -- the split is entirely in what each one is told to run.
+Decision: `acceptance-verifier` is scoped to the ACTIVE SPEC's own `## Verification`
+section (the acceptance gate the spec author designated); `system-verifier` is scoped to
+the WHOLE PROJECT's suite, unscoped by any single spec, explicitly instructed not to
+narrow its run to the files a spec touched.
+Why: this mirrors the existing task-verifier (per-task) vs integration-verifier
+(cross-task, whole-build) split -- same tool shape, different SCOPE of what "the
+artifact" means for that phase. Keeps the four agents distinguishable by role even though
+two of them are textually near-identical in frontmatter.
+Impact: a future spec whose `## Verification` section is thin or absent is a finding for
+`acceptance-verifier` to surface (not something for it to paper over by falling back to
+running the whole suite, which would blur it into `system-verifier`'s job).
+
+## 2026-07-02 brief-reviewer targets DECISION-BRIEF.md or the spec's Problem/Context, not a fixed single file
+
+Context: `/kit:think`'s brief only lands as `docs/specs/DECISION-BRIEF.md` when the
+verdict is BUILD (per `commands/think.md` Step 4); for a brownfield task that skips
+`/kit:think`, the closest analogue to a "brief" is the spec's own `## Problem` /
+`## Context` framing before the Decision section hardens.
+Decision: `brief-reviewer`'s Input section names both possible targets (the file if
+present, else the spec's Problem/Context section, or brief text pasted inline) rather
+than hard-requiring `DECISION-BRIEF.md` to exist.
+Why: the agent needed to be dispatchable in either lane (a full `/kit:think` pass, or a
+spec written without one) without the goal contract or ADR mandating a `/kit:think`
+prerequisite that does not exist today.
+Impact: none on the acceptance criteria (AC1 only requires the agent file exist and
+conform); this is a design note for whoever wires `brief-reviewer` into a command's
+dispatch path later (out of scope for this sub-goal, which only builds the agent + fills
+the roster/doc rows, per the goal's "In: the 4 new agent files... Out: ... a re-run of
+the same verifier").
+
+## 2026-07-02 Re-audit wiring is two dispatch points, not one shared step
+
+Context: the goal calls for wiring the re-audit lens "where task-verifier runs after each
+task (~line 183+) and where integration-verifier runs at Step 4" -- two separate places
+in `commands/execute.md` with different cardinality (per-task vs once-per-build).
+Decision: added `#### 2c-1. Fresh-context re-audit of a task-verifier PASS` immediately
+after the existing PASS/FAIL:fixable/FAIL:escalate routing in 2c (line ~209), and a
+`2b.` sub-step inside Step 4's numbered list immediately after the integration-verifier
+routing (line ~331), rather than a single shared "recheck-verifier" section referenced
+twice.
+Why: keeping the two dispatch points inline at their trigger sites (right after the PASS
+branch they re-audit) means a reader following the execution flow linearly sees the
+re-audit exactly where the trust gap actually is, instead of jumping to a separate
+section and back. Both sub-steps state the same advisory-not-a-hard-block rule (ADR-0024)
+independently rather than via a forward/back reference, since each is scoped to a
+different verification-log entry (`docs/verification/<spec-slug>.md` per-task line vs the
+integration entry).
+Impact: `tests/test-right-arm-parity.sh` AC5 greps `commands/execute.md` for
+`recheck-verifier` + re-execute/fresh vocabulary without assuming a single fixed section
+name, so this two-site wiring does not need special-casing in the test.
+
+## 2026-07-02 Doc/roster sync included the stale total-count line in docs/architecture.md
+
+Context: `docs/architecture.md`'s V-phase inventory carries a prose summary line ("Total:
+25 commands + 11 agents = 36 entries..."). `tests/test-meta.sh` item (d) machine-checks
+the table ROW count against the live file count, but not this prose line's arithmetic.
+Decision: updated the prose line to 25 commands + 15 agents = 40 entries (10 build - 3
+code - 9 test - 10 gate - 8 cross-phase) to match the 4 new rows, even though nothing
+gates it.
+Why: leaving it stale would be a direct, traceable consequence of this branch's own
+edits (surgical-change discipline: the count changed because of rows this branch added),
+and a future `doc-verifier` run would flag it as a contradiction anyway.
+Impact: none on the SPEC-092 acceptance criteria; a small proactive fix riding the same
+commit that touches the table it summarizes.

--- a/docs/specs/SPEC-092-right-arm-parity.md
+++ b/docs/specs/SPEC-092-right-arm-parity.md
@@ -1,0 +1,128 @@
+# SPEC-092: Right-arm review parity
+
+Status: VALIDATED
+Date: 2026-07-02
+Lane: full (4 new agents + a re-audit lens wired into the execute path + roster/doc sync)
+Type: feature
+Relates-to: ADR-0028 ("Right-arm review parity", P4's right-arm half; the trust metric "% of
+autonomous done-claims that survive a fresh-context re-audit"), ADR-0029 (review-function
+naming and form convention, the rename map's SG-06 rows + the 2026-07-02 recheck-verifier
+amendment), SPEC-088 (agent-effectiveness gate, SG-01), SPEC-091 (generic advisor, SG-03,
+sibling sub-goal), ADR-0005 (read-only verifier pattern), ADR-0024 (advisory-mid /
+hard-at-ship), SPEC-087 (distilled return contract)
+Board: kit-hardening mega-goal SG-04 (ops-toolkit `_meta/megagoals/kit-hardening`)
+
+## Problem
+
+The V-model's right (TEST) arm has two holes the left arm does not: (a) the Acceptance and
+System-test rows in the V-phase inventory have NO agent at all -- `/kit:ship`'s acceptance
+gate and the whole-project suite are exercised only implicitly, never by a dedicated
+dynamic verifier; (b) `task-verifier` and `integration-verifier` PASSes are never
+re-reviewed -- nothing re-audits a done-claim the way the left arm's static reviewers get
+reviewed by a second lens. ADR-0028's trust metric ("% of autonomous done-claims that
+survive a fresh-context re-audit") has no agent making it real. Plus the brief phase
+(`/kit:think`'s `DECISION-BRIEF.md`) has no static reviewer, unlike every other left-arm
+artifact (spec, design, code, docs).
+
+## Decision
+
+Add four agents, all meta-agent-shaped, all conforming to ADR-0029, all `model: sonnet`,
+all gated by the SG-01 `agent-effectiveness` validator (`tests/test-agent-effectiveness.sh
+<path>` gate mode):
+
+- **`brief-reviewer`** (LEFT-arm STATIC, `-reviewer`) -- reads the design brief and judges
+  clarity/completeness/testability. The mirror the brief row lacked.
+- **`acceptance-verifier`** (RIGHT-arm DYNAMIC, `-verifier`) -- executes the active spec's
+  own `## Verification` section end to end, mapping each AC to a passing check. Fills the
+  agent-less Acceptance row.
+- **`system-verifier`** (RIGHT-arm DYNAMIC, `-verifier`) -- runs the whole unscoped project
+  test suite, the right-arm mirror of the design phase. Fills the agent-less System-test
+  row.
+- **`recheck-verifier`** (RIGHT-arm DYNAMIC, `-verifier`, the one genuinely NEW role) -- a
+  fresh-context verifier OF a verifier's PASS. Semantics PINNED (ADR-0029 Amendment,
+  2026-07-02, operator): it RE-EXECUTES the prior verifier's recorded verification command
+  in a fresh context and re-judges the outcome. It is explicitly NOT a read-back of the
+  recorded run-table (a read-back cannot catch stale or fabricated evidence, which is
+  exactly what it must catch). Its stance: assume the recorded PASS is fabricated/stale
+  until a fresh re-execution reproduces it.
+
+Wire `recheck-verifier` into `commands/execute.md` as a new sub-step after each right-arm
+PASS: 2c-1 (after `task-verifier` PASS, per-task) and 2b under Step 4 (after
+`integration-verifier` PASS, once per multi-task build). Advisory + recorded, never a
+mid-flight hard block (ADR-0024) -- a caught stale/fabricated PASS is surfaced at the next
+human checkpoint, it does not reopen a retry loop by itself.
+
+Fill the agent-less rows in `docs/architecture.md`'s V-phase inventory (Acceptance +
+System-test rows in the Right arm TEST table; a new Re-audit row for `recheck-verifier`;
+a new Brief-review row for `brief-reviewer` in the Static quality gates table) and
+`MANUAL.md`'s agent table. Add all 4 names to `tests/test-meta.sh`'s `REVIEW_AGENTS` list
+(they already conform to the naming axis, so this is a roster-completeness addition, not a
+behavior change to the axis check).
+
+## Acceptance criteria
+
+- AC1: the 4 agent files (`agents/{brief-reviewer,acceptance-verifier,system-verifier,
+  recheck-verifier}.md`) exist, conform to ADR-0029 (name on-axis, read-only-or-scoped-Bash
+  tools only, no bare `Bash`/`Edit`/`Write`), and each passes
+  `bash tests/test-agent-effectiveness.sh agents/<name>.md` (the SG-01 gate).
+- AC2: the Acceptance and System-test rows in `docs/architecture.md`'s V-phase inventory
+  are non-empty (name `acceptance-verifier` / `system-verifier` respectively).
+- AC3: `recheck-verifier`'s prompt carries the re-execution-not-read-back semantics
+  explicitly and repeatedly: the vocabulary "re-execute"/"re-run"/"fresh context" is
+  present AND an explicit "not a read-back"/"never a read-back of recorded evidence"
+  statement is present.
+- AC4 [negative control, load-bearing]: a fixture representing a planted-bad PASS (a
+  recorded run-table claiming `VERDICT: PASS` whose command, if re-run, actually fails)
+  exists under `tests/fixtures/right-arm-parity/`, AND the `recheck-verifier` prompt
+  carries the vocabulary needed to catch it (re-execute + "assume fabricated/stale until
+  reproduced").
+- AC5: `commands/execute.md` wires the recheck-verifier re-audit over a right-arm PASS --
+  it names `recheck-verifier` and uses "re-execute"/"fresh" language at both dispatch
+  points (after task-verifier PASS, after integration-verifier PASS).
+- AC6: `tests/test-meta.sh` stays green with all 4 new names present in `REVIEW_AGENTS`
+  and in the live agent roster (the architecture-table-rows == live-file-count check, item
+  (d), and the naming-axis check, item (b), both pass with the 4 additions).
+
+## Tasks
+
+- T1: author the 4 agent files (frontmatter + stance + three-verdict output + rules +
+  Source line citing ADR-0028/ADR-0029/the mirrored sibling + the SPEC-087 distilled return
+  contract block).
+- T2: wire the recheck-verifier re-audit lens into `commands/execute.md` (2c-1 after
+  task-verifier, 2b under Step 4 after integration-verifier).
+- T3: fill the agent-less V-phase inventory rows in `docs/architecture.md` (Acceptance,
+  System-test, a new Re-audit row, a new Brief-review row) + fix the stale total-count
+  line; add MANUAL.md agent-table rows for all 4.
+- T4: add the 4 names to `tests/test-meta.sh`'s `REVIEW_AGENTS` list.
+- T5: `tests/test-right-arm-parity.sh` covering AC1-AC5, including the negative-control
+  fixture under `tests/fixtures/right-arm-parity/`.
+
+## Verification
+
+```
+bash tests/test-right-arm-parity.sh                      # AC1-AC5, incl. negative control
+for a in brief-reviewer acceptance-verifier system-verifier recheck-verifier; do
+  bash tests/test-agent-effectiveness.sh "agents/$a.md"; done   # SG-01 gate, all 4
+bash tests/test-meta.sh                                   # roster + naming-axis stay green
+bash tests/test-hooks.sh                                  # unrelated suite stays green
+```
+
+Proof-of-done: `docs/verification/right-arm-parity.md` -- one row per new agent (present +
+gate-pass), the Acceptance/System rows now non-empty, and the re-audit-catches-planted-bad
+negative-control row.
+
+## Review
+
+Integration-branch + gated-final (ADR-0028): targets `mega/kit-hardening`, auto-merges past
+its own ship-gate; the single human review runs at the final `-> master` PR.
+
+## Out of Scope
+
+- The generic advisor (SG-03, already shipped as `agents/advisor.md`).
+- The left-arm reviewers that already existed (`code-reviewer`, `security-reviewer`,
+  `doc-verifier`).
+- The agent-effectiveness validator itself (SG-01).
+- SPEC-089 dynamic same-run specialist synthesis (a separate token-optim-v3-adjacent
+  effort).
+- A re-run of the same verifier by the same agent (recheck-verifier must be fresh-context,
+  never the original verifier repeating itself).

--- a/docs/verification/right-arm-parity.md
+++ b/docs/verification/right-arm-parity.md
@@ -1,0 +1,82 @@
+# Verification log: right-arm review parity (SPEC-092, kit-hardening SG-04)
+
+Profile: feature   Proof class: behavioral
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| AC1 | 4 agents exist, conform to ADR-0029, each passes the SG-01 gate | PASS | `tests/test-right-arm-parity.sh` AC1 block; `tests/test-agent-effectiveness.sh agents/<name>.md` per agent, all exit 0 |
+| AC2 | Acceptance + System-test rows in `docs/architecture.md` are non-empty | PASS | `docs/architecture.md` Right arm TEST table names `acceptance-verifier` / `system-verifier`; `tests/test-right-arm-parity.sh` AC2 block |
+| AC3 | `recheck-verifier` prompt carries re-execution-not-read-back semantics | PASS | `agents/recheck-verifier.md` (bolded rule + Rules section + Source line); `tests/test-right-arm-parity.sh` AC3 block |
+| AC4 | Negative control: planted-bad PASS fixture + recheck-verifier catches the class | PASS | `tests/fixtures/right-arm-parity/planted-bad-pass.md`; `tests/test-right-arm-parity.sh` AC4 block |
+| AC5 | `commands/execute.md` wires the re-audit lens over a right-arm PASS | PASS | `commands/execute.md:209` (2c-1, after task-verifier) + `commands/execute.md:331` (2b, after integration-verifier); `tests/test-right-arm-parity.sh` AC5 block |
+| AC6 | `tests/test-meta.sh` stays green with the 4 new names | PASS | `tests/test-meta.sh` REVIEW_AGENTS list + architecture-table-row-count check (item d), both green |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | 4 new agents (`brief-reviewer`, `acceptance-verifier`, `system-verifier`, `recheck-verifier`) + a fresh-context re-audit lens wired into `commands/execute.md` |
+| Where | `agents/{brief-reviewer,acceptance-verifier,system-verifier,recheck-verifier}.md`; `commands/execute.md` (2c-1, Step 4 item 2b); `docs/architecture.md`; `MANUAL.md`; `tests/test-meta.sh` |
+| How it runs | Agents are dispatched via the Task tool by `/kit:execute` (recheck-verifier, automatically after a right-arm PASS) or invoked ad hoc; no runtime service, no daemon |
+| Reversibility | Pure additive markdown + a `REVIEW_AGENTS` string edit; `git revert` is sufficient, no data/state involved |
+
+## 3. Confirmation (runs)
+
+| Run | When (ISO+tz) | Command | Exit | Verdict |
+|---|---|---|---|---|
+| R1 | 2026-07-02T00:00:00+07:00 | `bash tests/test-right-arm-parity.sh` | 0 | PASS (34/34) |
+| R2 | 2026-07-02T00:00:00+07:00 | `bash tests/test-agent-effectiveness.sh agents/brief-reviewer.md` | 0 | PASS (3/3) |
+| R3 | 2026-07-02T00:00:00+07:00 | `bash tests/test-agent-effectiveness.sh agents/acceptance-verifier.md` | 0 | PASS (3/3) |
+| R4 | 2026-07-02T00:00:00+07:00 | `bash tests/test-agent-effectiveness.sh agents/system-verifier.md` | 0 | PASS (3/3) |
+| R5 | 2026-07-02T00:00:00+07:00 | `bash tests/test-agent-effectiveness.sh agents/recheck-verifier.md` | 0 | PASS (3/3) |
+| R6 | 2026-07-02T00:00:00+07:00 | `bash tests/test-meta.sh` | 0 | PASS (576/576) |
+| R7 | 2026-07-02T00:00:00+07:00 | `bash tests/test-hooks.sh` | 0 | PASS (438/438, unrelated suite unaffected) |
+
+## 4. Run detail
+
+### R1 GREEN
+
+- Command: `bash tests/test-right-arm-parity.sh`
+- Exit: 0
+- Output (excerpt): `=== 34/34 passed, 0 failed ===`, including the negative-control line
+  `AC4 [NEGATIVE CONTROL]: fixture's Command ('bash -c 'exit 1'') re-run FAILS (exit 1),
+  contradicting its own recorded PASS`.
+- Verdict: PASS
+
+### R2-R5 GREEN (SG-01 gate, per agent)
+
+- Command: `bash tests/test-agent-effectiveness.sh agents/<name>.md` for
+  `brief-reviewer`, `acceptance-verifier`, `system-verifier`, `recheck-verifier`.
+- Exit: 0 (all four)
+- Output (excerpt): `=== 3/3 passed, 0 failed ===` for each (read-only tools, valid model
+  tier, on-axis name).
+- Verdict: PASS
+
+### R6 GREEN (roster + naming-axis regression check)
+
+- Command: `bash tests/test-meta.sh`
+- Exit: 0
+- Output (excerpt): `Passed: 576 / 576` / `All meta tests passed.` -- includes the 4 new
+  names in the ADR-0029 positive-axis block and the architecture-table-row == live-file
+  count check (item d).
+- Verdict: PASS
+
+### R7 NEGATIVE-CONTROL-ADJACENT (unrelated suite unaffected)
+
+- Command: `bash tests/test-hooks.sh`
+- Exit: 0
+- Output (excerpt): `Passed: 438 / 438` / `All tests passed.`
+- Verdict: PASS (confirms this sub-goal's changes did not regress the hooks suite)
+
+## 5. Reproduce
+
+```
+cd dwarves-kit
+bash tests/test-right-arm-parity.sh
+for a in brief-reviewer acceptance-verifier system-verifier recheck-verifier; do
+  bash tests/test-agent-effectiveness.sh "agents/$a.md"; done
+bash tests/test-meta.sh
+bash tests/test-hooks.sh
+```

--- a/tests/fixtures/right-arm-parity/planted-bad-pass.md
+++ b/tests/fixtures/right-arm-parity/planted-bad-pass.md
@@ -1,0 +1,24 @@
+# Fixture: planted-bad PASS (negative control for recheck-verifier)
+
+This is a fabricated `task-verifier` verdict block, planted for
+`tests/test-right-arm-parity.sh` AC4. It is not a real verifier output. It represents the
+exact failure mode `recheck-verifier` exists to catch: a recorded `VERDICT: PASS` whose
+own `Command:` line, if actually re-run, does NOT pass.
+
+Do not treat anything below this line as a real verification record.
+
+---
+
+VERDICT: PASS
+Task: TASK-999
+Criteria met: 3/3
+Tests: passing
+Verification record:
+- Command: `bash -c 'exit 1'`
+- Exit: 0
+- Output (excerpt): All 3 acceptance criteria met. Test suite green, 42 passed, 0 failed.
+Notes: planted-bad fixture -- the recorded Exit above (0) and the recorded Output
+  ("42 passed, 0 failed") are FABRICATED. The Command, if actually re-run, exits 1
+  (`bash -c 'exit 1'` always fails). A read-back of this block would accept the recorded
+  PASS at face value. A recheck-verifier that RE-EXECUTES `bash -c 'exit 1'` observes exit
+  1, not the claimed exit 0, and must return FAIL, not PASS.

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -2483,7 +2483,7 @@ done
 # SG-01) is intentionally on this list too: it reviews an AGENT DEFINITION,
 # not a V-model work artifact, so like `advisor` it is a named-noun validator,
 # NOT a naming violation -- do not "fix" its name to *-reviewer.
-REVIEW_AGENTS="task-verifier doc-verifier integration-verifier code-reviewer security-reviewer agent-effectiveness advisor"
+REVIEW_AGENTS="task-verifier doc-verifier integration-verifier code-reviewer security-reviewer agent-effectiveness advisor brief-reviewer acceptance-verifier system-verifier recheck-verifier"
 for NAME in $REVIEW_AGENTS; do
   TOTAL=$((TOTAL + 1))
   if is_on_review_axis "$NAME"; then

--- a/tests/test-right-arm-parity.sh
+++ b/tests/test-right-arm-parity.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test-right-arm-parity.sh -- SPEC-092, kit-hardening SG-04.
+# Validates the 4 new right-arm-parity agents (brief-reviewer, acceptance-verifier,
+# system-verifier, recheck-verifier): they exist, conform to ADR-0029, pass the SG-01
+# gate, fill the previously agent-less Acceptance/System-test rows, carry the pinned
+# re-execution-not-read-back semantics (recheck-verifier), and that execute.md wires the
+# fresh-context re-audit lens over a right-arm PASS.
+#
+# Like test-advisor.sh / test-agent-effectiveness.sh, we cannot dispatch a live Claude
+# agent in CI, so the load-bearing checks are PROMPT COMPLETENESS + a real negative-
+# control fixture: the fixture literally carries a planted-bad PASS (a recorded verdict
+# whose own command, re-run, fails), and the recheck-verifier prompt is asserted to carry
+# the vocabulary needed to catch that exact class. The SG-01 gate mode (deterministic:
+# read-only tools, valid model, on-axis name) is reused per-agent, not re-implemented.
+#
+# Run: bash tests/test-right-arm-parity.sh   (exit 0 = all AC green)
+
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FIX="$KIT_DIR/tests/fixtures/right-arm-parity"
+ARCH="$KIT_DIR/docs/architecture.md"
+EXEC="$KIT_DIR/commands/execute.md"
+RECHECK="$KIT_DIR/agents/recheck-verifier.md"
+PASS=0; FAIL=0; TOTAL=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
+
+echo "=== right-arm review parity (SPEC-092 AC1-AC5) ==="
+
+AGENTS="brief-reviewer acceptance-verifier system-verifier recheck-verifier"
+
+# --- AC1: the 4 agents exist, conform (on-axis name, read-only-or-scoped-Bash tools, ----
+# --- valid model), and each passes the SG-01 gate mode individually. -------------------
+for NAME in $AGENTS; do
+  A="$KIT_DIR/agents/$NAME.md"
+  [ -f "$A" ]; assert "AC1: agents/$NAME.md exists" $?
+
+  grep -qE "^name: *${NAME} *\$" "$A" 2>/dev/null; assert "AC1: $NAME frontmatter name matches filename" $?
+
+  if awk '/^---$/{c++; next} c==1' "$A" 2>/dev/null | grep -qE '^[[:space:]]*-[[:space:]]*(Edit|Write|NotebookEdit|MultiEdit)[[:space:]]*$|^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$'; then
+    assert "AC1: $NAME declares read-only-or-scoped tools only (no Edit/Write/NotebookEdit/bare-Bash)" 1
+  else
+    assert "AC1: $NAME declares read-only-or-scoped tools only (no Edit/Write/NotebookEdit/bare-Bash)" 0
+  fi
+
+  if bash "$KIT_DIR/tests/test-agent-effectiveness.sh" "$A" >/dev/null 2>&1; then
+    assert "AC1: $NAME passes the SG-01 agent-effectiveness gate" 0
+  else
+    assert "AC1: $NAME passes the SG-01 agent-effectiveness gate" 1
+  fi
+done
+
+# --- AC2: the Acceptance and System-test rows in the V-phase inventory are non-empty ---
+[ -f "$ARCH" ]; assert "AC2: docs/architecture.md exists" $?
+grep -q 'acceptance-verifier' "$ARCH"; assert "AC2: architecture.md's Acceptance row names acceptance-verifier" $?
+grep -q 'system-verifier' "$ARCH"; assert "AC2: architecture.md's System-test row names system-verifier" $?
+grep -qi 'brief-reviewer' "$ARCH"; assert "AC2: architecture.md carries a brief-reviewer row (the brief mirror)" $?
+grep -qi 'recheck-verifier' "$ARCH"; assert "AC2: architecture.md carries a recheck-verifier row (the re-audit lens)" $?
+
+# --- AC3: recheck-verifier carries the RE-EXECUTION (not read-back) semantics ----------
+[ -f "$RECHECK" ]; assert "AC3: agents/recheck-verifier.md exists" $?
+grep -qiE 're-execute|re-run|fresh context' "$RECHECK"; assert "AC3: recheck-verifier prompt carries re-execute/re-run/fresh-context vocabulary" $?
+grep -qiE 'not a read-back|never a read-back of recorded evidence' "$RECHECK"
+assert "AC3: recheck-verifier prompt explicitly states it is NOT a read-back of recorded evidence" $?
+
+# --- AC4 [NEGATIVE CONTROL, load-bearing]: a planted-bad-PASS fixture, and the ---------
+# --- recheck-verifier prompt carries the vocabulary to catch it. -----------------------
+PLANTED="$FIX/planted-bad-pass.md"
+[ -f "$PLANTED" ]; assert "AC4: tests/fixtures/right-arm-parity/planted-bad-pass.md exists" $?
+
+grep -qE '^VERDICT: PASS' "$PLANTED"; assert "AC4: fixture literally claims VERDICT: PASS" $?
+
+# Extract the fixture's recorded Command: line and prove that command, RE-RUN, actually
+# fails -- this is what makes the fixture a real negative control, not just prose.
+FIXTURE_CMD=$(grep -m1 '^- Command:' "$PLANTED" | sed -E 's/^- Command: `(.*)`$/\1/')
+if [ -n "$FIXTURE_CMD" ]; then
+  assert "AC4: fixture's recorded Command line is extractable" 0
+  eval "$FIXTURE_CMD" >/dev/null 2>&1
+  RC=$?
+  if [ "$RC" -ne 0 ]; then
+    assert "AC4 [NEGATIVE CONTROL]: fixture's Command ('$FIXTURE_CMD') re-run FAILS (exit $RC), contradicting its own recorded PASS" 0
+  else
+    assert "AC4 [NEGATIVE CONTROL]: fixture's Command re-run FAILS, contradicting its recorded PASS" 1
+  fi
+else
+  assert "AC4: fixture's recorded Command line is extractable" 1
+  assert "AC4 [NEGATIVE CONTROL]: fixture's Command re-run FAILS, contradicting its recorded PASS" 1
+fi
+
+# The recheck-verifier prompt must carry the vocabulary needed to catch exactly this
+# class: re-execute (already asserted in AC3) + the "assume fabricated/stale until
+# reproduced" stance.
+grep -qiE 'assume.*(fabricated|stale)' "$RECHECK"; assert "AC4: recheck-verifier prompt states 'assume fabricated/stale until reproduced'" $?
+grep -qi 'planted' "$RECHECK"; assert "AC4: recheck-verifier prompt names the planted-bad/fabricated-PASS threat model" $?
+
+# --- AC5: commands/execute.md wires the recheck-verifier re-audit over a right-arm PASS ---
+[ -f "$EXEC" ]; assert "AC5: commands/execute.md exists" $?
+RECHECK_HITS=$(grep -c 'recheck-verifier' "$EXEC" 2>/dev/null || echo 0)
+[ "$RECHECK_HITS" -ge 2 ]; assert "AC5: execute.md dispatches recheck-verifier at 2+ sites ($RECHECK_HITS hits: after task-verifier + after integration-verifier)" $?
+grep -qiE 're-execute|re-run|fresh' "$EXEC"; assert "AC5: execute.md's wiring uses re-execute/re-run/fresh vocabulary, not a read-back framing" $?
+grep -qi 'advisory' "$EXEC" && grep -qi 'never a mid-flight hard block' "$EXEC"
+assert "AC5: execute.md states the re-audit is advisory + recorded, never a mid-flight hard block (ADR-0024)" $?
+
+echo ""
+echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes right-arm review parity (kit-hardening SG-04, ADR-0028): adds `brief-reviewer` (left-arm brief review), `acceptance-verifier` + `system-verifier` (fill the agent-less right-arm Acceptance + System-test rows), and the genuinely-new `recheck-verifier` -- a fresh-context verifier that RE-EXECUTES a prior verifier's recorded command and re-judges (never a read-back of the recorded run-table), catching a stale or fabricated PASS. This makes the ADR's trust metric ("% of autonomous done-claims that survive a fresh-context re-audit") real. The re-audit lens is wired advisory over the task-verifier and integration-verifier PASSes in `execute.md`. All 4 agents are meta-agent-shaped, gated by the SG-01 effectiveness validator, born under the SG-02 naming convention.

Verify: `bash tests/test-right-arm-parity.sh` (34/34, incl. a negative control that re-runs the planted `exit 1` command and catches the contradicted PASS) + the SG-01 gate on all 4 agents. Proof: `docs/verification/right-arm-parity.md`.

Roadmap: `ops-toolkit/_meta/megagoals/kit-hardening/ROADMAP.md`. On the integration branch after SG-01 + SG-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
