### PR TITLE
feat(execute): cheap-first sonnet worker default + meta-agent Mode B alignment

### DIFF
--- a/agents/meta-agent.md
+++ b/agents/meta-agent.md
@@ -77,15 +77,17 @@ ablation ledger is available, ask the router for the measured-cheapest-at-parity
 ```
 bash lib/route-suggest.sh <ledger.tsv> <task-or-fixture-name>
 # SUGGEST  model=<tier>  ... -> write that tier into the bare `Model:` line
-# ABSTAIN  reason=thin-data ... -> OMIT the `Model:` line (inherit the parent tier); never overfit
+# ABSTAIN  reason=thin-data ... -> write `Model: sonnet` (the cheap-first default, SPEC-107); OMIT only to deliberately inherit
 ```
 
 It is a SUGGESTER, not an auto-router: surface the suggestion (or the abstention) in the draft's
 `## Notes` so the human sees the basis. Effort is not in SG-09's measured schema, so the router
-abstains on effort; leave `Effort:` to inherit unless the human sets it. With no ledger, omit both
-lines (inherit) and say so. The default heuristic when abstaining: most sub-goals do not need opus
-(Opus dominated measured spend), so a human-set default of `sonnet` with `opus` reserved for genuinely
-hard reasoning is the safe fallback, but that is the human's call, not a silent auto-write.
+abstains on effort; leave `Effort:` to inherit unless the human sets it. With no ledger, write
+`Model: sonnet` (the cheap-first default) and OMIT `Effort:` (inherit), saying the basis is the
+SPEC-107 default, not a measurement. The stance (SPEC-107, reversing the earlier "human's call"):
+most sub-goals do not need opus (Opus dominated measured spend), so `sonnet` is the WRITTEN default
+on abstain, `opus` reserved for genuinely hard reasoning, and OMIT available as a deliberate
+"inherit the parent tier" choice a human can still pick.
 
 ## DRAFT marker (mandatory)
 

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -149,6 +149,15 @@ non-reused task; the worker itself is the same Task-tool dispatch as always.
 > the lead's context is worth the setup overhead, NOT for one-prompt tasks, a single tool call,
 > or when near a rate/budget limit. (research/2026-06-28-token-efficient-design.md Part 1.)
 
