### PR TITLE
docs(adr): accept mega-goal execution hygiene (0032)

### DIFF
--- a/docs/decisions/0032-megagoal-execution-hygiene.md
+++ b/docs/decisions/0032-megagoal-execution-hygiene.md
@@ -1,7 +1,7 @@
 # 0032. Mega-goal execution hygiene (delegation, model routing, ledgers, multiplexer)
 
 Date: 2026-07-03
-Status: Proposed
+Status: Accepted
 Relates-to: ADR-0017 (mega-decomposition lane), ADR-0027 (context hygiene), SPEC-087 (inter-sub-goal context hygiene), ADR-0030 (dag-wavefront scheduling), `lib/orchestrate.sh`, `lib/route-suggest.sh`, ops-toolkit `plan-for-mega-goal` skill + `research/2026-07-03-megagoal-execution-hygiene.md` (the rationale) + the kit-face token ledger + understanding-gate debt ledger
 
 ## Context


### PR DESCRIPTION
Flips ADR-0032 `Status: Proposed -> Accepted`, recording Han's bless to unblock the `orchestrate-hardening` mega-goal gate-zero (ADR-0028 gate-zero pattern).

**Why a fresh PR instead of #131:** the original proposal branch `docs/adr-execution-hygiene` (PR #131) drifted , it fell 7 commits behind master and no longer contains the ADR file at all (the ADR already landed on master via #132, as Proposed). Its diff is now unrelated persona-lens (SPEC-109) work. Merging #131 would not clear gate-zero and would land/revert unrelated changes. This one-line accept lands cleanly; #131 should be closed/retitled separately.

Gate-zero for orchestrate-hardening then passes and the delegate loop dispatches SG-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
