### PR TITLE
feat(telemetry): render subcommand for the lane routing diagram

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Run lane-classify rule tests (SPEC-098)
         run: bash tests/test-lane-classify.sh
 
+      - name: Run lane-telemetry render tests (SPEC-099)
+        run: bash tests/test-lane-telemetry.sh
+
       - name: Run ledger-durability tests (SPEC-097)
         run: bash tests/test-ledger-durability.sh
 

--- a/docs/implementation-notes/lane-render.md
+++ b/docs/implementation-notes/lane-render.md
@@ -26,3 +26,13 @@ kit-machinery hard-gate one PR earlier. The wave's own fix corrected the wave's 
 DEC-002: the filter is a bare substring match on lane OR type, not a `--lane=`/`--type=` flag
 pair. One positional arg covers the common asks ("full", "eval") and keeps the surface tiny
 (ponytail); a flag grammar would be speculative for a read-only view.
+
+## 2026-07-02 review fixes (8/10, no BLOCKER)
+
+- SHOULD-FIX: gate-coverage counted raw `GATE|phase|ran` LINES, so a phase re-recorded in
+  one run (a retry) inflated the count past the header run total. Fixed to dedupe per
+  (rid=FILENAME, phase) so it counts distinct runs (DEC-004). Pinned.
+- NIT: header said "1 runs"; pluralized to "run"/"runs".
+- NIT: the lane-OR-type substring filter intentionally over-includes (a `normal`-lane run
+  with a `full-stack` TYPE matches `render full`). Working-as-designed per DEC-002; added a
+  test pinning it + a SPEC note so the boundary can't silently regress.

--- a/docs/implementation-notes/lane-render.md
+++ b/docs/implementation-notes/lane-render.md
@@ -1,0 +1,28 @@
+# Implementation notes: lane-telemetry render (SPEC-099)
+
+Delta from SPEC-099.
+
+## 2026-07-02 dispatch must forward args (caught in test)
+
+`render` takes an optional filter, but `main()`'s `case` dispatched `render)   render ;;`
+without `"$@"`, so `render full` silently rendered ALL runs. Fixed to `render) render "$@" ;;`.
+The filter test caught it (the full-render and filtered-render outputs were identical). Lesson:
+a subcommand that takes args needs `"$@"` in the dispatch; `report`/`misfires` took none so the
+pattern wasn't there to copy.
+
+## 2026-07-02 gate-coverage respects the filter
+
+First cut computed gate coverage by globbing `$RUNS_DIR/*.log` directly, which ignored the
+filter (a filtered render showed corpus-wide coverage). Reworked to build the file list from
+the filtered rows' rids so the coverage section matches the table + flow.
+
+## 2026-07-02 dogfood win
+
+SG-04 itself classified `full` at intake because SG-03 added `lane-telemetry` to the
+kit-machinery hard-gate one PR earlier. The wave's own fix corrected the wave's own lane.
+
+## 2026-07-02 no filter grammar
+
+DEC-002: the filter is a bare substring match on lane OR type, not a `--lane=`/`--type=` flag
+pair. One positional arg covers the common asks ("full", "eval") and keeps the surface tiny
+(ponytail); a flag grammar would be speculative for a read-only view.