+**Model tiering (SPEC-107, cheap-first default).** Workers dispatch at `sonnet` by default ,
+mid-tier is the stated cheap-first stance (SPEC-087: Opus only on the hard sub-goals). The active
+spec's optional bare `Model:` header is the hard-reasoning escape hatch: a spec carrying
+`Model: opus` dispatches its workers on opus; absent, workers default to sonnet. Verifiers keep
+their own frontmatter tiers (unchanged). A fable-tier session still dispatches workers at sonnet ,
+the cheap-first default is stated policy, not a silent down-tier (SPEC-078: an explicit tier
+override is intentional). If the dispatch surface cannot pass a model override, omit it and note
+that in the run record (the SPEC-078 / review-team graceful-degrade clause).
+
 For each task, use the **Task tool** with this prompt structure (when 2b-0 produced a specialist PREAMBLE, that preamble REPLACES the generic "You are implementing a single task…" opener below):
 
 ```

--- a/docs/implementation-notes/SPEC-107-tier-defaults.md
+++ b/docs/implementation-notes/SPEC-107-tier-defaults.md
@@ -1,0 +1,34 @@
+# Implementation notes: SPEC-107 tier-defaults
+
+Delta from the spec. References, does not restate.
+
+## 2026-07-03 spec-validate findings resolved (wiring gate + honest "one stance")
+
+- **Context:** the adversarial spec-validate returned CHANGES-REQUIRED. Two HIGH findings:
+  (#1) the first-draft fixture re-encoded the sonnet-default rule inside the test (a
+  tautology), not exercising a real dispatch reader, so it failed the mega-goal's binding
+  WIRING GATE 04 ("the DEFAULT tier is actually APPLIED at dispatch; `_route`/execute reads
+  it"); (#2) `_route()` (orchestrate.sh:396-403) treats an omitted goal-file `Model:` as
+  INHERIT, not sonnet, so a naive "one stance = sonnet default" claim was a fresh contradiction.
+- **Decision:** do NOT modify `_route()`. Goal-file 04 lists exactly three surfaces and says
+  "Not: a fourth tier surface"; `_route` is the dispatch engine, not a surface. The sonnet
+  default is a **write-time** default (surfaces 2+3 bake `Model: sonnet` INTO goal files); the
+  existing `_route` reader then honors that explicit line at dispatch. The "positive default
+  applied at dispatch, `_route` reads it" proof is the EXISTING test-orchestrate.sh:187-206
+  fixture (a goal file carrying `Model: sonnet` -> orchestrator dispatches `--model sonnet`),
+  cited, not re-encoded.
+- **Why:** reconciles the goal-file's "Not: a fourth tier surface" with the ROADMAP wiring
+  gate's "`_route`/execute reads it" without a `lib/` edit (keeps `normal` lane) and without a
+  behavior change to core orchestrate routing. `_route`'s absent->inherit fallback is unchanged
+  and IS the "deliberate OMIT = inherit" path assumption 04 wants preserved.
+- **Honest split (finding #2):** the spec now names it explicitly , sonnet is the WRITE-TIME
+  default (surfaces write the line); `_route`'s READ-TIME behavior on a hand-omitted line stays
+  inherit. "One stance" is scoped to the authoring surfaces, not a claim that `_route` was
+  changed.
+- **Findings #3/#4 folded in:** verification gains a NEGATIVE grep proving the old meta-agent
+  contradiction text ("human's call, not a silent auto-write") is GONE, not just that new text
+  was added; and the spec adds no re-encoded `^Model:` grep (the `_route` reader is the single
+  source, no divergent duplicate).
+- **Surface-2 (dotfiles) is a LOCAL proof, not kit CI:** the template lives in the dotfiles
+  repo (absolute `~/workspace/tieubao/dotfiles/...`), unreadable by kit CI, so its grep is a
+  proof-table row run locally, never a `tests/` assertion.

--- a/docs/implementation-notes/kit-face-wave.md
+++ b/docs/implementation-notes/kit-face-wave.md
@@ -1,0 +1,33 @@
+# Implementation notes: kit-face wave (cross-cutting)
+
+Delta-log for decisions that span the whole kit-face mega-goal (roadmap:
+ops-toolkit `_meta/megagoals/kit-face/`), not any single spec. Per-spec deltas live in
+their own `docs/implementation-notes/SPEC-NNN-*.md`.
+
+## 2026-07-03 execution architecture (lead session anchored in ops-toolkit)
+
+- **Context:** the `/goal` loop driving this wave runs in a session whose cwd is
+  `~/workspace/tieubao/ops-toolkit` (where the mega-goal ROADMAP lives), NOT
+  `dwarves-kit`. ops-toolkit is ALSO kit-adopted.
+- **Decision:** the lead authors the kit artifacts (specs, command/agent edits, tests,
+  proofs) directly in `dwarves-kit` via absolute paths, runs `dwarves-kit`'s own test
+  scripts, dispatches the kit's verifier AGENTS (`kit:task-verifier`,
+  `kit:integration-verifier`, `kit:recheck-verifier`) with cwd pinned to `dwarves-kit`,
+  and records the gate-ledger entries the ship-gate requires.
+- **Why:** invoking the `/kit:*` slash-commands from an ops-toolkit-rooted session would
+  operate on the WRONG repo and could scaffold specs into ops-toolkit. Authoring directly
+  + running the real tests + dispatching cwd-pinned verifier agents fulfils the V-model
+  intent (real gates ran, real proofs) without the cross-repo contamination risk.
+- **Impact:** the phase discipline and proofs are honored; only the invocation surface
+  differs from a native in-repo `/kit:execute`.
+
+## 2026-07-03 branch topology (in-place, not worktrees)
+
+- **Decision:** feature branches `feat/kit-face-NN-<slug>` are created in-place in the
+  `dwarves-kit` main checkout (07 stacked on 06's branch; the rest off `master`), per the
+  mega-goal's explicit stacked-PR + retarget flow.
+- **Why:** the goal's stacked/auto-bottom-up/retarget merge posture is an explicit operator
+  instruction (overrides the default "branch into a worktree" rule); the lead is sequential
+  (one sub-goal at a time), so there is no parallel-writer index.lock collision the worktree
+  rule guards against. `dwarves-kit` is a separate repo from the lead's session cwd, so no
+  collision with ops-toolkit either.

--- a/docs/specs/SPEC-107-tier-defaults.md
+++ b/docs/specs/SPEC-107-tier-defaults.md
@@ -1,0 +1,99 @@
+# SPEC-107: cheap-tier defaults (three surfaces, one stance)
+
+Status: VALIDATED
+Lane: normal
+Type: spec-feature
+
+## Problem
+
+The kit's cheap-first routing stance (SPEC-087: "Opus dominated measured spend; the biggest
+$ lever is Opus only on the hard sub-goals") is stated in prose but is NOT the default on the
+three AUTHORING surfaces that decide a worker/sub-goal tier, and they disagree:
+
+1. **`commands/execute.md` worker dispatch (2b)** names no per-worker model, so task workers
+   INHERIT the session tier. A run started on opus dispatches every worker on opus , the exact
+   opus-for-everything cost SPEC-087 warns against.
+2. **The `plan-for-mega-goal` subgoal-template** (dotfiles) offers `Model: <haiku | sonnet |
+   opus, or OMIT ... to inherit>` , the placeholder shape makes "inherit" the path of least
+   resistance, not the cheap default.
+3. **`agents/meta-agent.md` Mode B** abstains to OMIT (inherit) and records "a human-set
+   default of `sonnet` ... is the safe fallback, but that is the human's call, not a silent
+   auto-write" , the opposite of a cheap default.
+
+Result: no single stance. The mega-goal (roadmap: ops-toolkit `_meta/megagoals/kit-face/`)
+resolves this to `sonnet` default across all three (ROADMAP `## Assumptions` 04).
+
+## Solution
+
+One stance , `sonnet` is the default worker/sub-goal tier; `opus` is the explicit
+hard-reasoning escape hatch , expressed consistently on all three AUTHORING surfaces:
+
+1. **execute.md 2b:** workers dispatch at `sonnet` by default. The active spec's optional bare
+   `Model:` header is the hard-reasoning escape hatch: a spec carrying `Model: opus` dispatches
+   its workers on opus; absent, workers dispatch sonnet. Verifiers keep their own frontmatter
+   tiers (unchanged). A fable-tier session STILL dispatches workers at sonnet , the cheap-first
+   default is a stated policy that applies regardless of session tier, not a silent down-tier
+   (consistent with SPEC-078's "an explicit tier override is intentional"). If the dispatch
+   surface cannot pass a model override, omit it and note that (the SPEC-078 / review-team
+   graceful-degrade clause).
+2. **dotfiles subgoal-template:** the `Model:` placeholder defaults to `sonnet` (bare line),
+   with OMIT documented as a DELIBERATE "inherit the parent tier" choice, not the default.
+3. **meta-agent Mode B:** on ABSTAIN, write `Model: sonnet` (the safe cheap default) instead of
+   OMITting. OMIT stays documented as the explicit "deliberate inherit" option; the abstain path
+   no longer leaves the field to chance. The two old contradiction lines (`-> OMIT the Model:
+   line` and "that is the human's call, not a silent auto-write") are rewritten, not merely
+   supplemented.
+
+**Write-time default, read-time honored (the honest scope of "one stance").** The sonnet
+default is applied at AUTHORING time: surfaces 2+3 bake `Model: sonnet` INTO each goal file.
+The existing dispatch reader `_route()` (lib/orchestrate.sh:396-403) then reads that explicit
+line and dispatches `--model sonnet` , this is the genuine "default applied at dispatch" (proven
+by the existing test-orchestrate fixture, below), NOT a re-encoded rule in a test. `_route()`
+itself is UNCHANGED: its absent->inherit fallback is exactly the "deliberate OMIT = inherit"
+path assumption 04 preserves. So "one stance" means the three authoring surfaces agree on
+`sonnet`; it does not claim `_route`'s omit-fallback was changed (it was not). No `lib/`/`hooks/`
+edit , `normal` lane.
+
+## Verification
+
+```bash
+cd dwarves-kit
+# Surface 1 (execute.md): sonnet default + spec Model escape hatch stated
+grep -qiE 'workers dispatch (at )?sonnet by default|default(s)? (to )?sonnet' commands/execute.md
+grep -qiE 'Model:.*(escape hatch|hard[- ]reasoning|override)' commands/execute.md
+# Surface 3 (meta-agent Mode B): sonnet-on-abstain written; old contradiction GONE (negative control)
+grep -qiE 'write .*Model: sonnet|sonnet-on-abstain' agents/meta-agent.md
+! grep -qF "human's call, not a silent auto-write" agents/meta-agent.md
+! grep -qE '->[[:space:]]*OMIT the .?Model:.? line' agents/meta-agent.md
+# Positive default APPLIED AT DISPATCH via the real reader (a goal file carrying the
+# template-default Model: sonnet is dispatched --model sonnet); + the opus/inherit cases:
+bash tests/test-orchestrate.sh   # incl. :187-206 mixed-tier fixture (Model: sonnet -> dispatch sonnet)
+bash tests/test-meta.sh          # green incl. the new tier-defaults surface block; frontmatter lint still green
+bash tests/test-meta-agent.sh    # Mode B stance rewrite does not break the meta-agent suite
+
+# Surface 2 (dotfiles half, LOCAL proof only , path absent in kit CI):
+grep -qE '^Model: sonnet' ~/workspace/tieubao/dotfiles/home/dot_claude/skills/plan-for-mega-goal/references/subgoal-template.md
+```
+
+## After state
+
+- `commands/execute.md` 2b states workers dispatch sonnet by default + the spec `Model:` escape
+  hatch + the fable-session clause.
+- `agents/meta-agent.md` Mode B writes `Model: sonnet` on abstain; the two old contradiction
+  lines are rewritten; OMIT documented as deliberate inherit.
+- The dotfiles `plan-for-mega-goal` subgoal-template defaults `Model: sonnet` (applied via
+  `chezmoi apply`, staged+committed atomically per the S-64 watcher rule).
+- `tests/test-meta.sh` carries a tier-defaults block: surface-1 + surface-3 greps + the
+  surface-3 negative control (no residual contradiction text).
+- `docs/verification/tier-defaults.md` carries the run-table, incl. the test-orchestrate
+  dispatch proof and the local dotfiles diff.
+
+## Open questions
+
+The "default applied at dispatch" is real for the goal-file path (`_route` reads the
+template-written `Model: sonnet`), and lead-driven for the execute.md worker path (execute.md is
+a prompt; the Task-tool worker dispatch has no shell reader , the sonnet default is instruction
+prose, grep-pinned, the accepted SPEC-078 fidelity, test-meta.sh:2266 precedent). No `lib/`
+helper is added: a machine-enforced worker-tier reader would escalate to `full` lane and
+duplicate `_route`'s `^Model:` extraction; filed to mega NOTES if lead-driven prose ever proves
+insufficient.

--- a/docs/verification/tier-defaults.md
+++ b/docs/verification/tier-defaults.md
@@ -1,0 +1,91 @@
+# Proof of done: cheap-tier defaults (SPEC-107, kit-face wave)
+
+The kit's cheap-first stance (`sonnet` default, `opus` = explicit hard-reasoning escape hatch)
+is now consistent across the three authoring surfaces, and the positive default is APPLIED at
+dispatch by the existing `_route` reader (a goal file carrying the template-default `Model:
+sonnet` dispatches `--model sonnet`), not merely asserted.
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | execute.md 2b: workers dispatch `sonnet` by default + the spec `Model:` header escape hatch + fable-session clause | PASS |
+| 2 | meta-agent Mode B writes `Model: sonnet` on abstain (was OMIT/inherit) | PASS |
+| 3 | dotfiles subgoal-template defaults `Model: sonnet` (surface 2, applied + committed atomically) | PASS |
+| 4 | Positive default APPLIED at dispatch via `_route` (goal file `Model: sonnet` -> `--model sonnet`) | PASS |
+| 5 | NEGATIVE CONTROL: an explicit `Model: opus`/none override still routes correctly (opus / inherit unchanged) | PASS |
+| 6 | NEGATIVE CONTROL: the old meta-agent contradiction text ("human's call…"; "OMIT the Model: line") is GONE, not merely supplemented | PASS |
+| 7 | `test-meta.sh`, `test-meta-agent.sh`, `test-orchestrate.sh` all green; agent-frontmatter lint still green | PASS |
+
+## Implementation
+
+- `commands/execute.md` 2b: "Model tiering (SPEC-107, cheap-first default)" paragraph , sonnet
+  default, spec `Model:` escape hatch, verifiers keep frontmatter tiers, fable-session + degrade
+  clauses (:152-159).
+- `agents/meta-agent.md` Mode B: abstain writes `Model: sonnet` (:80) and the stance paragraph
+  rewritten (the two old contradiction lines removed).
+- `tests/test-meta.sh`: SPEC-107 block , surface-1 + surface-3 greps + 2 negative controls.
+- dotfiles `plan-for-mega-goal/references/subgoal-template.md`: `Model: sonnet` default (value
+  line clean; guidance moved to the explanation bullet). Committed atomically (S-64 watcher):
+  dotfiles `9dd5c48`.
+- No `lib/`/`hooks/` edit , `_route` is UNCHANGED; the default is baked in by the authoring
+  surfaces and honored by `_route`'s existing `^Model:` read. `normal` lane held.
+
+## Confirmation run-table
+
+| Case | Command | Expected | Observed |
+|---|---|---|---|
+| s1 default | `grep -iE 'workers dispatch at .?sonnet.? by default' commands/execute.md` | match | match (:152) |
+| s1 escape hatch | `grep -iE 'Model:.*(escape hatch\|hard[- ]reasoning\|override)' commands/execute.md` | match | match (:154) |
+| s3 sonnet-on-abstain | `grep -iE 'write .?Model: sonnet' agents/meta-agent.md` | match | match (:80) |
+| s3 NC1 | `grep -F "human's call, not a silent auto-write" agents/meta-agent.md` | no match | exit 1 (absent) |
+| s3 NC2 | `grep -E 'OMIT the .?Model:.? line' agents/meta-agent.md` | no match | exit 1 (absent) |
+| s2 dotfiles | `grep -E '^Model: sonnet' <subgoal-template.md>` (source + target) | match | match (:14 both) |
+| dispatch (positive default) | `bash tests/test-orchestrate.sh` , SG-01 fixture carries `Model: sonnet` | routes `--model sonnet` | PASS "run passes --model/--effort for hinted SG-01" |
+| dispatch (NC inherit) | same , SG-02 fixture carries no Model | no `--model` (inherit) | PASS "run passes no --model for inherit SG-02" |
+| suite: meta | `bash tests/test-meta.sh` | all green | 583/583 |
+| suite: meta-agent | `bash tests/test-meta-agent.sh` | all green | 65/65 |
+| suite: orchestrate | `bash tests/test-orchestrate.sh` | all green | ALL PASS |
+
+## Run detail (captured 2026-07-03)
+
+```
+$ grep -niE 'workers dispatch at .?sonnet.? by default' commands/execute.md
+152:**Model tiering (SPEC-107, cheap-first default).** Workers dispatch at `sonnet` by default ,
+
+$ grep -niE 'write .?Model: sonnet' agents/meta-agent.md
+80:# ABSTAIN  reason=thin-data ... -> write `Model: sonnet` (the cheap-first default, SPEC-107); OMIT only to deliberately inherit
+
+$ grep -nF "human's call, not a silent auto-write" agents/meta-agent.md ; echo exit=$?
+exit=1                          # negative control: contradiction removed
+
+$ grep -nE 'OMIT the .?Model:.? line' agents/meta-agent.md ; echo exit=$?
+exit=1                          # negative control: old abstain phrasing removed
+
+# dotfiles half (surface 2), applied + committed atomically:
+$ grep -n '^Model: sonnet' ~/.claude/skills/plan-for-mega-goal/references/subgoal-template.md
+14:Model: sonnet
+$ git -C ~/workspace/tieubao/dotfiles log -1 --oneline
+9dd5c48 feat(plan-for-mega-goal): default subgoal-template Model to sonnet
+
+# dispatch proof (the default applied at dispatch by _route):
+$ bash tests/test-orchestrate.sh   # SG-01 fixture Model: sonnet
+PASS dry-run shows SG-01 routed model/effort
+PASS run passes --model/--effort for hinted SG-01
+PASS dry-run shows SG-02 inherit (no hints)      # NC: absent -> inherit (unchanged)
+PASS run passes no --model for inherit SG-02
+
+$ bash tests/test-meta.sh
+Passed: 583 / 583 ; All meta tests passed.
+```
+
+## Reproduce
+
+```bash
+cd dwarves-kit
+bash tests/test-meta.sh && bash tests/test-meta-agent.sh && bash tests/test-orchestrate.sh
+grep -niE 'workers dispatch at .?sonnet.? by default' commands/execute.md
+grep -niE 'write .?Model: sonnet' agents/meta-agent.md
+! grep -qF "human's call, not a silent auto-write" agents/meta-agent.md
+grep -n '^Model: sonnet' ~/workspace/tieubao/dotfiles/home/dot_claude/skills/plan-for-mega-goal/references/subgoal-template.md
+```

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -2516,6 +2516,26 @@ is_on_review_axis "foo-checker" && RC=1
 is_on_review_axis "foo-auditor" && RC=1
 assert_eq "negative control: is_on_review_axis REJECTS off-axis fake names" 0 $RC
 
+# ============================================================
+# SPEC-107: cheap-tier defaults , three authoring surfaces, one sonnet-first stance.
+# (Surface 2, the plan-for-mega-goal subgoal-template, lives in the dotfiles repo and
+#  is proven by a LOCAL diff, not here , its path is absent in CI.)
+# ============================================================
+EX="$KIT_DIR/commands/execute.md"
+RC=0; grep -qiE 'workers dispatch at .?sonnet.? by default' "$EX" || RC=1
+assert_eq "execute.md workers default to sonnet (SPEC-107 surface 1)" 0 $RC
+RC=0; grep -qiE 'Model:.*(escape hatch|hard[- ]reasoning|override)' "$EX" || RC=1
+assert_eq "execute.md names the spec Model: escape hatch (SPEC-107 surface 1)" 0 $RC
+
+MA="$KIT_DIR/agents/meta-agent.md"
+RC=0; grep -qiE 'write .?Model: sonnet' "$MA" || RC=1
+assert_eq "meta-agent Mode B writes Model: sonnet on abstain (SPEC-107 surface 3)" 0 $RC
+# Negative controls: the OLD contradicting stance is GONE, not merely supplemented.
+RC=0; grep -qF "human's call, not a silent auto-write" "$MA" && RC=1
+assert_eq "negative control: old 'human's call' contradiction removed from meta-agent" 0 $RC
+RC=0; grep -qE 'OMIT the .?Model:.? line' "$MA" && RC=1
+assert_eq "negative control: old 'OMIT the Model: line' abstain removed from meta-agent" 0 $RC
+
 echo ""
 echo "=== Results ==="
 # ============================================================


### PR DESCRIPTION
Cheap-tier defaults unified across the three authoring surfaces (SPEC-107, kit-face wave):

- **execute.md 2b**: workers dispatch `sonnet` by default; the active spec's optional bare `Model:` header is the hard-reasoning escape hatch (`Model: opus` → workers on opus); verifiers keep frontmatter tiers; fable sessions still dispatch workers at sonnet (stated policy, not silent down-tier, SPEC-078).
- **meta-agent Mode B**: writes `Model: sonnet` on abstain, reversing the earlier "human's call" stance; the two old contradiction lines are removed (negative-control tested), OMIT documented as the deliberate-inherit choice.
- **subgoal-template** (dotfiles half, `9dd5c48`, applied atomically): defaults `Model: sonnet`.

The positive default is **applied at dispatch** by the existing `_route` reader (a goal file carrying the template-default `Model: sonnet` dispatches `--model sonnet`; test-orchestrate fixture) — not re-encoded in a test. `_route` is unchanged; its absent→inherit fallback is the deliberate-OMIT path. `normal` lane (no lib/hooks edit).

**Verify:** `bash tests/test-meta.sh` (583/583, incl. the SPEC-107 surface greps + 2 negative controls) + `bash tests/test-meta-agent.sh` (65/65) + `bash tests/test-orchestrate.sh` (ALL PASS; the `_route` dispatch proof + inherit NC). Proof-of-done: `docs/verification/tier-defaults.md`.

Roadmap: ops-toolkit `_meta/megagoals/kit-face/ROADMAP.md` (sub-goal 04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
