### PR TITLE
feat(ui-design): UI done-modes + bounded quiescence loop

### DIFF
--- a/commands/ui-design.md
+++ b/commands/ui-design.md
@@ -74,6 +74,20 @@ Present the verdict + findings:
 - **REVISE**: enter Phase B (Step 5).
 - **RECONSIDER**: surface that the direction is fundamentally wrong; stop, do not regenerate.
 
+## Done-mode (SPEC-112): how much verification this UI sub-goal owes
+
+`$ARGUMENTS` may carry a `Done-mode:` flag , one of **proof** (default) | **over-test** |
+**quiescence** , chosen per UI sub-goal at decompose time (the subgoal-template `Done-mode:`
+field). **proof is the mandatory floor; over-test and quiescence are opt-in escalations.** Final
+acceptance stays a `gate` in EVERY mode , taste ships past the human eyeball only.
+
+- **proof** (default, if unspecified): the current bar , real-surface flows + 2-3 captures + a11y.
+  Phase B below runs as the plain bounded REVISE loop (cap 2).
+- **over-test**: proof, PLUS a `/kit:test-plan` matrix + `/kit:verify` execution, PLUS a
+  COVERAGE-DELTA row appended to the proof-of-done run-table , `ACs-covered / tests-added`,
+  before-vs-after (what the over-test pass added over the proof floor).
+- **quiescence**: Phase B is EXTENDED into a converging loop (Step 5 "quiescence branch" below).
+
 ## Step 5: Phase B, bounded auto-revise loop
 
 On a `REVISE` verdict, loop (max **2** regenerations, matching the fix-agent cap):
