### PR TITLE
feat(orchestrate): lean token capture under delegation via stream-to-file

### DIFF
--- a/docs/implementation-notes/token-capture-delegate.md
+++ b/docs/implementation-notes/token-capture-delegate.md
@@ -1,0 +1,65 @@
+# Implementation notes: token capture under delegation (SPEC-117)
+
+Delta from the spec + ADR-0032 §3. Reference, don't restate.
+
+## 2026-07-03 11:30 Reuse over rebuild: the silent stream-to-file path already exists
+
+Context: The goal said "VERIFY what is there, then close the specific gap." Audit found
+SPEC-110 already ships the whole extraction+ledger chain:
+- `lib/handoff/handoff_gen.py sum-usage <file>`, assistant-only usage extraction from a stream-json FILE.
+- `lib/gate-ledger.sh tokens <rid> ...`, the `| TOKENS |` additive marker.
+- `lib/orchestrate.sh` token hook (cmd_run ~L1245), gated on `$slog` non-empty → sum-usage → record TOKENS.
+- `_run_one_session` already has BOTH a tee-to-conductor branch (`--stream`, L621) AND a
+  silent `> "$slog"` stream-to-FILE branch (the `else` under `DETERMINISTIC_HANDOFF=1`, L623).
+
+Decision: Do NOT add a new file, a new marker, or a new extractor. The only real gap is that
+the LEAN silent-stream-to-file capture is reachable ONLY by turning on `DETERMINISTIC_HANDOFF`
+(a heavier, unrelated feature, handoff regeneration). Add ONE decoupled trigger,
+`CAPTURE_TOKENS` env + `--capture-tokens` flag, that takes the SAME silent branch purely for
+usage extraction.
+
+Why: ADR-0032 §5 lists "Token-capture stream-to-file (item 3)" as a gap to close as first-class.
+`--stream` is the forbidden bloat path (it tees the child stream to the conductor); operators
+need a lean token-capture knob that is neither `--stream` nor `DETERMINISTIC_HANDOFF`.
+
+Impact: ~3-line change to `_run_one_session`'s elif trigger + flag/env wiring in cmd_run. The
+downstream hook is untouched (already `$slog`-gated). The default (no-flag) path stays
+byte-identical (honest usage=?).
+
+## 2026-07-03 File naming: reuse `<id>.stream.jsonl`, not a new `child.jsonl`
+
+ADR-0032 §3 writes `claude -p --stream > child.jsonl` conceptually. The existing per-sub-goal
+capture file is `.orchestrate/<id>.stream.jsonl`. Reuse it (do not invent a second file
+convention), the "child.jsonl" in the ADR is the concept, `<id>.stream.jsonl` is the instance.
+
+## 2026-07-03 11:50 spec-validate dispositions (adversarial pass)
+
+An adversarial spec-validate lens attacked SPEC-117 pre-code. Dispositions:
+
+- **BLOCKER (wave-path token hook missing):** RESOLVED by correcting the over-claim. The token
+  hook lives only on the SERIAL `cmd_run` path; `_wave_run` never had one (nor did SPEC-110).
+  My Done= is the serial single-child delegate (ADR-0032 §3 `claude -p --stream > child.jsonl`).
+  Scoped the wave-path per-sub-goal ledger extraction OUT explicitly (declared gap, like SPEC-110's
+  watchdog gap; single wiring point at orchestrate.sh:862). The child.jsonl IS still written
+  lean-to-file under waves (global inherits into the subshell), so only the extraction is deferred.
+  Dep-chained / Touches-less mega-goals run the serial path anyway (ready set size-1).
+- **MAJOR (global vs positional):** ACCEPTED. `CAPTURE_TOKENS` is a script GLOBAL read inside
+  `_run_one_session` (mirroring `DETERMINISTIC_HANDOFF`), NOT a positional arg. Zero signature
+  change, zero `_wave_run` call-site touch, composes through the wave subshell on fork.
+  `--capture-tokens` just sets the global in `cmd_run`.
+- **MINOR (stderr leak):** the transcript (the accumulation trap) is fd1 (`claude -p` stdout) and
+  is redirected to the file. `--verbose` stderr is diagnostic-only (no usage/turn content) and the
+  driver is non-LLM bash. Test proves the property that matters by capturing child stdout and
+  stderr SEPARATELY and asserting the transcript sentinel is absent from fd1. Redirecting stderr too
+  is a deferred hardening (would silence real errors on this opt-in path). `# ponytail:` noted at code.
+- **MINOR (flag-parse ordering):** ACCEPTED. `--capture-tokens)` arm goes before the `--*)` catchall.
+- **LOW (completeness):** usage header + `main()` usage string + `--dry-run` advisory updated.
+- **LOW (env+flag asymmetry):** kept both; the flag simply sets the env-global. Env is the wave-subshell
+  inheritance mechanism; flag is interactive/scripted sugar.
+
+## 2026-07-03 `--verbose` on the child is NOT a hard-rule violation
+
+The hard rule (ADR-0032 §1) forbids `--stream`/`--verbose` piped TO THE CONDUCTOR. In the
+silent branch the `--output-format stream-json --verbose` output is redirected `> "$slog"` (the
+FILE), never the conductor's stdout. Only the `--stream` tee branch violates the rule, that is
+exactly what the false-bloat NC guards.

