### PR TITLE
feat(workflow): every-step review default in the full lane (SG-05)

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -146,9 +146,9 @@ checks: a static review when it is produced (left/vertex) and a dynamic test lat
    LEFT · BUILD (produce + review each artifact)        RIGHT · TEST (execute the mirror)
    ============================================        =================================
 
-   Brief / Requirement ............................... Acceptance test   /kit:ship gate
-   build /kit:think · /kit:assign  · review (none)
-    Solution-design .................................. System test       project test suite
+   Brief / Requirement ............................... Acceptance test   acceptance-verifier · /kit:ship
+   build /kit:think · /kit:assign  · review brief-reviewer
+    Solution-design .................................. System test       system-verifier · project suite
     build /kit:design  · review /kit:devs-team
      Spec ........................................... Integration test   integration-verifier
      build /kit:spec (+research-*) · review /kit:spec-validate
@@ -170,10 +170,12 @@ review when produced (left/vertex), a dynamic test when executed (right).
 
 | Artifact | Built by | Static review (when produced) | Dynamic test (executed later) |
 |---|---|---|---|
-| Brief / requirement | `/kit:think`, `/kit:assign` | (none; ship gate traces back) | Acceptance test (`/kit:ship`) |
-| Solution design | `/kit:design` | `/kit:devs-team` | System test (project suite) |
+| Brief / requirement | `/kit:think`, `/kit:assign` | `brief-reviewer` | Acceptance test (`acceptance-verifier` + `/kit:ship`) |
+| Solution design | `/kit:design` | `/kit:devs-team` | System test (`system-verifier` + project suite) |
 | Spec | `/kit:spec` (+ research-* agents) | `/kit:spec-validate` | Integration test (`integration-verifier`) |
 | Code | `/kit:execute`, `/kit:next` (+ `fix-agent`) | `/kit:review`, `/kit:review-team` (+ `code-reviewer`; deep: `security-reviewer`) | Unit / task test (`task-verifier`) |
+| (any right-arm PASS) | -- | -- | Fresh-context re-audit (`recheck-verifier`, re-executes the recorded command) |
+| (whole assembled work) | -- | `advisor` (kit-default extra lens, P5) | -- |
 | UI design (downstream) | `/kit:ui-design` | `/kit:visual-team` | (visual; no dynamic test) |
 | Docs | (written during build) | `/kit:docs` (+ `doc-verifier`) | (doc-verifier confirms vs code) |
 
@@ -222,32 +224,61 @@ Think, Design (opt-in), Design critique (opt-in), UI design (opt-in), Spec,
 Validate, Test plan (default for normal/full), Build, Review, Docs, Ship, Reflect, and
 Debug (off-cycle).
 
-**The mirror gaps.**
+**The mirror gaps (mostly closed by SG-03/04).**
 
-- **Brief / Requirement** has no static-review command; the `/kit:spec-validate`
-  acceptance-criteria check + the `/kit:ship` gate trace back to the brief instead.
+- **Brief / Requirement** now HAS a static-review agent, `brief-reviewer` (SG-04); the
+  `/kit:ship` acceptance gate + `acceptance-verifier` still validate it on the right arm.
 - **Test design is one late step, not shifted left.** `/kit:test-plan` (opt-in)
   writes the tests; workers write the test code at the vertex. The classic V designs
   a test at every left phase; the kit concentrates it, which is why the testing wing
   is on the right.
-- **No system-test command:** the project suite runs at build and at ship.
+- **System test now HAS an agent**, `system-verifier` (SG-04); it runs the whole
+  assembled suite (the project suite still runs at build and at ship too).
 
-### Coverage gaps
+### Coverage: the V is fully covered (SG-04)
 
-The V is nearly complete. One open hole, judged against PHILOSOPHY criterion #2
-(a feature must serve >= 2 lifecycle phases) and "no phantom features":
+Every V-model artifact now has BOTH a static review and a dynamic test (SG-04 closed
+the last right-arm holes). Judged against PHILOSOPHY criterion #2 (a feature must
+serve >= 2 lifecycle phases) and "no phantom features":
 