@@ -84,6 +98,32 @@ On a `REVISE` verdict, loop (max **2** regenerations, matching the fix-agent cap
 4. **Terminate** on `SOLID` (done), `RECONSIDER` (stop immediately, do not regenerate), or the max-iterations cap (stop, surface the last critique). A `frontend-design` error mid-loop also terminates the loop with the last successful critique.
 
 There is no numeric score threshold: `/kit:visual-team` returns a categorical verdict (plus per-lens scores), and `SOLID` is its "it holds" signal. Do not invent a combined score.
+
+### Step 5 quiescence branch (Done-mode: quiescence, SPEC-112)
+
+When `Done-mode: quiescence`, Phase B EXTENDS into a converging loop (it does NOT replace the plain
+REVISE loop above; `visual-team` stays single-pass stateless). Each round: critique (Step 3) -> apply
+the ACCEPTED fixes (the per-round approval Phase B already has) -> re-render -> re-critique.
+
+- **Stop condition (two-sided, load-bearing):** stop when a round yields **zero NEW findings >=HIGH AND no OPEN finding >=HIGH remains** (both halves, on purpose). "zero NEW" ALONE is not enough , a round that re-finds an
+  unresolved CRITICAL has zero NEW but an OPEN >=HIGH, so it does NOT quiesce (the falsely-calm
+  trap). Severity floor is `>=HIGH` (the kit has no MAJOR); MEDIUM/LOW findings DEFER, they do not
+  block.
+- **Round cap: 3** (test-plan-review-team parity). The plain REVISE loop above keeps its cap of 2
+  (fix-agent parity); the divergence is deliberate (DEC-018).
+- **Audit markers:** each round emits `[[QL-VERDICT round=N clean=BOOL findings=K]]` (clean = zero
+  NEW >=HIGH and no OPEN >=HIGH); the loop lead carries a cross-round dedup ledger IN-SESSION and
+  tags each finding `[resolved in round N | OPEN]`.
+- **Deferred findings:** sub-floor (<HIGH) findings + anything still OPEN at the cap land in a
+  `### Deferred findings` subsection. **The ui-design loop lead APPENDS `### Deferred findings` to
+  the FINAL `## Visual critique` AFTER the loop terminates** , an explicit carve-out to Step 3's
+  "do not write `## Visual critique` yourself" rule, because `visual-team` REWRITES that section
+  every round and is stateless (it cannot hold the cross-round deferred ledger). Appending
+  post-termination is why round N+1's rewrite does not eat it.
+- **Persona (06 dependency):** each round re-runs Step 3, which already threads the brief's
+  `Persona:` line into `visual-team`, so a supplied persona's 6th lens fires every quiescence round.
+- Terminate exactly as Phase B otherwise does on `SOLID` / `RECONSIDER` / a `frontend-design` error;
+  the quiescence stop + cap 3 are the additional terminations. Final acceptance stays a `gate`.
 
 ## Notes
 - Opt-in, report-only; never hard-gates `/kit:spec` or any build. The maintainer decides whether to proceed.

--- a/docs/implementation-notes/SPEC-112-done-modes.md
+++ b/docs/implementation-notes/SPEC-112-done-modes.md
@@ -1,0 +1,33 @@
+# Implementation notes: SPEC-112 done-modes
+
+Delta from the spec. References, does not restate.
+
+## 2026-07-03 spec-validate: CHANGES-REQUIRED, 2 HIGH + 4 minor folded
+
+- **F1 (HIGH):** the goal's crux proof (the fixture traces) was promised in After-state but not
+  pinned in the executable Verification. Fix: `docs/verification/done-modes.md` carries 4 worked
+  traces (converge / cap-out / no-false-quiescence / plain-REVISE regression) and test-meta greps
+  them, so the proof cannot pass on contract text alone.
+- **F2 (HIGH):** `### Deferred findings` authorship was undefined and collided with two live rules
+  (ui-design Step 3 says the loop must NOT write `## Visual critique`; visual-team REWRITES it each
+  round + is stateless). Resolved: the ui-design LOOP LEAD appends `### Deferred findings` to the
+  FINAL `## Visual critique` AFTER the loop terminates , an explicit carve-out, so round N+1's
+  rewrite cannot eat it. Pinned in ui-design.md + the spec + the proof.
+- **F3 (MEDIUM):** the two-sided-stop grep had an escape hatch (`|no OPEN .*HIGH` passed a one-sided
+  condition). Removed , the pin now requires the full `zero NEW >=HIGH AND no OPEN >=HIGH`
+  conjunction. (Also: the stop-condition text had wrapped across two lines, defeating the
+  line-based grep; put it on one line.)
+- **F4 (MEDIUM):** ">=HIGH is one notch stricter" was inverted. Reworded: the BLOCKING threshold is
+  one notch HIGHER (HIGH vs test-plan-review-team's MEDIUM); MEDIUM/LOW DEFER, not block.
+- **F5 (NIT):** noted why the strictly-falling-findings guard is NOT adopted (the two-sided severity
+  stop + hard cap 3 bound the loop; resolving a CRITICAL while surfacing a MEDIUM is progress).
+- **F6 (NIT):** the dotfiles `Done-mode:` field is marked UI-ONLY / OMIT-for-non-UI (like the
+  Persona line); the 06 persona dependency is closed explicitly (each quiescence round re-runs Step
+  3, which threads the brief's Persona line).
+
+## Notes
+
+- The quiescence loop is prose (ui-design has no shell dispatcher; not in CI, downstream-facing), so
+  the fixtures are worked round-sequence TRACES, and the load-bearing NC (a re-found CRITICAL does
+  not quiesce) is pinned structurally via the two-sided-conjunction grep + the trap statement.
+- Dotfiles half committed atomically: dotfiles `ac2c6a4`.

--- a/docs/specs/SPEC-112-done-modes.md
+++ b/docs/specs/SPEC-112-done-modes.md
@@ -1,0 +1,117 @@
+# SPEC-112: UI done-modes + quiescence loop
+
+Status: VALIDATED
+Lane: normal
+Type: spec-feature
+
+## Problem
+
+`/kit:ui-design`'s Phase B (Step 5) is a single bounded auto-revise loop (max 2 regenerations)
+with one fixed rigor. A UI sub-goal cannot declare HOW MUCH verification it owes: a trivial tweak
+and a flagship surface get the same treatment, and there is no "polish until the critique stops
+finding real issues" mode. The mega-goal (roadmap: ops-toolkit `_meta/megagoals/kit-face/`,
+assumptions 07) resolves this with three declared done-modes, consumed as a `/kit:ui-design`
+`$ARGUMENTS` flag.
+
+## Solution
+
+Three done-modes; **proof is the mandatory floor, over-test + quiescence are opt-in escalations
+chosen per UI sub-goal at decompose time** (proof if unspecified):
+
+1. **proof** (default) , the current bar: real-surface flows + 2-3 captures + a11y. Every UI
+   sub-goal gets at least this.
+2. **over-test** , proof + a `/kit:test-plan` matrix + `/kit:verify` execution + a COVERAGE-DELTA
+   row (ACs-covered / tests-added, before-vs-after) appended to the proof-of-done run-table.
+3. **quiescence** , Phase B EXTENDED into a converging loop: critique -> apply accepted fixes ->
+   re-render -> re-critique. **Stop when a round yields zero NEW findings >=HIGH AND no OPEN
+   finding >=HIGH remains** (two-sided by design), or at round cap 3. The loop lead carries a
+   cross-round dedup ledger in-session; each round emits a `[[QL-VERDICT round=N clean=BOOL
+   findings=K]]` marker (test-plan-review-team precedent) and tags each finding `[resolved in
+   round N | OPEN]`; sub-floor (<HIGH) + capped-out findings land in a `### Deferred findings`
+   subsection of the spec's `## Visual critique`. **Authorship (spec-validate F2):** the ui-design
+   LOOP LEAD appends `### Deferred findings` to the FINAL `## Visual critique` AFTER the loop
+   terminates , an explicit carve-out to ui-design's "do not write `## Visual critique` yourself"
+   rule (ui-design.md Step 3), because visual-team REPLACES that section every round and is
+   single-pass stateless (it cannot hold the cross-round deferred ledger, which is the loop lead's
+   in-session state). Appending post-termination avoids round N+1's replace eating it.
+
+**Final acceptance stays `gate` in every mode** , taste ships past the human eyeball only.
+`visual-team` stays single-pass stateless (quiescence extends ui-design's loop, not visual-team).
+
+**The two-sided stop is load-bearing (the named NC).** "zero NEW" ALONE falsely quiesces when a
+round re-finds an unresolved CRITICAL (it is not NEW, but it is OPEN and >=HIGH); the "AND no OPEN
+>=HIGH" clause pins this. Severity floor is >=HIGH (the kit has no MAJOR): the BLOCKING threshold
+sits one notch HIGHER than test-plan-review-team's "only LOW remain" (HIGH vs MEDIUM) , MEDIUM/LOW
+findings DEFER rather than block (they land in `### Deferred findings`), so the loop converges on
+the high-severity surface, not cosmetic churn. The strictly-falling-findings guard
+(test-plan-review-team) is deliberately NOT adopted , the two-sided severity stop + hard cap 3
+already bound the loop, and a round that resolves a CRITICAL while surfacing a new MEDIUM is
+progress, not a stall.
+
+**Cap divergence (a DEC).** quiescence caps at 3 (test-plan-review-team parity); the plain REVISE
+loop keeps cap 2 (fix-agent parity) , recorded as DEC-018 so the divergence is not read as an
+inconsistency.
+
+`Done-mode:` becomes a subgoal-template field (dotfiles half), next to `Proof:`.
+
+## Verification
+
+```bash
+cd dwarves-kit
+# Done-mode flag consumed + branches per mode (the wiring gate: ui-design reads the flag)
+grep -qiE 'Done-mode' commands/ui-design.md
+grep -qiE 'proof|over-test|quiescence' commands/ui-design.md
+# quiescence stop condition is TWO-SIDED (the no-false-quiescence NC): zero NEW >=HIGH AND no OPEN >=HIGH
+grep -qiE 'zero NEW.*>=?HIGH.*(AND|and).*no OPEN.*>=?HIGH' commands/ui-design.md   # full conjunction, no one-sided escape
+grep -qiE 're-found|re-find|still OPEN|does NOT quiesce|falsely quiesce' commands/ui-design.md   # the NC is stated
+# QL-VERDICT markers + resolved/OPEN tags + Deferred findings subsection
+grep -qF '[[QL-VERDICT' commands/ui-design.md
+grep -qiE 'resolved in round|OPEN\]' commands/ui-design.md
+grep -qiE 'Deferred findings' commands/ui-design.md
+# cap divergence: quiescence 3, plain REVISE still 2 (regression control) + the DEC
+grep -qiE 'cap.*3|round cap 3|3 rounds' commands/ui-design.md
+grep -qiE 'max .?2|cap .?2' commands/ui-design.md   # plain REVISE unchanged
+grep -q 'DEC-018' docs/specs/SPEC-112-done-modes.md
+# over-test coverage-delta row defined
+grep -qiE 'coverage.delta|ACs-covered|coverage delta' commands/ui-design.md
+bash tests/test-meta.sh   # green incl. the SPEC-112 ui-design done-modes pins
+# The fixture TRACES (the goal's crux proof) are pinned in the proof-of-done, not just the contract:
+grep -qiE 'converge' docs/verification/done-modes.md                 # fixture 1: round 2 stops clean
+grep -qiE 'cap|round 3' docs/verification/done-modes.md              # fixture 2: never-satisfied critic caps at 3
+grep -qiE 're-found|does NOT quiesce|falsely' docs/verification/done-modes.md   # NC: re-found CRITICAL does not quiesce
+grep -qiE 'plain REVISE|cap 2' docs/verification/done-modes.md       # regression: plain REVISE still 2
+# dotfiles half (local): Done-mode field in the subgoal-template
+grep -qiE '^\*?\*?Done-mode' ~/workspace/tieubao/dotfiles/home/dot_claude/skills/plan-for-mega-goal/references/subgoal-template.md
+```
+
+## After state
+
+- `commands/ui-design.md`: a Done-mode `$ARGUMENTS` flag (proof|over-test|quiescence); Phase B gains
+  the quiescence branch (two-sided stop, cap 3, QL-VERDICT markers, resolved/OPEN tags, `### Deferred
+  findings` subsection); over-test defines the coverage-delta row; plain REVISE unchanged (cap 2).
+- `docs/specs/SPEC-112-done-modes.md`: DEC-018 (the 3-vs-2 cap divergence).
+- dotfiles `plan-for-mega-goal` subgoal-template: a `Done-mode:` field next to `Proof:` (applied +
+  committed atomically per the S-64 watcher rule).
+- `tests/test-meta.sh`: SPEC-112 pins (flag consumed, two-sided stop, QL-VERDICT, Deferred findings,
+  cap divergence, coverage-delta).
+- `docs/verification/done-modes.md`: the run-table incl. the three quiescence fixtures + the
+  plain-REVISE regression.
+
+## Scope edges
+
+**In:** ui-design.md Phase B (quiescence mode + Done-mode arg + Deferred-findings subsection), the
+cap DEC, the coverage-delta row definition, the dotfiles template field, tests.
+**Out:** visual-team internals (stays single-pass stateless; 06 owns its only change); the advisor
+(its ADR-0028 station is the final boundary, NOT inside this loop).
+**Not:** a numeric combined score (ui-design bans inventing one); unbounded polish loops; auto-
+accepting critique fixes without the per-round approval Phase B already has.
+
+## Open questions
+
+The three quiescence fixtures (converge / cap-out / no-false-quiescence) are grep-pins on
+ui-design.md's prose (ui-design is a prompt with no shell dispatcher, the same SPEC-078/107/109/111
+fidelity; visual-team + ui-design are not in CI). The load-bearing no-false-quiescence NC is pinned
+structurally: the stop condition text MUST carry the two-sided "zero NEW >=HIGH AND no OPEN >=HIGH"
+clause + an explicit statement that a re-found unresolved CRITICAL does not quiesce. The behavioral
+loop itself runs downstream (the kit has no UI to dogfood it); the pins prove the CONTRACT is
+present + two-sided, not a live convergence run.

--- a/docs/verification/done-modes.md
+++ b/docs/verification/done-modes.md
@@ -1,0 +1,85 @@
+# Proof of done: UI done-modes + quiescence loop (SPEC-112, kit-face wave)
+
+`/kit:ui-design` gains a `Done-mode:` flag (proof | over-test | quiescence). proof is the mandatory
+floor; over-test adds a test-plan + coverage-delta; quiescence extends Phase B into a converging
+loop with a TWO-SIDED stop. Final acceptance stays a `gate` in every mode.
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | Done-mode flag consumed + branches (proof default, over-test, quiescence) | PASS |
+| 2 | quiescence stop is TWO-SIDED: zero NEW >=HIGH AND no OPEN >=HIGH | PASS |
+| 3 | NEGATIVE CONTROL: a re-found unresolved CRITICAL does NOT quiesce (falsely-calm trap) | PASS (trace 3) |
+| 4 | quiescence caps at 3; capped-out findings -> Deferred findings | PASS (trace 2) |
+| 5 | plain REVISE still caps at 2 (regression control) | PASS (trace 4) |
+| 6 | QL-VERDICT markers + resolved/OPEN tags; Deferred findings appended by loop lead post-termination | PASS |
+| 7 | over-test coverage-delta row defined (ACs-covered / tests-added) | PASS |
+| 8 | Done-mode field in the subgoal-template (dotfiles half, UI-only/optional) | PASS (dotfiles `ac2c6a4`) |
+| 9 | test-meta green (contract pins + fixture-trace pins) | PASS |
+
+## Fixture traces
+
+These are worked round-sequence TRACES: `/kit:ui-design` (like `/kit:visual-team`) is a prose loop
+with no shell dispatcher and is not in CI (it is downstream-facing; the kit has no UI to dogfood).
+The traces demonstrate the stop logic; the contract text is pinned in `test-meta.sh`.
+
+### Trace 1 , CONVERGE (quiescence stops clean at round 2)
+
+- Round 1: visual-team returns 2 findings , HIGH "contrast 3.1:1 on the CTA", MEDIUM "inconsistent
+  8px/12px spacing". `[[QL-VERDICT round=1 clean=false findings=2]]`. Apply the accepted fixes.
+- Round 2: re-render, re-critique. Zero NEW >=HIGH; the round-1 HIGH is now `[resolved in round 2]`;
+  no OPEN >=HIGH remains (the MEDIUM defers). `[[QL-VERDICT round=2 clean=true findings=0]]` -> STOP.
+- Deferred findings: the MEDIUM spacing note (sub-floor) appended to the final `## Visual critique`.
+
+### Trace 2 , CAP-OUT (a never-satisfied critic caps at round 3)
+
+- Round 1: HIGH A. Round 2: A resolved, but NEW HIGH B surfaces (`clean=false`). Round 3: B
+  resolved, NEW HIGH C surfaces (`clean=false`). Round cap 3 reached -> STOP with the last critique.
+- Deferred findings: OPEN HIGH C (capped-out) + any sub-floor findings appended to the final
+  `## Visual critique` , surfaced to the human, not silently dropped.
+
+### Trace 3 , NO-FALSE-QUIESCENCE (the load-bearing NC: a re-found CRITICAL does NOT quiesce)
+
+- Round 1: CRITICAL "focus trap in the modal" + HIGH "contrast". `clean=false`.
+- Round 2: the contrast HIGH is fixed, and the round surfaces zero NEW findings , BUT the CRITICAL
+  focus-trap is RE-FOUND unresolved (the applied fix did not land). Under a "zero NEW" ONLY stop this
+  would falsely quiesce. Under the TWO-SIDED stop it does NOT: there is an OPEN >=HIGH (the CRITICAL),
+  so `clean=false` and the loop continues. `[[QL-VERDICT round=2 clean=false findings=0]]` with the
+  CRITICAL tagged `[OPEN]`. This is the trap the two-sided condition exists to catch.
+
+### Trace 4 , PLAIN REVISE regression (proof mode, cap unchanged at 2)
+
+- Done-mode: proof (default). A `REVISE` verdict runs the plain Phase B loop: max 2 regenerations,
+  terminate on SOLID / RECONSIDER / cap 2. No quiescence extension, no QL-VERDICT markers. Cap stays
+  2 (fix-agent parity); the quiescence cap of 3 does not leak into proof mode (DEC-018).
+
+## Confirmation run-table
+
+| Case | Command | Expected | Observed |
+|---|---|---|---|
+| Done-mode flag | `grep -qiE 'Done-mode' commands/ui-design.md` | match | match |
+| two-sided stop | `grep -qiE 'zero NEW findings >=HIGH AND no OPEN' commands/ui-design.md` | match (full conjunction) | match |
+| NC stated | `grep -qiE 'does NOT quiesce\|re-finds' commands/ui-design.md` | match | match |
+| QL-VERDICT | `grep -qF '[[QL-VERDICT' commands/ui-design.md` | match | match |
+| cap divergence | `grep 'Round cap: 3'` + `grep 'cap of 2'` | both | both |
+| coverage-delta | `grep -qiE 'COVERAGE-DELTA\|ACs-covered'` | match | match |
+| dotfiles field | `grep '^**Done-mode:**' <subgoal-template>` | match | match (ac2c6a4) |
+| suite | `bash tests/test-meta.sh` | green incl. SPEC-112 block | (see run) |
+
+## Reproduce
+
+```bash
+cd dwarves-kit
+bash tests/test-meta.sh
+grep -qiE 'zero NEW findings >=HIGH AND no OPEN finding >=HIGH' commands/ui-design.md
+grep -q '^\*\*Done-mode:\*\*' ~/workspace/tieubao/dotfiles/home/dot_claude/skills/plan-for-mega-goal/references/subgoal-template.md
+```
+
+## Notes
+
+- DEC-018: quiescence caps at 3 (test-plan-review-team parity); plain REVISE keeps 2 (fix-agent
+  parity). The divergence is deliberate, not an inconsistency.
+- The `### Deferred findings` subsection is authored by the ui-design LOOP LEAD, appended to the
+  FINAL `## Visual critique` AFTER the loop terminates (a carve-out to Step 3's "do not write the
+  critique yourself" rule) , visual-team rewrites that section each round and is stateless.

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -2583,6 +2583,30 @@ assert_eq "DEC-017 recorded in SPEC-109 + reciprocal pointer in SPEC-016 (SPEC-1
 RC=0; grep -qiF 'operator-supplied' "$KIT_DIR/commands/kit-health.md" || RC=1
 assert_eq "kit-health check-13 carries the operator-persona carve-out (SPEC-109)" 0 $RC
 
+# ============================================================
+# SPEC-112: UI done-modes , the Done-mode flag + the TWO-SIDED quiescence stop (the no-false-
+# quiescence NC pinned as the full conjunction) + the fixture traces in the proof-of-done.
+# ============================================================
+UIDM="$KIT_DIR/commands/ui-design.md"
+RC=0; grep -qiE 'Done-mode' "$UIDM" || RC=1
+assert_eq "ui-design consumes a Done-mode flag (SPEC-112)" 0 $RC
+RC=0; grep -qiE 'zero NEW findings >=HIGH AND no OPEN finding >=HIGH' "$UIDM" || RC=1
+assert_eq "quiescence stop is TWO-SIDED: zero NEW >=HIGH AND no OPEN >=HIGH (no-false-quiescence NC)" 0 $RC
+RC=0; grep -qiE 'does NOT quiesce|re-finds an|falsely-calm' "$UIDM" || RC=1
+assert_eq "the re-found-CRITICAL-does-not-quiesce trap is stated (SPEC-112)" 0 $RC
+RC=0; grep -qF '[[QL-VERDICT' "$UIDM" || RC=1
+assert_eq "quiescence emits QL-VERDICT round markers (SPEC-112)" 0 $RC
+RC=0; grep -qiE 'Deferred findings' "$UIDM" || RC=1
+assert_eq "Deferred findings subsection defined (SPEC-112)" 0 $RC
+RC=0; { grep -qiE 'Round cap: 3' "$UIDM" && grep -qiE 'cap of 2' "$UIDM"; } || RC=1
+assert_eq "cap divergence pinned: quiescence 3, plain REVISE 2 (SPEC-112 DEC-018)" 0 $RC
+RC=0; grep -qiE 'COVERAGE-DELTA|ACs-covered' "$UIDM" || RC=1
+assert_eq "over-test coverage-delta row defined (SPEC-112)" 0 $RC
+# fixture TRACES pinned in the proof-of-done (the goal's crux proof, not just the contract text):
+DMPROOF="$KIT_DIR/docs/verification/done-modes.md"
+RC=0; { grep -qiE 'converge' "$DMPROOF" && grep -qiE 'cap-out|round 3|round cap 3' "$DMPROOF" && grep -qiE 're-found|does NOT quiesce|falsely' "$DMPROOF" && grep -qiE 'plain REVISE|cap.*2' "$DMPROOF"; } || RC=1
+assert_eq "done-modes proof carries the 3 quiescence fixtures + plain-REVISE regression (SPEC-112)" 0 $RC
+
 echo ""
 echo "=== Results ==="
 # ============================================================


### PR DESCRIPTION
UI done-modes + bounded quiescence loop (SPEC-112, kit-face wave). `/kit:ui-design` gains a `Done-mode:` flag: **proof** (default) | **over-test** | **quiescence**.

- **proof** (mandatory floor): real-surface flows + 2-3 captures + a11y (plain Phase B, cap 2).
- **over-test**: proof + `/kit:test-plan` + `/kit:verify` + a **coverage-delta** row (ACs-covered / tests-added) on the proof-of-done.
- **quiescence**: Phase B EXTENDED into a converging loop , critique → apply → re-render → re-critique.
  - **Two-sided stop (load-bearing NC):** stop when a round yields **zero NEW >=HIGH AND no OPEN >=HIGH**. "zero NEW" alone falsely quiesces on a re-found unresolved CRITICAL (it's not NEW but it's OPEN >=HIGH); the AND clause pins it. Severity floor >=HIGH; MEDIUM/LOW defer.
  - **Cap 3** (test-plan-review-team parity); plain REVISE stays **cap 2** (fix-agent parity) , divergence = **DEC-018**.
  - `[[QL-VERDICT round=N clean=BOOL findings=K]]` markers + `[resolved|OPEN]` tags; the loop lead appends `### Deferred findings` to the FINAL `## Visual critique` post-termination (carve-out — visual-team rewrites it each round + is stateless).

`visual-team` stays single-pass stateless; final acceptance stays a `gate` in every mode. Dotfiles half: `Done-mode:` subgoal-template field (UI-only, `ac2c6a4`).

**Verify:** `bash tests/test-meta.sh` (659/659, incl. the SPEC-112 contract pins + the two-sided-stop conjunction pin + the fixture-trace pins). All 12 CI suites green. Proof (4 worked fixture traces): `docs/verification/done-modes.md`.

Roadmap: ops-toolkit `_meta/megagoals/kit-face/ROADMAP.md` (sub-goal 07).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
