### PR TITLE
feat(orchestrate): opt-in tmux multiplexer for wavefront wave visibility

### DIFF
--- a/docs/implementation-notes/SPEC-119-multiplexer-panes.md
+++ b/docs/implementation-notes/SPEC-119-multiplexer-panes.md
@@ -1,0 +1,51 @@
+# Implementation notes: SPEC-119 multiplexer panes
+
+Delta from the spec only; decisions the spec didn't pin, deviations, tradeoffs.
+
+## 2026-07-03 10:00 Reap mechanism for pane-spawned sessions
+
+**Context:** `_wave_run`'s reap loop polls `kill -0 "$pid"` then `wait "$pid"` to get the exit
+code. `tmux new-window` returns as soon as the tmux server acks window creation, so `$!` after
+that call is the `tmux` CLI's own (short-lived) pid, not the pane's shell -- a bash `wait` on it
+cannot observe the pane's actual lifetime or exit code.
+
+**Decision:** the pane-exec wrapper (`_pane-exec` subcommand) writes its exit code to a donefile
+after `_run_one_session` returns. The reap loop polls `[ -f "$donefile" ]` instead of `kill -0`
+for any index spawned via the pane path (index-aligned `_WAVE_DONEFILES` array, empty string for
+the non-mux path). Mirrors the existing `_mtime`-poll pattern the watchdog path already uses
+(orchestrate.sh `_run_session_watchdog`), so it's not a new idiom in the file.
+
+**Why:** no clean way to `wait` on a grandchild in a different process tree spawned by a
+detached tmux server; a donefile is the same "poll for a side-channel completion signal"
+shape the watchdog path already established.
+
+## 2026-07-03 10:05 Real session runs inside the pane, not a tailed mirror
+
+Considered: mirror the existing background dispatch's output into a `tail -f` pane (simpler:
+no new subcommand, no re-exec). Rejected: the goal file's Proof and ADR-0032 s4 both say the
+wave session is *spawned into* the pane (`tmux new-window` *to spawn*), and `send-keys` needs a
+real foreground process attached to the pane's pty to have any effect (a `tail -f` pane has
+nothing meaningful to send keys to). So the pane hosts the actual `claude -p` dispatch via a
+`_pane-exec` re-entry into `orchestrate.sh` (reuses `_run_one_session`, no duplicated dispatch
+logic) rather than mirroring a log file.
+
+## 2026-07-03 10:10 Pane driver: tmux, not cmux (open-fork 2)
+
+Per ROADMAP.md open-fork 2 + this sub-goal's dispatch prompt: cmux is a GUI daily-driver app
+scoped to `CMUX_WORKSPACE_ID`, with a browser-oriented skill surface (`cmux-browser`), not a
+general scriptable pane driver reachable headlessly/in CI. tmux has a real CLI
+(`new-window`/`capture-pane`/`send-keys`) that is mockable via a `TMUX_CMD` env seam (same
+pattern as `CLAUDE_CMD`) and behaves identically on macOS/Linux/CI. Picking tmux is what keeps
+the on-path testable without a real terminal-multiplexer server in CI, and keeps the off-path
+trivially true (no cmux-specific state to avoid touching). No `cmux` code path was added; if a
+future need arises for a cmux driver, it is a separate, additive `PANE_DRIVER=cmux` branch, not
+a rework of this one.
+
+## 2026-07-03 10:15 Serial path (`cmd_run`, non-wave) is untouched
+
+The goal file and ADR-0032 s4 scope the multiplexer to *wavefront wave sessions* only ("each
+wavefront wave session is spawned into a pane"). The serial delegate path in `cmd_run` (used
+when `WAVE_CAP=1`, i.e. today's default) has exactly one in-flight session at a time already
+attached to the conductor's own terminal, so there is nothing to "watch across tabs" -- the
+multiplexer only wires into `_wave_run`'s per-sub-goal spawn step. `MULTIPLEXER=1` with
+`WAVE_CAP=1` is a no-op (no wave ever runs) rather than an error.

--- a/docs/specs/SPEC-119-multiplexer-panes.md
+++ b/docs/specs/SPEC-119-multiplexer-panes.md
@@ -1,0 +1,235 @@
+# Spec: multiplexer panes (opt-in wavefront visibility)
+Generated: 2026-07-03
+Status: DRAFT
+
+## Problem
+
+`lib/orchestrate.sh`'s wavefront path (`_wave_run`, ADR-0030) backgrounds each admitted wave
+sub-goal's `claude -p` session as a plain bash job (`( cd "$wt" && _run_one_session ... ) &`).
+When `WAVE_CAP>1` runs two or more sessions concurrently, their combined stdout/stderr interleave
+on whatever fd the conductor inherited: the operator cannot watch one session in isolation, and
+has no way to intervene in a specific in-flight session. ADR-0032 section 4 names this gap and
+authorizes an opt-in terminal-multiplexer wiring (tmux/cmux: `new-window` to spawn, `capture-pane`
+to receive, `send-keys` to control) that gives the operator the "watch + intervene across tabs"
+experience, without requiring it for orchestration (pure headless dispatch already works via
+Bash + `claude -p`, the delegate pattern).
+
+## Solution
+
+### Approaches considered
+
+1. **Mirror pane** (tail a log file the existing background job already writes into a new tmux
+   window). Simplest to build (no re-exec, no new subcommand), but a `tail -f` pane has no
+   foreground process attached to send keys to -- `send-keys` would be wired but functionally
+   inert, failing the "control / intervene" half of the Proof.
+2. **Host the real session in the pane** (`tmux new-window` runs the actual `claude -p` dispatch,
+   not a mirror). `capture-pane` reads its real live output; `send-keys` reaches a real attached
+   process. Costs a completion-signalling mechanism (see below), since `tmux new-window` returns
+   before the pane's command exits, so a bash `wait` cannot reap it.
+3. **A cmux-driven pane** (open-fork 2's other option). cmux is the operator's daily-driver GUI
+   app, scoped to a `CMUX_WORKSPACE_ID` workspace, with a browser-shaped skill surface
+   (`cmux-browser`); it has no general "spawn an arbitrary shell command into a new pane, headless,
+   scriptable from bash, mockable in CI" primitive the way tmux's CLI does.
+
+### Chosen approach + why
+
+**Approach 2 (real session hosted in a tmux pane), tmux as the driver (open-fork 2 resolved).**
+tmux's CLI (`new-window` / `capture-pane` / `send-keys`) is scriptable, already installed
+(minimum-infra), and mockable via a `TMUX_CMD` env seam identical in shape to the existing
+`CLAUDE_CMD` seam -- so the on-path is headless-testable in CI with no real tmux server, and the
+off-path has a trivial true negative control (a fake `TMUX_CMD` that errors if invoked, run under
+the default `MULTIPLEXER=0`, must never fire). cmux is rejected as the driver for exactly the
+reason ROADMAP open-fork 2 flags: it is the operator's interactive daily driver, not the
+portable/headless-safe default that keeps the off path (and the on path's tests) intact. Mirror
+piping (approach 1) is rejected because `send-keys` needs a real foreground process to mean
+anything.
+
+### Extensibility & boundaries
+
+- Load-bearing dimension: number of concurrent wave sessions (`WAVE_CAP`). Each gets its own tmux
+  window inside one shared per-megagoal tmux session (`_mux_session_name`); adding more wave
+  capacity adds more windows, no new machinery.
+- A future `PANE_DRIVER=cmux` variant (explicitly out of scope here, see Out of Scope) would be an
+  additive branch alongside the tmux one, not a rework -- the spawn/capture/send-keys surface
+  (`_pane_spawn` / `_pane_capture` / `_pane_send_keys`) is the seam a second driver would plug into.
+- Unit boundaries: `_pane_spawn` (spawn), `_pane_capture` (receive), `_pane_send_keys` (control) are
+  three single-purpose wrappers over the three tmux primitives named in the Proof; the `_pane-exec`
+  hidden subcommand is the one re-entry point a pane's shell uses to reach `_run_one_session`
+  (no duplicated dispatch logic).
+
+### Architecture
+
+```
+_wave_run spawn loop, per admitted sub-goal:
+
+  MULTIPLEXER=0 (default)                    MULTIPLEXER=1
+  ------------------------                   ----------------------------------------------
+  set -m                                     donefile=$(mktemp -u)
+  ( cd "$wt" &&                              _pane_spawn megadir id wt pfile route_flags donefile
+      _run_one_session ... ) &                 -> tmux new-window -d -t <mux> -n <id> -c "$wt" \
+  pid=$!                                           "$ORCH_DIR/orchestrate.sh" _pane-exec \
+  set +m                                              megadir id pfile route_flags donefile
+  _WAVE_PIDS+=("$pid")                       _WAVE_PIDS+=("")           # no reapable pid
+  _WAVE_DONEFILES+=("")                      _WAVE_DONEFILES+=("$donefile")
+
+reap loop, per index:
+  donefile empty?  -> kill -0 "$pid" / wait "$pid"        (byte-identical to today)
+  donefile set?    -> poll [ -f "$donefile" ], read exit code from it, rm it
+
+_pane-exec megadir id pfile route_flags donefile  (new hidden `main()` subcommand, real process
+  entry -- BASH_SOURCE==$0 holds, so this is never reached via `source`):
+    _run_one_session "$megadir" "$id" "$pfile" "$route_flags" 0
+    echo $? > "$donefile"
+```
+
+The pane's window is named `<id>` inside a per-megagoal tmux session (`_mux_session_name`), so
+`tmux capture-pane -p -t "<mux>:<id>"` / `tmux send-keys -t "<mux>:<id>" ...` address one wave
+session unambiguously.
+
+## Technical Design
+
+### Interfaces (I/O contract)
+
+- Inputs / consumes: `MULTIPLEXER` (env, default `0`/off), `TMUX_CMD` (env, default `tmux`,
+  mirrors `CLAUDE_CMD`'s test-mock seam), `TMUX_SESSION` (env, optional override of the derived
+  per-megagoal tmux session name). Consumes the same `megadir`/`id`/`wt`/`pfile`/`route_flags`
+  `_wave_run` already builds; adds nothing to the goal-file / ROADMAP contract.
+- Outputs / produces: when enabled, one tmux window per spawned wave sub-goal, capturable via
+  `tmux capture-pane`; a donefile per pane-spawned sub-goal (removed once reaped). No new
+  persistent state (no new ledger, no new daemon); the tmux session itself is the only new
+  artifact and it is exactly as long-lived as the operator's terminal multiplexer already is.
+- Invariants: with `MULTIPLEXER=0` (or unset), `_wave_run` never calls `$TMUX_CMD` -- zero tmux
+  process invocations, verified by a negative control. The reap loop's default (`donefile=""`)
+  branch is textually the pre-existing `kill -0`/`wait` code, unedited.
+
+### Data model changes
+
+None.
+
+### API changes
+
+None (bash script; `main()` gains one hidden subcommand `_pane-exec`, not documented in the
+`usage:` string -- it is an internal re-entry point, not an operator-facing command).
+
+### Infrastructure changes
+
+None (tmux is already installed per minimum-infra; no new daemon, no new listener, no new
+always-on process -- the tmux session exists only while wave panes are open).
+
+## Task Breakdown
+
+### Phase 1: Foundation
+- [ ] TASK-001: `_mux_session_name(megadir)`, derives a stable, sanitized tmux session name from
+  the megadir path (or `$TMUX_SESSION` override); pure function, unit-testable.
+- [ ] TASK-002: `_pane_spawn` / `_pane_capture` / `_pane_send_keys`, thin wrappers over
+  `tmux new-window` / `capture-pane` / `send-keys`, using `$TMUX_CMD`; ensure-session-exists
+  handled by `_pane_spawn` (`has-session` else `new-session -d`).
+- [ ] TASK-003: `_pane-exec` hidden `main()` subcommand, calls `_run_one_session`, writes exit
+  code to the donefile.
+
+### Phase 2: Core
+- [ ] TASK-004: wire `_pane_spawn` into `_wave_run`'s spawn loop behind `MULTIPLEXER=1`; add the
+  index-aligned `_WAVE_DONEFILES` global array (empty-guarded like `_WAVE_PIDS`/`_WAVE_PFILES`).
+- [ ] TASK-005: branch the reap loop per-index on `donefile` set/empty; donefile path polls
+  `[ -f "$donefile" ]` + reads the exit code instead of `kill -0`/`wait`.
+- [ ] TASK-006: `_wave_abort` additionally `tmux kill-window`s any pane-spawned index still
+  in-flight (best-effort, `|| true`), so an operator Ctrl-C during a muxed wave doesn't leave a
+  live pane running past the abort.
+
+### Phase 3: Polish
+- [ ] TASK-007: header docstring update (the `MULTIPLEXER` / `TMUX_CMD` / `TMUX_SESSION` env vars,
+  one paragraph, matching the existing `WATCHDOG_STALL_SECS` / `CAPTURE_TOKENS` doc style).
+- [ ] TASK-008: `tests/test-multiplexer.sh`, enabled-spawns-pane + capture-pane-visibility +
+  off-path-unchanged negative control (see Test plan below); a fake `tmux` fixture script
+  (`$TMP/tmux-mock`) that logs invocations and simulates `new-window`/`capture-pane`/`send-keys`
+  without a real tmux server.
+- [ ] TASK-009: pane-spawn sample + off-path-unchanged diff captured under
+  `docs/proof-of-done/SPEC-119-multiplexer-panes.md`.
+
+## After state
+
+- [ ] `MULTIPLEXER=1` + `WAVE_CAP>1`: each admitted wave sub-goal's session is spawned via
+  `tmux new-window` into its own pane; `tmux capture-pane` against that pane returns the session's
+  live output. (Today: wave sessions share the conductor's own stdout/stderr, uncapturable
+  per-session.)
+- [ ] `MULTIPLEXER=0` (default, unset): `_wave_run` never invokes `$TMUX_CMD`; the reap loop takes
+  the exact pre-existing `kill -0`/`wait` branch. Checkable by
+  `bash tests/test-orchestrate-wavefront.sh` (unedited) staying green AND
+  `bash tests/test-multiplexer.sh`'s negative control (a `tmux` that errors if called, run with
+  `MULTIPLEXER` unset, never fires).
+- [ ] `bash tests/test-multiplexer.sh` green.
+
+## Acceptance Criteria (global)
+- [ ] All tasks pass their individual acceptance criteria
+- [ ] Tests cover happy path (enabled + capture-pane visibility) + the off-path negative control
+- [ ] No regressions in existing functionality (`test-orchestrate.sh`, `test-orchestrate-wavefront.sh`,
+  `test-tier4-close.sh`, `test-token-capture.sh`, `test-model-routing.sh` all still green, unedited)
+
+## Verification
+
+```bash
+bash tests/test-multiplexer.sh              # the new coverage
+bash tests/test-orchestrate-wavefront.sh     # regression: wave path unchanged when MULTIPLEXER=0
+bash tests/test-orchestrate.sh               # regression: serial delegate path untouched
+bash tests/test-tier4-close.sh               # regression: TIER-4 close untouched
+bash tests/test-token-capture.sh             # regression: token capture untouched
+bash tests/test-meta.sh                      # structural integrity
+```
+
+Pass = `test-multiplexer.sh` all green AND every regression suite above still green.
+
+## Edge Cases
+
+1. `MULTIPLEXER=1` but `WAVE_CAP=1` (forces the always-serial loop), or a mega-goal whose
+   sub-goals declare no disjoint `## Touches` (so `_wave_gate` admits 0 concurrently and every
+   sub-goal runs via the serial fallthrough): no wave ever runs, so `_pane_spawn` is never
+   called -- a no-op, not an error.
+2. `MULTIPLEXER=1` and the wave has zero admitted sub-goals (nothing ready): `_wave_run`'s existing
+   empty-wave short-circuit (`spawned=0`) fires before any pane logic runs -- unchanged.
+3. A pane-spawned session crashes before writing its donefile (e.g. `tmux` itself dies): the reap
+   loop polls forever unless bounded. Mitigated by the existing wave-level operator abort
+   (`_wave_abort` / Ctrl-C); no new timeout is added (out of scope -- would duplicate the SG-11
+   watchdog's stall-detection role, which is a separate opt-in already).
+4. Two sub-goals share the same `id` across two concurrent wave cycles (shouldn't happen --
+   `_wave_gate` never re-admits a checked box) -- the tmux window name collision is the existing
+   `_wave_worktree` idempotent-resume invariant's problem to prevent, not a new one this spec
+   introduces.
+
+## Failure modes
+
+| Failure class | Detection signal | Mitigation / recovery |
+|---|---|---|
+| `tmux` binary missing/not on PATH while `MULTIPLEXER=1` | `_pane_spawn`'s `tmux new-window` call fails (nonzero) | `_pane_spawn` returns nonzero; the spawn loop treats it like the existing worktree-setup failure (`blocked` event, `wave_failed=1`, siblings still drain) -- no new failure path, reuses the existing one |
+| Pane process dies without writing donefile | reap loop never sees `-f "$donefile"` for that index | operator Ctrl-C (`_wave_abort`) reaps + `tmux kill-window`s it; no automatic timeout (edge case 3) |
+
+## Out of Scope
+
+- A `PANE_DRIVER=cmux` variant (open-fork 2 picks tmux only; a cmux driver is a separate additive
+  effort per the implementation notes).
+- Wiring the multiplexer into the serial (`cmd_run`, non-wave) delegate path -- ADR-0032 s4 and the
+  goal file both scope this to wavefront wave sessions only.
+- Any new terminal-control daemon, always-on listener, or DAG/scheduler beyond ADR-0030 wavefront.
+- Model routing (SG-01), token-capture stream-to-file (SG-02), the TIER-4 mega-close (SG-03), docs
+  wiring (SG-05) -- all separate sub-goals.
+
+## Touches
+- lib/orchestrate.sh
+- tests/test-multiplexer.sh
+- docs/proof-of-done/SPEC-119-multiplexer-panes.md
+
+## Decision Log
+- DEC-001: pane driver = tmux, not cmux (open-fork 2). Rationale: scriptable CLI, mockable
+  `TMUX_CMD` seam, headless/CI-safe. Alternatives rejected: cmux (GUI daily-driver, no headless
+  spawn-arbitrary-command primitive).
+- DEC-002: the pane hosts the real `claude -p` dispatch (via a `_pane-exec` re-entry into
+  `orchestrate.sh`), not a tailed mirror of a log file. Rationale: `send-keys` needs a real
+  attached foreground process; a mirror pane would make `send-keys` wiring inert.
+- DEC-003: completion signalled via a donefile (poll `[ -f ]`, read exit code), not a pid `wait`.
+  Rationale: `tmux new-window` returns before the pane's command exits, so its `$!` is not the
+  pane's actual process; a donefile mirrors the existing watchdog path's poll-a-side-channel idiom.
+- DEC-004: multiplexer wiring scoped to `_wave_run` only, not the serial `cmd_run` path. Rationale:
+  the serial path already has exactly one in-flight session attached to the conductor's own
+  terminal -- nothing to multiplex.
+
+## Open questions
+(none; a /goal loop appends here if it hits a decision this spec does not cover, then stops)

--- a/docs/verification/multiplexer-panes.md
+++ b/docs/verification/multiplexer-panes.md
@@ -1,0 +1,68 @@
+# Proof of done: multiplexer panes (SPEC-119, orchestrate-hardening 04)
+
+An OPT-IN multiplexer (`MULTIPLEXER=1`, default `0`): when enabled, `orchestrate.sh` spawns each
+wavefront wave session into its own tmux window (`tmux new-window`), so an operator can
+`tmux capture-pane` its live output or `tmux send-keys` to intervene. OFF by default: the headless
+wavefront path is byte-unchanged and `$TMUX_CMD` is never invoked. Executes ADR-0032 §4. Open-fork 2
+(tmux vs cmux) resolved: host the real session in a `tmux new-window` pane (tmux is the
+portable/headless-safe default; cmux noted as the operator's daily-driver alternative). The
+off-path-unchanged property is the load-bearing one and carries an explicit negative control.
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| A1 | `MULTIPLEXER=1` wave run completes (`_wave_run` rc 0) and flips every sub-goal box | PASS |
+| A2 | Each wave session is spawned via `tmux new-window -n SG-NN` (a pane per sub-goal) | PASS |
+| A3 | Visibility works: `tmux capture-pane` returns the wave session's live output | PASS |
+| A4 | Intervention works: `tmux send-keys` reaches a running wave session's pane | PASS |
+| N1 | OFF-DEFAULT NC: with `MULTIPLEXER` unset, `$TMUX_CMD` is NEVER invoked (no window, no send-keys) | PASS |
+| N2 | OFF-EXPLICIT NC: `MULTIPLEXER=0` never invokes tmux | PASS |
+| N3 | Off-path-unchanged: with the multiplexer off, the headless wavefront path completes and flips boxes even with a poisoned `$TMUX_CMD` (proves no coupling) | PASS |
+| R | Regression: `test-orchestrate-wavefront.sh`, `test-tier4-close.sh`, `test-meta.sh`; `shellcheck -S error lib/orchestrate.sh` clean | PASS |
+
+The off-path-unchanged NC is non-vacuous: the OFF cases run with a deliberately poisoned `$TMUX_CMD`,
+so any accidental tmux call on the headless path would fail the wave; boxes still flip via the
+pre-existing kill-0/wait background path, proving the multiplexer is additive, not on the critical path.
+
+## Run table
+
+```
+$ bash tests/test-multiplexer.sh
+PASS mux-on: _wave_run rc 0
+PASS mux-on: SG-01 box flipped
+PASS mux-on: SG-02 box flipped
+PASS mux-on: tmux new-window spawned a pane for SG-01
+PASS mux-on: tmux new-window spawned a pane for SG-02
+PASS mux-on: capture-pane SG-01 returns its live output
+PASS mux-on: capture-pane SG-02 returns its live output
+PASS mux-on: send-keys reached SG-01's pane
+PASS mux-off NC: _wave_run rc 0 (headless path unaffected by the poisoned tmux)
+PASS mux-off NC: SG-01 box flipped via the plain background path
+PASS mux-off NC: SG-02 box flipped via the plain background path
+PASS mux-off NC [NEGATIVE CONTROL]: $TMUX_CMD never invoked (no tmux window, no send-keys) with MULTIPLEXER unset
+PASS mux-off explicit (MULTIPLEXER=0) [NEGATIVE CONTROL]: tmux never invoked
+ALL PASS
+```
+
+Regression (all rc 0): `test-orchestrate-wavefront.sh`, `test-tier4-close.sh`, `test-meta.sh`;
+`shellcheck -S error lib/orchestrate.sh` clean.
+
+## Reproduce
+
+```
+cd <dwarves-kit>
+bash tests/test-multiplexer.sh          # ALL PASS (enabled spawn/capture/send-keys + off NCs)
+bash tests/test-orchestrate-wavefront.sh # regression: wave path intact
+```
+
+The test mocks tmux via `TMUX_CMD` (no real tmux server needed, CI-safe) and `claude` via `CLAUDE_CMD`,
+mirroring the existing orchestrate test seams.
+
+## Coverage delta
+
+- **Covered:** enabled pane spawn (A2) · capture-pane visibility (A3) · send-keys intervention (A4) ·
+  off-default NC (N1) · off-explicit NC (N2) · off-path-unchanged under poisoned tmux (N3).
+- **Uncovered (declared):** a live tmux server end-to-end (mock seam only, same discipline as the
+  other orchestrate suites) · cmux driver path (open-fork 2 picked tmux; cmux is a documented future
+  alternative, not wired) · multi-wave (>1 concurrent window) beyond the 2-session fixture.

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -37,6 +37,14 @@
 # human gate (never auto-merges past it). TIER4_CLOSE=0 restores the bare "done"-and-return;
 # TIER4_CORPUS overrides the no-orphan sweep root (default: the megadir's git repo root).
 #
+# Multiplexer panes (SPEC-119, env MULTIPLEXER=0 default -- OPT-IN, ADR-0032 s4): when a wave
+# actually admits >=1 sub-goal concurrently (WAVE_CAP>1 + disjoint `## Touches`), MULTIPLEXER=1
+# spawns each wave session into its own tmux window (`tmux new-window`) instead of a plain
+# background job, so an operator can `tmux capture-pane` its live output or `tmux send-keys` into
+# it (watch + intervene across tabs). Off by default: `_wave_run`'s spawn/reap take the exact
+# pre-existing kill-0/wait path and $TMUX_CMD is never invoked. TMUX_CMD mirrors CLAUDE_CMD's mock
+# seam; TMUX_SESSION overrides the derived per-megagoal tmux session name.
+#
 # The `claude` invocation is `$CLAUDE_CMD` (default: claude), so tests mock it and operators
 # tune the permission flags.
 set -uo pipefail
@@ -115,6 +123,18 @@ WAVE_CAP="${WAVE_CAP:-2}"
 # clean no-op. Tests set WAVE_MERGE_CMD to a mock that records merge ordering. Word-split intentionally
 # (operator config, not user data), mirroring CLAUDE_FLAGS. Override the lane via WAVE_MERGE_LANE.
 WAVE_MERGE_CMD="${WAVE_MERGE_CMD:-$ORCH_DIR/mega-merge.sh merge}"
+
+# Multiplexer panes (SPEC-119, executes ADR-0032 section 4). Opt-in (default 0/off): when a wave
+# runs (MULTIPLEXER=1, WAVE_CAP>1, sub-goals declaring disjoint Touches so >=1 is actually
+# admitted concurrently), each spawned wave session runs inside a tmux window instead of a plain
+# background job, so the operator can `tmux capture-pane`/`send-keys` it (watch + intervene across
+# tabs, ADR-0032 s4). OFF by default: `_wave_run`'s spawn/reap take the exact pre-existing
+# kill-0/wait code path and $TMUX_CMD is never invoked (the off-path-unchanged property this
+# sub-goal's Proof is built on). TMUX_CMD mirrors CLAUDE_CMD's mock seam (tests point it at a fake
+# `tmux` so no real tmux server is needed in CI). TMUX_SESSION overrides the derived per-megagoal
+# tmux session name (default: sanitized from the megadir path, see _mux_session_name).
+MULTIPLEXER="${MULTIPLEXER:-0}"
+TMUX_CMD="${TMUX_CMD:-tmux}"
 
 # TIER-4 mega-close (SPEC-118, executes ADR-0032 section 5). Default ON (1): when EVERY sub-goal box
 # is checked, `cmd_run` runs a real mega-level close over the ASSEMBLED WAVE instead of just printing
@@ -728,6 +748,61 @@ _wave_worktree() {  # repo id branch
   printf '%s\n' "$wt"
 }
 
+# ---- Multiplexer panes (SPEC-119, ADR-0032 s4) ------------------------------------------------
+# The per-megagoal tmux session name a wave's panes live in: $TMUX_SESSION if the operator set
+# one, else derived from the megadir's basename (sanitized to tmux-safe chars). Pure function.
+_mux_session_name() {  # megadir
+  [ -n "${TMUX_SESSION:-}" ] && { printf '%s\n' "$TMUX_SESSION"; return 0; }
+  local base; base=$(basename "$(cd "$1" 2>/dev/null && pwd || printf '%s' "$1")")
+  printf 'orch-%s\n' "$(printf '%s' "$base" | tr -c 'A-Za-z0-9_-' '-')"
+}
+
+# Spawn ONE wave sub-goal's REAL session inside a tmux window (visibility + intervention, ADR-0032
+# s4) instead of a plain backgrounded job. `tmux new-window` cannot call a bash function in THIS
+# process -- it execs a fresh command line -- so the pane re-enters `orchestrate.sh` via the hidden
+# `_pane-exec` subcommand, which runs the exact same `_run_one_session` the plain path uses (no
+# duplicated dispatch logic). Ensures the shared per-megagoal tmux session exists first (`has-session`
+# else `new-session -d`, so the first pane doesn't need a pre-existing session). `tmux new-window`
+# returns as soon as the window is created, before the pane's command exits, so a pid-based `wait`
+# in the caller cannot observe its completion; the pane's command writes its exit code to
+# `$donefile` instead (the caller's reap loop polls for that file). Mockable via `$TMUX_CMD`;
+# nonzero on any tmux failure (missing binary, no server, etc.).
+#
+# spec-validate finding (Failure Mode Analyst): a sub-goal whose PREVIOUS wave attempt failed
+# (session exited nonzero / crashed) leaves its named window sitting in the shared per-megagoal
+# tmux session -- nothing kills a completed pane's window on the normal path (only `_wave_abort`
+# kills windows, and only still-in-flight ones on an operator Ctrl-C). A retry (`_wave_gate`
+# re-admits an unchecked box on the next `orchestrate.sh run`) would then `new-window -n "$id"`
+# a SECOND window sharing that name, and tmux's `session:name` target resolution is not
+# guaranteed to pick the new one -- `capture-pane`/`send-keys` could address the stale pane.
+# Pre-clean idempotently (mirrors `_wave_worktree`'s reuse-clean-else-recreate stance for
+# worktrees): a no-op `|| true` when no such window exists yet.
+_pane_spawn() {  # megadir id wt pfile route_flags donefile
+  local megadir="$1" id="$2" wt="$3" pfile="$4" route_flags="$5" donefile="$6"
+  local mux; mux=$(_mux_session_name "$megadir")
+  "$TMUX_CMD" has-session -t "$mux" 2>/dev/null || "$TMUX_CMD" new-session -d -s "$mux" -n _init 2>/dev/null || return 1
+  "$TMUX_CMD" kill-window -t "$mux:$id" 2>/dev/null || true
+  "$TMUX_CMD" new-window -d -t "$mux" -n "$id" -c "$wt" \
+    "\"$ORCH_DIR/orchestrate.sh\" _pane-exec \"$megadir\" \"$id\" \"$pfile\" \"$route_flags\" \"$donefile\""
+}
+
+# Read a wave session's live pane output (the visibility half of the Proof: "a capture-pane read
+# returns the wave session's live output"). `-p` prints to stdout; `-t <mux>:<id>` addresses the
+# window by name (unique per megagoal wave, one window per sub-goal id).
+_pane_capture() {  # megadir id
+  local mux; mux=$(_mux_session_name "$1")
+  "$TMUX_CMD" capture-pane -p -t "$mux:$2" 2>/dev/null
+}
+
+# Send keys into a wave session's pane (the control/intervene half of the Proof) -- e.g. an
+# operator nudging a stuck session or Ctrl-C-ing it directly in its own pane.
+_pane_send_keys() {  # megadir id keys...
+  local megadir="$1" id="$2"; shift 2
+  local mux; mux=$(_mux_session_name "$megadir")
+  "$TMUX_CMD" send-keys -t "$mux:$id" "$@"
+}
+# -----------------------------------------------------------------------------------------------
+
 # Abort handler for `_wave_run`'s INT/TERM trap: kill every still-live wave job's PROCESS GROUP then
 # reap, so an operator ctrl-C never leaves an orphaned `claude -p` (mock) grandchild. `_WAVE_PIDS`
 # holds the backgrounded SUBSHELL WRAPPER pid (`( cd ... && _run_one_session ... ) &`), not the
@@ -741,9 +816,21 @@ _wave_worktree() {  # repo id branch
 _wave_abort() {
   local p ok=1
   for p in ${_WAVE_PIDS[@]+"${_WAVE_PIDS[@]}"}; do
+    [ -n "$p" ] || continue   # SPEC-119: a muxed entry has no reapable pid; handled below instead
     kill -TERM -- -"$p" 2>/dev/null || kill -TERM "$p" 2>/dev/null || ok=0
   done
   wait 2>/dev/null
+  # SPEC-119: a muxed wave session's REAL process lives in a tmux pane, not this shell's job
+  # table, so the pid loop above cannot reach it -- kill its window directly instead (best-effort;
+  # a failure here does not flip `ok`, the pid-loop TERM confirmation is unrelated to pane cleanup).
+  local n="${#_WAVE_DONEFILES[@]}" i mux
+  if [ -n "${_WAVE_MUX_MEGADIR:-}" ] && [ "$n" -gt 0 ]; then
+    mux=$(_mux_session_name "$_WAVE_MUX_MEGADIR")
+    for i in $(seq 0 $((n - 1))); do
+      [ -n "${_WAVE_DONEFILES[$i]:-}" ] || continue
+      "$TMUX_CMD" kill-window -t "$mux:${_WAVE_IDS[$i]}" 2>/dev/null || true
+    done
+  fi
   # Review-fix FIX 8: clean up any prompt temp files an interrupted wave leaves behind (they hold
   # the injected HANDOFF content; a Ctrl-C otherwise leaks them into ${TMPDIR:-/tmp}).
   rm -f "${_WAVE_PFILES[@]+"${_WAVE_PFILES[@]}"}" 2>/dev/null
@@ -795,16 +882,24 @@ _wave_run() {  # megadir roadmap
   _WAVE_LANDED=()
   # `_WAVE_PFILES` is GLOBAL too (review-fix FIX 8): each spawned session's prompt temp file, so
   # `_wave_abort` can `rm -f` any still-live ones on an INT/TERM instead of leaking them into
-  # ${TMPDIR:-/tmp}. Index-aligned with `_WAVE_PIDS` / wave_ids, same as the other reap-map arrays.
+  # ${TMPDIR:-/tmp}. Index-aligned with `_WAVE_PIDS` / `_WAVE_IDS`, same as the other reap-map arrays.
   _WAVE_PFILES=()
-  local wave_ids=() wave_done=()
+  # `_WAVE_IDS` / `_WAVE_DONEFILES` are GLOBAL (SPEC-119, same reason as `_WAVE_PIDS`): a muxed
+  # entry has no reapable pid, so `_wave_abort` needs the sub-goal id (to address its tmux window)
+  # and `_WAVE_DONEFILES[i]` non-empty is what marks index `i` as muxed vs plain-backgrounded.
+  # `_WAVE_MUX_MEGADIR` lets the abort handler derive the tmux session name; harmless when unset
+  # (the `n -gt 0` / non-empty-donefile guards make the whole block a no-op for a non-muxed wave).
+  _WAVE_IDS=()
+  _WAVE_DONEFILES=()
+  _WAVE_MUX_MEGADIR="$megadir"
+  local wave_done=()
   local wave_failed=0 spawned=0
 
   # Reap/kill the wave PID set on an abort so no `claude -p` (mock) child is orphaned. Cleared
   # before the normal return paths below.
   trap '_wave_abort' INT TERM
 
-  local decision id gf branch wt route_flags rmodel reffort pfile pid checked
+  local decision id gf branch wt route_flags rmodel reffort pfile pid donefile checked
   while IFS=$'\t' read -r decision id; do
     [ "$decision" = run ] || continue
     # Idempotent resume: a box already checked is skipped, never re-run.
@@ -845,29 +940,48 @@ _wave_run() {  # megadir roadmap
     } >> "$pfile"
     _emit_event "$megadir" "$id" executing "wave (worktree $wt)"
 
-    # Background the session INSIDE its worktree (genuine isolation). `_run_one_session` picks the
-    # run-path (plain in the default/test posture); its `_ROS_SLOG` global is unused on the wave
-    # path (deterministic-handoff regen is TASK-005), so losing it in the subshell is fine. The
-    # session's exit code comes back via `wait` in the reap loop, NOT via the subshell here.
-    #
-    # Job control ON only around the spawn itself (review-fix FIX 1): under `set -m` a `&` job
-    # becomes its OWN PROCESS GROUP (pgid == the job's pid), so `_wave_abort` can signal the WHOLE
-    # group -- the backgrounded subshell wrapper AND its `claude -p` grandchild -- via a negative-pid
-    # `kill`. Without this, `kill "$p"` reaches only the wrapper; the grandchild reparents to init and
-    # survives an abort (confirmed live: the prior "no orphaned children" claim was false). Scoped
-    # tightly (set +m right after `$!`) so monitor mode's job-control side effects never leak into the
-    # rest of the spawn loop or the reap loop below. bash 3.2 macOS has no `setsid`; job control is
-    # the only portable no-setsid way to get a fresh process group.
-    set -m
-    ( cd "$wt" 2>/dev/null && _run_one_session "$megadir" "$id" "$pfile" "$route_flags" 0 ) &
-    pid=$!
-    set +m
+    if [ "$MULTIPLEXER" = 1 ]; then
+      # SPEC-119: host the REAL session inside a tmux pane instead of a plain background job (the
+      # off-by-default path below is untouched). `tmux new-window` returns as soon as the window is
+      # created, before the pane's command exits, so there is no pid to `wait` on here -- the pane
+      # writes its own exit code to $donefile instead (the reap loop polls it, see below).
+      donefile=$(mktemp -u)
+      if ! _pane_spawn "$megadir" "$id" "$wt" "$pfile" "$route_flags" "$donefile"; then
+        echo "[orchestrate] [wave] [mux] $id: tmux pane spawn failed; marking wave failed." >&2
+        _emit_event "$megadir" "$id" blocked "wave: tmux pane spawn failed"
+        wave_failed=1
+        rm -f "$pfile"
+        continue
+      fi
+      pid=""
+      _say "[orchestrate] [wave] [mux] spawned $id in tmux pane $(_mux_session_name "$megadir"):$id (worktree $wt)"
+    else
+      # Background the session INSIDE its worktree (genuine isolation). `_run_one_session` picks the
+      # run-path (plain in the default/test posture); its `_ROS_SLOG` global is unused on the wave
+      # path (deterministic-handoff regen is TASK-005), so losing it in the subshell is fine. The
+      # session's exit code comes back via `wait` in the reap loop, NOT via the subshell here.
+      #
+      # Job control ON only around the spawn itself (review-fix FIX 1): under `set -m` a `&` job
+      # becomes its OWN PROCESS GROUP (pgid == the job's pid), so `_wave_abort` can signal the WHOLE
+      # group -- the backgrounded subshell wrapper AND its `claude -p` grandchild -- via a negative-pid
+      # `kill`. Without this, `kill "$p"` reaches only the wrapper; the grandchild reparents to init and
+      # survives an abort (confirmed live: the prior "no orphaned children" claim was false). Scoped
+      # tightly (set +m right after `$!`) so monitor mode's job-control side effects never leak into the
+      # rest of the spawn loop or the reap loop below. bash 3.2 macOS has no `setsid`; job control is
+      # the only portable no-setsid way to get a fresh process group.
+      set -m
+      ( cd "$wt" 2>/dev/null && _run_one_session "$megadir" "$id" "$pfile" "$route_flags" 0 ) &
+      pid=$!
+      set +m
+      donefile=""
+      _say "[orchestrate] [wave] spawned $id (pid $pid) in $wt"
+    fi
     _WAVE_PIDS+=("$pid")
-    wave_ids+=("$id")
+    _WAVE_IDS+=("$id")
+    _WAVE_DONEFILES+=("$donefile")
     _WAVE_PFILES+=("$pfile")
     wave_done+=(0)
     spawned=$((spawned + 1))
-    _say "[orchestrate] [wave] spawned $id (pid $pid) in $wt"
   done < <(_wave_gate "$megadir" "$roadmap")
 
   # Empty wave (nothing admitted, or every admitted box already checked): not a failure unless a
@@ -881,13 +995,21 @@ _wave_run() {  # megadir roadmap
   # which is bash 4.3+/absent on macOS). As each PID exits, reap it with `wait`, then run the
   # grounded box-flip check for THAT sub-goal. A nonzero exit OR an unflipped box marks the wave
   # failed but does NOT break the loop: in-flight siblings DRAIN to completion (never killed).
-  local remaining="$spawned" i rc box
+  # SPEC-119: a muxed index (`_WAVE_DONEFILES[i]` non-empty) has no reapable pid -- `tmux
+  # new-window` already returned -- so that index polls for its donefile instead of `kill -0`.
+  local remaining="$spawned" i rc box donefile
   while [ "$remaining" -gt 0 ]; do
     for i in $(seq 0 $((spawned - 1))); do
       [ "${wave_done[$i]}" = 1 ] && continue
-      pid="${_WAVE_PIDS[$i]}"; id="${wave_ids[$i]}"
-      kill -0 "$pid" 2>/dev/null && continue   # still in-flight -> leave it alone (do not kill)
-      rc=0; wait "$pid" 2>/dev/null || rc=$?    # exited -> reap the cached status
+      pid="${_WAVE_PIDS[$i]}"; id="${_WAVE_IDS[$i]}"; donefile="${_WAVE_DONEFILES[$i]}"
+      if [ -n "$donefile" ]; then
+        [ -f "$donefile" ] || continue          # still in-flight -> leave it alone
+        rc=0; read -r rc < "$donefile" 2>/dev/null || rc=0
+        rm -f "$donefile"
+      else
+        kill -0 "$pid" 2>/dev/null && continue   # still in-flight -> leave it alone (do not kill)
+        rc=0; wait "$pid" 2>/dev/null || rc=$?    # exited -> reap the cached status
+      fi
       wave_done[i]=1
       remaining=$((remaining - 1))
       rm -f "${_WAVE_PFILES[$i]}" 2>/dev/null
@@ -1438,12 +1560,28 @@ cmd_run() {
   done
 }
 
+# Hidden re-entry point for a tmux-hosted wave session (SPEC-119): `_pane_spawn` execs THIS
+# subcommand as the pane's command line -- `tmux new-window` always execs a fresh command line, it
+# cannot call a bash function living in the orchestrator's own process. Runs the EXACT same
+# `_run_one_session` the plain background-job path uses (no duplicated dispatch logic), then writes
+# its exit code to $donefile so `_wave_run`'s reap loop (which cannot `wait` on a grandchild in a
+# different process tree) can poll for completion instead of `kill -0`/`wait`. Never invoked by an
+# operator directly; deliberately absent from the `usage:` string in `main()` below.
+cmd_pane_exec() {  # megadir id pfile route_flags donefile
+  local megadir="$1" id="$2" pfile="$3" route_flags="$4" donefile="$5"
+  _run_one_session "$megadir" "$id" "$pfile" "$route_flags" 0
+  local rc=$?
+  printf '%s\n' "$rc" > "$donefile"
+  return "$rc"
+}
+
 main() {
   local cmd="${1:-}"; shift 2>/dev/null || true
   case "$cmd" in
     next) cmd_next "$@" ;;
     run)  cmd_run "$@" ;;
     flip) cmd_flip "$@" ;;
+    _pane-exec) cmd_pane_exec "$@" ;;
     *) echo "usage: orchestrate.sh {next|run|flip} <megagoal-dir> [<SG-NN>] [--dry-run] [--step] [--stream] [--capture-tokens] [--board=roadmap|kanban|both]" >&2; exit 64 ;;
   esac
 }

--- a/tests/test-multiplexer.sh
+++ b/tests/test-multiplexer.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# test-multiplexer.sh (SPEC-119, ADR-0032 s4): pins the opt-in multiplexer wiring in `_wave_run`.
+# MULTIPLEXER=1 spawns each wave session into a tmux window (`tmux new-window`) instead of a plain
+# background job, so `tmux capture-pane` returns its live output and `tmux send-keys` can reach it.
+# MULTIPLEXER=0 (default, unset) must be BYTE-UNCHANGED: `_wave_run` never invokes `$TMUX_CMD` --
+# the load-bearing negative control this whole sub-goal's Proof rests on.
+#
+# No real tmux server is used (headless-safe, no CI dependency): `$TMP/tmux-mock` fakes just enough
+# of has-session/new-session/new-window/capture-pane/send-keys/kill-window to prove the wiring --
+# `new-window` actually execs the given command line (a real `_pane-exec` re-entry into
+# orchestrate.sh, a REAL subprocess, not a test-only stub) and redirects its output to a per-window
+# log file that `capture-pane` reads back, so the whole spawn/capture chain is exercised for real.
+set -uo pipefail
+export TIER4_CLOSE=0
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/orchestrate.sh
+source "$KIT/lib/orchestrate.sh"
+ORCH="$KIT/lib/orchestrate.sh"
+
+fails=0
+pass() { echo "PASS $*"; }
+fail() { echo "FAIL $*"; fails=$((fails + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mk_git_mega() {  # repo
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email t@example.com
+  git -C "$repo" config user.name test
+  git -C "$repo" commit -q --allow-empty -m init
+}
+
+make_goal() {  # megadir id [glob]
+  local mg="$1" id="$2" glob="${3:-}"
+  mkdir -p "$mg/goals"
+  {
+    printf '# %s: sub-goal\n' "$id"
+    printf '**Branch:** feat/%s\n' "$(printf '%s' "$id" | tr 'A-Z' 'a-z')"
+    if [ -n "$glob" ]; then printf '\n## Touches\n- %s\n' "$glob"; fi
+  } > "$mg/goals/${id#SG-}-${id}.md"
+}
+
+# Fake tmux (no real server): implements has-session/new-session/new-window/capture-pane/
+# send-keys/kill-window over plain files under $TMUX_MOCK_STATE. `new-window` actually EXECS the
+# given command line in the background (mirroring how a real tmux server detaches a pane from the
+# invoking `tmux` CLI call) and redirects its output to a per-window log `capture-pane` reads back.
+cat > "$TMP/tmux-mock" <<'MOCK'
+#!/usr/bin/env bash
+set -u
+STATE="${TMUX_MOCK_STATE:?TMUX_MOCK_STATE not set}"
+mkdir -p "$STATE"
+printf '%s\n' "$*" >> "$STATE/calls.log"
+sub="$1"; shift
+case "$sub" in
+  has-session)
+    [ "$1" = -t ] && shift
+    [ -f "$STATE/session.$1" ]
+    exit $?
+    ;;
+  new-session)
+    name=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -s) name="$2"; shift 2 ;;
+        -n) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    : > "$STATE/session.$name"
+    ;;
+  new-window)
+    session="" id="" dir="" cmdline=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -d) shift ;;
+        -t) session="$2"; shift 2 ;;
+        -n) id="$2"; shift 2 ;;
+        -c) dir="$2"; shift 2 ;;
+        *) cmdline="$1"; shift ;;
+      esac
+    done
+    : > "$STATE/session.$session"
+    panelog="$STATE/pane.$session.$id.log"
+    : > "$panelog"
+    ( cd "$dir" 2>/dev/null || exit 1; eval "$cmdline" ) > "$panelog" 2>&1 &
+    ;;
+  capture-pane)
+    target=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -p) shift ;;
+        -t) target="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    cat "$STATE/pane.${target%%:*}.${target##*:}.log" 2>/dev/null
+    ;;
+  send-keys)
+    target=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) target="$2"; shift 2 ;;
+        *) break ;;
+      esac
+    done
+    printf '%s\n' "$*" >> "$STATE/keys.${target%%:*}.${target##*:}.log"
+    ;;
+  kill-window)
+    [ "$1" = -t ] && shift
+    : "$1"
+    ;;
+  *) exit 1 ;;
+esac
+MOCK
+chmod +x "$TMP/tmux-mock"
+
+# A poisoned tmux: any invocation is itself the test failure (records a sentinel + exits nonzero).
+# Used under the default MULTIPLEXER=0 to prove the off-path never touches tmux at all.
+cat > "$TMP/tmux-poison" <<'MOCK'
+#!/usr/bin/env bash
+echo "POISON: tmux invoked with: $*" >> "${TMUX_POISON_LOG:?}"
+exit 99
+MOCK
+chmod +x "$TMP/tmux-poison"
+
+# Claude mock: flips its sub-goal's box (via the locked flip CLI, matching the real wave-session
+# contract) and prints a recognizable line, so capture-pane's returned content is checkable.
+cat > "$TMP/claude-mux" <<'MOCK'
+#!/usr/bin/env bash
+prompt=$(cat)
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+echo "MUX-HELLO from $id"
+bash "$ORCH" flip "$MEGADIR" "$id" >/dev/null 2>&1
+exit 0
+MOCK
+chmod +x "$TMP/claude-mux"
+
+# ============================ (A) MULTIPLEXER=1: spawn + capture-pane visibility ============================
+A="$TMP/mux-on-repo"
+mk_git_mega "$A"
+AM="$A/mega"; mkdir -p "$AM"
+cat > "$AM/ROADMAP.md" <<'EOF'
+# Mega-goal: mux-on
+## Sub-goals
+- [ ] SG-01 alpha , auto , PR #__
+- [ ] SG-02 beta , auto , PR #__
+EOF
+echo "POINTER: resume from ROADMAP" > "$AM/POINTER_PROMPT.md"
+make_goal "$AM" SG-01 "lib/wave-a/**"
+make_goal "$AM" SG-02 "lib/wave-b/**"
+
+STATE_A="$TMP/tmux-state-a"; mkdir -p "$STATE_A"
+arc=0
+( export MULTIPLEXER=1 TMUX_CMD="$TMP/tmux-mock" TMUX_MOCK_STATE="$STATE_A" TMUX_SESSION=orch-test-a \
+    WAVE_CAP=2 CLAUDE_FLAGS="" CLAUDE_CMD="$TMP/claude-mux" ORCH="$ORCH" MEGADIR="$AM"
+  _wave_run "$AM" "$AM/ROADMAP.md" ) > "$TMP/a.out" 2>&1 || arc=$?
+
+[ "$arc" = 0 ] && pass "mux-on: _wave_run rc 0" || { fail "mux-on: _wave_run rc=$arc"; cat "$TMP/a.out"; }
+b1=$(_sg_line "$AM/ROADMAP.md" SG-01); b2=$(_sg_line "$AM/ROADMAP.md" SG-02)
+case "$b1" in '- [x] SG-01'*) pass "mux-on: SG-01 box flipped" ;; *) fail "mux-on: SG-01 not flipped ($b1)" ;; esac
+case "$b2" in '- [x] SG-02'*) pass "mux-on: SG-02 box flipped" ;; *) fail "mux-on: SG-02 not flipped ($b2)" ;; esac
+
+# spawn: a tmux new-window call happened per sub-goal, naming the window after its id.
+if grep -q 'new-window .*-n SG-01' "$STATE_A/calls.log" 2>/dev/null; then
+  pass "mux-on: tmux new-window spawned a pane for SG-01"
+else
+  fail "mux-on: no new-window call for SG-01"; cat "$STATE_A/calls.log" 2>/dev/null
+fi
+if grep -q 'new-window .*-n SG-02' "$STATE_A/calls.log" 2>/dev/null; then
+  pass "mux-on: tmux new-window spawned a pane for SG-02"
+else
+  fail "mux-on: no new-window call for SG-02"
+fi
+
+# receive: capture-pane against each pane returns that session's REAL live output.
+cap1=$(TMUX_MOCK_STATE="$STATE_A" "$TMP/tmux-mock" capture-pane -p -t "orch-test-a:SG-01")
+cap2=$(TMUX_MOCK_STATE="$STATE_A" "$TMP/tmux-mock" capture-pane -p -t "orch-test-a:SG-02")
+case "$cap1" in *"MUX-HELLO from SG-01"*) pass "mux-on: capture-pane SG-01 returns its live output" ;; *) fail "mux-on: capture-pane SG-01 empty/wrong: '$cap1'" ;; esac
+case "$cap2" in *"MUX-HELLO from SG-02"*) pass "mux-on: capture-pane SG-02 returns its live output" ;; *) fail "mux-on: capture-pane SG-02 empty/wrong: '$cap2'" ;; esac
+
+# control: _pane_send_keys reaches the right pane (send-keys wiring, the "intervene" half).
+( export TMUX_CMD="$TMP/tmux-mock" TMUX_MOCK_STATE="$STATE_A" TMUX_SESSION=orch-test-a
+  _pane_send_keys "$AM" SG-01 "hello-operator" ) >/dev/null 2>&1
+if grep -q 'hello-operator' "$STATE_A/keys.orch-test-a.SG-01.log" 2>/dev/null; then
+  pass "mux-on: send-keys reached SG-01's pane"
+else
+  fail "mux-on: send-keys did not land in SG-01's pane log"
+fi
+
+# ============================ (B) MULTIPLEXER=0 (default): off-path byte-unchanged NC ============================
+# Same shape as (A) (two disjoint sub-goals, WAVE_CAP=2) but MULTIPLEXER is left UNSET (the
+# operator default) and TMUX_CMD points at a POISONED tmux: any invocation is itself a failure. If
+# _wave_run's default path ever touched tmux, this NC would catch it; the existing (unedited)
+# tests/test-orchestrate-wavefront.sh passing is the complementary byte-unchanged regression proof.
+B="$TMP/mux-off-repo"
+mk_git_mega "$B"
+BM="$B/mega"; mkdir -p "$BM"
+cat > "$BM/ROADMAP.md" <<'EOF'
+# Mega-goal: mux-off
+## Sub-goals
+- [ ] SG-01 alpha , auto , PR #__
+- [ ] SG-02 beta , auto , PR #__
+EOF
+echo "POINTER: resume from ROADMAP" > "$BM/POINTER_PROMPT.md"
+make_goal "$BM" SG-01 "lib/wave-a/**"
+make_goal "$BM" SG-02 "lib/wave-b/**"
+
+POISON_LOG="$TMP/poison.log"; : > "$POISON_LOG"
+brc=0
+( # MULTIPLEXER deliberately left at its already-sourced default (0/off) -- an "unset" here would
+  # be an unbound-variable error under this test's own `set -u`, and is not what an operator's
+  # default (never having set it) looks like anyway: the var is defaulted once at source time.
+  export TMUX_CMD="$TMP/tmux-poison" TMUX_POISON_LOG="$POISON_LOG" \
+    WAVE_CAP=2 CLAUDE_FLAGS="" CLAUDE_CMD="$TMP/claude-mux" ORCH="$ORCH" MEGADIR="$BM"
+  _wave_run "$BM" "$BM/ROADMAP.md" ) > "$TMP/b.out" 2>&1 || brc=$?
+
+[ "$brc" = 0 ] && pass "mux-off NC: _wave_run rc 0 (headless path unaffected by the poisoned tmux)" \
+  || { fail "mux-off NC: _wave_run rc=$brc"; cat "$TMP/b.out"; }
+ob1=$(_sg_line "$BM/ROADMAP.md" SG-01); ob2=$(_sg_line "$BM/ROADMAP.md" SG-02)
+case "$ob1" in '- [x] SG-01'*) pass "mux-off NC: SG-01 box flipped via the plain background path" ;; *) fail "mux-off NC: SG-01 not flipped ($ob1)" ;; esac
+case "$ob2" in '- [x] SG-02'*) pass "mux-off NC: SG-02 box flipped via the plain background path" ;; *) fail "mux-off NC: SG-02 not flipped ($ob2)" ;; esac
+if [ -s "$POISON_LOG" ]; then
+  fail "mux-off NC: tmux WAS invoked while MULTIPLEXER was unset -- coupling leak"; cat "$POISON_LOG"
+else
+  pass "mux-off NC [NEGATIVE CONTROL]: \$TMUX_CMD never invoked (no tmux window, no send-keys) with MULTIPLEXER unset"
+fi
+
+# ============================ (C) MULTIPLEXER=1 explicit off (0) is the same NC ============================
+POISON_LOG2="$TMP/poison2.log"; : > "$POISON_LOG2"
+C="$TMP/mux-off2-repo"
+mk_git_mega "$C"
+CM="$C/mega"; mkdir -p "$CM"
+cat > "$CM/ROADMAP.md" <<'EOF'
+# Mega-goal: mux-off-explicit
+## Sub-goals
+- [ ] SG-01 alpha , auto , PR #__
+EOF
+echo "POINTER: resume from ROADMAP" > "$CM/POINTER_PROMPT.md"
+make_goal "$CM" SG-01 "lib/wave-a/**"
+crc=0
+( export MULTIPLEXER=0 TMUX_CMD="$TMP/tmux-poison" TMUX_POISON_LOG="$POISON_LOG2" \
+    WAVE_CAP=2 CLAUDE_FLAGS="" CLAUDE_CMD="$TMP/claude-mux" ORCH="$ORCH" MEGADIR="$CM"
+  _wave_run "$CM" "$CM/ROADMAP.md" ) > "$TMP/c.out" 2>&1 || crc=$?
+[ "$crc" = 0 ] && [ ! -s "$POISON_LOG2" ] \
+  && pass "mux-off explicit (MULTIPLEXER=0) [NEGATIVE CONTROL]: tmux never invoked" \
+  || { fail "mux-off explicit: rc=$crc, poison log: $(cat "$POISON_LOG2" 2>/dev/null)"; }
+
+echo "----"
+if [ "$fails" = 0 ]; then
+  echo "ALL PASS"
+  exit 0
+else
+  echo "$fails FAILING"
+  exit 1
+fi