-1. **CANDIDATE AGENT `acceptance-verifier`** (optional; v2 candidate). The acceptance
-   test is checked *inline* by `/kit:ship`; everywhere else the kit verifies with a
-   separate read-only agent (per "verify with a fresh context, not self-report").
-   Extracting acceptance into a read-only `acceptance-verifier` that both `/kit:ship`
-   and `/kit:verify` dispatch would complete the right-arm verifier set. Verdict:
-   **consider, not urgent** (the inline gate works today).
+- **`acceptance-verifier` (SHIPPED, SG-04)** -- the acceptance test is now a read-only
+  agent dispatched by `/kit:ship` and `/kit:verify`, no longer only inline. The former
+  "v2 candidate" is built.
+- **`system-verifier`, `brief-reviewer` (SHIPPED, SG-04)** -- fill the previously
+  agent-less System-test and Brief rows.
+- **`recheck-verifier` (SHIPPED, SG-04)** -- a fresh-context re-audit that re-executes
+  any right-arm PASS's recorded command, catching a stale or fabricated PASS.
 
-Two gaps closed 2026-05-23: the `security-reviewer` orphan (wired into `/kit:review-team`)
-and `/kit:verify` (shipped, SPEC-035, the on-demand right-arm executor). The V is now
-fully covered by commands + agents; the only open item is the optional `acceptance-verifier`
-(v2 candidate). Everything else would be a phantom.
+Prior gaps closed 2026-05-23: the `security-reviewer` orphan (wired into
+`/kit:review-team`) and `/kit:verify` (SPEC-035). With SG-04, every left AND right
+arm phase has a review/verifier agent; nothing further would be a phantom.
+
+### Every-step review in the full-autonomous lane (P4, SG-05)
+
+In the full lane, EVERY V-model phase maps to a review step that RUNS and records to
+the gate-ledger; no review-bearing phase is `skip`. The mapping (the phase -> review
+that validates it):
+
+| Phase | Review that runs (records to the gate-ledger) |
+|---|---|
+| Think / Brief | `brief-reviewer` (static) |
+| Design | `/kit:devs-team` (static) · `system-verifier` (dynamic) |
+| Spec | `/kit:spec-validate` (static) · `integration-verifier` (dynamic) |
+| Test plan | `/kit:test-plan-review-team` (static) |
+| Build / Code | `/kit:review` · `/kit:review-team` (+ `code-reviewer`, deep `security-reviewer`) · `task-verifier` (dynamic) |
+| Review | `advisor` critique (kit-default EXTRA lens, on top of the specialists) |
+| Docs | `/kit:docs` (+ `doc-verifier`) |
+| Acceptance / Ship | `acceptance-verifier` + the `/kit:ship` gate |
+| (any right-arm PASS) | `recheck-verifier` fresh-context re-audit |
+| Final boundary | `advisor` over-suggest (P6) before the human review |
+
+**Enforcement is at ship, never mid-flight (ADR-0024 + PHILOSOPHY).** Each phase's
+review RUNS and records (`bash lib/gate-ledger.sh record <rid> <phase> ran`);
+mid-flight a failing review is advisory and does NOT halt the run. The only wall is at
+ship: `hooks/ship-gate.sh` refuses a push whose lane has a `measure-twice` phase with
+no `ran`/`override` entry (the lane's required set is parsed from the lane x phase
+matrix). So the full lane inherits full-coverage review for free from bare `/kit:*`,
+with the hard gate at push and advisory records throughout.
 
 ## The advisor: the kit-default extra lens (ADR-0028 P5/P6)
 

--- a/docs/implementation-notes/every-step-review.md
+++ b/docs/implementation-notes/every-step-review.md
@@ -1,0 +1,28 @@
+# Implementation notes: SPEC-093 every-step review (kit-hardening SG-05)
+
+Delta from SPEC-093 / ADR-0028 P4.
+
+## 2026-07-02 No matrix change needed; the full lane already has no review-phase skip
+
+Context: the goal says "set the lane default (no phase skip)". Inspection of the
+WORKFLOW lane x phase matrix showed the full lane already has no `skip` for any
+review-bearing phase (`bash lib/gate-ledger.sh plan full` lists all 13 phases as
+required/lite; only Debug (off-cycle, not in the linear V) and UI-design (run-lite,
+downstream) are non-measure-twice, both legitimately). So SG-05 is WIRING + a
+documented mapping + a test, NOT a matrix edit. Touching the matrix would have been
+churn against a lane that was already correct.
+
+## 2026-07-02 SG-05 also fixed WORKFLOW drift SG-04 left behind
+
+SG-04 shipped acceptance-verifier / system-verifier / brief-reviewer / recheck-verifier
+and updated docs/architecture.md, but WORKFLOW.md's V-model duality table + "coverage
+gaps" prose still described the right arm as executor-only with acceptance-verifier as
+a "v2 candidate". SG-05's mapping section is where those agents belong, so the WORKFLOW
+update both wires the every-step mapping AND corrects that drift in one pass.
+
+## 2026-07-02 The negative control exercises the real gate-ledger, not prose
+
+AC2 is proven by isolating DWARVES_KIT_LOG_DIR to a temp dir, recording every required
+full-lane gate EXCEPT `review`, and asserting `gate-ledger check full <rid>` exits
+nonzero (blocks), then recording `review` and asserting it exits zero. This runs the
+actual enforcement path the ship-gate calls, not a documentation grep.