--- a/docs/research/2026-07-02-lane-usage-snapshot.md
+++ b/docs/research/2026-07-02-lane-usage-snapshot.md
@@ -1,0 +1,86 @@
+# Lane-usage snapshot, 2026-07-02 (SPEC-099 / ID-150)
+
+Dated capture of `lane-telemetry.sh render` over the durable run corpus (SG-01). Regenerate
+with `bash lib/lane-telemetry.sh render` (add a lane/type filter as an optional arg). This is
+a point-in-time snapshot; the live command is the source of truth.
+
+## Full render
+
+```
+Lane routing  (18 runs, window 2026-07-01T14:23:09Z .. 2026-07-02T09:47:59Z)
+
+  task-type            lane       runs  gates r/s/o    ships
+  -------------------------------------------------------------
+  ?                ->  ?             9  51/8/11            0
+  bug              ->  full          1  0/0/0              0
+  doc              ->  normal        3  9/0/0              3
+  docs             ->  normal        1  3/0/0              1
+  eval             ->  full          1  12/0/0             1
+  reconcile        ->  full          1  12/0/0             1
+  spec-feature     ->  full          2  16/0/0             1
+
+  routing flow (task-type -> lane -> gates):
+
+    ?                                        --> ?         (9 runs)
+    bug, spec-feature, eval, reconcile       --> full      (5 runs)
+    docs, doc                                --> normal    (4 runs)
+
+  gate coverage (runs recording each phase as ran):
+    spec             15
+    build            15
+    think            11
+    review           11
+    docs             11
+    validate         10
+    ship             7
+    test-plan        6
+    design-critique  5
+    design           5
+    grill            4
+    reflect          3
+
+  legend: gates r/s/o = ran / skipped / override summed over those runs;
+          "?" lane/type = runs with no START line (untracked; see ID-085).
+```
+
+## Filtered render (`render full`, full-lane runs only)
+
+```
+Lane routing  (5 runs, filter=full, window 2026-07-02T08:43:16Z .. 2026-07-02T09:47:59Z)
+
+  task-type            lane       runs  gates r/s/o    ships
+  -------------------------------------------------------------
+  bug              ->  full          1  0/0/0              0
+  eval             ->  full          1  12/0/0             1
+  reconcile        ->  full          1  12/0/0             1
+  spec-feature     ->  full          2  16/0/0             1
+
+  routing flow (task-type -> lane -> gates):
+
+    bug, spec-feature, eval, reconcile       --> full      (5 runs)
+
+  gate coverage (runs recording each phase as ran):
+    think            4
+    grill            4
+    design-critique  4
+    design           4
+    validate         3
+    test-plan        3
+    spec             3
+    ship             3
+    review           3
+    reflect          3
+    docs             3
+    build            3
+
+  legend: gates r/s/o = ran / skipped / override summed over those runs;
+          "?" lane/type = runs with no START line (untracked; see ID-085).
+```
+
+## Reading it
+
+- `?` lane/type rows are runs with no START line (untracked). At snapshot time they dominate
+  (the pre-SG-02 kit-harden corpus); the SPEC-073 eval's metric 3 (ID-085) tracks fixing the
+  START-wiring so future snapshots have real lane/type routing for every run.
+- `gates r/s/o` = ran / skipped / override summed across those runs.
+- `ships` = runs that recorded a `ship` gate.

--- a/docs/specs/SPEC-099-lane-render.md
+++ b/docs/specs/SPEC-099-lane-render.md
@@ -55,7 +55,9 @@ bash tests/test-meta.sh ; bash tests/test-hooks.sh   # stay green
 ## Decision Log
 - DEC-001: reuse `_rows()` rather than a new parser -- one aggregation source, and render
   automatically inherits START-AMEND / first-wins semantics.
-- DEC-002: the filter is a substring match on lane OR type -- one arg covers "show me the
-  full-lane runs" and "show me the eval runs" without a flag grammar.
+- DEC-002: the filter is a LITERAL substring match (awk `index()`, not `~`) on lane OR type
+  -- one arg covers "show me the full-lane runs" and "show me the eval runs" without a flag
+  grammar, and a filter that is a regex metacharacter (`.`, `[`) is a plain string, never an
+  awk regex that over-matches or crashes (review robustness fix).
 - DEC-003: graceful-empty returns exit 0 with an honest message (not an error) -- a fresh
   install running `render` is a normal state, not a failure.

--- a/docs/specs/SPEC-099-lane-render.md
+++ b/docs/specs/SPEC-099-lane-render.md
@@ -58,6 +58,12 @@ bash tests/test-meta.sh ; bash tests/test-hooks.sh   # stay green
 - DEC-002: the filter is a LITERAL substring match (awk `index()`, not `~`) on lane OR type
   -- one arg covers "show me the full-lane runs" and "show me the eval runs" without a flag
   grammar, and a filter that is a regex metacharacter (`.`, `[`) is a plain string, never an