### PR DESCRIPTION
Multiplexer panes (opt-in wavefront visibility): when enabled (`MULTIPLEXER=1`, default `0`), `orchestrate.sh` spawns each wavefront wave session into its own tmux window (`tmux new-window` to spawn, `capture-pane` to watch, `send-keys` to intervene) , watch + intervene over an otherwise headless parallel `claude -p` dispatch. OFF by default: the headless wavefront path is byte-unchanged and `$TMUX_CMD` is never invoked. Minimum-infra (tmux already installed, no new daemon). Executes ADR-0032 §4.

Lands on `master` after sub-goals 01 (#139) + 02 (#140) + 03 (#141), all merged.

**Open-fork 2 resolved:** host the real session in a `tmux new-window` pane (tmux = portable/headless-safe default; cmux noted as the operator's daily-driver alternative, not wired). `TMUX_CMD` mirrors `CLAUDE_CMD`'s mock seam so the test needs no real tmux server (CI-safe).

**Verify:** `bash tests/test-multiplexer.sh` (13/13): enabled spawn + capture-pane visibility + send-keys intervention; off-default + off-explicit NCs (`$TMUX_CMD` never invoked); off-path-unchanged under a poisoned tmux (the load-bearing property). Regression green: wavefront, tier4-close, meta; shellcheck clean. Proof: `docs/verification/multiplexer-panes.md`.

Roadmap: ops-toolkit `_meta/megagoals/orchestrate-hardening/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
