### PR TITLE
feat(lane): up-only lane escalation at the spec->build boundary (SG-06)

### DIFF
--- a/commands/execute.md
+++ b/commands/execute.md
@@ -13,6 +13,40 @@ Before starting, verify:
 
 If any prerequisite fails, tell the user what's missing and stop.
 
+### Spec->build lane re-check (SPEC-094, ADR-0028 refinement point 4)
+
+The lane is frozen at `/kit:assign` classify time -- every re-classify trigger up to
+this point keys on the ORIGINAL task text (intake, `/kit:grill` answers, the
+spec-drift re-check), never on scope that only became concrete once the spec was
+written. This is the spec->build boundary: the spec is VALIDATED/APPROVED and build
+is about to start, so it is the first point a `tiny`/`normal` task's emergent
+auth/data-model/migration scope is visible. Re-classify, up-only, before dispatching
+Step 1:
+
+```bash
+RID=$(bash lib/gate-ledger.sh rid)
+# CURRENT_LANE = the lane already recorded for this run (the spec's `Lane:` header,
+# or the last `gate-ledger.sh start`/`start --amend` line for $RID if the header is
+# missing).
+bash lib/lane-classify.sh escalate "$CURRENT_LANE" docs/specs/SPEC-NNN-<slug>.md
+```
+
+- **`ESCALATE <current> -> <heavier>`**: the spec's own text matches a heavier lane
+  than the one it carries. Re-plan up-only -- this never stops the run, it only adds
+  rigor:
+  1. `bash lib/gate-ledger.sh start --amend "$RID" <heavier> <classified-lane> <chosen-type> <ctype> <repo>` -- readers take the LAST START-AMEND (SPEC-077), so the ledger's effective lane becomes `<heavier>` and `required <heavier>`'s extra measure-twice gates are now required for this run.
+  2. Bump the spec's `Lane:` header UP to `<heavier>` (never down) -- `hooks/ship-gate.sh` reads that header to pick the required gate set, so the heavier set is enforced at ship, not just recorded mid-flight.
+  3. `bash lib/gate-ledger.sh action "$RID" "lane escalated <current> -> <heavier> at spec->build boundary (SPEC-094)"` -- one durable line naming the escalation.
+- **`HOLD <current>`**: the spec-implied lane is the same or lighter than the current
+  one. Do nothing. This is the downgrade guard (mirrors `lane-classify.sh check`):
+  escalation only ever adds rigor, it never removes it, and a lighter re-classification
+  is refused.
+
+Advisory + recorded, not a hard block (ADR-0024, PHILOSOPHY): `escalate` always exits
+0, and a missed or skipped re-check does not stop `/kit:execute`. An unescalated
+under-sized lane still surfaces later, the same place every other lane gap does
+(`hooks/ship-gate.sh` at push, `lib/lane-telemetry.sh misfires` at `/kit:retro`).
+
 ### Context layer detection
 
 Check once before dispatching any tasks:

--- a/docs/implementation-notes/lane-escalation.md
+++ b/docs/implementation-notes/lane-escalation.md
@@ -1,0 +1,61 @@
+# Implementation notes: SPEC-094 lane mid-flight escalation (kit-hardening SG-06)
+
+Delta from SPEC-094 / ADR-0028 refinement point 4.
+
+## 2026-07-02 Boundary hook lives in `commands/execute.md` Prerequisites, not `commands/spec.md`
+
+Context: the spec named two candidate wiring points ("`commands/execute.md` near the
+start, or `commands/spec.md` at its end -- pick the point where the SPEC is VALIDATED
+and build is about to start").
+Decision: wired into `commands/execute.md` Prerequisites (`commands/execute.md:16-49`),
+immediately after the existing spec-status check ("verify: spec exists and has status
+APPROVED or VALIDATED") and before Step 1 dispatches any task.
+Why: `commands/spec.md`'s own terminus (`### Step 4: Present for review`) only sets
+`Status: APPROVED` and hands off to a human for approval -- there is no guarantee
+`/kit:execute` runs in the same session, or even the same day, as `/kit:spec`. The
+re-check needs to run at the point build ACTUALLY starts, which is `/kit:execute`'s own
+entry gate, not `/kit:spec`'s exit. This also means the re-check re-fires every time
+`/kit:execute` is invoked against a spec (e.g. resumed after an interruption), which is
+the more conservative (never-miss) reading of "the first point real scope is concrete".
+
+## 2026-07-02 `escalate` re-classifies the whole spec file's raw text, not a section
+
+Context: the goal contract says "read the spec file, run the same classify_core logic
+on its content -- Problem/Decision/Tasks text".
+Decision: `escalate` runs `classify_core` over `cat <spec-file>` unfiltered (the whole
+file), not an extracted `## Problem`/`## Decision`/`## Tasks` slice.
+Why: `classify_core`'s flag-scoring regexes are simple case-insensitive substring
+matches (`grep -qE`) with no line-anchoring; a keyword anywhere in the spec (Problem,
+Decision, Task Breakdown, Failure modes, an inline code block) already trips the same
+flags the SPEC's Problem/Decision/Tasks prose would. Slicing sections would add parsing
+surface (heading regex, section boundaries) for zero behavioral gain, and would risk a
+false HOLD if the auth/migration language landed in, say, `## Edge Cases` instead of
+`## Decision`. Whole-file is simpler and strictly more conservative (catches more, never
+less) -- in the spirit of "when in doubt, heavier" that already governs
+`classify_core`.
+
+## 2026-07-02 `escalate` is a pure advisory function; the caller does the mutation
+
+Context: SPEC-094 AC1 needs `escalate` to be a deterministic, side-effect-free
+classifier callable from tests in isolation (mirrors `classify`/`explain`/`check`,
+none of which touch the gate-ledger or any spec file).
+Decision: `escalate` only prints `ESCALATE <cur> -> <heavier>` or `HOLD <cur>` and
+exits 0. It never calls `gate-ledger.sh`, never edits a spec file's `Lane:` header. All
+three re-plan actions (`start --amend`, bump the spec header, `action` log line) are
+documented as the CALLER's responsibility in `commands/execute.md`, run only on the
+`ESCALATE` branch.
+Why: keeps the up-only re-plan auditable at the call site (the orchestrator session
+that ran `/kit:execute` is the one that decided to amend), and keeps `escalate` unit-
+testable with a bare spec-file fixture and no ledger fixture required for AC1-AC3.
+
+## 2026-07-02 Downgrade guard reused verbatim, not re-implemented
+
+Context: guardrail -- "confirm it still blocks and reuse `lane_rank`, don't weaken it".
+Decision: `escalate` calls the exact same `lane_rank()` function `lane_check` (the
+`check` verb) already calls; no new rank table, no new comparison logic. The only new
+comparator is `sr -gt cr` (strictly heavier) vs. `lane_check`'s `cr -lt sr` (strictly
+lighter) -- same inequality, read from the opposite side, because `check` flags an
+UNDER-sized human choice while `escalate` looks for an OVER-due bump.
+Why: two independent rank tables would be exactly the kind of drift the "reuse, don't
+invent a new lane" guardrail exists to prevent; reusing `lane_rank` means a future rank
+change (e.g. a new lane tier) updates both `check` and `escalate` from one edit.

--- a/docs/specs/SPEC-094-lane-escalation.md
+++ b/docs/specs/SPEC-094-lane-escalation.md
@@ -1,0 +1,103 @@
+# SPEC-094: Lane mid-flight escalation on emergent scope
+
+Status: VALIDATED
+Date: 2026-07-02
+Lane: full (new classify trigger + gate-ledger re-plan touching ship-gate enforcement)
+Type: feature
+Relates-to: ADR-0028 (autonomous-loop hardening, refinement point 4), ADR-0024 (gate-ledger + ship-enforcement, advisory-mid/hard-at-ship), SPEC-053 (lane-classify floor guard / downgrade check), SPEC-061/SPEC-077 (gate-ledger START / START-AMEND routing facts)
+Board: kit-hardening mega-goal SG-06 (ops-toolkit `_meta/megagoals/kit-hardening`)
+
+## Problem
+The lane is frozen at classify time: every re-classify trigger the kit already has
+(`/kit:assign` intake, `/kit:grill` answers, the spec-drift text re-check) keys on the
+task's original one-line TEXT, never on scope that only becomes concrete once the SPEC
+is written. A `tiny`/`normal` task whose spec introduces auth, a data-model change, or a
+migration stays mis-laned for the rest of the run -- the same "untrustable autonomous
+run silently under-sizing its lane" failure class ADR-0028 targets. Per ADR-0028
+refinement point 4: "Re-run `lane-classify` against the SPEC at the spec->build boundary
+(the first point real scope is concrete); a heavier-lane trip escalates + re-plans the
+gate-ledger (up-only; the downgrade guard stays; advisory + recorded)."
+
+## Decision
+Add a spec->build-boundary re-classification, up-only, advisory, recorded:
+
+1. **`lib/lane-classify.sh escalate <current-lane> <spec-file>`** -- reads the spec
+   file's own text, runs it through the existing `classify_core` (the same
+   deterministic flag-scoring logic `classify`/`explain`/`check` already use), and
+   compares the spec-implied lane's `lane_rank` against `<current-lane>`'s:
+   - heavier -> prints `ESCALATE <current> -> <heavier>`
+   - same or lighter -> prints `HOLD <current>` (the downgrade guard: reuses
+     `lane_rank`, the same function `check` uses, so a lighter re-class is refused
+     exactly like an under-sized `check` choice is refused)
+   Always exits 0 ("Detect, don't dictate"). It only prints the decision; it does not
+   touch the gate-ledger or the spec file.
+2. **The caller re-plans up-only at the spec->build boundary.** Wired into
+   `commands/execute.md` Prerequisites (right after the spec-status check, before Step
+   1 dispatches any task -- the point the spec is VALIDATED/APPROVED and build is about
+   to start). On `ESCALATE`:
+   - `bash lib/gate-ledger.sh start --amend <rid> <heavier> ...` -- readers take the
+     LAST START-AMEND (SPEC-077), so the ledger's effective lane becomes `<heavier>`
+     and `required <heavier>`'s extra measure-twice gates are now required.
+   - Bump the spec's `Lane:` header UP to `<heavier>` (never down) -- `hooks/ship-gate.sh`
+     reads that header (`hooks/ship-gate.sh:140`) to pick the required gate set, so the
+     heavier set is enforced at ship.
+   - `bash lib/gate-ledger.sh action <rid> "lane escalated ..."` -- one durable line.
+   On `HOLD`: no action.
+
+This reuses the kit's existing heavy destination (the `full` lane) and the existing
+downgrade-guard mechanism (`lane_rank`); it adds only the missing TRIGGER (a
+re-classify at the spec boundary, not classify-time text).
+
+## Acceptance criteria
+- AC1: `lib/lane-classify.sh escalate <current-lane> <spec-file>` exists; classifies
+  the spec file's own text via `classify_core`; prints `ESCALATE <cur> -> <heavier>` or
+  `HOLD <cur>`; exits 0 in both cases.
+- AC2 [up-only]: a `tiny` current lane against a spec whose text carries
+  auth/data-model/migration scope escalates to `full`.
+- AC3 [downgrade guard, negative control]: a `full` current lane against a spec whose
+  text is trivial (no hard/soft flags) HOLDS at `full`; it never downgrades.
+- AC4 [re-plan]: after `gate-ledger.sh start` at a lighter lane then
+  `start --amend` at the heavier lane, `required <heavier>` returns strictly more
+  gates than `required <lighter>`, and the ledger's effective lane (last
+  START/START-AMEND) is the heavier one.
+- AC5 [advisory + recorded]: `escalate` always exits 0 (including on ESCALATE); the
+  `commands/execute.md` wiring documents the mechanism as advisory + recorded, never a
+  mid-flight hard block (ADR-0024).
+- AC6: the classify-time triggers (task text, grill answers, spec-drift re-check) are
+  unchanged; the downgrade guard (`lane_check`/`lane_rank`) still blocks a lighter
+  re-classification for its existing callers.
+
+## Tasks
+- T1: `lib/lane-classify.sh` -- add the `escalate` verb + `main()` dispatch + usage
+  string.
+- T2: `commands/execute.md` -- wire the spec->build boundary re-check into
+  Prerequisites (before Step 1 dispatch).
+- T3: `tests/test-lane-escalation.sh` -- positive escalate, gate-ledger re-plan,
+  downgrade-guard negative control, advisory-exits-0 assertion.
+- T4: `docs/verification/lane-escalation.md` -- table-first proof-of-done.
+- T5: `docs/implementation-notes/lane-escalation.md` -- deltas from this spec.
+
+## Verification
+```
+bash tests/test-lane-escalation.sh   # AC1-AC6
+bash tests/test-meta.sh              # stays green (no lib usage-string regressions)
+bash tests/test-hooks.sh             # stays green
+```
+
+## Out of Scope
+- The classify-time triggers (task text at `/kit:assign`, `/kit:grill` answers, the
+  spec-drift text re-check) -- unchanged, per ADR-0028 point 4 ("this supplies only
+  the missing TRIGGER").
+- The downgrade guard itself (`lane_check`/`lane_rank`) -- preserved, reused, not
+  modified beyond confirming it still blocks.
+- A new lane, or any lane-relaxation/downgrade mechanism of any kind.
+- A full re-plan of the run (only the gate-ledger's required-gate set and the spec's
+  `Lane:` header move; task breakdown, phases, and dispatch order are untouched).
+
+## Decision Log
+- DEC-001: `escalate` re-classifies the SPEC FILE's own text (not the original
+  one-line task description) -- the spec is the artifact that carries emergent scope;
+  the original task text is exactly what already failed to catch it.
+- DEC-002: the caller does the gate-ledger/spec-header mutation, not `escalate`
+  itself -- keeps the classifier a pure, side-effect-free advisory function
+  (mirrors `check`, which also only prints + logs, never mutates a spec or ledger).