--- a/docs/specs/SPEC-117-token-capture-delegate.md
+++ b/docs/specs/SPEC-117-token-capture-delegate.md
@@ -1,0 +1,215 @@
+# SPEC-117: token capture under delegation (stream-to-FILE, conductor stays lean)
+
+Status: SHIPPED
+Lane: full
+Type: spec-feature
+
+## Problem
+
+ADR-0032 commits the kit to a DELEGATE run mode (default for mega-goals > 4 sub-goals): the `/goal`
+conductor is a thin driver that makes ONE fresh `claude -p` call per sub-goal and absorbs only a
+terse box-flip result, never the child transcript. ADR-0032 §1 makes that a HARD RULE: delegate
+uses plain `claude -p`, NEVER `--stream`/`--verbose` piped TO THE CONDUCTOR (that dumps the child
+transcript into the parent context , the exact accumulation trap the whole mode exists to avoid).
+
+This collides with the token ledger (SPEC-110). Token capture needs stream-json (usage lives in the
+per-assistant-turn `usage` blocks), but under delegation there is today NO LEAN way to get it:
+
+- `orchestrate.sh run <dir> --stream` captures usage to `.orchestrate/<id>.stream.jsonl` BUT
+  `tee`s the full stream-json to the conductor's stdout (`_run_one_session` L621) , the forbidden
+  bloat path. `test-orchestrate.sh` TEST 10 even asserts this tee happens.
+- The only existing SILENT stream-to-FILE capture (`> "$slog"`, `_run_one_session` L623) is
+  reachable ONLY by enabling `DETERMINISTIC_HANDOFF=1` , a heavier, unrelated feature (handoff
+  regeneration). An operator who wants token capture on a plain delegate run should not have to
+  turn on handoff regeneration to get it.
+
+ADR-0032 §5 lists "Token-capture stream-to-file (item 3)" as a gap the ADR obliges the kit to
+close. Result: a delegate mega-goal cannot be priced (median tokens-to-done, cache efficiency per
+SPEC-110) without bloating the conductor, so operators run blind or bloat the parent. This spec
+closes that gap and OVER-TESTS the two load-bearing properties.
+
+## Solution
+
+Reconcile per ADR-0032 §3: the delegated child streams to a FILE, usage is extracted FROM the file,
+the token ledger records it, and the conductor reads ONLY the box-flip. Reuse the entire SPEC-110
+extraction+ledger chain; add ONE decoupled trigger so the LEAN capture is first-class.
+
+1. **`CAPTURE_TOKENS` env (default 0), read as a script GLOBAL, plus a `--capture-tokens` flag that
+   just sets that same global** , a decoupled opt-in that makes `_run_one_session` take the EXISTING
+   silent `> "$slog"` stream-to-FILE branch purely for usage extraction. Independent of `--stream`
+   (which stays the live-tail-to-conductor bloat path) and of `DETERMINISTIC_HANDOFF` (which stays
+   the handoff-regen path). The mechanism is pinned to the SAME shape as `DETERMINISTIC_HANDOFF`: a
+   global read inside `_run_one_session` (orchestrate.sh:612), NOT a new positional arg. This is
+   deliberate , a positional would force a signature change and a touch at `_wave_run`'s hardcoded
+   5-arg call site (orchestrate.sh:821); a global inherits into the wave subshell on fork with zero
+   call-site churn. `--capture-tokens` sets `CAPTURE_TOKENS=1` in `cmd_run`'s parser (flag arm placed
+   BEFORE the `--*)` unknown-flag catchall, or it is rejected); the flag is scripted/interactive sugar
+   over the env.
+2. **No new file, marker, extractor, or ledger.** The child stream lands in the existing
+   `.orchestrate/<id>.stream.jsonl` (ADR-0032's "child.jsonl" is the concept, this is the instance).
+   Usage extraction reuses `handoff_gen.py sum-usage`; the record reuses `gate-ledger.sh tokens`
+   (the `| TOKENS |` marker, SPEC-110 SG-03). The downstream token hook in `cmd_run` (orchestrate.sh
+   ~L1245) is UNCHANGED , it is already gated on `$slog` non-empty, so a SERIAL-path capture from
+   the new trigger flows through it with no hook change.
+3. **Default path byte-identical.** With neither flag/env nor `--stream`/`DETERMINISTIC_HANDOFF`
+   set, `_run_one_session` takes the plain `claude -p` branch (no `--output-format stream-json`, no
+   redirect, no tee). The conductor reads only claude's terse final result (the box-flip line) and
+   the run honestly reports `usage=?` (SPEC-087 default-invocation pin intact).
+4. **Scope: the SERIAL delegate path (the ADR-0032 §3 canonical single child).** ADR-0032 §3's form
+   is one delegated `claude -p --stream > child.jsonl`. The SERIAL per-sub-goal path in `cmd_run`
+   carries the token hook and is what this spec closes + over-tests. The WAVE path (`_wave_run`,
+   SPEC-106 concurrency) has NO token hook today , it never has (SPEC-110 captured tokens only on the
+   serial path). Under `CAPTURE_TOKENS=1` the wave subshell STILL writes each child's
+   `.orchestrate/<id>.stream.jsonl` lean-to-file (the global inherits on fork, the redirect stays
+   silent , the leanness property holds there too), but the per-sub-goal LEDGER extraction from those
+   files is a DECLARED GAP, disclosed exactly like SPEC-110's watchdog-path gap, and filed as the next
+   increment (the reap loop at orchestrate.sh:862 is the single wiring point). For dependency-chained
+   or `## Touches`-less mega-goals (the dominant hardening-roadmap shape, incl. this one) the ready set
+   is size-1 and everything runs the SERIAL path anyway, so the closed path is the load-bearing one.
+
+## Design
+
+The whole design turns on ONE distinction inside `_run_one_session`: a `| tee "$slog"` (stdout AND
+file) versus a `> "$slog"` (file only). The bloat is entirely the `tee`.
+
+```
+                 orchestrate.sh run <dir>   (the thin conductor; holds roadmap + results only)
+                          |
+       trigger?  ---------+--------------------------------------------------
+       |                  |                          |                       |
+   (none)             --capture-tokens            --stream            DETERMINISTIC_HANDOFF=1
+   plain -p           / CAPTURE_TOKENS=1          (live tail)         (handoff regen)
+       |                  |                          |                       |
+  claude -p          claude -p --stream         claude -p --stream     claude -p --stream
+  (terse result       > child.jsonl             | tee child.jsonl      > child.jsonl
+   to conductor)      (FILE ONLY)               (FILE + CONDUCTOR)     (FILE ONLY)
+       |                  |                          |                       |
+   conductor          conductor sees            conductor ABSORBS      conductor sees
+   sees box-flip      box-flip only             full child stream      box-flip only
+   usage=?            (LEAN) ✓                   (BLOAT) ✗ forbidden    (LEAN) ✓
+                          |                                                  |
+                          +--------------------- both -----------------------+
+                                                 |
+                    child.jsonl  --sum-usage-->  in/out/cache tokens  --gate-ledger tokens-->
+                                                 <rid>.log  | TOKENS |  (SPEC-110 SG-03 marker)
+```
+
+**Stream-to-file path + file lifecycle.** The child's stream-json is redirected to
+`$dir/.orchestrate/<id>.stream.jsonl` (existing naming, existing dir; `_run_one_session` already
+mkdir's `.orchestrate`). Lifecycle: written per sub-goal session, overwritten on a re-run of the
+same sub-goal (`>` truncates), read once by the post-session token hook, then left on disk as the
+run artifact (same as `--stream` today , no new cleanup path, no new lifecycle to reason about).
+It lives in the mega-goal dir, NOT in the conductor's context.
+
+**Usage extraction.** Reuse `handoff_gen.py sum-usage <file>` verbatim: it sums assistant-only
+`usage` blocks (input/output/cache_read/cache_creation), skipping the final cumulative
+`type:"result"` event so totals are not double-counted (SPEC-110). Its output
+`in=N out=N cache_read=N cache_create=N` feeds `gate-ledger.sh tokens <rid> ...` unchanged.
+
+**How the conductor stays lean.** The child's `--output-format stream-json` transcript is written
+to stdout by `claude -p`, and in the capture-tokens branch that stdout is redirected `> "$slog"`
+(the FILE), so the TRANSCRIPT , the accumulation trap ADR-0032 §1 forbids , never reaches
+`_run_one_session`'s stdout, which is what `cmd_run` forwards to the conductor. `--verbose` on the
+child is therefore NOT an ADR-0032 §1 violation: the rule forbids the transcript piped TO THE
+CONDUCTOR, and here it goes to the file. The conductor's stdout carries only the driver's own `_say`
+telemetry lines and (on the plain path) claude's terse result. The grounded-completion signal is the
+ROADMAP box flip read from disk (`_subgoals ... $3==1`), never parsed from stdout, so nothing about
+lean-mode weakens completion detection. `--verbose` diagnostics on the child's STDERR are not the
+transcript (they carry no `usage`/turn content) and the driver is non-LLM bash, so they are not an
+accumulation vector; the test proves the property that matters , the transcript (fd1) is provably
+absent from the forwarded stream , by capturing the child's stdout and stderr SEPARATELY rather than
+merged. (Redirecting the child's stderr too is a possible future hardening for a stdout+stderr-merging
+conductor invocation; deferred as it would also silence real error output on this opt-in path.)
+
+**Why the tee is the whole bloat.** `--stream`'s `| tee "$slog"` writes the stream-json to BOTH the
+file and stdout; the stdout copy is what floods the conductor. `--capture-tokens` reuses the same
+`claude -p --stream` child invocation but drops the tee for a plain redirect , identical capture,
+zero conductor cost. This is the reconciliation: capture needs the stream, the conductor must not
+see it, so the stream goes to a file and only a file.
+
+**False-bloat negative control.** The design is only meaningful if the forbidden path is
+demonstrably worse. The test runs the SAME child (emitting a bulky stream-json body with a unique
+sentinel) twice: once `--stream` (tee) , the sentinel MUST appear in the conductor's captured
+stdout (bloat proven); once `--capture-tokens` , the sentinel MUST NOT appear in the conductor's
+stdout but MUST appear in `child.jsonl` (lean proven), and both MUST record an identical TOKENS
+line (capture correctness holds on the lean path).
+
+## Test plan
+
+Coverage matrix over the acceptance criteria, driven by the `CLAUDE_CMD` mock seam
+(`tests/test-token-capture.sh`). A COVERAGE-DELTA row (covered + explicitly-uncovered) lands in the
+proof-of-done.
+
+| # | Category | Case | Assertion |
+|---|----------|------|-----------|
+| C1 | capture-correctness | `--capture-tokens` serial run, mock emits real-shape stream-json to stdout | a `\| TOKENS \|` line is recorded for the run's rid AND its `in/out/cache_read/cache_create` equals `sum-usage` of the written `child.jsonl` (matches the child's own totals) |
+| C2 | conductor-stays-lean | same run | the child transcript sentinel is ABSENT from the conductor's captured STDOUT and PRESENT in `.orchestrate/<id>.stream.jsonl` |
+| C3 | false-bloat NC | SAME child under `--stream` (tee) vs `--capture-tokens` (redirect) | sentinel PRESENT in conductor stdout under `--stream` (bloat proven) and ABSENT under `--capture-tokens` (lean proven), with both recording an identical TOKENS line |
+| C4 | stderr-separation | capture run, child writes diagnostics to stderr | with stdout/stderr captured SEPARATELY, the transcript sentinel is absent from fd1 (the forwarded stream); the leanness claim is fd1-rigorous, not merged-capture-hand-wavy |
+| C5 | env parity | `CAPTURE_TOKENS=1` env, no flag | identical behavior to `--capture-tokens` (TOKENS recorded, conductor lean) , proves the flag is sugar over the global and the global inherits |
+| C6 | flag accepted | `orchestrate.sh run <dir> --capture-tokens` | NOT rejected as `unknown flag` (exit != 64 on the flag itself) |
+| C7 | default NC | no flag, no env, no `--stream`/`DETERMINISTIC_HANDOFF` | NO stream-json child invocation, NO TOKENS line (honest `usage=?`), default invocation byte-unchanged |
+| C8 | regression | full `tests/test-orchestrate.sh` | existing `--stream` capture + SPEC-110 token wiring + no-capture NC all still green |
+
+**COVERAGE-DELTA , explicitly UNCOVERED (with reason):**
+- **Wave-path per-sub-goal ledger extraction** , declared gap (`_wave_run` has no token hook; the
+  child.jsonl is still written lean-to-file under waves). Not tested here; single wiring point filed.
+- **Watchdog-path capture** , pre-existing SPEC-110 gap; unchanged, untested here.
+- **Live LLM run** , mock seam only (deterministic + free); a live `claude -p` is not exercised.
+- **stderr-redirect hardening** , the child's stderr is not redirected away from the conductor
+  (deferred); C4 proves the fd1 transcript is clean, which is the load-bearing property.
+
+## Verification
+
+```bash
+cd dwarves-kit
+# The three load-bearing properties + the false-bloat NC, all via the CLAUDE_CMD mock seam:
+bash tests/test-token-capture.sh
+#   (a) capture correctness: a --capture-tokens delegate run records a TOKENS line whose usage
+#       equals sum-usage of the child.jsonl the child emitted (matches the child's own totals).
+#   (b) conductor-stays-lean: the child stream-json body (sentinel) is ABSENT from the conductor's
+#       stdout under --capture-tokens, PRESENT in child.jsonl.
+#   (c) false-bloat NC: the SAME child under --stream PUTS the sentinel in the conductor stdout
+#       (bloat), while --capture-tokens leaves it out (lean) , the anti-pattern is proven worse.
+#   (d) default-path NC: no flag/env -> no stream-json child, no TOKENS line (usage=?), byte-unchanged.
+# Regression: the existing capture + token wiring still green.
+bash tests/test-orchestrate.sh
+```
+
+## After state
+
+- `lib/orchestrate.sh`: `CAPTURE_TOKENS` global (default 0) as a third trigger for the silent
+  `> "$slog"` stream-to-FILE branch inside `_run_one_session` (no signature change); `--capture-tokens`
+  flag arm in `cmd_run` (before the `--*)` catchall) that sets that global; the usage header, `main()`
+  usage string, and `--dry-run` advisory list `--capture-tokens`. Default path byte-identical; serial
+  token hook unchanged (already `$slog`-gated); `--stream` tee path unchanged (it is the NC's forbidden
+  path); `_wave_run` untouched.
+- `tests/test-token-capture.sh`: new; the three properties + false-bloat NC + default NC, with a
+  COVERAGE-DELTA row (covered + explicitly-uncovered).
+- `docs/verification/token-capture-delegate.md`: run-table with the green run, the COVERAGE-DELTA
+  row, and the NC evidence.
+- `docs/implementation-notes/token-capture-delegate.md`: the delta log (reuse-over-rebuild).
+
+## Scope edges
+
+**In:** the `--capture-tokens`/`CAPTURE_TOKENS` decoupled trigger for the existing silent
+stream-to-file branch, the conductor-stays-lean guarantee, the tests + coverage-delta + false-bloat NC.
+**Out:** the model routing (sub-goal 01); the TIER-4 mega close (03); the multiplexer panes (04);
+the docs pass (05); flipping the SPEC-087 default path to json (SACRED pin).
+**Not:** piping the child transcript (`--stream` tee) to the conductor (the forbidden bloat path ,
+the NC guards it); inventing a second token-marker or a second capture file convention (reuse
+SPEC-110's `| TOKENS |` + `.orchestrate/<id>.stream.jsonl`); rebuilding the token ledger, `sum-usage`,
+or the telemetry aggregation (this feeds them under delegation, unchanged); the watchdog-path capture
+(a declared SPEC-110 gap, still a gap); the WAVE-path per-sub-goal ledger extraction (`_wave_run` has
+no token hook and never did; the child.jsonl is still written lean-to-file under waves, only the
+extraction is deferred , declared gap, single wiring point at orchestrate.sh:862, filed as the next
+increment); changing the signature of `_run_one_session` or touching `_wave_run`'s call site (the
+global mechanism avoids both).
+
+## Open questions
+
+The proof uses the kit's standard MOCK `CLAUDE_CMD` (the test-orchestrate seam) emitting a
+real-shape stream-json, exercising the REAL orchestrate -> silent-capture -> sum-usage ->
+gate-ledger-tokens path deterministically, without a live LLM call. If SPEC-110's canonical
+ledger-observatory schema for the `| TOKENS |` marker ever diverges from `sum-usage`'s output,
+defer to that schema (this spec reuses, never redefines it).

--- a/docs/verification/token-capture-delegate.md
+++ b/docs/verification/token-capture-delegate.md
@@ -1,0 +1,73 @@
+# Proof of done: token capture under delegation (SPEC-117, orchestrate-hardening 02)
+
+A delegated `claude -p --stream > child.jsonl` run records faithful usage to the kit token ledger
+(SPEC-110 `| TOKENS |` marker) via the new lean `--capture-tokens`/`CAPTURE_TOKENS` trigger, and the
+CONDUCTOR reads only the box-flip , never the child transcript. Executes ADR-0032 §3. Both
+load-bearing properties are tested, plus the false-bloat negative control.
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| C1 | `--capture-tokens` serial run records a `\| TOKENS \|` line equal to the child's ASSISTANT-only totals (`in=1200 out=80 cache_read=8000 cache_create=0`); the cumulative `type:result` line is NOT double-counted (would be `in=2400`) | PASS |
+| C1b | Recorded usage == `sum-usage(child.jsonl)` (the record IS the captured file's totals) | PASS |
+| C2 | Conductor-stays-lean: the child transcript sentinel is ABSENT from the conductor's stdout, PRESENT in `.orchestrate/<id>.stream.jsonl` | PASS |
+| C3 | FALSE-BLOAT NC: the SAME child under `--stream` (tee) PUTS the transcript in the conductor stdout (bloat), while `--capture-tokens` (redirect) leaves it out (lean); BOTH record the identical TOKENS line | PASS |
+| C4 | fd1-rigorous: with stdout/stderr captured SEPARATELY, the transcript sentinel is absent from fd1 (the forwarded stream) | PASS |
+| C5 | env parity: `CAPTURE_TOKENS=1` (no flag) behaves identically (records TOKENS, conductor lean) | PASS |
+| C6 | `--capture-tokens` is an accepted flag (not `unknown flag`) + shows its `--dry-run` advisory | PASS |
+| C7 | default NC: no flag/env -> NO stream-json child file, NO TOKENS line (honest `usage=?`, SPEC-087 default invocation intact) | PASS |
+| R | Regression: `test-orchestrate.sh`, `test-orchestrate-wavefront.sh`, `test-meta.sh` (662), `test-lane-telemetry.sh` (25), `test-spec-index.sh` (9); `shellcheck` clean | PASS |
+
+The two load-bearing properties were confirmed NON-vacuous by a fresh-context verifier's mutation
+testing: (1) swapping the silent `> "$slog"` redirect back to `| tee "$slog"` flipped C2/C4/C3-contrast/C5
+to FAIL (leak detected); (2) removing the `CAPTURE_TOKENS` trigger flipped C1/C2/C4/C3/C5 to FAIL.
+Both mutations restored; suite green.
+
+## Run table
+
+```
+$ bash tests/test-token-capture.sh
+PASS C1 capture-correctness: TOKENS line == child assistant totals (in=1200 out=80 cache_read=8000 cache_create=0); result line not double-counted
+PASS C1 capture-from-file: recorded usage == sum-usage(child.jsonl) (in=1200 out=80 cache_read=8000 cache_create=0)
+PASS C2 conductor-stays-lean: child transcript in child.jsonl, ABSENT from conductor stdout
+PASS C4 fd1-rigorous: transcript sentinel absent from the conductor's fd1 (leanness proven, not merged-capture)
+PASS C7 default NC: no stream-json child file, NO TOKENS line (honest usage=?, default invocation intact)
+PASS C3 false-bloat NC: --stream (tee) PUTS the child transcript in the conductor stdout (bloat proven)
+PASS C3 contrast: stream-to-FILE leaves the conductor lean while --stream bloats; BOTH record the same TOKENS (in=1200 out=80 cache_read=8000 cache_create=0)
+PASS C5 env parity: CAPTURE_TOKENS=1 env records TOKENS + keeps the conductor lean (flag is sugar over the global)
+PASS C6 flag accepted: --capture-tokens parses (not rejected) + shows its dry-run advisory
+ALL PASS
+```
+
+## COVERAGE-DELTA
+
+**Covered:** C1 capture-correctness (+ result-line-not-double-counted) · C2 conductor-lean ·
+C3 false-bloat NC (tee-vs-redirect contrast) · C4 fd1-rigorous · C5 env-parity · C6 flag-accepted ·
+C7 default-NC (`usage=?`).
+
+**Explicitly UNcovered (with reason):**
+- **Wave-path per-sub-goal ledger extraction** , `_wave_run` has no token hook and never did (SPEC-110
+  captured only on the serial path). Under `CAPTURE_TOKENS=1` the wave subshell STILL writes each
+  child's `.orchestrate/<id>.stream.jsonl` lean-to-file (the global inherits on fork), so only the
+  per-sub-goal extraction is deferred , single wiring point at `orchestrate.sh` reap loop (~L862),
+  filed as the next increment. Dep-chained / `## Touches`-less mega-goals run the serial path anyway.
+- **Watchdog-path capture** (`WATCHDOG_STALL_SECS>0`) , a pre-existing SPEC-110 gap; unchanged.
+- **Live LLM run** , mock `CLAUDE_CMD` seam only (deterministic + free); no live `claude -p`.
+- **stderr-redirect hardening** , the child's `--verbose` fd2 is not redirected away from the
+  conductor (deferred; it would silence real errors on this opt-in path). C4 proves the fd1 transcript
+  , the actual accumulation trap , is clean, which is the load-bearing property.
+
+## Operator note (security)
+
+`.orchestrate/<id>.stream.jsonl` holds the child's FULL plaintext transcript (already true for
+`--stream`/`DETERMINISTIC_HANDOFF`; `.orchestrate/` is gitignored). `--capture-tokens` is meant to be
+the routine delegate-run flag, so it widens how often this artifact is written to disk , do not run
+sub-goals that touch live secrets under a capture flag without an appropriate scratch/cleanup posture.
+
+## Gate ledger
+
+Run `oh-02-token-capture`, lane `full`: grill(skipped) · think · design · design-critique ·
+ui-design(skipped) · spec · validate · test-plan · build · review · docs · ship. Reviewed via
+review-team (architecture + security, both PASS) + a fresh-context acceptance-verifier (8/8 PASS),
+per SPEC-069 (a `lib/` touch uses multi-lens review).

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -13,6 +13,8 @@
 #       --dry-run  print the plan only (no claude)
 #       --step     pause for the operator after each sub-goal (resume on Enter, q to stop)
 #       --stream   stream each session live (stream-json) + capture to .orchestrate/<id>.stream.jsonl
+#       --capture-tokens  stream each session SILENTLY to .orchestrate/<id>.stream.jsonl for token
+#                  usage extraction (SPEC-117); the conductor stays lean (no tee). Also CAPTURE_TOKENS=1.
 #       --board=roadmap|kanban|both  surface progress as a per-mega-goal kanban (SG-10); default
 #                  detects (backlog.sh present -> both, else roadmap). Event-sourced + derived;
 #                  ROADMAP.md stays canonical, the repo-wide BACKLOG cockpit is never touched.
@@ -52,6 +54,19 @@ HANDOFF_MAX_LINES="${HANDOFF_MAX_LINES:-80}"
 # B fields preserved; no LLM in the handoff path). Always-produced + reproducible beats
 # occasionally-excellent-but-skippable.
 DETERMINISTIC_HANDOFF="${DETERMINISTIC_HANDOFF:-0}"
+
+# Lean token capture under delegation (SPEC-117, executes ADR-0032 section 3). Off (0) by default.
+# On (1, via CAPTURE_TOKENS=1 or the --capture-tokens flag) -> the delegated child streams to a FILE
+# (`claude -p --stream > .orchestrate/<id>.stream.jsonl`) purely so the post-session token hook can
+# extract usage; the conductor reads only the box-flip, NEVER the child transcript. It is a THIRD,
+# DECOUPLED trigger for the SAME silent `> "$slog"` stream-to-file branch that DETERMINISTIC_HANDOFF
+# uses -- NOT `--stream` (that tees the transcript to the conductor = the ADR-0032 section 1 forbidden
+# bloat path) and NOT coupled to handoff regeneration. Read as a GLOBAL (like DETERMINISTIC_HANDOFF,
+# not a positional arg) so it inherits into the wave subshell on fork with no `_run_one_session`
+# signature change and no `_wave_run` call-site touch. The serial token hook is already `$slog`-gated,
+# so this needs no hook change; the wave-path per-sub-goal ledger extraction is a declared gap (the
+# child.jsonl is still written lean-to-file under waves, only the extraction is deferred).
+CAPTURE_TOKENS="${CAPTURE_TOKENS:-0}"
 
 # Kanban renderer reused by the board-view (SG-10). Resolved next to this script; override in
 # tests. When absent, board mode fail-safes to roadmap-only so a kit without the tooling runs.
@@ -609,10 +624,12 @@ _run_one_session() {  # dir id pfile route_flags stream
     # (Deterministic-handoff capture is not wired through the watchdog path; the two opt-in
     # paths are independent. See docs/implementation-notes/v3-deterministic-handoff.md.)
     _run_session_watchdog "$dir" "$id" "$pfile" "$route_flags" || rc=$?
-  elif [ "$stream" = 1 ] || [ "$DETERMINISTIC_HANDOFF" = 1 ]; then
-    # Capture stream-json when either the operator wants a live tail (--stream) OR the
-    # deterministic handoff needs the transcript (DETERMINISTIC_HANDOFF=1). The live `tee` to
-    # the terminal happens only under --stream; det-handoff capture is silent.
+  elif [ "$stream" = 1 ] || [ "$DETERMINISTIC_HANDOFF" = 1 ] || [ "$CAPTURE_TOKENS" = 1 ]; then
+    # Capture stream-json when the operator wants a live tail (--stream) OR the deterministic
+    # handoff needs the transcript (DETERMINISTIC_HANDOFF=1) OR lean token capture is on
+    # (CAPTURE_TOKENS=1, SPEC-117). The live `tee` to the terminal happens ONLY under --stream;
+    # det-handoff and capture-tokens both take the SILENT `> "$slog"` branch below, so the child
+    # transcript lands in the FILE only and never reaches the conductor's stdout (ADR-0032 s3).
     local logdir="$dir/.orchestrate"; mkdir -p "$logdir"
     slog="$logdir/${id}.stream.jsonl"
     # shellcheck disable=SC2086 # CLAUDE_FLAGS + route_flags are operator/goal config; word-splitting is intended.
@@ -620,6 +637,11 @@ _run_one_session() {  # dir id pfile route_flags stream
       _say "[orchestrate] streaming $id -> $slog (live tail + captured)"
       "$CLAUDE_CMD" -p $route_flags --output-format stream-json --verbose $CLAUDE_FLAGS < "$pfile" | tee "$slog" || rc=$?
     else
+      # ponytail: fd1-only redirect. The transcript (the ADR-0032 accumulation trap) is claude's
+      # STDOUT and goes to the file; `--verbose` STDERR (diagnostic, no usage/turn content) is left
+      # on fd2. Redirecting stderr too (`2>...`) is a deferred hardening for a stdout+stderr-merging
+      # conductor invocation -- skipped because it would also silence real error output on this opt-in
+      # path, and the driver is non-LLM bash so stderr is not an accumulation vector.
       "$CLAUDE_CMD" -p $route_flags --output-format stream-json --verbose $CLAUDE_FLAGS < "$pfile" > "$slog" || rc=$?
     fi
   else
@@ -993,6 +1015,7 @@ cmd_run() {
       --dry-run)  dry=1 ;;
       --step)     step=1 ;;
       --stream)   stream=1 ;;
+      --capture-tokens) CAPTURE_TOKENS=1 ;;   # SPEC-117: lean token capture (silent stream-to-file); sets the global
       --board)    board_arg="both" ;;
       --board=*)  board_arg="${1#--board=}" ;;
       --*)        echo "unknown flag: $1" >&2; return 64 ;;
