### PR TITLE
fix(orchestrate): close command injection in multiplexer pane spawn

### DIFF
--- a/docs/implementation-notes/SPEC-119-pane-injection-fix.md
+++ b/docs/implementation-notes/SPEC-119-pane-injection-fix.md
@@ -1,0 +1,40 @@
+# SPEC-119 delta: `_pane_spawn` command-injection fix
+
+Delta from SPEC-119 (multiplexer panes), found by the orchestrate-hardening TIER-4 close
+security lens. Not a spec change; a security defect in the shipped implementation.
+
+## What was wrong
+
+`_pane_spawn` (`lib/orchestrate.sh`) built the pane command as a SINGLE joined string passed to
+`tmux new-window`. Real tmux hands a lone command string to `$SHELL -c` , a second shell parse,
+i.e. an `eval`. Each field was wrapped in escaped quotes (`\"$route_flags\"`), and `route_flags`
+derives from the goal file's UNSANITIZED `Model:`/`Effort:` header (`_route`, no validation). So a
+hostile/careless mega-goal PR with a `Model:` value like `opus"; touch X; echo "` closed the quote
+wrapper, injected a host command, and ran it on the operator's box under `MULTIPLEXER=1`.
+Reproduced live by the reviewer (a sentinel file was created) and re-reproduced in the test's D1
+positive control.
+
+## Fix
+
+Pass the pane command as SEPARATE argv tokens after `--` (`tmux new-window ... -- prog a b c`).
+tmux execs that argv directly, with no `$SHELL -c` re-parse. `route_flags` stays ONE argv token, so
+`cmd_pane_exec` still receives its 5 positional args and `_run_one_session`'s existing unquoted
+`$route_flags` word-splitting is unchanged (non-mux-path parity). Downstream is safe because
+unquoted expansion word-splits but does not re-interpret metacharacters (the same reason the
+non-mux dispatch was never vulnerable).
+
+## Test delta
+
+- The mock tmux `new-window` now models BOTH real behaviors: a multi-arg command (post-`--`) is
+  exec'd directly (no re-parse); a single string is `eval`'d (the pre-fix sink). Without this, the
+  NC could not distinguish the two forms.
+- Section D: D1 positive control feeds the old joined-string form and asserts the payload DOES fire
+  (proves the NC is non-vacuous); D2 drives the real fixed `_pane_spawn` with the same payload and
+  asserts it stays inert. D2 is the load-bearing negative control.
+
+## Scope note
+
+Fix-forward on `master` after SG-04 (#142) merged, rather than amending it. The other three wave
+surfaces (`--model` routing, token capture, TIER-4 close) were reviewed and are clean (non-mux
+`$route_flags` is word-split not re-parsed; token capture takes the silent `> $slog` branch never
+`tee`; the close prompt is fed on stdin never a command line).

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -782,8 +782,14 @@ _pane_spawn() {  # megadir id wt pfile route_flags donefile
   local mux; mux=$(_mux_session_name "$megadir")
   "$TMUX_CMD" has-session -t "$mux" 2>/dev/null || "$TMUX_CMD" new-session -d -s "$mux" -n _init 2>/dev/null || return 1
   "$TMUX_CMD" kill-window -t "$mux:$id" 2>/dev/null || true
-  "$TMUX_CMD" new-window -d -t "$mux" -n "$id" -c "$wt" \
-    "\"$ORCH_DIR/orchestrate.sh\" _pane-exec \"$megadir\" \"$id\" \"$pfile\" \"$route_flags\" \"$donefile\""
+  # SECURITY (SPEC-119 fix): pass the pane command as SEPARATE argv tokens after `--`, never a
+  # single joined string. tmux hands a lone command STRING to `$SHELL -c`, a second shell parse
+  # (an eval); with the multi-arg form it execs directly, no re-parse. `route_flags` is built from
+  # the goal file's unsanitized `Model:`/`Effort:` header, so the joined form was a host command
+  # injection reachable via a hostile mega-goal PR under MULTIPLEXER=1. It stays ONE argv token so
+  # cmd_pane_exec still receives 5 positional args (route_flags splits later, non-mux path parity).
+  "$TMUX_CMD" new-window -d -t "$mux" -n "$id" -c "$wt" -- \
+    "$ORCH_DIR/orchestrate.sh" _pane-exec "$megadir" "$id" "$pfile" "$route_flags" "$donefile"
 }
 
 # Read a wave session's live pane output (the visibility half of the Proof: "a capture-pane read

--- a/tests/test-multiplexer.sh
+++ b/tests/test-multiplexer.sh
@@ -72,20 +72,30 @@ case "$sub" in
     : > "$STATE/session.$name"
     ;;
   new-window)