--- a/docs/verification/lane-escalation.md
+++ b/docs/verification/lane-escalation.md
@@ -1,0 +1,109 @@
+# Proof of done: lane mid-flight escalation (SPEC-094, ADR-0028 pt 4, kit-hardening SG-06)
+
+Verdict: PASS
+
+## Acceptance criteria -> confirmation
+
+| AC | Criterion | How proven | Result |
+|----|-----------|------------|--------|
+| AC1 | `escalate <current-lane> <spec-file>` exists, dispatches, classifies the spec's own text | `lib/lane-classify.sh` `escalate()` + `main()` case; usage string | PASS |
+| AC2 [up-only] | a `tiny` current lane + a spec whose text carries auth/data-model/migration scope escalates to `full` | `escalate tiny tests/fixtures/lane-escalation/heavy-scope-spec.md` -> `ESCALATE tiny -> full` | PASS |
+| AC3 [downgrade guard, NEGATIVE CONTROL] | a `full` current lane + a trivial spec never downgrades | `escalate full tests/fixtures/lane-escalation/trivial-spec.md` -> `HOLD full`, never `ESCALATE`; same-rank case also HOLDs; the pre-existing `check` guard still fires unmodified | PASS |
+| AC4 [re-plan] | `start` then `start --amend` at a heavier lane re-plans the ledger up-only | `required full` (11 gates) > `required tiny` (0 gates); last `START-AMEND` line carries `lane=full`; both `START` and `START-AMEND` lines persist (append-only) | PASS |
+| AC5 [advisory + recorded] | `escalate` always exits 0; the wiring documents advisory, never a hard block | exit 0 on both ESCALATE and HOLD; `commands/execute.md` contains "advisory", "not a hard block", the `escalate` call, `start --amend`, and the up-only `Lane:` header rule | PASS |
+| AC6 [scope edges] | classify-time triggers + the pre-existing downgrade guard are unchanged | `classify "add jwt authentication and a data-model migration"` still returns `full`; `check tiny "...jwt sessions..."` still prints `LANE-DOWNGRADE` | PASS |
+
+## Implementation
+
+- `lib/lane-classify.sh` -- new `escalate()` function (re-classifies the SPEC file's
+  own text via the existing `classify_core`, compares `lane_rank` against the current
+  lane, prints `ESCALATE <cur> -> <heavier>` or `HOLD <cur>`, exits 0 always); wired
+  into `main()`'s case statement and the usage string. Pure, side-effect-free -- it
+  does not touch the gate-ledger or any spec file.
+- `commands/execute.md` -- new "Spec->build lane re-check (SPEC-094, ADR-0028
+  refinement point 4)" subsection in Prerequisites, right after the spec-status check
+  and before Step 1 dispatches any task. On `ESCALATE`: (1) `gate-ledger.sh start
+  --amend` re-plans the ledger's effective lane up, (2) the spec's `Lane:` header is
+  bumped up (never down) so `hooks/ship-gate.sh:140` enforces the heavier required-gate
+  set, (3) `gate-ledger.sh action` records the escalation. On `HOLD`: no action. All
+  advisory (exit 0 always); a missed re-check does not stop `/kit:execute` (ADR-0024).
+- `tests/fixtures/lane-escalation/heavy-scope-spec.md` -- a spec whose text carries
+  auth + data-model + migration language, for the positive case.
+- `tests/fixtures/lane-escalation/trivial-spec.md` -- a purely cosmetic spec, for the
+  downgrade-guard negative control.
+- `tests/test-lane-escalation.sh` -- 22 assertions across AC1-AC6.
+- `docs/implementation-notes/lane-escalation.md` -- deltas (boundary-hook placement,
+  whole-file classification, pure-function/caller-mutates split, `lane_rank` reuse).
+
+## Confirmation run-table
+
+| Command | Exit | Result |
+|---------|------|--------|
+| `bash tests/test-lane-escalation.sh` | 0 | 22/22 passed |
+| `bash tests/test-meta.sh` | 0 | 576/576 passed |
+| `bash tests/test-hooks.sh` | 0 | 438/438 passed |
+
+## Run detail
+
+```
+=== lane-escalation (SPEC-094 AC1-AC6) ===
+  PASS AC1: lane-classify.sh dispatches 'escalate'
+  PASS AC1: usage string documents the escalate signature
+
+=== POSITIVE: tiny + emergent-scope spec escalates to full ===
+  PASS AC2: escalate tiny+heavy-scope-spec prints ESCALATE tiny -> full
+  PASS AC2: escalate exits 0 on ESCALATE
+
+=== DOWNGRADE GUARD [NEGATIVE CONTROL]: full + trivial spec never downgrades ===
+  PASS AC3 [NEGATIVE CONTROL]: escalate full+trivial-spec HOLDs at full (never downgrades)
+  PASS AC3 [NEGATIVE CONTROL]: no ESCALATE line ever appears for a lighter re-class
+  PASS AC3: escalate exits 0 on HOLD too
+  PASS AC3: same-rank re-class also HOLDs (bug vs bug-ranked text)
+  PASS AC6: the pre-existing 'check' downgrade guard still fires (untouched)
+
+=== GATE-LEDGER RE-PLAN: start --amend re-plans up-only ===
+  PASS AC4: required(full) has strictly more gates than required(tiny)
+  PASS AC4: last START-AMEND wins -- ledger's effective lane is now full
+  PASS AC4: the amend line is recorded as START-AMEND, not a second plain START
+  PASS AC4: append-only stands (2 lines: START then START-AMEND, neither overwritten)
+
+=== ADVISORY + RECORDED: escalate never halts; the wiring says so ===
+  PASS AC5: escalate exits 0 on ESCALATE (advisory, never blocks)
+  PASS AC5: escalate exits 0 on HOLD (advisory, never blocks)
+  PASS AC5: commands/execute.md wiring documents advisory
+  PASS AC5: commands/execute.md wiring documents 'not a hard block'
+  PASS AC5: commands/execute.md wires the escalate call
+  PASS AC5: commands/execute.md wires the up-only start --amend re-plan
+  PASS AC5: commands/execute.md documents bumping the spec Lane: header
+  PASS AC5: commands/execute.md states the header bump is up-only (never down)
+
+=== SCOPE EDGES: classify-time triggers untouched ===
+  PASS AC6: classify-time trigger (task text) still lands on full unchanged
+
+=== 22/22 passed, 0 failed ===
+```
+
+## NEGATIVE CONTROL (the downgrade guard is load-bearing)
+
+The dangerous direction ADR-0028 pt 4 explicitly rules out is escalation sliding into a
+downgrade mechanism. The control: `escalate full tests/fixtures/lane-escalation/trivial-spec.md`
+re-classifies a purely cosmetic spec (matches the `tiny` rule -- "pure cosmetic") against
+a `full` current lane. `lane_rank(tiny)=1 < lane_rank(full)=3`, so the comparator
+(`sr -gt cr`) is false and the function prints `HOLD full`, never `ESCALATE full ->
+tiny`. A second assertion greps the raw output for any `^ESCALATE` line and fails the
+suite if one is found. A third control confirms a SAME-rank re-class (`bug` vs.
+bug-ranked text) also HOLDs -- "only heavier escalates" covers both the lighter and
+the equal case. If a future edit flipped the comparator to `-ge` or `-lt`, this test
+would go from HOLD to a false ESCALATE and the suite would fail red. The pre-existing
+`lane_check`/`check` downgrade guard (a different call site, same `lane_rank` function)
+is asserted unmodified in the same run, so a regression in the shared `lane_rank`
+would fail both guards together, not just this new one.
+
+## Reproduce
+
+```
+cd dwarves-kit
+bash tests/test-lane-escalation.sh   # 22/22, exit 0
+bash tests/test-meta.sh              # 576/576, exit 0
+bash tests/test-hooks.sh             # 438/438, exit 0
+```

