### PR TITLE
fix(docs): update stale pane-viewer spec references

### DIFF
--- a/docs/decisions/0031-understanding-gate.md
+++ b/docs/decisions/0031-understanding-gate.md
@@ -1,7 +1,7 @@
 # 0031. The understanding gate (design record + explainer/quiz)
 
 Date: 2026-07-03
-Status: Accepted (2026-07-03, operator bless)
+Status: Accepted
 Relates-to: ADR-0018 (v-model phase frame , this adds a third axis to it), ADR-0024 (gate-ledger + ship-enforcement), ADR-0025 (proof-of-done ship gate , the VERIFICATION gate this complements), ADR-0028 (autonomous-loop hardening , the fast autonomous runs this counterbalances), SPEC-008 (solution-design depth), SPEC-011 (design lane), ops-toolkit `research/2026-07-03-understanding-bottleneck-sdlc.md` (the motivation) + the `understanding-gate` mega-goal + the learning skills (`deep-understand`, `narrate-log`, `svg-knowledge-diagram`, `interactive-concept-board`, `learning-ledger`)
 
 ## Context

--- a/docs/decisions/0032-megagoal-execution-hygiene.md
+++ b/docs/decisions/0032-megagoal-execution-hygiene.md
@@ -90,10 +90,10 @@ default.
 - Replacing `/goal` (it stays the official activator; ADR-0017 activator-agnostic stands).
 - The weekend-batch / understanding-gate mechanics (their own ADR-0031 + mega-goal).
 
-## Addendum (2026-07-03, SPEC-120): viewer push widens section 4's surface
+## Addendum (2026-07-03, SPEC-121): viewer push widens section 4's surface
 
 Section 4 authorized tmux-only mechanics (`new-window` / `capture-pane` / `send-keys`), opt-in and
-off by default. SPEC-120 (operator decision 2026-07-03) adds the PUSH half on top: when a wave
+off by default. SPEC-121 (operator decision 2026-07-03) adds the PUSH half on top: when a wave
 spawns panes under `MULTIPLEXER=1`, `orchestrate.sh` opens ONE viewer tab/surface in the
 operator's own terminal app (cmux workspace, `kitty @ launch`, `wezterm cli spawn`,
 `open -na Ghostty`, or `osascript` against iTerm/Terminal) already attached to the wave's tmux
@@ -102,4 +102,4 @@ session , i.e. the authorized surface grows from in-tmux-server control to DEFAU
 only when the multiplexer is already on AND a viewer is detected on a real TTY (headless stays
 byte-identical, pull-only); `PANE_VIEWER=none` restores section 4's exact behavior; the exec is
 argv-direct + charset-gated + allowlist-validated (the #143 pattern), fire-and-forget, and can
-never fail a wave. Full design + security pins: `docs/specs/SPEC-120-pane-viewer-push.md`.
+never fail a wave. Full design + security pins: `docs/specs/SPEC-121-pane-viewer-push.md`.

--- a/docs/implementation-notes/SPEC-121-pane-viewer-push.md
+++ b/docs/implementation-notes/SPEC-121-pane-viewer-push.md
@@ -1,4 +1,4 @@
-# Implementation notes: SPEC-120 pane viewer push
+# Implementation notes: SPEC-121 pane viewer push
 
 Delta from the spec only; decisions the spec didn't pin, deviations, tradeoffs.
 

--- a/docs/verification/pane-viewer-push.md
+++ b/docs/verification/pane-viewer-push.md
@@ -1,4 +1,4 @@
-# Proof of done: pane viewer push (SPEC-120, board ID-092)
+# Proof of done: pane viewer push (SPEC-121, board ID-092)
 
 The PUSH half of SPEC-119's pull-only multiplexer panes, DEFAULT ON (`PANE_VIEWER=auto`,
 operator decision 2026-07-03): on wave spawn under `MULTIPLEXER=1`, ONE viewer tab/surface
@@ -115,7 +115,7 @@ ran.
   `_viewer_resolve` unknown-value fallback (T3).
 - **Uncovered (declared):** real GUI viewers end-to-end (seam-mocked, same discipline as the
   TMUX_CMD/CLAUDE_CMD suites) - the iTerm2 `tmux -CC` control-mode path (documented as the
-  zero-code operator alternative in SPEC-120, deliberately not built) - a real cmux socket
+  zero-code operator alternative in SPEC-121, deliberately not built) - a real cmux socket
   round-trip (the `--focus false` pin is argv-asserted, not app-observed) - a genuinely hung
   viewer stalling test (fire-and-forget is proven by construction + disown, not by a live
   hang fixture) - closed-tab re-open (spec edge case 5, intended no-op).

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -45,7 +45,7 @@
 # pre-existing kill-0/wait path and $TMUX_CMD is never invoked. TMUX_CMD mirrors CLAUDE_CMD's mock
 # seam; TMUX_SESSION overrides the derived per-megagoal tmux session name.
 #
-# Pane viewer push (SPEC-120, env PANE_VIEWER=auto default): the push half of the multiplexer --
+# Pane viewer push (SPEC-121, env PANE_VIEWER=auto default): the push half of the multiplexer --
 # on wave spawn, ONE viewer tab/surface (cmux/kitty/wezterm/ghostty/iterm/terminal, auto-detected)
 # opens in the operator's terminal app already attached to the wave's tmux session. `none` = the
 # pull behavior above exactly; headless (no TTY / nothing detected) degrades silently to pull.