-  awk regex that over-matches or crashes (review robustness fix).
+  awk regex that over-matches or crashes (review robustness fix). The match is lane OR type,
+  so `render full` intentionally also includes a `normal`-lane run whose TYPE contains "full"
+  (e.g. `full-stack`); this is by design (one filter for "the full lane" and "full-stack
+  work") and is pinned in the test so the substring boundary can't silently regress.
+- DEC-004 (review): gate-coverage counts DISTINCT runs per phase (dedupe on rid+phase), not
+  raw ledger lines, so a phase re-recorded within one run (a retry) never inflates the count
+  past the header's run total.
 - DEC-003: graceful-empty returns exit 0 with an honest message (not an error) -- a fresh
   install running `render` is a normal state, not a failure.

--- a/docs/specs/SPEC-099-lane-render.md
+++ b/docs/specs/SPEC-099-lane-render.md
@@ -1,0 +1,61 @@
+# SPEC-099: lane-telemetry render (routing diagram + run counts)
+
+Status: VALIDATED
+Date: 2026-07-02
+Lane: full (adds a subcommand to lib/lane-telemetry.sh, a covered enforcement/telemetry lib)
+Type: feature
+Relates-to: SPEC-061 (lane-telemetry record+aggregate), SPEC-097 (durable corpus), SPEC-098 (lane-telemetry is now hard-gated)
+Board: ops-toolkit ID-150 (narrowed remainder); kit-telemetry mega-goal SG-04
+
+## Problem
+The record+aggregate half of lane telemetry exists (`report`/`misfires`, SPEC-061), but
+lane usage is not VISUALIZED: there is no task-type -> lane -> gate routing view with run
+counts. ID-150 (narrowed) asks for the render/dashboard over the existing data, now that
+SG-01 made the corpus durable.
+
+## Decision
+Add a `render` subcommand to `lib/lane-telemetry.sh` that draws, from the durable ledgers
+(reusing `_rows()`, no second parser, no new dependency):
+1. a `task-type -> lane` table with run counts + gates(ran/skip/override) + ships,
+2. an ASCII routing flow grouping task-types by the lane they routed into,
+3. per-phase gate coverage (how many runs recorded each gate ran),
+4. an optional positional filter `render [<lane-or-type-substring>]` that narrows to matching
+   runs (table, flow, and gate-coverage all respect it).
+ASCII + markdown only, TTY-gated bold reused from the file (pipe-safe). A dated markdown
+snapshot lands at `docs/research/2026-07-02-lane-usage-snapshot.md`.
+
+## Acceptance criteria
+- AC1: `render` prints the routing header, a type->lane table, the ASCII flow, and gate coverage.
+- AC2: run counts are correct (a 3-run seeded corpus reports 3 runs; the type->lane rows sum to 3).
+- AC3 [filter]: `render <lane>` narrows to matching runs only (a `full` filter excludes normal-lane runs), and the gate-coverage respects the filter.
+- AC4 [filter no-match]: `render <nomatch>` prints an honest "no runs match", not a crash.
+- AC5 [graceful-empty, NEGATIVE CONTROL]: an empty/fresh LOG_DIR renders "no runs recorded yet", never a crash or fake zeros.
+- AC6 [no regression]: `test-meta.sh`, `test-hooks.sh` stay green; `report`/`misfires`/`trace` unchanged.
+
+## Tasks
+- T1: `lib/lane-telemetry.sh` -- `render()` + dispatch `render) render "$@"` + usage/header.
+- T2: `tests/test-lane-telemetry.sh` (new) -- AC1-AC5 over a seeded corpus + the empty NC.
+- T3: `docs/research/2026-07-02-lane-usage-snapshot.md` -- dated capture (full + filtered).
+- T4: `docs/verification/lane-dashboard.md` -- table-first proof (2-3 captures).
+- T5: `.github/workflows/test.yml` -- wire the new suite into CI.
+
+## Verification
+```
+bash tests/test-lane-telemetry.sh   # AC1-AC5, 13 pins
+bash lib/lane-telemetry.sh render          # real-corpus capture
+bash lib/lane-telemetry.sh render full     # filtered capture
+bash tests/test-meta.sh ; bash tests/test-hooks.sh   # stay green
+```
+
+## Out of Scope
+- A web UI, charts/images, a new binary, per-repo dashboards (contract's Not-list).
+- Collecting/aggregating (exists, SPEC-061); storage (SG-01); rule changes (SG-03).
+- Fixing the untracked-run dominance (ID-085) -- render surfaces it honestly, does not fix it.
+
+## Decision Log
+- DEC-001: reuse `_rows()` rather than a new parser -- one aggregation source, and render
+  automatically inherits START-AMEND / first-wins semantics.
+- DEC-002: the filter is a substring match on lane OR type -- one arg covers "show me the
+  full-lane runs" and "show me the eval runs" without a flag grammar.
+- DEC-003: graceful-empty returns exit 0 with an honest message (not an error) -- a fresh
+  install running `render` is a normal state, not a failure.

--- a/docs/verification/lane-dashboard.md
+++ b/docs/verification/lane-dashboard.md
@@ -26,7 +26,7 @@ Verdict: PASS
 
 | Command | Exit | Result |
 |---------|------|--------|
-| `bash tests/test-lane-telemetry.sh` | 0 | 13/13 passed |
+| `bash tests/test-lane-telemetry.sh` | 0 | 18/18 passed (incl. metachar-literal, coverage-dedup, filter-over-inclusion pins) |
 | `bash tests/test-meta.sh` | 0 | 578/578 passed |
 | `bash tests/test-hooks.sh` | 0 | 438/438 passed |
 | `NO_COLOR=1 bash lib/lane-telemetry.sh render` | 0 | full routing diagram (captured in the snapshot doc) |

--- a/docs/verification/lane-dashboard.md
+++ b/docs/verification/lane-dashboard.md
@@ -1,0 +1,57 @@
+# Proof of done: lane-telemetry render (SPEC-099, kit-telemetry SG-04)
+
+Verdict: PASS
+
+## Acceptance criteria -> confirmation
+
+| AC | Criterion | How proven | Result |
+|----|-----------|------------|--------|
+| AC1 | render prints header + type->lane table + ASCII flow + gate coverage | `test-lane-telemetry.sh`: header/`routing flow`/`gate coverage` all present | PASS |
+| AC2 | run counts correct | test: 3-run seeded corpus -> "3 runs"; type rows sum to 3 | PASS |
+| AC3 [filter] | `render <lane>` narrows to matching runs; coverage respects it | test: `render full` -> "2 runs", "filter=full", excludes the normal-lane run | PASS |
+| AC4 [filter no-match] | honest message, no crash | test: `render nosuchlane` -> "no runs match" | PASS |
+| AC5 [graceful-empty NC] | empty LOG_DIR -> honest "no runs recorded", no crash | test: temp empty dir -> "no runs recorded", no error/unbound/syntax token | PASS |
+| AC6 [no regression] | suites green; report/misfires/trace unchanged | `test-meta` 578/578, `test-hooks` 438/438 | PASS |
+
+## Implementation
+
+- `lib/lane-telemetry.sh` -- new `render()` (reuses `_rows()`); dispatch `render) render "$@"`;
+  usage + header comment updated. Optional positional filter narrows table + flow + coverage.
+- `tests/test-lane-telemetry.sh` (new) -- 13 pins incl. the graceful-empty + filter-exclusion
+  negative controls.
+- `docs/research/2026-07-02-lane-usage-snapshot.md` -- dated capture (full + filtered).
+- `.github/workflows/test.yml` -- new suite wired into CI.
+
+## Confirmation run-table
+
+| Command | Exit | Result |
+|---------|------|--------|
+| `bash tests/test-lane-telemetry.sh` | 0 | 13/13 passed |
+| `bash tests/test-meta.sh` | 0 | 578/578 passed |
+| `bash tests/test-hooks.sh` | 0 | 438/438 passed |
+| `NO_COLOR=1 bash lib/lane-telemetry.sh render` | 0 | full routing diagram (captured in the snapshot doc) |
+| `NO_COLOR=1 bash lib/lane-telemetry.sh render full` | 0 | filtered to the 5 full-lane runs |
+| `DWARVES_KIT_LOG_DIR=<empty> bash lib/lane-telemetry.sh render` | 0 | "no runs recorded yet" (graceful) |
+
+## Run detail (capture 1: full render, real corpus)
+
+See `docs/research/2026-07-02-lane-usage-snapshot.md` for the committed full + filtered
+captures. Shape:
+
+```
+Lane routing  (N runs, window <first> .. <last>)
+  task-type            lane       runs  gates r/s/o    ships
+  ...
+  routing flow (task-type -> lane -> gates):
+    <types> --> <lane> (K runs)
+  gate coverage (runs recording each phase as ran):
+    <phase> <count>
+```
+
+## Reproduce
+
+```
+bash tests/test-lane-telemetry.sh
+bash lib/lane-telemetry.sh render          # full
+bash lib/lane-telemetry.sh render full     # filtered
+```

--- a/lib/lane-telemetry.sh
+++ b/lib/lane-telemetry.sh
@@ -263,7 +263,9 @@ render() {
   fi
   local rows; rows="$(_rows)"
   if [ -n "$filter" ]; then
-    rows="$(printf '%s\n' "$rows" | awk -v f="$filter" 'BEGIN{FS="\t"} $3 ~ f || $5 ~ f')"
+    # LITERAL substring match (index), not a regex (~), so a filter like "." or "[" is a
+    # plain string, never an awk regex that over-matches or crashes (review robustness).
+    rows="$(printf '%s\n' "$rows" | awk -v f="$filter" 'BEGIN{FS="\t"} index($3,f)>0 || index($5,f)>0')"
   fi
   if [ -z "$rows" ]; then
     [ -n "$filter" ] && echo "Lane routing: no runs match '$filter'." || echo "Lane routing: no runs recorded yet."

--- a/lib/lane-telemetry.sh
+++ b/lib/lane-telemetry.sh
@@ -275,7 +275,8 @@ render() {
   n="$(printf '%s\n' "$rows" | grep -c .)"
   first="$(printf '%s\n' "$rows" | awk 'BEGIN{FS="\t"}{print $14}' | sort | head -1)"
   last="$(printf '%s\n' "$rows" | awk 'BEGIN{FS="\t"}{print $15}' | sort | tail -1)"
-  printf '%sLane routing%s  (%s runs%s, window %s .. %s)\n\n' "$C_BOLD" "$C_OFF" "$n" "${filter:+, filter=$filter}" "$first" "$last"
+  local runword="runs"; [ "$n" = "1" ] && runword="run"
+  printf '%sLane routing%s  (%s %s%s, window %s .. %s)\n\n' "$C_BOLD" "$C_OFF" "$n" "$runword" "${filter:+, filter=$filter}" "$first" "$last"
 
   # type -> lane aggregate table (sorted)
   printf '  %-16s     %-9s %5s  %-13s %6s\n' "task-type" "lane" "runs" "gates r/s/o" "ships"
@@ -305,7 +306,10 @@ render() {
   while IFS= read -r rid; do [ -n "$rid" ] && [ -f "$RUNS_DIR/$rid.log" ] && files+=("$RUNS_DIR/$rid.log"); done \
     < <(printf '%s\n' "$rows" | awk 'BEGIN{FS="\t"}{print $1}')
   local cov=""
-  [ "${#files[@]}" -gt 0 ] && cov="$(awk -F' [|] ' '$2=="GATE" && $4=="ran"{ gsub(/^ | $/,"",$3); c[$3]++ }
+  # count DISTINCT runs recording each phase (dedupe per rid=FILENAME + phase), not raw
+  # lines: a phase re-recorded within one run (a retry) must not inflate past the run count.
+  [ "${#files[@]}" -gt 0 ] && cov="$(awk -F' [|] ' '$2=="GATE" && $4=="ran"{ gsub(/^ | $/,"",$3);
+      k=FILENAME SUBSEP $3; if (!(k in seen)) { seen[k]=1; c[$3]++ } }
     END{ for (p in c) printf "    %-16s %d\n", p, c[p] }' "${files[@]}" 2>/dev/null | sort -k2 -rn)"
   [ -n "$cov" ] && printf '%s\n' "$cov" || echo "    (none)"
 

--- a/lib/lane-telemetry.sh
+++ b/lib/lane-telemetry.sh
@@ -11,6 +11,8 @@
 #   lane-telemetry.sh report      -> per-lane + per-type aggregates over every run ledger
 #   lane-telemetry.sh misfires    -> the runs where chosen lane != classified lane, plus
 #                                    completeness.log LANE-CHECK lines: the feed for keyword fixes
+#   lane-telemetry.sh render      -> task-type -> lane -> gate routing diagram + run counts
+#                                    (SPEC-099 / ID-150); ASCII, graceful-empty, no new dep
 #   lane-telemetry.sh trace <rid> -> one run's full story, formatted for review (SPEC-063)
 #
 # Line formats consumed (produced by gate-ledger.sh):
@@ -249,13 +251,76 @@ trace() {
     }' "$f"
 }
 
+# render: the task-type -> lane -> gate routing DIAGRAM with run counts over the durable
+# ledgers (SPEC-099 / ID-150). ASCII + markdown only, no new dependency, renders over ssh.
+# Reuses _rows() (no second parser); degrades gracefully to an honest "no runs recorded"
+# on an empty/fresh install rather than crashing or printing fake zeros.
+render() {
+  local filter="${1:-}"   # optional: keep only runs whose lane OR type contains this string
+  if [ ! -d "$RUNS_DIR" ]; then
+    echo "Lane routing: no runs recorded yet (no ledger dir at $RUNS_DIR)."
+    return 0
+  fi
+  local rows; rows="$(_rows)"
+  if [ -n "$filter" ]; then
+    rows="$(printf '%s\n' "$rows" | awk -v f="$filter" 'BEGIN{FS="\t"} $3 ~ f || $5 ~ f')"
+  fi
+  if [ -z "$rows" ]; then
+    [ -n "$filter" ] && echo "Lane routing: no runs match '$filter'." || echo "Lane routing: no runs recorded yet."
+    return 0
+  fi
+  local n first last
+  n="$(printf '%s\n' "$rows" | grep -c .)"
+  first="$(printf '%s\n' "$rows" | awk 'BEGIN{FS="\t"}{print $14}' | sort | head -1)"
+  last="$(printf '%s\n' "$rows" | awk 'BEGIN{FS="\t"}{print $15}' | sort | tail -1)"
+  printf '%sLane routing%s  (%s runs%s, window %s .. %s)\n\n' "$C_BOLD" "$C_OFF" "$n" "${filter:+, filter=$filter}" "$first" "$last"
+
+  # type -> lane aggregate table (sorted)
+  printf '  %-16s     %-9s %5s  %-13s %6s\n' "task-type" "lane" "runs" "gates r/s/o" "ships"
+  printf '  %s\n' "-------------------------------------------------------------"
+  printf '%s\n' "$rows" | awk 'BEGIN{FS="\t"}
+    { k=$5 SUBSEP $3; cnt[k]++; ran[k]+=$7; skip[k]+=$8; ovr[k]+=$9; ship[k]+=$12 }
+    END { for (k in cnt) { split(k,a,SUBSEP);
+      printf "  %-16s ->  %-9s %5d  %-13s %6d\n", a[1], a[2], cnt[k], ran[k]"/"skip[k]"/"ovr[k], ship[k] } }' \
+    | sort
+
+  # ASCII flow: for each lane, the task-types that routed into it + run count
+  echo ""
+  printf '  routing flow (task-type -> lane -> gates):\n\n'
+  printf '%s\n' "$rows" | awk 'BEGIN{FS="\t"}
+    { laneruns[$3]++
+      if (index(SUBSEP seen[$3] SUBSEP, SUBSEP $5 SUBSEP)==0) {
+        types[$3]=types[$3] (types[$3]?", ":"") $5; seen[$3]=seen[$3] SUBSEP $5 } }
+    END { for (l in laneruns) printf "    %-40s --> %-9s (%d run%s)\n",
+            substr(types[l],1,40), l, laneruns[l], (laneruns[l]==1?"":"s") }' \
+    | sort -t'>' -k2
+
+  # gate coverage across the (possibly filtered) runs: per phase, how many runs recorded it ran
+  echo ""
+  printf '  gate coverage (runs recording each phase as ran):\n'
+  local files=()
+  local rid
+  while IFS= read -r rid; do [ -n "$rid" ] && [ -f "$RUNS_DIR/$rid.log" ] && files+=("$RUNS_DIR/$rid.log"); done \
+    < <(printf '%s\n' "$rows" | awk 'BEGIN{FS="\t"}{print $1}')
+  local cov=""
+  [ "${#files[@]}" -gt 0 ] && cov="$(awk -F' [|] ' '$2=="GATE" && $4=="ran"{ gsub(/^ | $/,"",$3); c[$3]++ }
+    END{ for (p in c) printf "    %-16s %d\n", p, c[p] }' "${files[@]}" 2>/dev/null | sort -k2 -rn)"
+  [ -n "$cov" ] && printf '%s\n' "$cov" || echo "    (none)"
+
+  echo ""
+  printf '  legend: gates r/s/o = ran / skipped / override summed over those runs;\n'
+  printf '          "?" lane/type = runs with no START line (untracked; see ID-085).\n'
+  return 0
+}
+
 main() {
   local sub="${1:-}"; shift || true
   case "$sub" in
     report)   report ;;
     misfires) misfires ;;
+    render)   render "$@" ;;
     trace)    trace "$@" ;;