--- a/lib/lane-classify.sh
+++ b/lib/lane-classify.sh
@@ -28,6 +28,8 @@
 #   lane-classify.sh classify "<desc>"                 -> prints the lane, exit 0
 #   lane-classify.sh explain  "<desc>"                 -> prints the lane + reason + fired flags
 #   lane-classify.sh check <chosen-lane> "<desc>"      -> warn+log if chosen < floor, exit 0
+#   lane-classify.sh escalate <current-lane> <spec-file>  -> up-only spec->build re-classify
+#                                                            (ESCALATE <cur> -> <heavier> | HOLD <cur>), exit 0
 #   lane-classify.sh lanes                              -> prints the 5 lane names
 #   lane-classify.sh flags                              -> prints the flag names
 
@@ -165,15 +167,52 @@ lane_check() {
   return 0
 }
 
+# Spec->build-boundary re-classification (SPEC-094, ADR-0028 refinement point 4,
+# kit-hardening SG-06). `check` above compares the CHOSEN lane against the original
+# task TEXT at intake; `escalate` compares the lane RECORDED at intake against the
+# SPEC's own text at the point the spec is validated and build is about to start --
+# the first point emergent scope (auth / data-model / migration the one-line task
+# description never carried) is concrete. Up-only: a heavier spec-implied lane
+# escalates; a same-or-lighter one HOLDS (the downgrade guard -- reuses lane_rank,
+# same as lane_check, so a lighter re-class can never win). Advisory: prints the
+# decision and exits 0 always ("Detect, don't dictate"; ADR-0024 mid-flight never
+# hard-blocks). It does NOT mutate the gate-ledger or the spec file itself -- the
+# caller (commands/execute.md Prerequisites) does the recording on ESCALATE.
+escalate() {
+  local current="${1:-}" spec_file="${2:-}" cr spec_lane sr
+  if [ -z "$current" ] || [ -z "$spec_file" ]; then
+    echo "usage: lane-classify.sh escalate <current-lane> <spec-file>" >&2; return 64
+  fi
+  [ -f "$spec_file" ] || { echo "escalate: spec file '$spec_file' not found" >&2; return 64; }
+
+  cr="$(lane_rank "$current")"
+  if [ "$cr" -lt 0 ]; then
+    echo "LANE-UNKNOWN: '$current' is not a lane (tiny|normal|full|bug|backfill); not checked" >&2
+    return 0
+  fi
+
+  classify_core "$(cat "$spec_file")"
+  spec_lane="$LANE"
+  sr="$(lane_rank "$spec_lane")"
+
+  if [ "$sr" -gt "$cr" ]; then
+    printf 'ESCALATE %s -> %s\n' "$current" "$spec_lane"
+  else
+    printf 'HOLD %s\n' "$current"
+  fi
+  return 0
+}
+
 main() {
   local sub="${1:-}"; shift || true
   case "$sub" in
     classify) classify_core "$@"; printf '%s\n' "$LANE";;
     explain)  classify_core "$@"; printf '%s\nreason: %s\nflags: %s\n' "$LANE" "$REASON" "${FIRED:-none}";;
     check)    lane_check "$@";;