@@ -142,7 +142,7 @@ WAVE_MERGE_CMD="${WAVE_MERGE_CMD:-$ORCH_DIR/mega-merge.sh merge}"
 MULTIPLEXER="${MULTIPLEXER:-0}"
 TMUX_CMD="${TMUX_CMD:-tmux}"
 
-# Pane viewer push (SPEC-120). SPEC-119's panes are PULL-only (the operator must know the tmux
+# Pane viewer push (SPEC-121). SPEC-119's panes are PULL-only (the operator must know the tmux
 # session name and attach by hand); PANE_VIEWER is the PUSH half: on wave spawn, open ONE viewer
 # surface in the operator's own terminal app, already attached to the wave's tmux session (one
 # surface per wave session per run, never one per worker -- noise control; tmux's own window keys
@@ -833,7 +833,7 @@ _pane_send_keys() {  # megadir id keys...
   "$TMUX_CMD" send-keys -t "$mux:$id" "$@"
 }
 
-# ---- Pane viewer push (SPEC-120) ----------------------------------------------------------------
+# ---- Pane viewer push (SPEC-121) ----------------------------------------------------------------
 # The push half of SPEC-119's pull-only panes: on wave spawn, open ONE viewer tab/surface in the
 # operator's terminal app, attached to the wave's tmux session. Three functions: a pure env
 # detector, a mode resolver, and the best-effort opener. See the PANE_VIEWER env block up top.
@@ -844,7 +844,7 @@ _pane_send_keys() {  # megadir id keys...
 _viewer_tty() { [ -t 2 ]; }
 
 # Pure env sniff -> the running viewer's name, or nothing. Order is load-bearing: cmux embeds a
-# terminal that sets $TERM_PROGRAM too, so the cmux env must win (SPEC-120 edge case 1).
+# terminal that sets $TERM_PROGRAM too, so the cmux env must win (SPEC-121 edge case 1).
 _viewer_detect() {
   if [ -n "${CMUX_WORKSPACE_ID:-}" ]; then printf 'cmux\n'; return 0; fi
   case "${TERM_PROGRAM:-}" in
@@ -1093,7 +1093,7 @@ _wave_run() {  # megadir roadmap
       fi
       pid=""
       _say "[orchestrate] [wave] [mux] spawned $id in tmux pane $(_mux_session_name "$megadir"):$id (worktree $wt)"
-      # SPEC-120 push: open ONE viewer surface attached to this wave's tmux session. Reuse-guarded
+      # SPEC-121 push: open ONE viewer surface attached to this wave's tmux session. Reuse-guarded
       # inside (one surface per session per run) and best-effort (always rc 0) -- a viewer failure
       # never marks the wave failed. Scoped INSIDE the MULTIPLEXER=1 branch: with the multiplexer
       # off there is no tmux session to attach, so the default path stays byte-identical.
@@ -1441,7 +1441,7 @@ cmd_run() {
   esac
   [ "$WAVE_CAP" -lt 1 ] && { echo "orchestrate: WAVE_CAP must be >=1 (got: '$WAVE_CAP')" >&2; return 64; }
 
-  # PANE_VIEWER pre-flight allowlist (SPEC-120, mirrors the WAVE_CAP rejection above): an unknown
+  # PANE_VIEWER pre-flight allowlist (SPEC-121, mirrors the WAVE_CAP rejection above): an unknown
   # value is REJECTED loudly here, never silently coerced to none -- a typo (`PANE_VIEWER=kity`)
   # must not quietly disable the push the operator asked for. EXACT-token enumeration, not a
   # substring test against the joined allowlist (review fix, security P2: `PANE_VIEWER="cmux

--- a/tests/test-pane-viewer.sh
+++ b/tests/test-pane-viewer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test-pane-viewer.sh (SPEC-120): pins the PUSH half of the SPEC-119 multiplexer. PANE_VIEWER
+# test-pane-viewer.sh (SPEC-121): pins the PUSH half of the SPEC-119 multiplexer. PANE_VIEWER
 # (default `auto`) opens ONE viewer tab/surface per wave attached to the wave's tmux session;
 # `none` = today's pull behavior exactly; headless (no TTY / nothing detected) degrades silently
 # so CI is byte-identical to today -- the named negative control. The viewer argv is exec-direct
@@ -22,7 +22,7 @@ fails=0
 pass() { echo "PASS $*"; }
 fail() { echo "FAIL $*"; fails=$((fails + 1)); }
 
-# The viewer exec is fire-and-forget (backgrounded + disowned, SPEC-120 review fix), so a
+# The viewer exec is fire-and-forget (backgrounded + disowned, SPEC-121 review fix), so a
 # recorder/poison write can land shortly AFTER _viewer_open/_wave_run returns. wait_nonempty
 # polls for a positive write (bounded); settle gives a would-be late write time to land before
 # an emptiness or exact-count assertion.


### PR DESCRIPTION
Reference-only follow-up to #146 (renumber landed as renames-only; in-file refs stayed on the old number). No behavior change: comments, proof, impl-notes, ADR-0032 addendum, ADR-0031 status format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)