### PR TITLE
docs(readme): mermaid lifecycle hero + test-pinned layout counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@
 
 Agent workflows are shifting from `prompt -> output` to `goal -> loop -> evaluate -> improve -> result`. dwarves-kit is the **closed** kind of that loop: you set the goal and the gates up front, agents iterate inside them. The loop is one spec-driven lifecycle, **think → spec → execute → review → ship → retro**, with a gate at every phase boundary:
 
+```mermaid
+flowchart LR
+  goal([goal + gates<br/>set up front]) --> T
+  T[think<br/>forcing questions] -->|advisory| S[spec<br/>the contract]
+  S -->|spec-drift guard| X[execute<br/>worker → verifier → fix-agent]
+  X -->|BLOCKING: verification pipeline| R[review<br/>verdict recorded]
+  R -->|advisory| SH[ship<br/>version + PR]
+  SH -->|BLOCKING: ship-gate + push-to-main| RE[retro]
+  RE -.->|feeds the next cycle| T
 ```
-  goal --> think --> spec --> execute --> review --> ship --> retro --+
-            |          |         |           |          |             |
-        6 forcing   the spec   worker ->   verdict   ship gate +      |
-        questions   is the     verifier -> recorded  push-to-main     |
-        (advisory)  contract   fix-agent   (advisory) blocker         |
-                               (max 2)                                |
-   ^                                                                  |
-   +------------------ retro feeds the next cycle --------------------+
-```
+
+Two gate classes sit on those boundaries: **blocking** (the verification pipeline, the ship-gate, the push-to-main blocker , mechanical, they stop a bad outcome) and **advisory** (think, review , they surface findings, never block). The autonomous-loop hardening adds a fresh-context re-audit of every done-claim, a kit-default cross-cutting advisor lens on top of the specialized reviewers, and a deployable-done proof gate, so a closed loop can run long without drifting into self-graded slop.
 
 Every build task runs a verification pipeline (worker → verifier → fix-agent retry), and hooks enforce safety automatically (`rm -rf`, push-to-main, force-push, and secret-file reads are blocked). The worker is also **specialized per task**: when a task needs a role no built-in agent covers (security, migration, a doc writer, ...), the kit synthesizes one on the fly and dispatches it, or `/kit:draft-agent` installs a reusable named agent ([SPEC-089](docs/specs/SPEC-089-dynamic-agent-synthesis.md)).
 
@@ -265,9 +267,9 @@ dwarves-kit/
   install.sh / settings.json    Bash install path
   .claude-plugin/               Plugin install path (plugin.json, marketplace.json)
   .github/workflows/test.yml    CI: macOS + Ubuntu test matrix
-  agents/                       (11 files) Subagents dispatched by commands
+  agents/                       (24 files) Subagents dispatched by commands
   commands/                     (27 markdown command prompts)
-  hooks/                        (14 scripts + hooks.json plugin manifest)
+  hooks/                        (17 scripts + hooks.json plugin manifest)
   lib/dispatch-gate.sh          Disjointness gate + drift guard for /kit:dispatch (pure-bash concurrency moat)
   lib/lane-classify.sh          Deterministic task-type -> risk-lane classifier + advisory floor check (used by /kit:assign + /kit:dispatch); optional `--files "<paths>"` on classify/explain/check escalates the kit-machinery gate on an actual EDIT to lib/ or hooks/, not a mere textual mention (SPEC-105, edit-vs-mention)
   lib/goal-registry.sh          Cross-session running-goal registry: claim/list/log/release (multi-session moat + monitor)

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -133,6 +133,10 @@ entry point (a bug-lane loop), not a linear phase between Reflect and the next c
 
 ## The V-model lens
 
+> The ASCII V below is the canonical rendering. For a rendered vector version, see
+> [`docs/v-model.svg`](docs/v-model.svg). (The README hero is a 6-phase mermaid lifecycle, the
+> 10-second view; this section + the SVG are the full V.)
+
 The cycle table above is the canonical phase list. This section reads it as a **V**.
 The **left arm BUILDS**: each phase produces an artifact and statically reviews it
 (verification, "did we build this right?"). The **right arm TESTS**: it executes the

--- a/docs/implementation-notes/SPEC-113-readme-hero.md
+++ b/docs/implementation-notes/SPEC-113-readme-hero.md
@@ -1,0 +1,20 @@
+# Implementation notes: SPEC-113 readme-hero
+
+Delta from the spec. References, does not restate.
+
+## 2026-07-03 deltas
+
+- **Count is 24, not the goal's "18".** The goal title said "agents 11->18"; docs run LAST, so the
+  FINAL live count (after 09 added 6 agents) is 24. Fixed to 24 (this is why the docs sub-goals run
+  after all machinery , they reflect final state).
+- **The agents directory-layout pin is NEW; hooks already had one.** test-meta already carried a
+  SPEC-085 hooks parity pin (README hooks summary/rows == hook files), which is why hooks stayed at
+  the right count. The AGENTS directory-layout count had NO pin , which is exactly why it drifted to
+  11. SPEC-113 adds the agents (and a redundant-but-harmless hooks) layout-count pin.
+- **Render "capture" is the gh markdown API tag**, not a pixel screenshot (uncapturable from the
+  loop): `gh api -X POST /markdown` returns `class="highlight highlight-source-mermaid"` for the
+  fence, i.e. GitHub renders it as a mermaid diagram. The parity pin is the durable guarantee (a
+  screenshot rots; the pin does not).
+- **architecture.md:77 prose total** ("15 agents / 40 entries", flagged in the 09 review) is a
+  DIFFERENT surface (docs/architecture.md prose, not README) , left for sub-goal 02 (docs index) or
+  TIER-4; out of 01's README-scoped surgical change. Noted in mega NOTES.

--- a/docs/specs/SPEC-113-readme-hero.md
+++ b/docs/specs/SPEC-113-readme-hero.md
@@ -1,0 +1,71 @@
+# SPEC-113: README hero + parity pin
+
+Status: VALIDATED
+Lane: normal
+Type: spec-feature
+
+## Problem
+
+The README hero is a hand-drawn ASCII lifecycle, and its directory-layout counts are STALE:
+`agents/ (11 files)` (live: 24), `hooks/ (14 scripts)` (live: 17). The 11-vs-live agents drift is
+the exact class the mega-goal quality bar calls out ("died untested once; never again"). A new
+external reader (OSS intent) meets a stale, hand-maintained hero. The mega-goal (roadmap:
+ops-toolkit `_meta/megagoals/kit-face/`, assumptions 01) resolves this: a native-rendered mermaid
+lifecycle + corrected, TEST-PINNED counts.
+
+## Solution
+
+1. **Mermaid hero** , replace the ASCII lifecycle block (README ~12-21) with a native ```mermaid
+   flowchart: 6 phases (think -> spec -> execute -> review -> ship -> retro), a one-line role each,
+   and the GATE CLASS at each boundary (two classes: **blocking** = the verification pipeline +
+   ship-gate + push-to-main blocker; **advisory** = think/review). Reads in 10s on github.com; NOT
+   the full V-model (that stays `docs/v-model.svg`, linked from WORKFLOW.md).
+2. **Trust-story sentence** , one sentence folding in the kit-hardening upgrade (fresh-context
+   re-audit + the advisor extra lens + deployable-done), NOT five feature bullets.
+3. **Corrected + PINNED counts** , `agents/ (24 files)`, `hooks/ (17 scripts)` in the
+   directory-layout; a NEW test-meta parity pin extracts the README layout counts and asserts them
+   `== ls agents/*.md | wc -l` / `ls hooks/*.sh | wc -l` (SPEC-085 computed-pin shape), so the drift
+   class dies like the hooks/commands pins did.
+4. **WORKFLOW.md** keeps the ASCII canon (unchanged) and gains a `docs/v-model.svg` link (disposition
+   of the orphaned asset).
+5. Tighten prose only; Credits intact.
+
+## Verification
+
+```bash
+cd dwarves-kit
+# mermaid hero present, ASCII hero gone
+grep -qF '```mermaid' README.md
+! grep -qF 'goal --> think --> spec --> execute' README.md   # old ASCII hero removed
+# 6 phases + two gate classes named
+grep -qiE 'think.*spec.*execute.*review.*ship.*retro|retro' README.md
+grep -qiE 'blocking' README.md && grep -qiE 'advisory' README.md
+# counts corrected + PINNED (the parity pin computes, does not hardcode)
+grep -qE 'agents/ *\(24 files\)' README.md
+grep -qE 'hooks/ *\(17 ' README.md
+# WORKFLOW links the svg (ASCII canon kept)
+grep -qF 'v-model.svg' WORKFLOW.md
+grep -q DEC README.md 2>/dev/null || true
+bash tests/test-meta.sh   # green incl. the new README layout-count parity pin (agents + hooks)
+```
+
+## After state
+
+- `README.md`: mermaid hero (6 phases, gate classes) replacing the ASCII lifecycle; trust-story
+  sentence; `agents/ (24 files)` + `hooks/ (17 scripts)`; Credits intact.
+- `WORKFLOW.md`: `docs/v-model.svg` link; ASCII canon unchanged.
+- `tests/test-meta.sh`: a README-layout parity pin (agents + hooks counts computed from live files).
+- `docs/verification/readme-hero.md`: the run-table + the GitHub-mermaid render check.
+
+## Scope edges
+
+**In:** README.md hero + counts, WORKFLOW.md svg link, the test-meta parity pin.
+**Out:** docs index (02); MANUAL.md (already correct at 24 after 09).
+**Not:** delegating README tables to MANUAL; a full-V-model diagram in the README; touching Credits.
+
+## Open questions
+
+The GitHub-render "capture" is verified by (a) valid ```mermaid fence syntax + (b) `gh api`
+markdown-render returning 200 with the diagram, since a pixel screenshot is not capturable from the
+loop; GitHub renders ```mermaid natively. The parity pin is the durable guarantee the counts never
+re-drift (a screenshot rots; the pin does not).

--- a/docs/verification/readme-hero.md
+++ b/docs/verification/readme-hero.md
@@ -1,0 +1,63 @@
+# Proof of done: README hero + parity pin (SPEC-113, kit-face wave)
+
+The README hero is a native mermaid lifecycle (replacing the ASCII), the directory-layout counts
+match live reality (24 agents, 17 hooks), and a new test-meta parity pin makes the agents-count
+drift class die like the hooks/commands pins did.
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | Mermaid hero (6 phases + gate classes) replaces the ASCII lifecycle | PASS |
+| 2 | GitHub renders the mermaid fence as a diagram (not a code block) | PASS (gh markdown API tags it `highlight-source-mermaid`) |
+| 3 | Two gate classes named (blocking / advisory) | PASS |
+| 4 | Trust-story sentence (re-audit + advisor + deployable-done), not 5 bullets | PASS |
+| 5 | Directory-layout counts corrected: agents 24, hooks 17 | PASS |
+| 6 | NEW parity pin: README agents/hooks layout counts == live file counts (computed) | PASS |
+| 7 | WORKFLOW.md keeps ASCII canon + gains the `docs/v-model.svg` link | PASS |
+| 8 | Credits intact; test-meta + all 12 CI green | PASS |
+
+## Implementation
+
+- `README.md`: ```mermaid flowchart (goal -> think -> spec -> execute -> review -> ship -> retro,
+  edges labeled advisory / BLOCKING) + a two-gate-classes sentence + the trust-story sentence;
+  `agents/ (24 files)`, `hooks/ (17 scripts)`; old ASCII hero removed; Credits untouched.
+- `WORKFLOW.md`: a blockquote linking `docs/v-model.svg` before "## The V-model lens"; ASCII V unchanged.
+- `tests/test-meta.sh`: a README directory-layout parity pin , `README agents/ count == ls agents/*.md`
+  and `README hooks/ count == ls hooks/*.sh` (computed, mirrors the architecture inventory pin). The
+  agents pin is NEW (hooks already had a SPEC-085 pin; the AGENTS directory-layout count had none ,
+  which is exactly why it drifted to 11).
+
+## Confirmation run-table
+
+| Case | Command | Expected | Observed |
+|---|---|---|---|
+| mermaid hero | `grep -qF '```mermaid' README.md` | match | match |
+| old ASCII gone | `grep -qF 'goal --> think --> spec --> execute' README.md` | no match | absent |
+| counts corrected | `grep -qE 'agents/ *\(24 files\)'` / `'hooks/ *\(17 '` | match | match |
+| parity pin | `bash tests/test-meta.sh` (README agents/hooks layout count == live) | 24==24, 17==17 | PASS |
+| gate classes | `grep blocking && grep advisory` README.md | both | both |
+| WORKFLOW svg | `grep -qF 'v-model.svg' WORKFLOW.md` | match | match |
+| GitHub render | `gh api -X POST /markdown -f text=<hero>` | mermaid recognized | `class="highlight highlight-source-mermaid"` |
+| suite | `bash tests/test-meta.sh` | green | 661/661 |
+| all CI | 12 suites | green | all pass |
+
+## Run detail (captured 2026-07-03)
+
+```
+$ bash tests/test-meta.sh
+  PASS README agents/ layout count == live agents (24 == 24)
+  PASS README hooks/ layout count == live hooks (17 == 17)
+Passed: 661 / 661 ; All meta tests passed.
+$ gh api -X POST /markdown -f text="$(sed -n '10,30p' README.md)" | grep -o 'highlight-source-mermaid'
+highlight-source-mermaid        # GitHub renders the fence as a mermaid diagram
+```
+
+## Reproduce
+
+```bash
+cd dwarves-kit
+bash tests/test-meta.sh
+grep -qF '```mermaid' README.md && grep -qE 'agents/ *\(24 files\)' README.md
+grep -qF 'v-model.svg' WORKFLOW.md
+```

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -1357,6 +1357,14 @@ LIVE_COUNT=$((CMD_COUNT + AGT_COUNT))
 assert_eq "architecture.md inventory table rows == live file count ($ARCH_TABLE_ROWS == $LIVE_COUNT)" \
   "$LIVE_COUNT" "$ARCH_TABLE_ROWS"
 
+# SPEC-113: the README directory-layout counts stay pinned to the LIVE file counts (the 11-vs-live
+# agents drift class , "died untested once, never again" , dies like the architecture pin above).
+README_AGT=$(grep -oE 'agents/ *\([0-9]+ files\)' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
+README_HOOK=$(grep -oE 'hooks/ *\([0-9]+ ' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
+HOOK_COUNT=$(ls "$KIT_DIR/hooks/"*.sh 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "README agents/ layout count == live agents ($README_AGT == $AGT_COUNT)" "$AGT_COUNT" "$README_AGT"
+assert_eq "README hooks/ layout count == live hooks ($README_HOOK == $HOOK_COUNT)" "$HOOK_COUNT" "$README_HOOK"
+
 # ============================================================
 echo ""
 echo "=== Parallel-execution boundary un-nerf (SPEC-032 C1 / ADR-0019) ==="


### PR DESCRIPTION
README hero: native mermaid lifecycle + test-pinned counts (SPEC-113, kit-face wave).

- **Mermaid hero** replaces the hand-drawn ASCII lifecycle: 6 phases (goal→think→spec→execute→review→ship→retro), edges labeled by **gate class** (blocking = verification pipeline / ship-gate / push-to-main; advisory = think / review). Reads in 10s; GitHub renders it natively (markdown API: `highlight-source-mermaid`). The full V-model stays `docs/v-model.svg`, now linked from WORKFLOW.md (which keeps the ASCII canon).
- **Trust-story sentence** folds in the kit-hardening upgrade (fresh-context re-audit + the advisor lens + deployable-done) instead of feature bullets.
- **Counts corrected + PINNED:** `agents/ (24 files)`, `hooks/ (17 scripts)`, and a NEW test-meta parity pin computes both from the live files , so the 11-vs-live agents drift ("died untested once, never again") dies like the hooks pin. Credits intact.

**Verify:** `bash tests/test-meta.sh` (661/661, incl. `README agents/ count == 24`, `README hooks/ count == 17`). All 12 CI suites green. Proof: `docs/verification/readme-hero.md`.

Roadmap: ops-toolkit `_meta/megagoals/kit-face/ROADMAP.md` (sub-goal 01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
