### PR TITLE
docs: expand docs/README into a navigable thematic map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,3 +20,33 @@ This folder is large because the kit was built **through its own workflow**: eve
 ## How to read it (for maintainers)
 
 Start with `architecture.md` for the mental model, then `PHILOSOPHY.md` for the guardrails. From there, a spec (`specs/SPEC-NNN-*.md`) is the contract for one feature and an ADR (`decisions/NNNN-*.md`) is the reasoning behind one decision; ADRs supersede each other in place (the `## Status:` line names the superseder) rather than being rewritten.
+
+## The full record, by theme
+
+The `## What's here` table above is the quick map. The complete set of record classes, for a
+maintainer navigating the whole `docs/` tree (every path below is in place; this is one central
+map, not per-dir READMEs , `specs/` and `verification/` keep their own, deliberately):
+
+**Design + decisions**
+- [`specs/`](specs/) , one spec per feature, the live spec store. Numbering is per-namespace and
+  local (each `*/docs/specs/` owns its own `SPEC-001..` sequence). Enumerate them with
+  `bash lib/spec-index.sh` (the read-only registry view) rather than a per-file list here , a
+  hand-kept list would rot. See [`specs/README.md`](specs/README.md) for the numbering convention.
+- [`decisions/`](decisions/) , ADRs (`NNNN-<slug>.md`), superseded in place.
+
+**Build trail (what the workflow leaves behind , the two classes the quick map omits)**
+- [`implementation-notes/`](implementation-notes/) , per-spec DELTA logs: the decisions made
+  *during* a build that the spec did not pin, deviations, and constraints future-you should know.
+  One file per spec-slug.
+- [`verification/`](verification/) , per-feature proof-of-done records (run-tables + negative
+  controls). **LOAD-BEARING:** [`verification/README.md`](verification/README.md) is the
+  proof-of-done marker the ship-gate keys on (`hooks/ship-gate.sh`) , link it, never move it.
+- [`retro/`](retro/) , per-cycle retrospectives (output of `/kit:retro`).
+
+**Sourcing**
+- [`research/`](research/) , dated deep-scans that fed specific specs.
+- [`absorption/`](absorption/) , templates + index for the `/kit:absorb` workflow.
+
+No counts live in this map on purpose (a count rots; the README's directory-layout counts are the
+ones under a test-meta parity pin). To count or list any class, read the directory or run
+`bash lib/spec-index.sh` for specs.

