### PR TITLE
fix(kit): slop resolution memory + session debounce + override guard

### DIFF
--- a/docs/implementation-notes/cc-hyg-04-stop-tax.md
+++ b/docs/implementation-notes/cc-hyg-04-stop-tax.md
@@ -1,0 +1,72 @@
+# Implementation notes cc-hyg-04 (delta from spec)
+
+## Decisions the spec left open
+
+- **slop-cleaner: kept, not dropped.** The bloat signal is worth keeping; only the
+  repetition was the tax. Resolution memory fixes the repetition without losing the
+  signal.
+- **session-state-save: change-gated debounce chosen** over time-debounce (staleness
+  risk) and over keep-every-Stop (the 38 min/month churn the mega-goal targets).
+
+## Deltas discovered during build
+
+1. **session-state fingerprint must exclude the hook's own output.** First cut used
+   `git status --porcelain | wc -l`, but that counts the untracked
+   `.claude/session-state/` files the hook itself writes, so the fingerprint changed
+   every run and the debounce never fired. Also git collapses a wholly-untracked dir
+   to a single `?? .claude/` line, so a plain `grep -vF '.claude/session-state/'`
+   missed it. Fix: `git status --porcelain --untracked-files=all` (lists individual
+   files) then filter `.claude/session-state/`. Caught by the debounce test failing.
+
+2. **override rejection is deploy-path-aware, not extension-only.** First cut rejected
+   any override whose remainder had a source-code EXTENSION. That broke
+   `test-deployable-done.sh` AC4 (a `deploy/rollout.sh` is a `.sh`, but a deploy
+   script is override-able by design , SPEC-095 verifies deploy via deploy-proof/UAT,
+   and the override is the sanctioned manual-verification escape). Fix: exclude files
+   under a `deploy/` path from the source-remainder check. So: source code OUTSIDE
+   `deploy/` -> reject (the rtk-611 case, a `lib/` change); anything under `deploy/`
+   or any non-code file -> still override-able. Reconciles cc-hyg-04 with SPEC-095.
+
+3. **Test signal for the debounce = the DEBUG "skipping" line, not archive count.**
+   Archive filenames are `state-<YYYYmmdd-HHMMSS>.md` (1s resolution); rapid test runs
+   collide on the same name, so counting archives is flaky. The test runs the hook with
+   `DWARVES_KIT_DEBUG=1` and asserts the "skipping" message appears/absents instead.
+
+## Tests added
+
+- `test-hooks.sh`: slop resolution memory (report once / silent on unchanged /
+  re-flag on content change); session-state change-gated debounce (skip unchanged /
+  write after a real change); proof-ledger override (source -> REJECTED,
+  deploy-inert -> PASS).
+- `test-deployable-done.sh` AC4b: override on NON-deploy source is still rejected.
+
+## Proof
+
+See `docs/proof-of-done.md` (co-located per SPEC-016 style): full CI run-table,
+all 11 suites green.
+
+## Adversarial review round (kit:security-reviewer, REVISE -> fixed)
+
+The security review reproduced three real bypasses against the first cut; all fixed
++ covered by new tests (test-hooks 445 -> 449):
+
+1. **`deploy/` exemption was a substring match at any depth** (`grep -vE '(^|/)deploy/'`)
+   -> `src/deploy/core.py` (real app logic) bypassed rejection, reopening rtk-611.
+   Fix: exempt only SANCTIONED deploy locations via `case`: `deploy/*` (repo root) or
+   `tools/*/deploy/*` (per-tool). Nested `src/deploy/`, `lib/deploy/` are NOT exempt.
+2. **Extensionless shebang scripts bypassed the extension regex** (the kit's own
+   `lib/handoff-gen` is such a file). Fix: a file with no dot in its basename counts
+   as source if it is a shebang script (`head -c2 == '#!'`).
+3. **session-state debounce used a dirty-file COUNT** -> further edits to an
+   already-dirty file (count unchanged) were silently skipped, staling crash recovery
+   for a single-file editing streak. Fix: fingerprint the CONTENT (hash of
+   `git diff HEAD` + the untracked list, minus `.claude/session-state/`), not a count.
+
+New tests: proof-ledger (c) nested-deploy REJECTED, (c2) tools/*/deploy PASS, (d)
+extensionless shebang REJECTED; session-state content-change-to-already-dirty-file
+re-saves.
+
+## Spec/impl-notes naming
+
+Named `cc-hyg-04-*` (not the next `SPEC-099`) to avoid colliding with the concurrent
+kit-telemetry mega-goal's SPEC numbering; marks its cc-hygiene provenance.

--- a/docs/specs/cc-hyg-04-stop-tax.md
+++ b/docs/specs/cc-hyg-04-stop-tax.md
@@ -1,0 +1,61 @@
+# Spec cc-hyg-04: reduce the Stop-hook + override tax
+
+Cross-repo: sub-goal 04 of the ops-toolkit **cc-hygiene** mega-goal
+(`ops-toolkit/_meta/megagoals/cc-hygiene/goals/04-kit-stop-tax.md`). Lane `full`
+(kit-machinery: `proof-gate`/`proof-ledger` are hard-gated). Gate-ledger run
+`cc-hyg-04`.
+
+## Problem (measured, from research/2026-07-02-process-benchmark.md §1, §5)
+
+1. **slop-cleaner Stop hook** re-flags the same 7 files up to 19 times in a row:
+   8,483-8,526 runs / 30d, p50 ~497ms (p95 5.4s, max 11.5s), ~70 min/month
+   wall-clock, all re-reporting already-seen files. It has no resolution memory.
+2. **session-state-save** runs every Stop: 8,483 x ~271ms ~= 38 min/month. No
+   debounce; keep-or-debounce never decided from the data.
+3. **proof-gate override** blanket-passes the whole branch once a slug is
+   overridden, even when the unproofed remainder touches SOURCE files. The single
+   recorded override (2026-07-01, rtk-611) shipped a broken source change reverted
+   9h later.
+
+## Solution (decided)
+
+1. **slop-cleaner: KEEP + add resolution memory** (not drop). The hook's signal is
+   useful; the tax was pure repetition. A per-session seen-state file
+   (`$DWARVES_KIT_LOG_DIR/slop-seen-<session_id>.tsv`, `path<TAB>contenthash`) makes
+   a flagged file nudge once per session and re-nudge only when its content changes.
+   Keyed by `session_id` (read from the Stop payload); stale seen-files (>7d) pruned.
+2. **session-state-save: DEBOUNCE (change-gated), not keep-every-Stop.** A fingerprint
+   (`branch | uncommitted-count | HEAD`) is stored; an unchanged Stop skips the whole
+   rewrite+rotate. Chosen over time-debounce because it has zero staleness risk (the
+   existing state is still correct when nothing changed) and over keep-every-Stop
+   because that was ~38 min/month of pure churn. The dirty count excludes the hook's
+   own `.claude/session-state/` output (`--untracked-files=all` + filter), else the
+   fingerprint never stabilizes.
+3. **proof-gate override: reject source remainder.** An override no longer blanket-passes
+   the branch. If the diff contains application source-code files (by extension) OUTSIDE
+   a `deploy/` path, the override is rejected and a real proof of done is demanded. Deploy
+   scripts under `deploy/` stay override-able (verified via deploy-proof/UAT per SPEC-095).
+   This closes rtk-611 (a non-deploy source change shipped under a blanket override).
+
+## Scope
+
+**In:** `hooks/slop-cleaner.sh`, `hooks/session-state-save.sh`,
+`lib/proof-gate.sh` / `lib/proof-ledger.sh` override path, and their tests.
+**Out:** other Stop hooks (em-dash-fix, secret-guard-stop, citation-guard , measured
+cheap), gate-ledger durability (kit-telemetry SG-01 owns it), anti-rationalization.sh.
+**Not:** no hook-framework rewrite, no new config surface beyond what the fix needs,
+no touching kit-telemetry's scope.
+
+## Verification (proof of done)
+
+- New tests: (a) slop-cleaner flags a file; a second Stop with unchanged content
+  stays silent; a content change re-flags. (b) proof-ledger override on a batch
+  whose remainder touches a source file is rejected / demands the exclusion list.
+- The full kit CI suite (test-hooks, test-proof-visual-evidence, test-meta,
+  test-e2e, test-lane-classify, test-ledger-durability, test-meta-agent,
+  test-orchestrate, test-review-team-plants, test-role-classify) stays green.
+- Run-table committed: each command + exit 0 + real stdout slice; plus a
+  before/after note on hook behavior.
+
+**Done =** both new behaviors covered by green tests AND the full kit suite passes,
+proven by the committed run-table.

--- a/docs/verification/cc-hyg-04-stop-tax.md
+++ b/docs/verification/cc-hyg-04-stop-tax.md
@@ -1,0 +1,70 @@
+# Proof of done cc-hyg-04: Stop-hook + override tax reduction
+
+VERDICT: PASS
+
+## Acceptance criteria
+
+Both new behaviors covered by green tests AND the full kit suite passes:
+1. slop-cleaner reports a flagged file once/session, silent until content changes.
+2. session-state-save debounces on an unchanged Stop.
+3. proof-gate override rejects a source-file remainder (deploy-inert still passes).
+
+## Implementation
+
+- `hooks/slop-cleaner.sh`: per-session seen-state (`slop-seen-<session_id>.tsv`, `path<TAB>hash`), skip already-reported-at-same-hash files, prune >7d.
+- `hooks/session-state-save.sh`: change-gated debounce on `branch|dirty|HEAD` fingerprint (dirty via `--untracked-files=all` minus the hook's own `.claude/session-state/`).
+- `lib/proof-ledger.sh` `check()`: an override on a source-code file outside `deploy/` is rejected (exit 1); deploy scripts + non-code stay override-able.
+
+## Confirmation run-table (2026-07-02, Air, cc-hyg-04 worktree)
+
+| # | Command | Exit | Output |
+|---|---------|------|--------|
+| 1 | `bash tests/test-hooks.sh` | 0 | `Passed: 449 / 449` (incl. 4 review-round tests) |
+| 2 | `bash tests/test-deployable-done.sh` | 0 | `17/17 passed, 0 failed` |
+| 3 | `bash tests/test-proof-visual-evidence.sh` | 0 | (green) |
+| 4 | `bash tests/test-ledger-durability.sh` | 0 | `32/32 passed` |
+| 5 | `bash tests/test-meta.sh` | 0 | `Passed: 578 / 578` |
+| 6 | `bash tests/test-e2e.sh` | 0 | `Passed: 20 / 20` |
+| 7 | `bash tests/test-lane-classify.sh` | 0 | `16/16 passed` |
+| 8 | `bash tests/test-meta-agent.sh` | 0 | `65/65 passed` |
+| 9 | `bash tests/test-orchestrate.sh` | 0 | (green) |
+| 10 | `bash tests/test-review-team-plants.sh` | 0 | `Passed: 8 / 8` |
+| 11 | `bash tests/test-role-classify.sh` | 0 | `15/15 passed` |
+
+All 11 CI suites: exit 0, 0 total failures.
+
+## NEGATIVE CONTROL
+
+The override-rejection is falsifiable, not a rubber stamp:
+
+- **Source change + override -> REJECTED (exit 1).** A branch changing `lib/a.sh`
+  with a logged override:
+  ```
+  $ proof-ledger.sh check <repo> <base> x   # override 'x' logged
+  proof-of-done: override for 'x' REJECTED -- the branch changes source files with no proof of done:
+      - lib/a.sh
+  Exit: 1
+  ```
+- **Deploy-path change + override -> PASS (exit 0).** The same shape under `deploy/`:
+  ```
+  $ proof-ledger.sh check <repo> <base> y   # override 'y' logged, deploy/roll.sh
+  proof-of-done: OVERRIDDEN for 'y' (docs/deploy-inert remainder; logged, ...)
+  Exit: 0
+  ```
+  Proves the gate discriminates source (reject) from deploy-inert (pass), not a
+  blanket allow/deny.
+- **Debounce is falsifiable:** the test asserts the DEBUG "skipping" line is PRESENT
+  on an unchanged Stop and ABSENT after a real commit. Before the fingerprint fix
+  (which excludes the hook's own untracked output), that test failed , the debounce
+  never fired , which is how the untracked-churn bug was caught.
+
+## Reproduce
+
+```
+cd <dwarves-kit>/.claude/worktrees/cc-hyg-04   # or the merged master
+for t in test-hooks test-deployable-done test-proof-visual-evidence \
+         test-ledger-durability test-meta test-e2e test-lane-classify \
+         test-meta-agent test-orchestrate test-review-team-plants test-role-classify; do
+  bash "tests/$t.sh" >/dev/null 2>&1 && echo "OK $t" || echo "FAIL $t"
+done
+```

--- a/hooks/session-state-save.sh
+++ b/hooks/session-state-save.sh
@@ -30,6 +30,25 @@ trap 'exit 0' ERR
 
 mkdir -p "$STATE_DIR" "$ARCHIVE_DIR"
 
+# Change-gated debounce (cc-hyg-04): skip the rewrite+rotate when nothing material
+# changed since the last save. The existing last-state.md is still accurate for crash
+# recovery, so skipping is safe, and it cuts the every-Stop tax (measured ~38 min/mo)
+# with no staleness risk. Fingerprint = branch | uncommitted-count | HEAD sha.
+FP_FILE="$STATE_DIR/.last-fingerprint"
+# Fingerprint the CONTENT of the working state, not a dirty-file count: hash the
+# tracked diff (`git diff HEAD`) plus the untracked file list. A count would miss
+# further edits to an already-dirty file (same count -> stale crash-recovery
+# snapshot for the rest of a single-file editing streak). Exclude the hook's own
+# untracked .claude/session-state/ output, else the fingerprint never stabilizes.
+FP=$(printf '%s|%s|%s' \
+  "$(git branch --show-current 2>/dev/null || echo -)" \
+  "$( { git diff HEAD 2>/dev/null; git status --porcelain --untracked-files=all 2>/dev/null | { grep -vF '.claude/session-state/' || true; }; } | { shasum 2>/dev/null || sha1sum 2>/dev/null; } | awk '{print $1}')" \
+  "$(git rev-parse HEAD 2>/dev/null || echo -)")
+if [ -f "$STATE_FILE" ] && [ -f "$FP_FILE" ] && [ "$FP" = "$(cat "$FP_FILE" 2>/dev/null)" ]; then
+  [ "${DWARVES_KIT_DEBUG:-0}" = "1" ] && echo "[dwarves-kit:session-state] unchanged since last save, skipping" >&2
+  exit 0
+fi
+
 # Rotate: archive current state before overwriting
 if [ -f "$STATE_FILE" ]; then
   ARCHIVE_TS=$(date +"%Y%m%d-%H%M%S")
@@ -102,6 +121,9 @@ Read CLAUDE.md and the active spec (docs/specs/SPEC-NNN) for full context.
 Check git status for uncommitted work.
 Run 'start' to detect what to do next.
 STATE
+
+# Record the fingerprint so the next unchanged Stop can debounce.
+printf '%s' "$FP" > "$FP_FILE" 2>/dev/null || true
 
 [ "${DWARVES_KIT_DEBUG:-0}" = "1" ] && echo "[dwarves-kit:session-state] state saved to $STATE_FILE" >&2
 

--- a/hooks/slop-cleaner.sh
+++ b/hooks/slop-cleaner.sh
@@ -52,6 +52,18 @@ RECENT_FILES=$(find . \
 
 BLOAT_FILES=""
 
+# Resolution memory (cc-hyg-04): report a flagged file once per session, or until
+# its content changes. Without this the same files re-nudge on every Stop (measured:
+# the same ~7 files re-flagged up to 19x in a row). State is per-session, keyed by
+# session_id, storing "path<TAB>contenthash" for each already-reported file.
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null || echo default)
+SEEN_LOG_DIR="${DWARVES_KIT_LOG_DIR:-$HOME/.claude/dwarves-kit/logs}"
+mkdir -p "$SEEN_LOG_DIR" 2>/dev/null || true
+SEEN_FILE="$SEEN_LOG_DIR/slop-seen-${SESSION_ID//[^A-Za-z0-9._-]/_}.tsv"
+# Prune stale seen-files (>7d) so the dir does not grow unbounded across sessions.
+find "$SEEN_LOG_DIR" -name 'slop-seen-*.tsv' -mtime +7 -delete 2>/dev/null || true
+TAB=$(printf '\t')
+
 while IFS= read -r FILE; do
   [ ! -f "$FILE" ] && continue
   ISSUES=""
@@ -91,6 +103,18 @@ while IFS= read -r FILE; do
   [ "$DUPES" -gt 0 ] && ISSUES+="$DUPES duplicate code blocks, "
 
   if [ -n "$ISSUES" ]; then
+    # Resolution memory: skip if already reported this session at the same content
+    # hash; re-report only when the file's content changed since the last nudge.
+    FHASH=$( (shasum "$FILE" 2>/dev/null || sha1sum "$FILE" 2>/dev/null) | awk '{print $1}' )
+    if [ -n "$FHASH" ] && grep -qF "${FILE}${TAB}${FHASH}" "$SEEN_FILE" 2>/dev/null; then
+      continue
+    fi
+    if [ -n "$FHASH" ]; then
+      # Replace any stale hash line for this file, then record the current hash.
+      grep -vF "${FILE}${TAB}" "$SEEN_FILE" 2>/dev/null > "${SEEN_FILE}.tmp" || true
+      mv -f "${SEEN_FILE}.tmp" "$SEEN_FILE" 2>/dev/null || true
+      printf '%s\t%s\n' "$FILE" "$FHASH" >> "$SEEN_FILE"
+    fi
     BLOAT_FILES+="  $FILE: ${ISSUES%, }\n"
   fi
 done <<< "$RECENT_FILES"

--- a/lib/proof-ledger.sh
+++ b/lib/proof-ledger.sh
@@ -147,7 +147,36 @@ check() {
   [ "$class" = "inert" ] && return 0          # docs/cosmetic: no ritual.
 
   if [ -n "$slug" ] && is_overridden "$slug"; then
-    echo "proof-of-done: OVERRIDDEN for '$slug' (logged, see $OVERRIDE_LOG)" >&2
+    # cc-hyg-04: an override excuses docs / deploy-inert work, NOT application source
+    # code. A blanket override that silently passes an unproven SOURCE change is the
+    # rtk-611 hole (2026-07-01: an overridden branch shipped a broken source change,
+    # reverted 9h later). Deploy scripts under a deploy/ path stay override-able (they
+    # are verified via deploy-proof/UAT per SPEC-095); source code elsewhere is not.
+    # Build the source-code remainder. A file counts as source if it has a code
+    # extension OR is an extensionless shebang script (e.g. the kit's own
+    # lib/handoff-gen); deploy scripts at a SANCTIONED location (repo-root deploy/
+    # or a per-tool tools/<name>/deploy/) are exempt -- but a `deploy` dir nested
+    # anywhere else (src/deploy/, lib/deploy/) is NOT, or it would reopen the hole.
+    local src_remainder="" f
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      case "$f" in deploy/*|tools/*/deploy/*) continue ;; esac   # sanctioned deploy: override-able
+      if printf '%s' "$f" | grep -qE '\.(sh|bash|zsh|py|js|jsx|mjs|cjs|ts|tsx|go|rs|rb|c|h|cc|cpp|hpp|java|php|swift|kt|kts|scala|clj|cljs|ex|exs|lua|pl|pm|r|m|mm|sql)$'; then
+        src_remainder="${src_remainder}${f}"$'\n'; continue
+      fi
+      # extensionless file (no dot in basename): treat as source if it is a shebang script.
+      case "$(basename "$f")" in
+        *.*) : ;;
+        *) [ -f "$root/$f" ] && [ "$(head -c2 "$root/$f" 2>/dev/null)" = '#!' ] && src_remainder="${src_remainder}${f}"$'\n' ;;
+      esac
+    done < <(_changed "$root" "$base")
+    if [ -n "$src_remainder" ]; then
+      echo "proof-of-done: override for '$slug' REJECTED -- the branch changes source files with no proof of done:" >&2
+      printf '%s' "$src_remainder" | sed 's/^/    - /' >&2
+      echo "  An override excuses docs / deploy-inert work only. Provide a proof of done for the source change (run /kit:verify), or split it out." >&2
+      return 1
+    fi
+    echo "proof-of-done: OVERRIDDEN for '$slug' (docs/deploy-inert remainder; logged, see $OVERRIDE_LOG)" >&2
     return 0
   fi
 

--- a/tests/test-deployable-done.sh
+++ b/tests/test-deployable-done.sh
@@ -116,6 +116,19 @@ fi
 grep -qF "| deploy-noproof-override | OVERRIDE | emergency hotfix, deploy verified manually" "$LOGDIR/proof-overrides.log" 2>/dev/null
 assert "AC4: the override is logged to the audit trail (slug + reason present)" $?
 
+# --- cc-hyg-04: an override does NOT excuse application source code outside deploy/.
+# (deploy scripts above stay override-able; a lib/ source change must not.)
+D4B="$(mktemp -d)"; mkrepo "$D4B"
+B4B="$(base "$D4B")"
+mkdir -p "$D4B/lib"; printf 'echo broken\n' > "$D4B/lib/handler.sh"
+git -C "$D4B" add -A; git -C "$D4B" commit -qm "feat(handler): urgent source change"
+DWARVES_KIT_LOG_DIR="$LOGDIR" bash "$LIB" override src-noproof-override "urgent, trust me" >/dev/null 2>&1
+if run_check "$D4B" "$B4B" "src-noproof-override" >/dev/null 2>&1; then
+  assert "AC4b: override on NON-deploy source is still REJECTED (rtk-611 hole closed)" 1
+else
+  assert "AC4b: override on NON-deploy source is still REJECTED (rtk-611 hole closed)" 0
+fi
+
 # ============================================================
 echo ""
 echo "=== AC5 [contract]: AGENTS.md zone 3 carries the Deployable-done clause ==="

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -705,6 +705,19 @@ SLOP_NG=$( cd "$NOGIT" && echo '{"stop_hook_active":false,"assistant_response":"
   | DWARVES_KIT_SESSION_MARKER="$SCAN_MARKER" bash "$KIT_DIR/hooks/slop-cleaner.sh" 2>/dev/null )
 assert_output_not_contains "slop: no scan outside a git work tree (guard)" "orphan.py" "$SLOP_NG"
 
+# --- cc-hyg-04: resolution memory. A flagged file nudges once per session, then
+# stays silent until its content changes (kills the "same 7 files re-flagged 19x" tax).
+MEM_MARK=$(mktemp "${TMPDIR:-/tmp}/dk-memmark.XXXXXX"); touch -t 202001010000 "$MEM_MARK"
+MEM_DIR=$(mktemp -d "${TMPDIR:-/tmp}/dk-mem.XXXXXX"); ( cd "$MEM_DIR" && git init -q )
+printf 'v%s = 1\n' $(seq 350) > "$MEM_DIR/big.py"      # >300 lines -> bloat
+_slop_mem() { ( cd "$MEM_DIR" && echo '{"stop_hook_active":false,"session_id":"memtest"}' \
+  | DWARVES_KIT_SESSION_MARKER="$MEM_MARK" bash "$KIT_DIR/hooks/slop-cleaner.sh" 2>/dev/null ); }
+MEM1=$(_slop_mem); assert_output_contains "slop-mem: first Stop reports the file" "big.py" "$MEM1"
+MEM2=$(_slop_mem); assert_output_not_contains "slop-mem: second Stop (unchanged) is silent" "big.py" "$MEM2"
+printf 'x%s = 2\n' $(seq 360) > "$MEM_DIR/big.py"      # content changes, still bloated
+MEM3=$(_slop_mem); assert_output_contains "slop-mem: content change re-flags" "big.py" "$MEM3"
+rm -rf "$MEM_DIR" "$MEM_MARK"
+
 # ============================================================
 echo ""
 echo "=== session-state-save.sh (SPEC-086) ==="
@@ -723,6 +736,28 @@ printf 'q = 9\n' > "$NOGIT2/orphan.py"
   | DWARVES_KIT_SESSION_MARKER="$SCAN_MARKER" bash "$KIT_DIR/hooks/session-state-save.sh" 2>/dev/null )
 SS_NG=$(cat "$NOGIT2/.claude/session-state/last-state.md" 2>/dev/null)
 assert_output_not_contains "session-state: no scan outside a git work tree (guard)" "orphan.py" "$SS_NG"
+
+# --- cc-hyg-04: change-gated debounce. An unchanged Stop skips the rewrite+rotate;
+# a real change writes again (cuts the every-Stop tax without staleness risk).
+DB_DIR=$(mktemp -d "${TMPDIR:-/tmp}/dk-db.XXXXXX")
+( cd "$DB_DIR" && git init -q && git config user.email t@t && git config user.name t && git commit -q --allow-empty -m base )
+# DEBUG=1 makes the hook print a "skipping" line when it debounces -- a robust
+# signal (archive filenames collide at 1s resolution, so counting is flaky).
+_ss_run() { ( cd "$DB_DIR" && echo '{"stop_hook_active":false}' | DWARVES_KIT_DEBUG=1 bash "$KIT_DIR/hooks/session-state-save.sh" 2>&1 ); }
+_ss_run >/dev/null                                          # first save (establishes fingerprint)
+DB2=$(_ss_run)                                              # unchanged -> should debounce
+assert_output_contains "session-state: debounce skips when unchanged" "skipping" "$DB2"
+( cd "$DB_DIR" && git commit -q --allow-empty -m change )   # HEAD changes -> fingerprint differs
+DB3=$(_ss_run)
+assert_output_not_contains "session-state: writes again after a real change" "skipping" "$DB3"
+# finding 3: further edits to an ALREADY-dirty file (dirty COUNT unchanged) must re-save.
+# A count-based fingerprint would wrongly debounce this; a content hash re-saves.
+( cd "$DB_DIR" && echo one > tracked.txt && git add tracked.txt && git commit -q -m addfile && echo edit1 >> tracked.txt )
+_ss_run >/dev/null                                          # save with tracked.txt dirty (1 dirty file)
+( cd "$DB_DIR" && echo edit2-more >> tracked.txt )          # same file, still 1 dirty -> count unchanged
+DB4=$(_ss_run)
+assert_output_not_contains "session-state: content change to an already-dirty file re-saves (not count)" "skipping" "$DB4"
+rm -rf "$DB_DIR"
 
 rm -rf "$SCAN_DIR" "$NOGIT" "$NOGIT2" "$SCAN_MARKER"
 
@@ -1084,14 +1119,40 @@ bash "$PL" check "$ROOT" "$BASE" mig >/dev/null 2>&1; assert_exit "ledger: state
 mkdir -p "$ROOT/docs/verification"; printf '## entry\n- Command: x\n- Verdict: [UNAVAILABLE: no staging db]\n' > "$ROOT/docs/verification/mig.md"
 git -C "$ROOT" add -A; git -C "$ROOT" commit -q -m "test(db): proof unavailable"
 bash "$PL" check "$ROOT" "$BASE" mig >/dev/null 2>&1; assert_exit "ledger: stateful, [UNAVAILABLE] -> PASS" 0 "$?"
-# logged override turns a block into a pass (and leaves a trace).
+# cc-hyg-04: an override excuses docs / deploy-inert work, NOT source code.
+# (a) override on a SOURCE change -> still REJECTED (rtk-611 hole closed).
 R=$(_pl_repo); ROOT=${R% *}; BASE=${R#* }
 git -C "$ROOT" switch -q -c feat/hot; mkdir -p "$ROOT/lib"; echo z > "$ROOT/lib/z.sh"
-git -C "$ROOT" add -A; git -C "$ROOT" commit -q -m "feat(z): urgent behavior change"
+git -C "$ROOT" add -A; git -C "$ROOT" commit -q -m "feat(z): urgent source change"
 bash "$PL" check "$ROOT" "$BASE" hot >/dev/null 2>&1; assert_exit "ledger: pre-override -> BLOCK" 1 "$?"
 bash "$PL" override hot "emergency, proof to follow" >/dev/null 2>&1
-bash "$PL" check "$ROOT" "$BASE" hot >/dev/null 2>&1; assert_exit "ledger: logged override -> PASS" 0 "$?"
+bash "$PL" check "$ROOT" "$BASE" hot >/dev/null 2>&1; assert_exit "ledger: override on SOURCE -> still REJECTED (cc-hyg-04)" 1 "$?"
 assert_true "ledger: override leaves a trace" "$([ -f "$DWARVES_KIT_LOG_DIR/proof-overrides.log" ] && grep -q hot "$DWARVES_KIT_LOG_DIR/proof-overrides.log" && echo 0 || echo 1)"
+# (b) override on a docs/deploy-inert (non-source) change -> PASS.
+R=$(_pl_repo); ROOT=${R% *}; BASE=${R#* }
+git -C "$ROOT" switch -q -c feat/cfg; mkdir -p "$ROOT/deploy"; printf 'port: 8080\n' > "$ROOT/deploy/app.yaml"
+git -C "$ROOT" add -A; git -C "$ROOT" commit -q -m "chore(deploy): bump port"
+bash "$PL" check "$ROOT" "$BASE" cfg >/dev/null 2>&1; assert_exit "ledger: config-only pre-override -> BLOCK" 1 "$?"
+bash "$PL" override cfg "config-only, no behavioral claim" >/dev/null 2>&1
+bash "$PL" check "$ROOT" "$BASE" cfg >/dev/null 2>&1; assert_exit "ledger: override on deploy-inert -> PASS (cc-hyg-04)" 0 "$?"
+# (c) a `deploy` dir NESTED under source (src/deploy/) is NOT the sanctioned location -> REJECTED.
+R=$(_pl_repo); ROOT=${R% *}; BASE=${R#* }
+git -C "$ROOT" switch -q -c feat/nest; mkdir -p "$ROOT/src/deploy"; echo 'print(1)' > "$ROOT/src/deploy/core.py"
+git -C "$ROOT" add -A; git -C "$ROOT" commit -q -m "feat: nested deploy source"
+bash "$PL" override nest "trust me" >/dev/null 2>&1
+bash "$PL" check "$ROOT" "$BASE" nest >/dev/null 2>&1; assert_exit "ledger: override on src/deploy source -> REJECTED (nested deploy not sanctioned)" 1 "$?"
+# (c2) a per-tool tools/<name>/deploy/ script IS sanctioned -> override PASSES.
+R=$(_pl_repo); ROOT=${R% *}; BASE=${R#* }
+git -C "$ROOT" switch -q -c feat/tooldep; mkdir -p "$ROOT/tools/foo/deploy"; echo 'echo go' > "$ROOT/tools/foo/deploy/roll.sh"
+git -C "$ROOT" add -A; git -C "$ROOT" commit -q -m "chore: tool deploy script"
+bash "$PL" override tooldep "manual deploy verified" >/dev/null 2>&1
+bash "$PL" check "$ROOT" "$BASE" tooldep >/dev/null 2>&1; assert_exit "ledger: override on tools/*/deploy script -> PASS (sanctioned)" 0 "$?"
+# (d) an extensionless shebang script counts as source -> override REJECTED.
+R=$(_pl_repo); ROOT=${R% *}; BASE=${R#* }
+git -C "$ROOT" switch -q -c feat/shebang; printf '#!/usr/bin/env bash\necho hi\n' > "$ROOT/mytool"; chmod +x "$ROOT/mytool"
+git -C "$ROOT" add -A; git -C "$ROOT" commit -q -m "feat: extensionless tool"
+bash "$PL" override shebang "trust me" >/dev/null 2>&1
+bash "$PL" check "$ROOT" "$BASE" shebang >/dev/null 2>&1; assert_exit "ledger: override on extensionless shebang script -> REJECTED" 1 "$?"
 
 # the ship-gate HOOK itself blocks (exit 2) a behavioral change with no proof in an
 # opted-in, SPEC-LESS repo (proves the wall + the bridge), and passes when proof exists.


### PR DESCRIPTION
## Outcome

Kills two measured Stop-hook taxes and closes an override hole (cc-hygiene sub-goal 04, closes ID-238 + ID-239):

1. **slop-cleaner: resolution memory.** A flagged file nudges once per session, then stays silent until its content changes (was: same ~7 files re-flagged up to 19x, ~70 min/mo). Kept the hook (signal is useful); only the repetition was the tax.
2. **session-state-save: change-gated debounce.** An unchanged Stop skips the rewrite+rotate (was: every-Stop, ~38 min/mo). Fingerprint = `branch|dirty|HEAD`, excluding the hook's own output. Chosen over time-debounce (zero staleness risk) and over keep-every-Stop.
3. **proof-gate override: reject source remainder.** An override no longer blanket-passes a branch that changes application source code outside `deploy/` (closes rtk-611, where an overridden branch shipped a broken source change reverted 9h later). Deploy scripts under `deploy/` stay override-able (verified via deploy-proof/UAT per SPEC-095).

## Proof

All 11 CI suites green (0 failures). New tests: slop resolution memory (report once / silent / re-flag on change), session-state debounce (skip unchanged / write after change), override (source→REJECTED, deploy-inert→PASS), test-deployable-done AC4b (non-deploy source override→blocked).

| Command | Exit | Output |
|---|---|---|
| `bash tests/test-hooks.sh` | 0 | Passed: 445/445 |
| `bash tests/test-deployable-done.sh` | 0 | 17/17 passed |
| (9 more CI suites) | 0 | all green |

Full run-table + negative control: `docs/verification/cc-hyg-04-stop-tax.md`.

## Decisions

- slop-cleaner KEPT (not dropped): the bloat signal is worth it, repetition was the tax.
- session-state DEBOUNCED (change-gated), not keep-every-Stop.

## Meta

- Closes ops-toolkit **ID-238** + **ID-239**. Lane `full` (kit-machinery). gate-ledger run `cc-hyg-04`.
- Part of the ops-toolkit **cc-hygiene** mega-goal: `ops-toolkit/_meta/megagoals/cc-hygiene/ROADMAP.md` (sub-goal 04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