--- a/docs/specs/SPEC-093-every-step-review.md
+++ b/docs/specs/SPEC-093-every-step-review.md
@@ -1,0 +1,52 @@
+# SPEC-093: Every-step review default (P4)
+
+Status: VALIDATED
+Date: 2026-07-02
+Lane: full (WORKFLOW lane default + gate-ledger wiring for the enforcement surface)
+Type: feature
+Relates-to: ADR-0028 (P4 every-step review), ADR-0024 (gate-ledger, advisory-mid/hard-at-ship), SPEC-076 (V-model descent), SPEC-091 (advisor), SPEC-092 (right-arm parity)
+Board: kit-hardening mega-goal SG-05
+
+## Problem
+ADR-0028 P4 requires that in the full-autonomous-to-final lane, EVERY V-model phase
+(left + right arm) has a review step that RUNS and records to the gate-ledger, with no
+phase `skip`. The reviewers exist (SG-03 advisor, SG-04 right-arm agents) but WORKFLOW
+still described the right arm as executor-only with agent-less Acceptance/System rows
+and acceptance-verifier as a "v2 candidate" -- stale after SG-04. Nothing documented
+the phase -> review mapping as a lane default, and the ship-gate enforcement of a
+missing phase-review was not covered by a test.
+
+## Decision
+Wire SG-03/04's reviewers into the full lane as the DEFAULT: document the complete
+phase -> review mapping (every V-model phase -> the review that validates it), confirm
+no review-bearing phase is `skip`, and prove the enforcement contract: each phase's
+review RUNS and records; mid-flight a failing review is ADVISORY (never halts); the
+only hard wall is the ship-gate, which refuses a push whose lane has a measure-twice
+phase with no `ran`/`override` entry (ADR-0024, unchanged). This is WIRING, not new
+reviewers or a new mid-flight block.
+
+## Acceptance criteria
+- AC1: every full-lane V-model phase maps to a review agent/command (the WORKFLOW every-step mapping); no review-bearing phase is `skip`.
+- AC2 [negative control]: the ship-gate (gate-ledger check) BLOCKS a push whose lane has a required phase-review missing, and PASSES once it is recorded.
+- AC3: enforcement is at ship only; a failing phase-review mid-flight is advisory and does not halt the run (no new hard stop).
+
+## Tasks
+- T1: update WORKFLOW.md V-model (ASCII V + duality table + mirror/coverage prose) for the SG-03/04 agents.
+- T2: add the "Every-step review in the full-autonomous lane" mapping + enforcement section.
+- T3: `tests/test-every-step-review.sh` covering AC1-AC3 with a real gate-ledger negative control.
+
+## Verification
+```
+bash tests/test-every-step-review.sh   # AC1-AC3; real gate-ledger block/pass negative control
+bash lib/gate-ledger.sh required full   # the required phase set (every review-bearing phase)
+bash tests/test-meta.sh                 # WORKFLOW/roster stays green
+```
+Proof-of-done: table-first run-table with the mapping-coverage rows + the block/pass negative control.
+
+## Review
+Integration-branch + gated-final (ADR-0028): targets `mega/kit-hardening`, auto-merges past its own ship-gate; single human review at the final `-> master` PR.
+
+## Out of Scope
+- Creating reviewers (SG-03/04 did that).
+- Hard-gating any phase mid-flight (ADR-0024 + PHILOSOPHY stand).
+- Adding review to lanes other than the full-autonomous lane.