+    escalate) escalate "$@";;
     lanes)    printf 'tiny\nnormal\nfull\nbug\nbackfill\n';;
     flags)    printf '%s\n' "${_hard_name[@]}" "${_soft_name[@]}";;
-    *) echo "usage: lane-classify.sh {classify \"<desc>\"|explain \"<desc>\"|check <chosen-lane> \"<desc>\"|lanes|flags}" >&2; return 64;;
+    *) echo "usage: lane-classify.sh {classify \"<desc>\"|explain \"<desc>\"|check <chosen-lane> \"<desc>\"|escalate <current-lane> <spec-file>|lanes|flags}" >&2; return 64;;
   esac
 }
 

--- a/tests/fixtures/lane-escalation/heavy-scope-spec.md
+++ b/tests/fixtures/lane-escalation/heavy-scope-spec.md
@@ -1,0 +1,18 @@
+# Spec: add password reset endpoint
+
+Status: VALIDATED
+Lane: tiny
+
+## Problem
+The original task text was "add a password reset link to the settings page", which
+read as a tiny cosmetic UI tweak. Writing the spec surfaced real scope: the reset flow
+needs a new authentication token, a session refresh path, and a data-model migration
+to add a `reset_token` column with a retention/expiry policy on the users table.
+
+## Decision
+Add a new auth token issuance path (login/session touching), and a schema migration
+for the new column.
+
+## Tasks
+- TASK-001: add the `reset_token` migration (schema change, retention policy)
+- TASK-002: wire the login flow to issue + validate the token (auth, session)