@@ -1020,6 +1043,7 @@ cmd_run() {
     _say "[plan] mega-goal: $dir"
     [ "$step" = 1 ]   && _say "  (--step: pause for the operator after each sub-goal)"
     [ "$stream" = 1 ] && _say "  (--stream: each session streamed live + captured to .orchestrate/<id>.stream.jsonl)"
+    [ "$CAPTURE_TOKENS" = 1 ] && _say "  (--capture-tokens: each session streamed to .orchestrate/<id>.stream.jsonl for usage extraction; conductor stays lean)"
     local any=0
     while IFS=$'\t' read -r sg ppolicy; do
       any=1
@@ -1272,7 +1296,7 @@ main() {
     next) cmd_next "$@" ;;
     run)  cmd_run "$@" ;;
     flip) cmd_flip "$@" ;;
-    *) echo "usage: orchestrate.sh {next|run|flip} <megagoal-dir> [<SG-NN>] [--dry-run] [--step] [--stream] [--board=roadmap|kanban|both]" >&2; exit 64 ;;
+    *) echo "usage: orchestrate.sh {next|run|flip} <megagoal-dir> [<SG-NN>] [--dry-run] [--step] [--stream] [--capture-tokens] [--board=roadmap|kanban|both]" >&2; exit 64 ;;
   esac
 }
 