--- a/docs/verification/every-step-review.md
+++ b/docs/verification/every-step-review.md
@@ -1,0 +1,59 @@
+# Proof of done: every-step review default (SPEC-093, ADR-0028 P4, kit-hardening SG-05)
+
+Verdict: PASS
+
+## Acceptance criteria -> confirmation
+
+| AC | Criterion | How proven | Result |
+|----|-----------|------------|--------|
+| AC1 | Every full-lane phase maps to a review; no review phase skip | WORKFLOW every-step mapping wires all reviewers (spec-validate, review-team, task/integration/acceptance/system-verifier, brief-reviewer, doc-verifier, recheck-verifier, advisor); required-full set includes spec+review+ship | PASS |
+| AC2 [NEGATIVE CONTROL] | ship-gate blocks a missing required phase-review | real gate-ledger: `check full` BLOCKS with `review` missing, PASSES once recorded | PASS |
+| AC3 | Enforcement at ship, not mid-flight | WORKFLOW states "Enforcement is at ship, never mid-flight"; a mid-flight failing review is advisory; no new hard stop added | PASS |
+
+## Implementation
+
+- `WORKFLOW.md` -- V-model ASCII + duality table updated for the SG-03/04 agents (brief-reviewer, acceptance-verifier, system-verifier, recheck-verifier, advisor); new "Every-step review in the full-autonomous lane (P4, SG-05)" section with the phase -> review mapping + the enforcement-at-ship-not-mid-flight contract; the stale "acceptance-verifier v2 candidate" prose corrected to SHIPPED.
+- `tests/test-every-step-review.sh` -- AC1-AC3 incl. the real gate-ledger block/pass negative control.
+- No matrix change: the full lane already had no review-phase skip (see impl-notes).
+
+## Confirmation run-table
+
+| Command | Exit | Result |
+|---------|------|--------|
+| `bash tests/test-every-step-review.sh` | 0 | 17/17 passed |
+| `bash tests/test-meta.sh` | 0 | All meta tests passed |
+| `bash tests/test-hooks.sh` | 0 | All tests passed |
+
+## Run detail
+
+```
+=== every-step review (SPEC-093 AC1-AC3) ===
+  PASS AC1: WORKFLOW has the every-step review mapping section
+  PASS AC1: mapping wires a review: spec-validate / review-team / task-verifier /
+           integration-verifier / doc-verifier / acceptance-verifier / system-verifier /
+           brief-reviewer / recheck-verifier / advisor
+  PASS AC1: full lane's required set includes spec+review+ship (no review phase skipped)
+  PASS AC2 [NEGATIVE CONTROL]: check BLOCKS when required 'review' gate is missing
+  PASS AC2: check PASSES once every required phase-review is recorded
+  PASS AC3: WORKFLOW states enforcement at ship, never mid-flight
+  PASS AC3: a failing phase-review mid-flight is advisory, does not halt the run
+  PASS AC3: every-step review did NOT become a new hard stop (still advisory + ship-gate only)
+=== 17/17 passed, 0 failed ===
+```
+
+## NEGATIVE CONTROL (the load-bearing proof)
+
+The risk (ADR-0028) is every-step review degrading into a mid-flight hard block, OR the
+ship-gate NOT actually blocking a missing review. Both are controlled: AC2 runs the real
+`gate-ledger check full` against an isolated ledger with `review` deliberately omitted
+and asserts it BLOCKS (exit nonzero), then records `review` and asserts it PASSES. AC3
+asserts the four-hard-stops table gained no phase-review blocker, so the enforcement
+stayed at ship and mid-flight stayed advisory.
+
+## Reproduce
+
+```
+cd dwarves-kit
+bash tests/test-every-step-review.sh   # 17/17, exit 0
+bash lib/gate-ledger.sh required full    # the required phase set
+```