-    session="" id="" dir="" cmdline=""
+    session="" id="" dir=""; cmd_argv=()
     while [ "$#" -gt 0 ]; do
       case "$1" in
         -d) shift ;;
         -t) session="$2"; shift 2 ;;
         -n) id="$2"; shift 2 ;;
         -c) dir="$2"; shift 2 ;;
-        *) cmdline="$1"; shift ;;
+        --) shift; cmd_argv=("$@"); break ;;             # fixed form: everything after -- is argv
+        *) cmd_argv=("$1"); shift ;;                     # legacy single-string form (kept for the
+                                                         # injection positive-control below)
       esac
     done
     : > "$STATE/session.$session"
     panelog="$STATE/pane.$session.$id.log"
     : > "$panelog"
-    ( cd "$dir" 2>/dev/null || exit 1; eval "$cmdline" ) > "$panelog" 2>&1 &
+    if [ "${#cmd_argv[@]}" -gt 1 ]; then
+      # Real tmux with a multi-arg command execs the argv DIRECTLY -- no `$SHELL -c`, no second
+      # parse. Modelled by running the array as-is (the fix's whole guarantee).
+      ( cd "$dir" 2>/dev/null || exit 1; "${cmd_argv[@]}" ) > "$panelog" 2>&1 &
+    else
+      # Real tmux with a single command STRING hands it to `$SHELL -c` -- a second shell parse,
+      # i.e. an eval. This is the pre-fix sink the injection positive-control exercises.
+      ( cd "$dir" 2>/dev/null || exit 1; eval "${cmd_argv[0]:-}" ) > "$panelog" 2>&1 &
+    fi
     ;;
   capture-pane)
     target=""
@@ -247,6 +257,46 @@ crc=0
 [ "$crc" = 0 ] && [ ! -s "$POISON_LOG2" ] \
   && pass "mux-off explicit (MULTIPLEXER=0) [NEGATIVE CONTROL]: tmux never invoked" \
   || { fail "mux-off explicit: rc=$crc, poison log: $(cat "$POISON_LOG2" 2>/dev/null)"; }