--- a/tests/test-token-capture.sh
+++ b/tests/test-token-capture.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# test-token-capture.sh (SPEC-117)
+# Pins the LEAN token capture under delegation (ADR-0032 section 3): a delegated child streams to a
+# FILE (`.orchestrate/<id>.stream.jsonl`), usage is extracted FROM that file and recorded to the kit
+# token ledger via the SPEC-110 `| TOKENS |` marker, and the CONDUCTOR reads only the box-flip, NEVER
+# the child transcript. The two load-bearing properties are BOTH tested, plus the false-bloat NC that
+# proves piping the transcript to the conductor (`--stream` tee) is the forbidden bloat path.
+#
+# All via the CLAUDE_CMD mock seam (no live LLM). WAVE_CAP=1 forces the SERIAL delegate path this
+# spec targets (the ADR-0032 s3 canonical single child); the wave-path ledger extraction is a
+# declared, out-of-scope gap.
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORCH="$KIT/lib/orchestrate.sh"
+HGEN="$KIT/lib/handoff/handoff_gen.py"
+fails=0
+pass() { echo "PASS $*"; }
+fail() { echo "FAIL $*"; fails=$((fails + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The known, real-shape stream-json the mock emits. Assistant usage sums to
+# in=1200 out=80 cache_read=8000 cache_create=0. The final type:result line carries the CUMULATIVE
+# usage and MUST NOT be re-summed (SPEC-110) -- if it were, in would be 2400, so asserting 1200 also
+# proves the result-line is excluded. Each transcript line carries the unique BLOAT_SENTINEL so we can
+# detect whether the child transcript reached the conductor. `--verbose` diagnostics go to STDERR
+# (DIAG_SENTINEL) so the fd-separation test can prove the transcript is fd1-only.
+EXPECT="in=1200 out=80 cache_read=8000 cache_create=0"
+
+# Mock claude: emits the stream-json transcript to STDOUT (fd1), a diagnostic to STDERR (fd2), then
+# flips the named sub-goal's box in the SHARED roadmap ($CAP_RM). Ignores its args + reads stdin, like
+# the real `claude -p`. Quoted heredocs so $CAP_RM stays literal (resolved at mock runtime).
+cat > "$TMP/claude-cap" <<'MOCK'
+#!/usr/bin/env bash
+cat >/dev/null   # consume the injected prompt on stdin
+cat <<'JSON'
+{"type":"system","subtype":"init","note":"BLOAT_SENTINEL_XYZZY session start"}
+{"type":"assistant","message":{"usage":{"input_tokens":1000,"output_tokens":50,"cache_read_input_tokens":8000,"cache_creation_input_tokens":0}},"note":"BLOAT_SENTINEL_XYZZY reasoning turn one lots of transcript body"}
+{"type":"assistant","message":{"usage":{"input_tokens":200,"output_tokens":30,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"note":"BLOAT_SENTINEL_XYZZY reasoning turn two more body"}
+{"type":"result","subtype":"success","message":{"usage":{"input_tokens":1200,"output_tokens":80,"cache_read_input_tokens":8000,"cache_creation_input_tokens":0}},"note":"BLOAT_SENTINEL_XYZZY cumulative result"}
+JSON
+echo "DIAG_SENTINEL_STDERR verbose diagnostic noise" >&2
+awk '{ if ($0 ~ /^- \[ \] SG-01 /) sub(/\[ \]/, "[x]"); print }' "$CAP_RM" > "$CAP_RM.t" && mv "$CAP_RM.t" "$CAP_RM"
+MOCK
+chmod +x "$TMP/claude-cap"
+
+# Stand up a mega-goal: SG-01 auto (executes) then SG-02 gate (natural stop). The goal file carries
+# **Branch:** so the rid (and thus the ledger file) is derivable. No `## Touches` -> serial path.
+mk_mg() {  # dir branch
+  local d="$1" branch="$2"
+  mkdir -p "$d/goals"
+  cat > "$d/ROADMAP.md" <<'EOF'
+# Mega-goal: token-capture fixture
+## Sub-goals
+- [ ] SG-01 do the thing , auto , PR #__
+- [ ] SG-02 gated thing , gate , PR #__
+EOF
+  echo "POINTER: resume from ROADMAP" > "$d/POINTER_PROMPT.md"
+  printf '# SG-01\n**Branch:** %s\n' "$branch" > "$d/goals/01-do.md"
+}
+
+run_cap() {  # dir extra-flags... ; sets stdout/stderr to $TMP/<name>.{out,err} via caller redirection
+  local d="$1"; shift
+  CAP_RM="$d/ROADMAP.md" CLAUDE_CMD="$TMP/claude-cap" WAVE_CAP=1 \
+    DWARVES_KIT_LOG_DIR="$TMP/logs" bash "$ORCH" run "$d" "$@" < /dev/null
+}
+
+LEDGER_OF() { echo "$TMP/logs/runs/$1.log"; }
+
+# ============ C1 + C2 + C4: --capture-tokens serial run (correctness + lean + fd-separation) ============
+D1="$TMP/mg1"; mk_mg "$D1" "feat/kit-captok-c1"
+run_cap "$D1" --capture-tokens > "$TMP/c1.out" 2> "$TMP/c1.err"
+SLOG1="$D1/.orchestrate/SG-01.stream.jsonl"
+LED1="$(LEDGER_OF kit-captok-c1)"
+
+# C1a: a TOKENS line was recorded, and it equals the child's assistant-only totals (result not double-counted).
+TOKLINE="$(grep '| TOKENS |' "$LED1" 2>/dev/null | head -1 | sed -E 's/.*\| TOKENS \| //')"
+[ "$TOKLINE" = "$EXPECT" ] \
+  && pass "C1 capture-correctness: TOKENS line == child assistant totals ($EXPECT); result line not double-counted" \
+  || { fail "C1 TOKENS wrong: got '$TOKLINE' want '$EXPECT'"; echo "--out--"; cat "$TMP/c1.out"; echo "--led--"; cat "$LED1" 2>&1; }
+
+# C1b: the recorded usage MATCHES sum-usage of the captured child.jsonl (the record IS the file's totals).
+FSUM="$(python3 "$HGEN" sum-usage "$SLOG1" 2>/dev/null)"
+[ "$TOKLINE" = "$FSUM" ] \
+  && pass "C1 capture-from-file: recorded usage == sum-usage(child.jsonl) ($FSUM)" \
+  || fail "C1 mismatch: ledger '$TOKLINE' vs file '$FSUM'"
+
+# C2: conductor stays lean -- the child transcript sentinel is ABSENT from the conductor's stdout,
+#     PRESENT in the child.jsonl file.
+if ! grep -q 'BLOAT_SENTINEL_XYZZY' "$TMP/c1.out" && grep -q 'BLOAT_SENTINEL_XYZZY' "$SLOG1"; then
+  pass "C2 conductor-stays-lean: child transcript in child.jsonl, ABSENT from conductor stdout"
+else
+  fail "C2 leak: transcript reached the conductor stdout (or missing from file)"; echo "--out--"; cat "$TMP/c1.out"
+fi
+
+# C4: fd-separation -- with stdout/stderr captured SEPARATELY, the TRANSCRIPT sentinel is absent from
+#     fd1 (the stream cmd_run forwards). The stderr diagnostic is fd2-only (not the transcript).
+if ! grep -q 'BLOAT_SENTINEL_XYZZY' "$TMP/c1.out"; then
+  pass "C4 fd1-rigorous: transcript sentinel absent from the conductor's fd1 (leanness proven, not merged-capture)"
+else
+  fail "C4: transcript sentinel present on fd1"
+fi
+
+# ============ C7: default (no flag/env) NC -- no stream capture, no TOKENS line, usage=? ============
+D7="$TMP/mg7"; mk_mg "$D7" "feat/kit-captok-c7"
+run_cap "$D7" > "$TMP/c7.out" 2>&1
+LED7="$(LEDGER_OF kit-captok-c7)"
+if [ ! -f "$D7/.orchestrate/SG-01.stream.jsonl" ] && { [ ! -f "$LED7" ] || ! grep -q '| TOKENS |' "$LED7"; }; then
+  pass "C7 default NC: no stream-json child file, NO TOKENS line (honest usage=?, default invocation intact)"
+else
+  fail "C7: default path captured/recorded something"; ls "$D7/.orchestrate/" 2>&1; cat "$LED7" 2>&1
+fi
+
+# ============ C3: false-bloat NEGATIVE CONTROL -- --stream tees the transcript to the conductor ============
+# SAME child, two paths. --stream (tee) => transcript IN the conductor stdout (bloat). --capture-tokens
+# (redirect) => transcript ABSENT (lean). Both record the SAME correct TOKENS line (capture unaffected).
+D3="$TMP/mg3"; mk_mg "$D3" "feat/kit-captok-c3"
+run_cap "$D3" --stream > "$TMP/c3_stream.out" 2>/dev/null
+LED3="$(LEDGER_OF kit-captok-c3)"
+STREAM_TOK="$(grep '| TOKENS |' "$LED3" 2>/dev/null | head -1 | sed -E 's/.*\| TOKENS \| //')"
+
+if grep -q 'BLOAT_SENTINEL_XYZZY' "$TMP/c3_stream.out"; then
+  pass "C3 false-bloat NC: --stream (tee) PUTS the child transcript in the conductor stdout (bloat proven)"
+else
+  fail "C3: --stream did not bloat (tee path broken?)"; head -5 "$TMP/c3_stream.out"
+fi
+# lean arm already proven at C2 (--capture-tokens leaves the conductor stdout clean); assert the contrast + equal capture.
+if ! grep -q 'BLOAT_SENTINEL_XYZZY' "$TMP/c1.out" && [ "$STREAM_TOK" = "$EXPECT" ] && [ "$TOKLINE" = "$EXPECT" ]; then
+  pass "C3 contrast: stream-to-FILE leaves the conductor lean while --stream bloats; BOTH record the same TOKENS ($EXPECT)"
+else
+  fail "C3 contrast: stream_tok='$STREAM_TOK' cap_tok='$TOKLINE'"
+fi
+
+# ============ C5: env parity -- CAPTURE_TOKENS=1 (no flag) behaves like --capture-tokens ============
+D5="$TMP/mg5"; mk_mg "$D5" "feat/kit-captok-c5"
+CAP_RM="$D5/ROADMAP.md" CLAUDE_CMD="$TMP/claude-cap" WAVE_CAP=1 CAPTURE_TOKENS=1 \
+  DWARVES_KIT_LOG_DIR="$TMP/logs" bash "$ORCH" run "$D5" > "$TMP/c5.out" 2> "$TMP/c5.err" < /dev/null
+LED5="$(LEDGER_OF kit-captok-c5)"
+ENV_TOK="$(grep '| TOKENS |' "$LED5" 2>/dev/null | head -1 | sed -E 's/.*\| TOKENS \| //')"
+if [ "$ENV_TOK" = "$EXPECT" ] && ! grep -q 'BLOAT_SENTINEL_XYZZY' "$TMP/c5.out"; then
+  pass "C5 env parity: CAPTURE_TOKENS=1 env records TOKENS + keeps the conductor lean (flag is sugar over the global)"
+else
+  fail "C5 env parity broken: tok='$ENV_TOK' (stdout leak? $(grep -c BLOAT_SENTINEL_XYZZY "$TMP/c5.out"))"
+fi
+
+# ============ C6: --capture-tokens is an accepted flag (not 'unknown flag') ============
+D6="$TMP/mg6"; mk_mg "$D6" "feat/kit-captok-c6"
+CAP_RM="$D6/ROADMAP.md" WAVE_CAP=1 DWARVES_KIT_LOG_DIR="$TMP/logs" \
+  bash "$ORCH" run "$D6" --capture-tokens --dry-run > "$TMP/c6.out" 2>&1 < /dev/null; rc6=$?
+if [ "$rc6" = 0 ] && ! grep -q 'unknown flag' "$TMP/c6.out" && grep -q -- '--capture-tokens:' "$TMP/c6.out"; then
+  pass "C6 flag accepted: --capture-tokens parses (not rejected) + shows its dry-run advisory"
+else
+  fail "C6 flag not accepted (rc=$rc6)"; cat "$TMP/c6.out"
+fi
+
+echo "----"
+echo "COVERAGE-DELTA (SPEC-117):"
+echo "  covered:   C1 capture-correctness(+result-not-double-counted) | C2 conductor-lean | C3 false-bloat NC |"
+echo "             C4 fd1-rigorous | C5 env-parity | C6 flag-accepted | C7 default-NC(usage=?)"
+echo "  UNcovered: wave-path per-sub-goal ledger extraction (declared gap, _wave_run has no hook) |"
+echo "             watchdog-path capture (pre-existing SPEC-110 gap) | live LLM run (mock seam only) |"
+echo "             stderr-redirect hardening (fd2 not redirected; C4 proves fd1 is the load-bearing property)"
+echo "----"
+[ "$fails" = 0 ] && { echo "ALL PASS"; exit 0; } || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
Token capture under delegation: the delegated child runs `claude -p --stream > child.jsonl`, usage is extracted from the FILE and recorded to the kit token ledger (SPEC-110 `| TOKENS |` marker), and the conductor reads only the box-flip , token capture works WITHOUT dumping the child transcript into the conductor. Executes ADR-0032 §3.

Lands on `master` after sub-goal 01 (#139, merged). Mechanism: a decoupled `CAPTURE_TOKENS` global (default 0) + `--capture-tokens` flag taking the SAME silent `> child.jsonl` branch purely for usage extraction, reusing SPEC-110's sum-usage. Default `claude -p` path byte-identical (SPEC-087 pin); the `--stream` tee path (the false-bloat NC's forbidden path) is unchanged.

**Verify:** `bash tests/test-token-capture.sh` (9/9): capture-correctness (result line not double-counted), conductor-stays-lean (fd1-rigorous), the false-bloat NC (`--stream` tee vs `>` redirect), env parity, flag-accepted, default usage=? NC. Regression green: orchestrate, wavefront, meta (662), lane-telemetry (25), shellcheck clean.

**Declared gap** (honest, filed): wave-path per-sub-goal ledger extraction , `child.jsonl` is still written lean-to-file under waves, but `_wave_run` has no per-sub-goal TOKENS hook yet (single wiring point, same discipline as SPEC-110's watchdog-path gap).

Roadmap: ops-toolkit `_meta/megagoals/orchestrate-hardening/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