--- a/tests/test-every-step-review.sh
+++ b/tests/test-every-step-review.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# test-every-step-review.sh -- SPEC-093, kit-hardening SG-05 (ADR-0028 P4).
+# Proves: in the full lane every V-model phase maps to a review that RUNS and
+# records to the gate-ledger; the ship-gate BLOCKS a push with a required
+# phase-review missing (real gate-ledger negative control); enforcement is at
+# ship, NOT a mid-flight hard block.
+#
+# Run: bash tests/test-every-step-review.sh   (exit 0 = all AC green)
+
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WF="$KIT_DIR/WORKFLOW.md"
+GL="$KIT_DIR/lib/gate-ledger.sh"
+PASS=0; FAIL=0; TOTAL=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
+
+echo "=== every-step review (SPEC-093 AC1-AC3) ==="
+
+# --- AC1: every full-lane phase maps to a review in WORKFLOW's every-step mapping ---
+grep -qi 'Every-step review in the full-autonomous lane' "$WF"; assert "AC1: WORKFLOW has the every-step review mapping section" $?
+# each review-bearing phase names a concrete review agent/command in the V-model + mapping
+for pair in "spec-validate" "review-team" "task-verifier" "integration-verifier" "doc-verifier" "acceptance-verifier" "system-verifier" "brief-reviewer" "recheck-verifier" "advisor"; do
+  grep -qi "$pair" "$WF"; assert "AC1: mapping wires a review: $pair" $?
+done
+# no review-bearing full-lane phase is skip: every 'required full' phase resolves in the plan
+REQ=$(bash "$GL" required full 2>/dev/null | tr '\n' ' ')
+[ -n "$REQ" ] && echo "$REQ" | grep -q 'spec' && echo "$REQ" | grep -q 'review' && echo "$REQ" | grep -q 'ship'
+assert "AC1: full lane's required set includes spec+review+ship (no review phase skipped)" $?
+
+# --- AC2 [NEGATIVE CONTROL]: ship-gate (gate-ledger check) BLOCKS a missing required review ---
+# Real exercise of the enforcement path in an isolated ledger dir.
+TMPLOG="$(mktemp -d "${TMPDIR:-/tmp}/every-step.XXXXXX")"
+export DWARVES_KIT_LOG_DIR="$TMPLOG"
+RID="everystep-negctl"
+# record ALL required full gates EXCEPT 'review'
+for g in $REQ; do
+  [ "$g" = "review" ] && continue
+  bash "$GL" record "$RID" "$g" ran "test" >/dev/null 2>&1
+done
+if bash "$GL" check full "$RID" >/dev/null 2>&1; then
+  assert "AC2 [NEGATIVE CONTROL]: check PASSES with 'review' missing (SHOULD block)" 1
+else
+  assert "AC2 [NEGATIVE CONTROL]: check BLOCKS when required 'review' gate is missing" 0
+fi
+# now record the missing gate -> check must pass
+bash "$GL" record "$RID" review ran "test" >/dev/null 2>&1
+if bash "$GL" check full "$RID" >/dev/null 2>&1; then
+  assert "AC2: check PASSES once every required phase-review is recorded" 0
+else
+  assert "AC2: check PASSES once every required phase-review is recorded" 1
+fi
+unset DWARVES_KIT_LOG_DIR
+rm -rf "$TMPLOG" 2>/dev/null || true
+
+# --- AC3: enforcement at ship, NOT a mid-flight hard block ---
+grep -qiE 'Enforcement is at ship, never mid-flight' "$WF"; assert "AC3: WORKFLOW states enforcement at ship, never mid-flight" $?
+grep -qiE 'advisory and does NOT halt|advisory.*does not halt|mid-flight.*advisory' "$WF"; assert "AC3: a failing phase-review mid-flight is advisory, does not halt the run" $?
+# the four-hard-stops table must NOT have gained a phase-review / every-step blocker
+if awk '/### The four hard stops/{f=1} f&&/^## /&&!/hard stops/{f=0} f' "$WF" | grep -qiE 'every-step|phase-review'; then
+  assert "AC3: every-step review did NOT become a new hard stop" 1
+else
+  assert "AC3: every-step review did NOT become a new hard stop (still advisory + ship-gate only)" 0
+fi
+
+echo ""
+echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Wires the every-step review default into the full-autonomous lane (kit-hardening SG-05, ADR-0028 P4): documents the complete phase -> review mapping (wiring SG-03's `advisor` extra lens + SG-04's `brief-reviewer`/`acceptance-verifier`/`system-verifier`/`recheck-verifier` right-arm agents in), so every V-model phase has a review that RUNS and records to the gate-ledger. Enforcement stays exactly where ADR-0024 puts it: reviews run + record mid-flight (advisory, never a halt); the only hard wall is the ship-gate at push. Also corrects WORKFLOW V-model drift SG-04 left (acceptance-verifier was still marked a "v2 candidate"). No lane-matrix change (the full lane already had no review-phase skip); no new mid-flight hard block.

Verify: `bash tests/test-every-step-review.sh` (17/17, incl. a real gate-ledger negative control that BLOCKS a missing required review and PASSES once recorded). Proof: `docs/verification/every-step-review.md`.

Roadmap: `ops-toolkit/_meta/megagoals/kit-hardening/ROADMAP.md`. On the integration branch after SG-03 + SG-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