--- a/tests/fixtures/lane-escalation/trivial-spec.md
+++ b/tests/fixtures/lane-escalation/trivial-spec.md
@@ -1,0 +1,13 @@
+# Spec: fix a typo in the README
+
+Status: VALIDATED
+Lane: full
+
+## Problem
+There is a wording typo in the README's install section.
+
+## Decision
+Fix the typo.
+
+## Tasks
+- TASK-001: fix the typo, no other changes

--- a/tests/test-lane-escalation.sh
+++ b/tests/test-lane-escalation.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# test-lane-escalation.sh -- SPEC-094, kit-hardening SG-06.
+# Validates the spec->build-boundary lane re-classification: the `escalate` verb
+# (up-only, advisory), the gate-ledger re-plan it drives (start --amend adds rigor),
+# and the downgrade guard (a lighter re-class is refused -- the load-bearing
+# negative control).
+#
+# Run: bash tests/test-lane-escalation.sh   (exit 0 = all AC green)
+
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LC="$KIT_DIR/lib/lane-classify.sh"
+GL="$KIT_DIR/lib/gate-ledger.sh"
+EX="$KIT_DIR/commands/execute.md"
+FIX="$KIT_DIR/tests/fixtures/lane-escalation"
+
+PASS=0; FAIL=0; TOTAL=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  TOTAL=$((TOTAL+1))
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo -e "  ${GREEN}PASS${NC} $name"; PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC} $name"; FAIL=$((FAIL+1))
+  fi
+}
+
+echo "=== lane-escalation (SPEC-094 AC1-AC6) ==="
+
+# --- AC1: the verb exists and is wired into main() dispatch ---
+grep -qE '^[[:space:]]*escalate\)[[:space:]]*escalate' "$LC"; assert "AC1: lane-classify.sh dispatches 'escalate'" $?
+grep -qF 'escalate <current-lane> <spec-file>' "$LC"; assert "AC1: usage string documents the escalate signature" $?
+
+# ============================================================
+echo ""
+echo "=== POSITIVE: tiny + emergent-scope spec escalates to full ==="
+# ============================================================
+OUT_POS="$(bash "$LC" escalate tiny "$FIX/heavy-scope-spec.md" 2>&1)"
+EXIT_POS=$?
+assert_contains "AC2: escalate tiny+heavy-scope-spec prints ESCALATE tiny -> full" "ESCALATE tiny -> full" "$OUT_POS"
+assert "AC2: escalate exits 0 on ESCALATE" $([ "$EXIT_POS" -eq 0 ] && echo 0 || echo 1)
+
+# ============================================================
+echo ""
+echo "=== DOWNGRADE GUARD [NEGATIVE CONTROL]: full + trivial spec never downgrades ==="
+# ============================================================
+OUT_NEG="$(bash "$LC" escalate full "$FIX/trivial-spec.md" 2>&1)"
+EXIT_NEG=$?
+assert_contains "AC3 [NEGATIVE CONTROL]: escalate full+trivial-spec HOLDs at full (never downgrades)" "HOLD full" "$OUT_NEG"
+if printf '%s' "$OUT_NEG" | grep -qE '^ESCALATE'; then
+  assert "AC3 [NEGATIVE CONTROL]: no ESCALATE line ever appears for a lighter re-class" 1
+else
+  assert "AC3 [NEGATIVE CONTROL]: no ESCALATE line ever appears for a lighter re-class" 0
+fi
+assert "AC3: escalate exits 0 on HOLD too" $([ "$EXIT_NEG" -eq 0 ] && echo 0 || echo 1)
+
+# same-lane control: normal spec text against a normal current lane also HOLDs (same
+# rank, not just lighter -- "same or lighter" both refuse to escalate)
+SAME_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dwarves-kit-lane-esc.XXXXXX")"
+printf '# Spec: bounded fix\n\n## Problem\nA bounded bug fix, nothing more.\n' > "$SAME_DIR/bug-spec.md"
+OUT_SAME="$(bash "$LC" escalate bug "$SAME_DIR/bug-spec.md" 2>&1)"
+assert_contains "AC3: same-rank re-class also HOLDs (bug vs bug-ranked text)" "HOLD bug" "$OUT_SAME"
+
+# existing downgrade guard (lane_check / the 'check' verb) is untouched and still blocks
+CHECK_OUT="$(bash "$LC" check tiny "add user authentication with jwt sessions" 2>&1)"
+assert_contains "AC6: the pre-existing 'check' downgrade guard still fires (untouched)" "LANE-DOWNGRADE" "$CHECK_OUT"
+
+# ============================================================
+echo ""
+echo "=== GATE-LEDGER RE-PLAN: start --amend re-plans up-only ==="
+# ============================================================
+LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dwarves-kit-lane-esc-ledger.XXXXXX")"
+RID="lane-esc-test-run"
+DWARVES_KIT_LOG_DIR="$LOG_DIR" bash "$GL" start "$RID" tiny tiny feature feature testrepo >/dev/null 2>&1
+REQ_TINY="$(bash "$GL" required tiny 2>/dev/null)"
+REQ_FULL="$(bash "$GL" required full 2>/dev/null)"
+N_TINY=$(printf '%s\n' "$REQ_TINY" | grep -c .)
+N_FULL=$(printf '%s\n' "$REQ_FULL" | grep -c .)
+if [ "$N_FULL" -gt "$N_TINY" ]; then
+  assert "AC4: required(full) has strictly more gates than required(tiny)" 0
+else
+  assert "AC4: required(full) has strictly more gates than required(tiny)" 1
+fi
+
+DWARVES_KIT_LOG_DIR="$LOG_DIR" bash "$GL" start --amend "$RID" full tiny feature feature testrepo >/dev/null 2>&1
+LEDGER_TAIL="$(DWARVES_KIT_LOG_DIR="$LOG_DIR" bash "$GL" show "$RID" 2>/dev/null | grep -E 'START|START-AMEND' | tail -1)"
+assert_contains "AC4: last START-AMEND wins -- ledger's effective lane is now full" "lane=full" "$LEDGER_TAIL"
+if printf '%s' "$LEDGER_TAIL" | grep -q 'START-AMEND'; then
+  assert "AC4: the amend line is recorded as START-AMEND, not a second plain START" 0
+else
+  assert "AC4: the amend line is recorded as START-AMEND, not a second plain START" 1
+fi
+FULL_LOG="$(DWARVES_KIT_LOG_DIR="$LOG_DIR" bash "$GL" show "$RID" 2>/dev/null | grep -c 'START')"
+if [ "$FULL_LOG" -eq 2 ]; then
+  assert "AC4: append-only stands (2 lines: START then START-AMEND, neither overwritten)" 0
+else
+  assert "AC4: append-only stands (2 lines: START then START-AMEND, neither overwritten)" 1
+fi
+
+# ============================================================
+echo ""
+echo "=== ADVISORY + RECORDED: escalate never halts; the wiring says so ==="
+# ============================================================
+bash "$LC" escalate tiny "$FIX/heavy-scope-spec.md" >/dev/null 2>&1
+assert "AC5: escalate exits 0 on ESCALATE (advisory, never blocks)" $?
+bash "$LC" escalate full "$FIX/trivial-spec.md" >/dev/null 2>&1
+assert "AC5: escalate exits 0 on HOLD (advisory, never blocks)" $?
+
+grep -qiE 'advisory' "$EX"; assert "AC5: commands/execute.md wiring documents advisory" $?
+grep -qiE 'never a (mid-flight )?hard block|not a hard block' "$EX"; assert "AC5: commands/execute.md wiring documents 'not a hard block'" $?
+grep -qF 'lib/lane-classify.sh escalate' "$EX"; assert "AC5: commands/execute.md wires the escalate call" $?
+grep -qF 'gate-ledger.sh start --amend' "$EX"; assert "AC5: commands/execute.md wires the up-only start --amend re-plan" $?
+grep -qE "Lane:.*header" "$EX"; assert "AC5: commands/execute.md documents bumping the spec Lane: header" $?
+grep -qiE 'never down' "$EX"; assert "AC5: commands/execute.md states the header bump is up-only (never down)" $?
+
+# ============================================================
+echo ""
+echo "=== SCOPE EDGES: classify-time triggers untouched ==="
+# ============================================================
+CLASSIFY_OUT="$(bash "$LC" classify "add jwt authentication and a data-model migration" 2>&1)"
+assert_contains "AC6: classify-time trigger (task text) still lands on full unchanged" "full" "$CLASSIFY_OUT"
+
+echo ""
+echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Adds mid-flight lane escalation on emergent scope (kit-hardening SG-06, ADR-0028 refinement pt4): a new `lane-classify escalate <current> <spec>` verb re-runs classification against the SPEC's text at the spec->build boundary (the first point real scope is concrete). A heavier-lane trip escalates + re-plans the gate-ledger up-only (`start --amend`, so the heavier lane's measure-twice gates now apply) and bumps the spec's `Lane:` header up; a `tiny`/`normal` task that grows into auth/data-model/migration scope no longer stays mis-laned. UP-ONLY: the existing downgrade guard still refuses a lighter re-class. Advisory + recorded, never a mid-flight hard block (ADR-0024).

Verify: `bash tests/test-lane-escalation.sh` (22/22, incl. the downgrade-guard negative control: `escalate full <trivial-spec>` HOLDs, never downgrades). Proof: `docs/verification/lane-escalation.md`.

Roadmap: `ops-toolkit/_meta/megagoals/kit-hardening/ROADMAP.md`. Independent; on the integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