--- a/docs/implementation-notes/SPEC-114-docs-index.md
+++ b/docs/implementation-notes/SPEC-114-docs-index.md
@@ -1,0 +1,19 @@
+# Implementation notes: SPEC-114 docs-index
+
+Delta from the spec.
+
+- **Front door kept verbatim; extension appended below** (not woven into the existing "What's here"
+  table). git diff shows ZERO removed lines , the quick map stays as the getting-started subset;
+  the new "## The full record, by theme" section is the complete map incl. the two omitted classes.
+- **No unpinned counts** , the map points at `bash lib/spec-index.sh` for spec enumeration and
+  describes each dir without a rotting number. The only pinned counts are the README directory-layout
+  ones (SPEC-113's parity pin); the map explicitly says so.
+- **verification/ LOAD-BEARING** , linked, never moved; the note names `hooks/ship-gate.sh` as the
+  consumer so a future maintainer does not relocate `verification/README.md`.
+- **02 adds no test-meta pins** (scope: docs/README.md only) , the proof is a link-check + the
+  existing proof-marker/spec-README pins staying green. No test-meta footer edit, so no risk to
+  other sub-goals' pins.
+- **Not fixed here (out of 02's docs/README.md scope):** `docs/architecture.md:77` prose total
+  ("15 agents / 40 entries") is stale (now 24 agents / 51 entries) , flagged in the 09 review, a
+  DIFFERENT doc surface; filed to mega NOTES for TIER-4 / a follow-up (the gate-covered inventory
+  TABLE is correct; only the human-readable prose total is uncovered).

--- a/docs/specs/SPEC-114-docs-index.md
+++ b/docs/specs/SPEC-114-docs-index.md
@@ -1,0 +1,61 @@
+# SPEC-114: docs index expansion
+
+Status: VALIDATED
+Lane: normal
+Type: spec-feature
+
+## Problem
+
+`docs/README.md`'s "What's here" table is a good front door but an INCOMPLETE map: it omits two
+whole record classes , `implementation-notes/` (per-spec build-deltas) and `verification/`
+(proof-of-done records, LOAD-BEARING: the ship-gate keys on `verification/README.md`) , and offers
+no way to navigate the large `specs/` set. A maintainer cannot find every record class in one hop.
+The mega-goal (roadmap: ops-toolkit `_meta/megagoals/kit-face/`, assumptions 02) resolves this: keep
+the front door verbatim, extend it into a navigable thematic map, no rotting counts.
+
+## Solution
+
+Extend `docs/README.md` BELOW the existing content (front door byte-identical) with a "## The full
+record, by theme" section grouping every record class:
+- **Design + decisions:** `specs/` (enumerate via `bash lib/spec-index.sh`, no per-file rows, no
+  rotting count; per-namespace local numbering noted) + `decisions/` (ADRs).
+- **Build trail:** `implementation-notes/` + `verification/` (the two the quick map omits) +
+  `retro/`. `verification/README.md` is flagged LOAD-BEARING (ship-gate consumer named), linked,
+  never moved.
+- **Sourcing:** `research/` + `absorption/`.
+No counts in the map (the only pinned counts are the README directory-layout ones, SPEC-113); one
+central map, no new per-dir READMEs (`specs/` + `verification/` keep their own, deliberately).
+
+## Verification
+
+```bash
+cd dwarves-kit
+# front door byte-identical (extension is addition-only)
+git diff master -- docs/README.md | grep -E '^-' | grep -v '^---'   # empty
+# both omitted classes + the load-bearing link + the spec-index pointer present
+grep -q 'implementation-notes/' docs/README.md && grep -q 'verification/README.md' docs/README.md
+grep -q 'lib/spec-index.sh' docs/README.md
+# every relative link resolves; no rotting counts in the map
+bash tests/test-meta.sh   # proof-marker + spec-README pins unaffected (661/661)
+```
+
+## After state
+
+- `docs/README.md`: the front door verbatim + a "## The full record, by theme" section (all record
+  classes, spec-index pointer, verification/ load-bearing link, no counts).
+- `docs/verification/docs-index.md`: link-check run-table + front-door-verbatim proof.
+
+## Scope edges
+
+**In:** `docs/README.md` only.
+**Out:** new per-dir READMEs (specs/ + verification/ have theirs); moving any file; the README hero
+(01); the `architecture.md` prose-count drift (a different doc surface, filed to mega NOTES).
+**Not:** an auto-generated index (spec-index.sh is pointed at, not wrapped); per-file annotation of
+the specs; any rotting count.
+
+## Open questions
+
+The proof is a link-check + the front-door-verbatim `git diff` + the existing proof-marker/spec pins
+staying green , 02 adds no new test-meta pin (scope is docs/README.md only), so it cannot regress
+another sub-goal's pins. Counts are deliberately absent from the map (a count rots; SPEC-113's
+directory-layout parity pin is the one place counts are asserted, and the map says so).

--- a/docs/verification/docs-index.md
+++ b/docs/verification/docs-index.md
@@ -1,0 +1,48 @@
+# Proof of done: docs index expansion (SPEC-114, kit-face wave)
+
+`docs/README.md` extends into a navigable thematic map , adding the two record classes the quick
+map omitted (`implementation-notes/`, `verification/`) + a `lib/spec-index.sh` pointer for the
+specs , with the 23-line front door byte-identical and no rotting counts.
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | Front door (intro + What's here + How to read) byte-identical; extension is pure addition below | PASS (git diff: 0 lines removed) |
+| 2 | `implementation-notes/` + `verification/` added (the two the quick map missed) | PASS |
+| 3 | `verification/README.md` LINKED, untouched in place (ship-gate keys on it) | PASS |
+| 4 | Spec enumeration via `lib/spec-index.sh` pointer , NO per-file rows | PASS |
+| 5 | NO unpinned counts anywhere in the map | PASS (grep: none) |
+| 6 | Every relative link resolves | PASS (13/13) |
+| 7 | Files stay put (no moves, no new per-dir READMEs) | PASS |
+| 8 | test-meta green (proof-marker + spec-README pins unaffected) | PASS (661/661) |
+
+## Confirmation run-table
+
+| Case | Command | Expected | Observed |
+|---|---|---|---|
+| front-door verbatim | `git diff master -- docs/README.md \| grep '^-'` | no removed lines | none (pure addition) |
+| link-check | resolve every `](path)` relative to docs/ | all exist | 13/13 OK |
+| no counts | `awk '/full record/{f=1}f' docs/README.md \| grep -oE '[0-9]+ (specs\|files\|...)'` | none | none |
+| verification link | `grep -q 'verification/README.md' docs/README.md` | match | match |
+| spec-index pointer | `grep -q 'lib/spec-index.sh' docs/README.md` | match | match |
+| suite | `bash tests/test-meta.sh` | green | 661/661 |
+
+## Run detail (2026-07-03)
+
+```
+$ git diff master -- docs/README.md | grep -E '^-' | grep -v '^---'
+(empty)                          # front door byte-identical, extension is addition-only
+# link-check: ../README.md, architecture.md, PHILOSOPHY.md, ABSORPTION.md, specs/, specs/README.md,
+#   decisions/, implementation-notes/, verification/, verification/README.md, retro/, research/,
+#   absorption/  -> all 13 resolve
+$ bash tests/test-meta.sh -> 661/661 ; All meta tests passed.
+```
+
+## Reproduce
+
+```bash
+cd dwarves-kit
+git diff master -- docs/README.md | grep -E '^-' | grep -v '^---'   # empty = front door verbatim
+bash tests/test-meta.sh
+```


### PR DESCRIPTION
Expand `docs/README.md` into a navigable thematic map (SPEC-114, kit-face wave). The front door stays **byte-identical** (git diff: 0 removed lines); a "## The full record, by theme" section is appended below:

- Adds the two record classes the quick map omitted: **`implementation-notes/`** (per-spec build-deltas) and **`verification/`** (proof-of-done records). `verification/README.md` is flagged **LOAD-BEARING** (the ship-gate keys on it, `hooks/ship-gate.sh`) , linked, never moved.
- Points at `bash lib/spec-index.sh` for spec enumeration (no per-file rows, no rotting count; per-namespace local numbering noted).
- One central map, no new per-dir READMEs (`specs/` + `verification/` keep their own).
- **No counts** in the map on purpose (the only pinned counts are SPEC-113's README directory-layout ones; the map says so).

**Verify:** front door verbatim (`git diff master -- docs/README.md | grep '^-'` empty); 13/13 relative links resolve; `bash tests/test-meta.sh` 661/661 (proof-marker + spec-README pins unaffected). All 12 CI suites green. Proof: `docs/verification/docs-index.md`.

Roadmap: ops-toolkit `_meta/megagoals/kit-face/ROADMAP.md` (sub-goal 02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
