### PR TITLE
Model-routing enforcement: pin + prove the Model: field reaches --model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to dwarves-kit are documented here.
 
 ## [Unreleased]
 
+### Added
+- **Model-routing enforcement pinned + proven (SPEC-116).** Resolves `orchestrate-hardening`
+  open-fork 3: the enforcement site is `lib/orchestrate.sh` (`_route()` + the serial/wave delegate
+  dispatch sites, which already existed under SPEC-087), not `lib/route-suggest.sh` (a decompose-time
+  suggester with no dispatch-time call site, so it structurally cannot contradict an explicit
+  `Model:` field). The no-`Model:`-field fallback tier is confirmed as "inherit the parent session's
+  tier" (SPEC-107). `tests/test-model-routing.sh` proves the default-applied positive case for
+  opus/sonnet/haiku on the serial path plus one case on the concurrent wave path, and the fallback
+  negative control. No `lib/` behavior change; this is a proof + documentation pin.
+
 ## [2.0.0] - 2026-07-03
 
 The release hold lifts: its stated condition , the **kit-hardening** megagoal , is complete, and

--- a/docs/implementation-notes/model-routing-enforce.md
+++ b/docs/implementation-notes/model-routing-enforce.md
@@ -1,0 +1,56 @@
+# Implementation notes , model-routing enforcement
+
+Delta from `docs/specs/SPEC-116-model-routing-enforce.md` (orchestrate-hardening sub-goal 01).
+
+## 2026-07-03 , the enforcement mechanism already existed (SPEC-087); this sub-goal is proof + pin
+
+Read `lib/orchestrate.sh` before writing anything: `_route()` (SPEC-087, :392-403) already reads a
+goal file's `Model:`/`Effort:` lines and both delegate dispatch sites (`cmd_run` serial :1159-1162,
+`_wave_run` concurrent :784-788) already build `route_flags` and thread it through the single shared
+`_run_one_session()` into the real `"$CLAUDE_CMD" -p $route_flags ...` call, across all three of its
+mutually-exclusive run-paths (watchdog / stream-json / plain). There was no gap to build. The sub-goal
+file (written before this session read the code) assumed the field was "documented but not provably
+threaded" , that assumption was wrong; the wiring is real and was already partially proven by
+`tests/test-orchestrate.sh` TEST 8 (sonnet tier + inherit negative control only).
+
+## 2026-07-03 , route-suggest.sh cannot contradict Model: by construction, not by new code
+
+`lib/route-suggest.sh` is a decompose-time SUGGESTER invoked by a human/`agents/meta-agent.md` Mode B
+when DRAFTING a goal file, never by `lib/orchestrate.sh` at dispatch time (`grep -rn route-suggest
+lib/orchestrate.sh` , zero hits). The "alignment check" the sub-goal asked for is therefore a
+STRUCTURAL grep negative control (no call site in the dispatch functions), not a runtime mock , there
+is no runtime interaction between the two scripts to mock.
+
+## 2026-07-03 , fallback tier is "inherit", already decided by SPEC-107, not reopened here
+
+SPEC-107 ("cheap-tier defaults") already resolved the write-time vs read-time distinction: authoring
+surfaces now write `Model: sonnet` by default instead of omitting the field, but `_route()`'s
+absent-field behavior (empty `route_flags` -> the child `claude -p` inherits the parent tier) was
+explicitly left UNCHANGED (SPEC-107 "Open questions"). This spec's negative control proves that
+read-time fallback is real (no crash, no silently-wrong tier), it does not re-decide what the fallback
+should be.
+
+## 2026-07-03 , test scope: full tier matrix on serial, one case on wave (not a full matrix)
+
+`tests/test-model-routing.sh` extends the serial-path mock pattern from `tests/test-orchestrate.sh`
+(cheap: no git-init, no worktree) to prove opus/sonnet/haiku all thread correctly, plus the no-`Model:`
+negative control. For the wave (concurrent) path it proves exactly ONE tier (opus) end-to-end via the
+heavier throwaway-git-init mock pattern from `tests/test-orchestrate-wavefront.sh` , the wave dispatch
+site is byte-identical in structure to the already-proven serial site (same `_route()` call, same
+`route_flags` construction), so a full second tier matrix on the wave path would be redundant proof at
+disproportionate cost (git-init + worktree spin-up per case). If `_wave_run`'s routing logic ever
+diverges from `_route()`'s shared contract, this one case still catches it.
+
+## 2026-07-03 , independent code-review pass (kit:code-reviewer, test-coverage lens)
+
+Mutation-tested the new suite before shipping: neutralized the `--model` flag build on the serial
+line and, separately, on the wave line in a scratch copy of `lib/orchestrate.sh`, and confirmed the
+matching test cases correctly flip to FAIL each time (rules out a rubber-stamp test that would pass
+even if the wiring broke). Two advisory, non-blocking gaps the reviewer flagged, filed here rather
+than fixed, since they are pre-existing or explicitly out of this spec's scope: (1) `_route()`'s own
+parse edge cases (case-insensitive match, trailing whitespace, multiple `Model:` lines, malformed
+lines) have no dedicated test anywhere in the repo , cheap to add later, not introduced by this spec;
+(2) the wave path's sonnet/haiku tiers are untested (opus only, by design , see the note above).
+`tests/test-routing.sh` (route-suggest.sh's own suite, untouched by this diff) fails on this host
+under the stock `/bin/bash` 3.2 (needs bash 4+ for `mapfile`/assoc arrays); pre-existing environment
+gap, confirmed green under homebrew bash 5.3, not caused by or in scope for this change.

--- a/docs/specs/SPEC-116-model-routing-enforce.md
+++ b/docs/specs/SPEC-116-model-routing-enforce.md
@@ -1,0 +1,133 @@
+# SPEC-116: model-routing enforcement (the `Model:` field reaches `--model`)
+
+Status: VALIDATED
+Lane: full
+Type: spec-feature
+
+## Spec validation (5-lens adversarial pass, self-run headless per AGENTS.md zone 2)
+
+- **Security:** no auth/secret/injection surface (shell dispatch of an internal `--model` flag,
+  no user-facing input). Pass, no findings.
+- **Failure modes:** an invalid `Model:` value (e.g. a typo'd tier) is passed verbatim to
+  `claude -p --model <value>` unchanged from today's behavior , `claude`'s own CLI validates the
+  tier name, `_route()` does not duplicate that validation (SPEC-087's design, unchanged here).
+  Noted, not a defect this spec introduces. No other failure-mode gaps found.
+- **Assumptions:** confirmed no competing model-selection mechanism exists (`grep -n
+  'CLAUDE_MODEL\|ANTHROPIC_MODEL' lib/*.sh` , zero hits) that could race or override `--model` at
+  dispatch. The MOCK-`CLAUDE_CMD` test pattern assumes the shim faithfully stands in for the real
+  `claude` binary's argv handling, the same assumption `tests/test-orchestrate.sh` already relies
+  on (established precedent, not new risk).
+- **Scope:** atomic , one spec doc + one new test file (+ fixtures), zero `lib/` edits. Verification
+  commands are concrete and runnable. Test coverage is scoped to what the Done criteria requires:
+  per-tier default-applied proof via the existing serial-path mock harness (extending
+  `tests/test-orchestrate.sh`'s TEST 8 pattern to opus/haiku, not just sonnet) plus ONE wave-path
+  case (opus) reusing `tests/test-orchestrate-wavefront.sh`'s throwaway-git-init mock pattern, not a
+  full tier x path matrix , that would exceed what "prove the wiring is real" requires. No
+  loop-reachable scope/architecture decision is made autonomously; the two decisions this spec
+  makes (enforcement site, fallback tier) are both read directly off already-Accepted precedent
+  (ADR-0032, SPEC-107), not invented.
+- **Solution design:** simplest possible design , reuse the two existing mock-`CLAUDE_CMD` test
+  patterns already in the repo rather than building a new harness; zero new abstractions; zero
+  `lib/` changes since the mechanism already exists. The alternative (adding a `route-suggest.sh`
+  call inside `orchestrate.sh` to "double-check" the tier at dispatch) was considered and rejected:
+  it would add a runtime dependency + failure mode for zero benefit, since the two surfaces already
+  cannot conflict by construction (disjoint phases).
+
+**Verdict: APPROVED**, no critical issues, no warnings requiring a fix before implementation.
+
+## Problem
+
+ADR-0032 section 2 (ACCEPTED) decides the routing RULE, planning-dominant sub-goals -> `opus`,
+execution-dominant -> `sonnet`, trivial -> `haiku`, and says the mechanism is "`Model:` field ->
+orchestrate `--model`". `orchestrate-hardening` open-fork 3 asks WHERE that enforcement lives
+(`lib/orchestrate.sh` vs `lib/route-suggest.sh`) and whether `route-suggest.sh`'s "Opus-spend"
+suggester could silently disagree with an explicit `Model:` field. Neither question has a written
+answer, and no test proves the DEFAULT-applied case (a goal file that carries `Model: opus` and
+reaches a real `claude -p --model opus` dispatch) across all three tiers , `tests/test-orchestrate.sh`
+TEST 8 (:187-225) proves only the `sonnet` tier + the inherit negative control, not `opus`/`haiku`,
+and not the wave (concurrent) delegate path.
+
+## Research (what already exists , this spec ENFORCES/PROVES, does not build)
+
+- `lib/orchestrate.sh:_route()` (SPEC-087, :392-403) already reads a goal file's bare `Model:` /
+  `Effort:` lines and is already threaded into `--model`/`--effort` at BOTH delegate dispatch sites:
+  the serial path (`cmd_run`, :1159-1162) and the concurrent wave path (`_wave_run`, :786-788). Both
+  feed `route_flags` into the single shared `_run_one_session()` (:601-631), whose three mutually
+  exclusive run-paths (watchdog / stream-json / plain) each pass `$route_flags` straight into the real
+  `"$CLAUDE_CMD" -p $route_flags ...` invocation. An absent `Model:` line yields an empty `route_flags`
+  , the session inherits the parent tier (documented at :394 and reaffirmed by SPEC-107's "one stance":
+  `_route()`'s absent-field->inherit fallback is UNCHANGED by SPEC-107, only the write-time default on
+  the authoring surfaces changed).
+- `lib/route-suggest.sh` (token-optim-v3 SG-06) is a standalone CLI invoked by a human/`agents/meta-agent.md`
+  Mode B at DECOMPOSE time, when DRAFTING a goal file's `Model:` line from measured SG-09 ablation data.
+  `grep -rn route-suggest.sh lib/ | grep -v route-suggest.sh` (i.e. every caller except the file itself)
+  returns zero hits inside `lib/orchestrate.sh` , the dispatch path never invokes it. It cannot silently
+  override an explicit `Model:` field because it has no dispatch-time call site at all.
+
+## Solution (pins open-fork 3; proves the existing wiring; adds the dedicated test)
+
+1. **Enforcement site (open-fork 3): `lib/orchestrate.sh`.** `_route()` + the two `route_flags`
+   dispatch sites are the enforcement mechanism; `route-suggest.sh` stays a decompose-time SUGGESTER
+   only (per its own header comment: "a SUGGESTER, never an auto-router"). This is not a new decision,
+   it is what the code already does; this spec is the first place it is written down and load-bearing.
+2. **Route-suggest alignment (structural, not runtime):** because `route-suggest.sh` has no call site
+   in `lib/orchestrate.sh`, an explicit `Model:` field can never be contradicted at dispatch time , the
+   two surfaces operate in disjoint phases (decompose-time suggestion vs dispatch-time enforcement).
+   `tests/test-model-routing.sh` pins this with a grep negative control (no `route-suggest` call site
+   in the dispatch functions) instead of a runtime mock, since there is no runtime interaction to mock.
+3. **Fallback tier (the no-`Model:`-field default): inherit the parent session's tier.** This is the
+   EXISTING, already-documented default (`_route()` :394, SPEC-107 "Open questions"): a goal file with
+   no `Model:` line makes `route_flags` empty, so `_run_one_session()` passes no `--model` flag and the
+   `claude -p` child inherits whatever tier launched the conductor. SPEC-107 changed the WRITE-time
+   default on authoring surfaces (write `Model: sonnet` instead of omitting) but explicitly left this
+   READ-time fallback unchanged. This spec's negative control proves the fallback is real (no crash, no
+   silently-wrong tier) rather than re-asserting the write-time policy.
+4. **`tests/test-model-routing.sh`** (new, dedicated file , distinct from `tests/test-routing.sh`, which
+   covers `route-suggest.sh`'s suggestion logic, not dispatch enforcement): a MOCK `CLAUDE_CMD` shim
+   (same pattern as `tests/test-orchestrate.sh`) records its invocation args; drives BOTH delegate paths
+   (serial `run` and the wave path via `WAVE_CAP>=2`) with fixture goal files carrying `Model: opus`,
+   `Model: sonnet`, `Model: haiku`, and no `Model:` line; asserts the recorded args contain the matching
+   `--model <tier>` (or none, for the no-field case); asserts the route-suggest non-contradiction grep.
+
+No `lib/` code changes are required , the enforcement already exists and is already wired into both
+delegate paths under SPEC-087/SPEC-106. This spec's diff is `docs/specs/`, `docs/decisions/` cross-reference,
+and `tests/test-model-routing.sh` + its fixtures.
+
+## Verification
+
+```bash
+cd dwarves-kit
+bash tests/test-model-routing.sh   # new: per-tier default-applied (opus/sonnet/haiku), serial + wave,
+                                    # route-suggest alignment grep, no-field fallback negative control
+bash tests/test-orchestrate.sh     # unchanged, still green (TEST 8 sonnet+inherit case)
+bash tests/test-meta.sh            # structural integrity unaffected
+
+# tests/test-routing.sh (route-suggest.sh's own suggestion-logic suite) is UNTOUCHED by this diff
+# and out of scope, but on this host fails under the stock /bin/bash 3.2 (no mapfile/assoc-arrays):
+# pre-existing, unrelated to model-routing enforcement. Confirm with homebrew bash:
+/opt/homebrew/bin/bash tests/test-routing.sh   # green with bash 4+
+```
+
+## After state
+
+- `docs/specs/SPEC-116-model-routing-enforce.md` (this file) pins open-fork 3: enforcement site =
+  `lib/orchestrate.sh`, fallback tier = inherit.
+- `tests/test-model-routing.sh` + `tests/fixtures/model-routing/` prove the default-applied positive
+  case for opus/sonnet/haiku on both delegate paths, the route-suggest non-contradiction, and the
+  no-`Model:`-field negative control.
+- No behavior change to `lib/orchestrate.sh` or `lib/route-suggest.sh` , this is a proof + pin, not a
+  new feature.
+
+## Scope edges
+
+**In:** the enforcement-site decision (open-fork 3), the route-suggest alignment confirmation, the
+`tests/test-model-routing.sh` proof (serial + wave, all three tiers, negative control).
+**Out:** token capture (orchestrate-hardening sub-goal 02), the TIER-4 mega-close (03), multiplexer
+panes (04), docs-wiring (05). `ROADMAP.md` lives in the `ops-toolkit` repo and is not touched here.
+**Not:** re-deciding ADR-0032's routing RULE; changing `route-suggest.sh`'s heuristic; changing
+`_route()`'s absent-field fallback (inherit stays inherit, per SPEC-107).
+
+## Open questions
+
+None , both open questions this spec was scoped to resolve (enforcement site, fallback tier) are
+answered above from the code and SPEC-107's already-accepted precedent, not newly invented here.

--- a/docs/verification/model-routing-enforce.md
+++ b/docs/verification/model-routing-enforce.md
@@ -1,0 +1,83 @@
+# Proof of done , model-routing enforcement (SPEC-116, orchestrate-hardening sub-goal 01)
+
+## Acceptance criteria (per the sub-goal's `Done =` line)
+
+| # | Criterion | Status |
+|---|---|---|
+| 1 | Delegate call passes `--model` from the goal file's `Model:` field, default-applied, for opus/sonnet/haiku | met (run-table below; existing mechanism, SPEC-087, newly proven per-tier) |
+| 2 | `route-suggest.sh`'s heuristic confirmed non-contradictory with an explicit `Model:` | met (structural: zero call sites in the dispatch path) |
+| 3 | No-`Model:`-field fallback lands on the documented default (not a crash, not a silently wrong tier) | met (fallback = inherit, per SPEC-107; negative-control row below) |
+| 4 | Open-fork 3 (enforcement site) resolved | met: `lib/orchestrate.sh`, pinned in SPEC-116 |
+| 5 | Tests green | met (below) |
+
+## Why this is a proof-and-pin, not a new feature
+
+`_route()` (SPEC-087) and both delegate dispatch sites (serial `cmd_run`, concurrent `_wave_run`)
+already threaded `Model:` into `--model` before this sub-goal started. `tests/test-orchestrate.sh`
+TEST 8 already proved the `sonnet` tier + the inherit fallback on the serial path only. This sub-goal
+adds the missing tiers (opus, haiku), the wave-path case, the route-suggest structural check, and
+writes down the two decisions (enforcement site, fallback tier) that were previously implicit in code
+comments and a different spec (SPEC-107), not yet load-bearing as an explicit pin. See
+`docs/implementation-notes/model-routing-enforce.md` for the full delta trail.
+
+## Run-table
+
+`_route()` reads a goal file's bare `Model:` line and both delegate dispatch sites build
+`route_flags="--model <tier>"`, threaded into the real `"$CLAUDE_CMD" -p $route_flags ...` call.
+
+| Path | Goal file | Dispatched as | Result |
+|---|---|---|---|
+| serial | `Model: opus` | `--model opus` | default-applied, proven |
+| serial | `Model: sonnet` | `--model sonnet` | default-applied, proven |
+| serial | `Model: haiku` | `--model haiku` | default-applied, proven |
+| serial | (no `Model:` line) | no `--model` flag | inherit fallback, proven (negative control) |
+| wave (concurrent) | `Model: opus` | `--model opus` | default-applied, proven |
+| n/a | `route-suggest.sh` call sites in `lib/orchestrate.sh` dispatch functions | 0 | structurally cannot contradict an explicit `Model:` |
+
+## GREEN run
+
+```
+$ bash tests/test-model-routing.sh
+PASS route-suggest alignment: lib/orchestrate.sh has no route-suggest.sh call site (cannot contradict an explicit Model: field)
+PASS serial: Model: opus -> dispatch '--model opus' (default-applied)
+PASS serial: Model: sonnet -> dispatch '--model sonnet' (default-applied)
+PASS serial: Model: haiku -> dispatch '--model haiku' (default-applied)
+PASS serial: no Model: field -> no --model flag (inherit fallback, no crash)
+PASS wave: Model: opus -> dispatch '--model opus' (default-applied, concurrent delegate path)
+
+=== 6/6 passed, 0 failed ===
+```
+
+Regression (unchanged, still green):
+
+```
+$ bash tests/test-orchestrate.sh
+... (60 assertions) ...
+ALL PASS
+
+$ bash tests/test-meta.sh
+Passed: 662 / 662
+All meta tests passed.
+```
+
+`tests/test-routing.sh` (route-suggest.sh's own suite, untouched by this diff) needs bash 4+; green
+under `/opt/homebrew/bin/bash`, fails on this host's stock `/bin/bash` 3.2 , a pre-existing environment
+gap unrelated to this change (confirmed present on `master` before this diff too).
+
+## Independent review
+
+`kit:code-reviewer` (test-coverage lens) mutation-tested the new suite: broke the `--model` flag build
+on the serial dispatch line and, separately, the wave dispatch line, in a scratch copy of
+`lib/orchestrate.sh`; the matching test cases correctly flipped to FAIL in each case, ruling out a
+rubber-stamp test. No blocking findings. Two advisory gaps filed in the implementation notes (pre-
+existing `_route()` parse edge cases untested repo-wide; wave path covers only the opus tier by
+design).
+
+## Reproduce
+
+```bash
+cd <dwarves-kit-worktree>
+bash tests/test-model-routing.sh
+bash tests/test-orchestrate.sh
+bash tests/test-meta.sh
+```

--- a/tests/test-model-routing.sh
+++ b/tests/test-model-routing.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# test-model-routing.sh -- SPEC-116: proves the `Model:` field is LOAD-BEARING on the delegate
+# dispatch path, not advisory. Companion to (not a replacement for):
+#   - tests/test-orchestrate.sh TEST 8, which proves the `sonnet` tier + the inherit fallback on
+#     the SERIAL path only.
+#   - tests/test-routing.sh, which proves lib/route-suggest.sh's SUGGESTION logic (decompose-time),
+#     not dispatch-time enforcement.
+#
+# This file proves:
+#   1. the DEFAULT-APPLIED positive case for ALL THREE tiers (opus/sonnet/haiku) on the serial
+#      delegate path -- a goal file carrying `Model: <tier>` reaches a real
+#      `claude -p --model <tier>` invocation, not just that the field is read.
+#   2. the SAME on the concurrent wave delegate path, for one tier (opus) -- the wave dispatch site
+#      shares `_route()` with the serial site; one case catches drift without a full second matrix.
+#   3. route-suggest.sh has NO call site in the dispatch functions, so it cannot silently override
+#      an explicit `Model:` field (the "alignment" ADR-0032/open-fork-3 asks for is structural).
+#   4. the NEGATIVE CONTROL: a goal file with NO `Model:` field passes no `--model` flag (documented
+#      default: inherit the parent session's tier, SPEC-107 "Open questions"), not a crash and not a
+#      silently wrong tier.
+#
+# Run: bash tests/test-model-routing.sh   (exit 0 = pass, 1 = fail)
+
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORCH="$KIT/lib/orchestrate.sh"
+fails=0; total=0
+pass() { total=$((total + 1)); echo "PASS $*"; }
+fail() { total=$((total + 1)); echo "FAIL $*"; fails=$((fails + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ============================ SECTION 1: route-suggest alignment (structural) ============================
+# route-suggest.sh is a decompose-time SUGGESTER (invoked by a human / agents/meta-agent.md Mode B
+# when DRAFTING a goal file's Model: line). It has NO call site in lib/orchestrate.sh's dispatch
+# functions, so it cannot contradict an already-written explicit Model: field at dispatch time --
+# the two surfaces operate in disjoint phases. This is a structural grep, not a runtime mock: there
+# is no runtime interaction between the two scripts to mock.
+if grep -n 'route-suggest' "$ORCH" >/dev/null 2>&1; then
+  fail "route-suggest alignment: lib/orchestrate.sh calls route-suggest.sh at dispatch time (would need a runtime alignment check, not just this structural one)"
+else
+  pass "route-suggest alignment: lib/orchestrate.sh has no route-suggest.sh call site (cannot contradict an explicit Model: field)"
+fi
+
+# ============================ SECTION 2: serial delegate path, all three tiers + negative control ==========
+mk_megagoal_tiered() {  # dir model-line-or-empty
+  local d="$1" modelline="$2"
+  mkdir -p "$d/goals"
+  cat > "$d/ROADMAP.md" <<'EOF'
+# Mega-goal: tiered fixture
+## Sub-goals
+- [ ] SG-01 only auto , auto , PR #__
+EOF
+  echo "POINTER: resume from ROADMAP" > "$d/POINTER_PROMPT.md"
+  {
+    printf '# SG-01\n'
+    [ -n "$modelline" ] && printf '%s\n' "$modelline"
+    printf '\nGOALFILE-MARKER-01 contract for SG-01\n'
+  } > "$d/goals/01-first.md"
+}
+
+# Mock claude: logs "<id>|<argv flags>" (prompt arrives on stdin, argv carries only route flags),
+# then flips SG-01's box so the loop advances cleanly (grounded completion).
+cat > "$TMP/claude-route" <<'EOF'
+#!/usr/bin/env bash
+prompt=$(cat)
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+printf '%s|%s\n' "$id" "$*" >> "$ROUTE_LOG"
+awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' "$ROUTE_RM" > "$ROUTE_RM.tmp" && mv "$ROUTE_RM.tmp" "$ROUTE_RM"
+EOF
+chmod +x "$TMP/claude-route"
+
+run_serial_case() {  # tier(opus|sonnet|haiku|none) expect_flag(--model X or empty)
+  local tier="$1" want="$2" d log
+  d="$TMP/serial-$tier"; log="$TMP/serial-$tier.log"; : > "$log"
+  if [ "$tier" = none ]; then
+    mk_megagoal_tiered "$d" ""
+  else
+    mk_megagoal_tiered "$d" "Model: $tier"
+  fi
+  ROUTE_LOG="$log" ROUTE_RM="$d/ROADMAP.md" CLAUDE_FLAGS="" \
+    CLAUDE_CMD="$TMP/claude-route" bash "$ORCH" run "$d" >/dev/null 2>&1
+  if [ -n "$want" ]; then
+    grep -q "^SG-01|.*$want" "$log" \
+      && pass "serial: Model: $tier -> dispatch '$want' (default-applied)" \
+      || { fail "serial: Model: $tier did NOT reach '$want'"; cat "$log"; }
+  else
+    { grep '^SG-01|' "$log" | grep -qv -- '--model'; } \
+      && pass "serial: no Model: field -> no --model flag (inherit fallback, no crash)" \
+      || { fail "serial: no-Model: case got an unexpected --model flag"; cat "$log"; }
+  fi
+}
+
+run_serial_case opus   "--model opus"
+run_serial_case sonnet "--model sonnet"
+run_serial_case haiku  "--model haiku"
+run_serial_case none   ""
+
+# ============================ SECTION 3: wave (concurrent) delegate path, opus tier ============================
+# Source orchestrate.sh to call _wave_run directly (the tests/test-orchestrate-wavefront.sh pattern).
+# The guard in orchestrate.sh (`[ "${BASH_SOURCE[0]}" = "$0" ]`-style main gate) keeps `main "$@"`
+# from firing on source.
+# shellcheck source=../lib/orchestrate.sh
+source "$ORCH"
+
+mk_git_mega() {  # repo-root
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email t@example.com
+  git -C "$repo" config user.name test
+  git -C "$repo" commit -q --allow-empty -m init
+}
+
+WR="$TMP/wave-repo"; mk_git_mega "$WR"
+WM="$WR/mega"; mkdir -p "$WM/goals"
+cat > "$WM/ROADMAP.md" <<'EOF'
+# Mega-goal: wave-tiered fixture
+## Sub-goals
+- [ ] SG-01 only auto , auto , PR #__
+EOF
+echo "POINTER: resume from ROADMAP" > "$WM/POINTER_PROMPT.md"
+cat > "$WM/goals/01-SG-01.md" <<'EOF'
+# SG-01: sub-goal
+**Branch:** feat/sg-01
+Model: opus
+
+## Touches
+- lib/wave-tiered/**
+EOF
+
+WAVE_LOG="$TMP/wave.log"; : > "$WAVE_LOG"
+cat > "$TMP/claude-wave-route" <<'EOF'
+#!/usr/bin/env bash
+prompt=$(cat)
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+printf '%s|%s\n' "$id" "$*" >> "$WAVE_ROUTE_LOG"
+"$ORCH" flip "$MEGADIR" "$id" >/dev/null 2>&1
+EOF
+chmod +x "$TMP/claude-wave-route"
+
+wrc=0
+( export WAVE_ROUTE_LOG="$WAVE_LOG" ORCH="$ORCH" MEGADIR="$WM" CLAUDE_FLAGS="" WAVE_CAP=2 \
+    CLAUDE_CMD="$TMP/claude-wave-route"
+  _wave_run "$WM" "$WM/ROADMAP.md" ) > "$TMP/wave.out" 2>&1 || wrc=$?
+
+if [ "$wrc" = 0 ] && grep -q '^SG-01|.*--model opus' "$WAVE_LOG"; then
+  pass "wave: Model: opus -> dispatch '--model opus' (default-applied, concurrent delegate path)"
+else
+  fail "wave: Model: opus did not reach --model on the wave path (rc=$wrc)"; cat "$WAVE_LOG" "$TMP/wave.out" 2>/dev/null
+fi
+
+echo ""
+echo "=== $((total - fails))/$total passed, $fails failed ==="
+[ "$fails" -eq 0 ]


### PR DESCRIPTION
Model-routing enforcement: `orchestrate.sh` honors the per-sub-goal `Model:` field on the delegate path , the goal file's `Model: opus|sonnet|haiku` reaches `claude -p --model ...` at dispatch (default-applied, not override-only), and `route-suggest.sh`'s Opus-spend heuristic is confirmed non-contradictory. Executes ADR-0032 section 2.

**What this is:** the enforcement mechanism (`_route()` + the serial/wave delegate dispatch sites in `lib/orchestrate.sh`) already existed under SPEC-087, threading a goal file's `Model:` line into `--model` at both dispatch sites. `tests/test-orchestrate.sh` TEST 8 already proved this for the `sonnet` tier + the inherit fallback, serial path only. This PR:

- Resolves `orchestrate-hardening` open-fork 3 (enforcement site): `lib/orchestrate.sh`, not `lib/route-suggest.sh` (a decompose-time suggester with zero dispatch-time call sites, so it cannot structurally contradict an explicit `Model:` field).
- Pins the no-`Model:`-field fallback tier as "inherit the parent session's tier" (already the documented behavior per SPEC-107's "Open questions", now load-bearing via a negative-control test).
- Adds `tests/test-model-routing.sh`: default-applied proof for opus/sonnet/haiku on the serial delegate path, one case (opus) on the concurrent wave path, the route-suggest structural non-contradiction check, and the fallback negative control.

No `lib/` behavior change. `docs/specs/SPEC-116-model-routing-enforce.md` is the spec (VALIDATED, 5-lens self-review); `docs/implementation-notes/model-routing-enforce.md` has the full delta trail; `docs/verification/model-routing-enforce.md` is the proof-of-done.

Independent review: `kit:code-reviewer` (test-coverage lens) mutation-tested the new suite (broke the `--model` build on both the serial and wave dispatch lines in a scratch copy; matching cases correctly failed) , no blocking findings.

Verify: `bash tests/test-model-routing.sh` (per-tier default-applied + route-suggest alignment + no-field fallback NC). Roadmap: ops-toolkit `_meta/megagoals/orchestrate-hardening/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