-    *) echo "usage: lane-telemetry.sh {report|misfires|trace <rid>}" >&2; return 64 ;;
+    *) echo "usage: lane-telemetry.sh {report|misfires|render|trace <rid>}" >&2; return 64 ;;
   esac
 }
 

--- a/tests/test-lane-telemetry.sh
+++ b/tests/test-lane-telemetry.sh
@@ -55,6 +55,23 @@ has "no runs match" "$OUTD"; ok "filter '.' is literal (no regex over-match)" $?
 OUTB="$(NO_COLOR=1 bash "$LT" render "[" 2>&1)"
 if printf '%s' "$OUTB" | grep -qiE 'awk|character class|syntax'; then ok "filter '[' does not crash awk [NC]" 1; else ok "filter '[' does not crash awk [NC]" 0; fi
 
+# --- gate coverage counts DISTINCT runs, not raw lines (a re-recorded phase counts once) ---
+DD="$(mktemp -d)/logs"
+DWARVES_KIT_LOG_DIR="$DD" bash "$GL" start rr full full spec-feature spec-feature rp >/dev/null 2>&1
+DWARVES_KIT_LOG_DIR="$DD" bash "$GL" record rr think ran x >/dev/null 2>&1
+DWARVES_KIT_LOG_DIR="$DD" bash "$GL" record rr think ran "retry" >/dev/null 2>&1   # same phase, same run, twice
+OUTC="$(DWARVES_KIT_LOG_DIR="$DD" NO_COLOR=1 bash "$LT" render 2>&1)"
+has "1 run," "$OUTC"; ok "single run pluralizes as 'run' not 'runs'" $?
+# coverage line for think must read 1 (distinct runs), not 2 (raw lines)
+if printf '%s' "$OUTC" | grep -E 'think +[2-9]' >/dev/null; then ok "gate coverage dedupes a re-recorded phase (think=1, not 2)" 1; else ok "gate coverage dedupes a re-recorded phase (think=1, not 2)" 0; fi
+
+# --- filter matches lane OR type substring (DEC-002, intentional): a type substring hits too ---
+DT="$(mktemp -d)/logs"
+DWARVES_KIT_LOG_DIR="$DT" bash "$GL" start t1 normal normal full-stack full-stack rp >/dev/null 2>&1
+DWARVES_KIT_LOG_DIR="$DT" bash "$GL" record t1 think ran x >/dev/null 2>&1
+OUTT="$(DWARVES_KIT_LOG_DIR="$DT" NO_COLOR=1 bash "$LT" render full 2>&1)"
+has "full-stack" "$OUTT"; ok "filter matches a TYPE substring too (DEC-002 lane-OR-type), not only lane" $?
+
 # --- graceful-empty NEGATIVE CONTROL: empty/fresh LOG_DIR ---
 OUTE="$(DWARVES_KIT_LOG_DIR="$(mktemp -d)/empty" NO_COLOR=1 bash "$LT" render 2>&1)"
 has "no runs recorded" "$OUTE"; ok "empty corpus renders an honest 'no runs recorded' [NC]" $?

--- a/tests/test-lane-telemetry.sh
+++ b/tests/test-lane-telemetry.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# test-lane-telemetry.sh -- SPEC-099, kit-telemetry SG-04.
+# Pins the `render` routing-diagram subcommand: a seeded corpus renders the
+# task-type -> lane -> gate table + flow + counts; the filter narrows; an empty
+# corpus degrades gracefully (no crash, no fake zeros).
+#
+# Run: bash tests/test-lane-telemetry.sh   (exit 0 = all green)
+
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LT="$KIT_DIR/lib/lane-telemetry.sh"
+GL="$KIT_DIR/lib/gate-ledger.sh"
+
+PASS=0; FAIL=0; TOTAL=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+ok() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
+has() { printf '%s' "$2" | grep -qF -- "$1"; }
+
+# seeded corpus: a fixed DWARVES_KIT_LOG_DIR with three runs of distinct lane/type
+export DWARVES_KIT_LOG_DIR="$(mktemp -d)/logs"
+seed() {  # rid lane type
+  bash "$GL" start "$1" "$2" "$2" "$3" "$3" testrepo >/dev/null 2>&1
+  bash "$GL" record "$1" think ran x >/dev/null 2>&1
+  bash "$GL" record "$1" build ran x >/dev/null 2>&1
+}
+seed r-full-a full spec-feature
+seed r-full-b full eval
+seed r-norm   normal doc
+
+echo "=== lane-telemetry render (SPEC-099) ==="
+
+OUT="$(NO_COLOR=1 bash "$LT" render 2>&1)"
+has "Lane routing" "$OUT"; ok "render prints the routing header" $?
+has "3 runs" "$OUT"; ok "render counts all seeded runs" $?
+has "spec-feature" "$OUT"; ok "render shows a task-type row" $?
+has "-> " "$OUT"; ok "render shows the type -> lane mapping" $?
+has "routing flow" "$OUT"; ok "render draws the ASCII flow section" $?
+has "gate coverage" "$OUT"; ok "render shows per-phase gate coverage" $?
+# gate coverage counts both full runs' think = 2 (seeded think in all 3, so >=1)
+has "think" "$OUT"; ok "render lists a covered gate phase" $?
+
+# --- filter narrows to matching lane ---
+OUTF="$(NO_COLOR=1 bash "$LT" render full 2>&1)"
+has "filter=full" "$OUTF"; ok "render <filter> notes the active filter" $?
+has "2 runs" "$OUTF"; ok "filter=full keeps only the 2 full-lane runs" $?
+if has "normal" "$OUTF"; then ok "filter excludes the normal-lane run [NC]" 1; else ok "filter excludes the normal-lane run [NC]" 0; fi
+
+# --- filter with no match ---
+OUTN="$(NO_COLOR=1 bash "$LT" render nosuchlane 2>&1)"
+has "no runs match" "$OUTN"; ok "filter with no match degrades gracefully" $?
+
+# --- graceful-empty NEGATIVE CONTROL: empty/fresh LOG_DIR ---
+OUTE="$(DWARVES_KIT_LOG_DIR="$(mktemp -d)/empty" NO_COLOR=1 bash "$LT" render 2>&1)"
+has "no runs recorded" "$OUTE"; ok "empty corpus renders an honest 'no runs recorded' [NC]" $?
+if printf '%s' "$OUTE" | grep -qiE 'error|not found|unbound|syntax'; then ok "empty render does not crash [NC]" 1; else ok "empty render does not crash [NC]" 0; fi
+
+echo ""
+echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test-lane-telemetry.sh
+++ b/tests/test-lane-telemetry.sh
@@ -49,6 +49,12 @@ if has "normal" "$OUTF"; then ok "filter excludes the normal-lane run [NC]" 1; e
 OUTN="$(NO_COLOR=1 bash "$LT" render nosuchlane 2>&1)"
 has "no runs match" "$OUTN"; ok "filter with no match degrades gracefully" $?
 
+# --- filter is a LITERAL substring, not a regex: metachars don't over-match or crash ---
+OUTD="$(NO_COLOR=1 bash "$LT" render "." 2>&1)"
+has "no runs match" "$OUTD"; ok "filter '.' is literal (no regex over-match)" $?
+OUTB="$(NO_COLOR=1 bash "$LT" render "[" 2>&1)"
+if printf '%s' "$OUTB" | grep -qiE 'awk|character class|syntax'; then ok "filter '[' does not crash awk [NC]" 1; else ok "filter '[' does not crash awk [NC]" 0; fi
+
 # --- graceful-empty NEGATIVE CONTROL: empty/fresh LOG_DIR ---
 OUTE="$(DWARVES_KIT_LOG_DIR="$(mktemp -d)/empty" NO_COLOR=1 bash "$LT" render 2>&1)"
 has "no runs recorded" "$OUTE"; ok "empty corpus renders an honest 'no runs recorded' [NC]" $?


### PR DESCRIPTION
`lane-telemetry.sh render`: the task-type -> lane -> gate routing diagram + run counts over the durable corpus (ops board **ID-150**, narrowed). kit-telemetry mega-goal SG-04. Off master (has SG-01/02/03).

## What
- `render` draws a type->lane table (runs + gates r/s/o + ships), an ASCII routing flow, and per-phase gate coverage, reusing `_rows()` (no new parser/dep). Optional literal-substring filter narrows all three sections. Graceful-empty on a fresh install.
- Dated snapshot at `docs/research/2026-07-02-lane-usage-snapshot.md` (full + filtered captures).
- New `tests/test-lane-telemetry.sh` (18 pins) wired into CI.

## Review-caught + fixed
- filter is a literal substring (not a regex) , `.`/`[` no longer over-match or crash awk.
- gate-coverage counts distinct runs per phase (a re-recorded retry no longer inflates the count).

Verify:
```
bash tests/test-lane-telemetry.sh   # 18/18
bash lib/lane-telemetry.sh render          # full
bash lib/lane-telemetry.sh render full     # filtered
```
Proof: `docs/verification/lane-dashboard.md`. Roadmap: ops-toolkit `_meta/megagoals/kit-telemetry/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