+
+# ============================ (D) command-injection NC (SPEC-119 security fix) ============================
+# `route_flags` is built from the goal file's UNSANITIZED `Model:` header. The pre-fix `_pane_spawn`
+# joined the pane command into ONE string that real tmux re-parses via `$SHELL -c` (an eval), so a
+# hostile `Model:` value broke out and ran on the host under MULTIPLEXER=1. The fix passes the
+# command as separate argv tokens after `--` (exec-direct, no re-parse). Two halves:
+#  D1 positive control -- proves the payload + the mock's eval path CAN inject (NC is non-vacuous);
+#  D2 the fix -- the real `_pane_spawn` (multi-arg) leaves the same payload inert.
+PWNED_POS="$TMP/pwned-positive"; PWNED_FIX="$TMP/pwned-fixed"
+rm -f "$PWNED_POS" "$PWNED_FIX" 2>/dev/null || true
+# A Model:-derived route_flags whose metachars CLOSE the escaped-quote wrapper the pre-fix code put
+# around each field (`\"$route_flags\"`), break out, run a command, then reopen the quote.
+INJ='--model opus"; touch '"$PWNED_POS"'; echo "'
+
+# D1: feed the OLD joined-string form (each field wrapped in escaped quotes, exactly as the pre-fix
+# `_pane_spawn` built it) straight to the mock's new-window -> the mock's eval path re-parses it.
+DSTATE="$TMP/inj-state"; mkdir -p "$DSTATE"
+INJ_CMDLINE="\"/bin/true\" _pane-exec \"x\" \"SG-01\" \"pf\" \"$INJ\" \"df\""
+TMUX_MOCK_STATE="$DSTATE" "$TMP/tmux-mock" new-window -d -t sess -n SG-01 -c "$TMP" \
+  "$INJ_CMDLINE" >/dev/null 2>&1
+for _ in 1 2 3 4 5 6 7 8; do [ -e "$PWNED_POS" ] && break; sleep 0.25; done
+if [ -e "$PWNED_POS" ]; then
+  pass "inj D1 positive control: the joined-string form DOES inject (payload + mock eval are live)"
+else
+  fail "inj D1 positive control: payload did not fire via the joined string -- NC would be vacuous"
+fi
+
+# D2: the real, fixed `_pane_spawn` with the SAME payload as route_flags -> exec-direct, no re-parse.
+D2STATE="$TMP/inj-fix-state"; mkdir -p "$D2STATE"
+( export TMUX_CMD="$TMP/tmux-mock" TMUX_MOCK_STATE="$D2STATE" TMUX_SESSION=orch-inj \
+    ORCH_DIR="$TMP" ORCH="$ORCH"
+  # a stub orchestrate.sh so the pane's exec target exists and is itself inert
+  printf '#!/usr/bin/env bash\n:\n' > "$TMP/orchestrate.sh"; chmod +x "$TMP/orchestrate.sh"
+  _pane_spawn "$TMP/mega-x" SG-01 "$TMP" "$TMP/pf" "$INJ" "$TMP/df" ) >/dev/null 2>&1
+for _ in 1 2 3 4 5 6 7 8; do [ -e "$PWNED_FIX" ] && break; sleep 0.25; done
+if [ -e "$PWNED_FIX" ]; then
+  fail "inj D2 [NEGATIVE CONTROL]: FIXED _pane_spawn STILL injected -- host command ran"
+else
+  pass "inj D2 [NEGATIVE CONTROL]: fixed _pane_spawn passes route_flags as argv; the metachar Model: value is inert (no host command)"
+fi
 
 echo "----"
 if [ "$fails" = 0 ]; then


### PR DESCRIPTION
**CRITICAL security fix** found by the `orchestrate-hardening` TIER-4 close security lens, over the merged wave (SG-01..04).

**The hole:** `_pane_spawn` passed the pane command to `tmux new-window` as a single joined string. Real tmux hands a lone command string to `$SHELL -c` , a second shell parse (an `eval`) , and each field was wrapped in escaped quotes (`\"$route_flags\"`). `route_flags` is built from the goal file's UNSANITIZED `Model:`/`Effort:` header (`_route` does zero validation). So a hostile/careless mega-goal PR with `Model: opus"; <cmd>; echo "` broke out of the quote wrapper and ran `<cmd>` on the operator's host whenever `MULTIPLEXER=1`. Reproduced live (a sentinel file was created).

**The fix (2 lines):** pass the command as separate argv tokens after `--` (`tmux new-window ... -- prog args`), which tmux execs directly with no `$SHELL -c` re-parse. `route_flags` stays one argv token, so `cmd_pane_exec` keeps its 5 positional args and `_run_one_session`'s existing unquoted word-splitting is unchanged (non-mux-path parity , that path was never vulnerable because word-splitting does not re-interpret metacharacters).

**Verify:** `bash tests/test-multiplexer.sh` , section D injection NC: **D1** positive control proves the old joined-string form DOES inject (non-vacuous), **D2** proves the fixed `_pane_spawn` leaves the same payload inert. The mock tmux now models both real forms (multi-arg = exec-direct, single-string = eval). Full suite green (multiplexer, wavefront, tier4-close, model-routing, token-capture, meta); shellcheck clean.

Other three wave surfaces were reviewed and are clean (see `docs/implementation-notes/SPEC-119-pane-injection-fix.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
