### PR TITLE
feat(spec): design record before build (understanding gate)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -54,7 +54,7 @@ For the full playbook (every scenario, the autonomy dial, the freeform front doo
 
 **Phase:** opt-in interactive solution-design beat (between Think and Spec)
 **Reads:** `docs/specs/DECISION-BRIEF.md` (if present), the codebase
-**Writes:** appends a `## Solution` section to `docs/specs/DECISION-BRIEF.md` (never clobbers the brief's product framing)
+**Writes:** appends a `## Solution` section to `docs/specs/DECISION-BRIEF.md` (never clobbers the brief's product framing); when the design is design-bearing, also appends a `## Design` section (diagram + ADR link(s), ADR-0031 §1 / SPEC-122) that `/kit:spec` folds into the spec
 **When to invoke:** when you want to shape the solution with the agent (2-3 approaches, one question at a time, approve per section) before `/kit:spec`. Opt-in; skip it and `/kit:spec` works as before.
 **Common gotcha:** under bypassPermissions the per-section `AskUserQuestion` prompts may auto-resolve, hollowing the feedback. Use it interactively. It does not execute and is not a gate. Realizes SPEC-008 Part C; forked from `superpowers:brainstorming`.
 
@@ -139,7 +139,7 @@ schedules, sequences, or merges. Source: SPEC-036; ADR-0022.
 **Reads:** `docs/specs/SPEC-NNN-<slug>.md`
 **Writes:** comments in chat; the maintainer flips SPEC Status to VALIDATED manually after addressing findings
 **When to invoke:** before `/execute` on any spec longer than ~5 tasks
-**Common gotcha:** 5 reviewers (security, failure-mode, assumption-destroyer, scope-critic, solution-design & extensibility) run sequentially. Budget ~10-12 minutes. The 5th reviewer (SPEC-008) flags shallow or non-extensible designs and is calibrated against false positives + legacy specs.
+**Common gotcha:** 6 reviewers (security, failure-mode, assumption-destroyer, scope-critic, solution-design & extensibility, design-record) run sequentially. Budget ~10-12 minutes. The 5th reviewer (SPEC-008) flags shallow or non-extensible designs and is calibrated against false positives + legacy specs. The 6th, Reviewer 6 (SPEC-122 / ADR-0031 §1), is the one BLOCKING check in the set: a design-bearing spec with an empty `## Design` block cannot flip to VALIDATED.
 
 ### `/kit:execute`
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -355,6 +355,7 @@ the V-model lens above. Every cell is one of:
 | UI design (opt-in) | skip | skip | run-lite | skip | skip |
 | Spec | skip | measure-twice | measure-twice | skip | run-lite |
 | Validate | skip | skip | measure-twice | skip | skip |
+| Design record (design-bearing, ADR-0031 §1) | skip | run-lite | measure-twice | skip | skip |
 | Test plan (default) | skip | run-lite | measure-twice | run-lite | skip |
 | Build | run-lite | measure-twice | measure-twice | measure-twice | skip |
 | Review | run-lite | run-lite | measure-twice | measure-twice | run-lite |
@@ -384,6 +385,14 @@ the V-model lens above. Every cell is one of:
   (AGENTS.md, CLAUDE.md, specs). This is the one phase that must be done fully.
 - **backfill / Build = skip**: the lane table explicitly prohibits app-code
   edits; Build (the verification pipeline executing tasks) does not apply.
+- **Design record / normal = run-lite, not measure-twice**: a normal-lane spec is only
+  SOMETIMES design-bearing (new component, schema change); the common normal-lane case is the
+  obvious one that collapses to one line (`obvious: <why>`), so run-lite reflects "check it
+  collapsed correctly," not full ceremony. Full lane's usual triggers (auth/authz/schema/
+  external integration/migration) hit design-bearing far more often, so measure-twice.
+  Enforcement is `/kit:spec-validate` Reviewer 6, not a separate command; this row is a
+  DIFFERENT gate from `Design (opt-in)` above (the interactive `/kit:design` facilitator lane
+  the user pulls before `/kit:spec`), though `/kit:design`'s output can seed this row's block.
 
 When a new phase is added to the cycle table (and the V-model lens gains a row),
 add a column here and assign a depth per lane before shipping the change.

--- a/commands/design.md
+++ b/commands/design.md
@@ -27,13 +27,14 @@ Present the chosen design in sections scaled to complexity. After EACH section, 
 - Extensibility & boundaries (what changes when the load-bearing dimension grows; unit boundaries: one purpose, a defined interface, testable independently)
 - Interfaces (I/O contract), if this exposes or consumes one
 - Failure modes, if it touches an external provider, data loss, or a migration
+- **Diagram + ADR link(s) (ADR-0031 §1), when the design is design-bearing** (new component/module, non-obvious control flow, a schema/data-model change, an external integration, an irreversible choice, or 2+ viable approaches): ask which diagram shape actually clarifies it (sequence / state / ER / flowchart / C4 container-or-component, LITE, ONE level only), sketch it in Mermaid with the user, and note the ADR(s) that record any lasting/irreversible call the design makes. Skip this bullet entirely for obviously non-design-bearing work; do not manufacture a diagram nobody needs.
 Go back and revise when the user pushes back. Do not advance a section the user has not approved.
 
-### Step 5: Write the Solution into the brief
-Once the user approves the design, **append** a `## Solution` section (and `## Failure modes` / an I/O contract sub-section if produced) to `docs/specs/DECISION-BRIEF.md`, using the SPEC-008 sub-section shape: `### Approaches considered`, `### Chosen approach + why`, `### Extensibility & boundaries`. **Do NOT overwrite** the brief's existing product framing. If the brief does not exist, create it with a one-line Problem stub plus the Solution.
+### Step 5: Write the Solution (and Design) into the brief
+Once the user approves the design, **append** a `## Solution` section (and `## Failure modes` / an I/O contract sub-section if produced) to `docs/specs/DECISION-BRIEF.md`, using the SPEC-008 sub-section shape: `### Approaches considered`, `### Chosen approach + why`, `### Extensibility & boundaries`. **If Step 4 produced a diagram + ADR link(s)** (the design was design-bearing), also **append a `## Design` section** with `### Diagram` (the Mermaid block) and `### ADR link(s)` , the shape `/kit:spec`'s own `## Design` block expects (ADR-0031 §1). Skip the `## Design` append entirely when the design was not design-bearing; `/kit:spec`'s template collapses it to `obvious: <why>` on its own. **Do NOT overwrite** the brief's existing product framing. If the brief does not exist, create it with a one-line Problem stub plus the Solution.
 
 ### Step 6: Hand off
-Tell the user the design is captured and the next step is `/kit:spec`, which reads the brief and folds the Solution into the spec's `## Solution`. Do NOT run `/kit:spec` yourself; this lane only shapes and records the design.
+Tell the user the design is captured and the next step is `/kit:spec`, which reads the brief and folds the Solution into the spec's `## Solution` (and the Design section, if present, into the spec's `## Design`). Do NOT run `/kit:spec` yourself; this lane only shapes and records the design.
 
 ## Source
 Forked from `superpowers:brainstorming` (one-question-at-a-time, present-in-sections, per-section approval). Realizes SPEC-008 Part C; see `docs/specs/SPEC-011-design-lane.md`.

--- a/commands/spec-validate.md
+++ b/commands/spec-validate.md
@@ -1,12 +1,12 @@
 ---
-description: "Adversarial review of a spec before implementation. 5 specialist lenses attack the spec from different angles."
+description: "Adversarial review of a spec before implementation. 6 specialist lenses attack the spec from different angles (5 advisory, 1 blocking on the design record)."
 ---
 
 You are running an adversarial spec review. Read the spec from `docs/specs/SPEC-NNN-<slug>.md` (the most recent non-shipped spec if several exist). If no spec exists, tell the user to run `/kit:spec` first.
 
-## The 5 reviewers
+## The 6 reviewers
 
-Run each reviewer sequentially. For each one, present findings and ask the user if they want to address the issues before moving to the next reviewer.
+Run each reviewer sequentially. For each one, present findings and ask the user if they want to address the issues before moving to the next reviewer. Reviewers 1-5 are advisory; Reviewer 6 (below) is the one exception that can block the `VALIDATED` flip.
 
 ### Reviewer 1: Security Auditor
 Look for:
@@ -59,9 +59,33 @@ Look for:
 
 Source: forked from superpowers:brainstorming ("design for isolation and clarity") + its spec-document-reviewer calibration. See docs/specs/SPEC-008.
 
+### Reviewer 6: Design Record Auditor (ADR-0031 §1, BLOCKING)
+Unlike Reviewers 1-5 above (all advisory), this check can REFUSE the `VALIDATED` flip.
+
+1. **Decide design-bearing.** Is the spec above the tiny lane AND does it do any of: introduce
+   a new component/module, non-obvious control flow, a schema/data-model change, an external
+   integration, an irreversible choice, or offer 2+ viable approaches?
+2. **If design-bearing:** the spec's `## Design` section must be non-empty and contain a
+   diagram (mermaid preferred) picked by fit (sequence / state / ER / flowchart / C4-lite) plus
+   a chosen approach. A missing `## Design` section, an empty one, or a bare `obvious: <why>`
+   collapse on a spec that genuinely IS design-bearing is a **CRITICAL, BLOCKING** finding: do
+   NOT flip Status to `VALIDATED`. List it under Critical Issues and stop; the author fills the
+   block and re-runs this reviewer.
+3. **If NOT design-bearing** (an obvious/tiny-shaped change): the `## Design` section
+   correctly collapsing to `obvious: <why>` is a PASS , do not require a diagram. If the spec
+   still carries a heavy Design block for genuinely obvious work, flag it as a PROPORTIONALITY
+   warning (compliance theater), non-blocking.
+4. **Legacy grace.** A spec written before this template existed (no `## Design` heading at
+   all) and judged NOT design-bearing is not penalized for the section's absence, mirroring
+   Reviewer 5's legacy-grace clause.
+
+**Calibration (critical):** this is the ONE reviewer whose finding can withhold `VALIDATED`.
+Keep the design-bearing test honest in both directions , neither rubber-stamping a real
+architecture change as `obvious`, nor demanding a diagram for a one-line config tweak.
+
 ## Output format
 
-After all 5 reviewers complete, produce a summary:
+After all 6 reviewers complete, produce a summary:
 
 ```markdown
 # Spec Validation Report
@@ -82,4 +106,4 @@ Spec: [spec name]
 
 If NEEDS REVISION, update `docs/specs/SPEC-NNN-<slug>.md` with the fixes and mark the Decision Log with entries for each change made.
 
-If APPROVED, update the Status line in SPEC.md to `VALIDATED`.
+If APPROVED, update the Status line in SPEC.md to `VALIDATED`. **Exception (ADR-0031 §1):** if Reviewer 6 raised a CRITICAL, BLOCKING finding (a design-bearing spec with an empty/missing `## Design` block), the Verdict is NEEDS REVISION regardless of Reviewers 1-5's outcome, and Status does NOT flip to `VALIDATED` until the Design block is filled and this reviewer re-runs clean.

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -8,7 +8,7 @@ You are a senior technical architect producing a development specification. The 
 
 ### Step 1: Gather intent
 
-If a `docs/specs/DECISION-BRIEF.md` exists, read it first (it may include a Solution design appended by `/kit:design`; fold that into the spec's `## Solution`). Otherwise, ask the user:
+If a `docs/specs/DECISION-BRIEF.md` exists, read it first (it may include a Solution design appended by `/kit:design`; fold that into the spec's `## Solution`. It may also include a `## Design` section, from the same command, with a diagram + ADR link(s); fold that into the spec's own `## Design` , ADR-0031 §1). Otherwise, ask the user:
 - What are you building? (one paragraph)
 - Is this greenfield or modifying existing code?
 - What's the tech stack? (or read from CLAUDE.md / package.json / go.mod)
@@ -92,8 +92,41 @@ Which one, and what the rejected alternatives traded away.
 - What changes when the load-bearing dimension grows (more data, more scale, a new variant)? Name the dimension; don't hand-wave "it scales".
 - Unit boundaries: each piece has one purpose, a defined interface, testable independently. A unit needing more than 3 sentences to describe is a split candidate.
 
-### Architecture (diagram if it helps)
-[High-level shape / data flow.]
+### Architecture
+See `## Design` below , ADR-0031 §1 promotes the diagram out of this sub-section into its
+own gated block, so a design-bearing spec cannot ship an empty architecture hint.
+
+## Design
+<!-- ADR-0031 §1 (the understanding gate, BEFORE half). Required (non-empty) for any spec
+     above the tiny lane that is DESIGN-BEARING: new component/module, non-obvious control
+     flow, schema/data-model change, external integration, an irreversible choice, or 2+
+     viable approaches. Otherwise collapse this WHOLE block to one line: `obvious: <why>` --
+     do not force a diagram or the sub-headings below on obvious work.
+     Enforced by /kit:spec-validate Reviewer 6: a design-bearing spec with an empty/missing
+     Design block is refused VALIDATED (blocking, unlike the other 5 advisory reviewers). -->
+
+### Approaches considered + chosen
+Point at `## Solution`'s `### Approaches considered` / `### Chosen approach + why` above (the
+same SPEC-008 depth); do not re-litigate it here unless the design view surfaces a new tradeoff.
+
+### Diagram (pick by fit, mermaid-first)
+One diagram, the kind that actually clarifies , not all five:
+- **sequence** -- control flow / protocol between actors
+- **state** -- an entity's lifecycle
+- **ER** -- schema / data-model shape
+- **flowchart** -- an algorithm / decision path
+- **C4 container-or-component (LITE)** -- where a new component sits; ONE level only, never
+  four cargo-culted levels
+
+Prefer Mermaid (GitHub-native, diffable, hand-editable) over a binary image.
+
+### ADR link(s)
+Link the ADR(s) that record any lasting or irreversible decision this design makes. If the
+decision is irreversible and no ADR exists yet, say so and note the follow-up.
+
+### Boundaries & failure modes
+Required when this design touches data, an external integration, or a migration. What is out
+of bounds for this design; point at `## Failure modes` below rather than duplicating its table.
 
 ## Technical Design
 <!-- Interfaces + Failure modes forked from ops-toolkit SDD (agency-lead-radar / tide). See docs/specs/SPEC-009. -->

--- a/docs/implementation-notes/design-record.md
+++ b/docs/implementation-notes/design-record.md
@@ -1,0 +1,69 @@
+# Implementation notes: design record before build (understanding-gate SG-01)
+
+Spec: SPEC-122. Branch: `feat/ug-01-design-record`, worktree `.claude/worktrees/ug-01`, off
+master. Built lane-normal via the lib machinery (a cross-repo mega-goal sub-goal; no `/kit:*`
+slash commands, since the run's cwd is unstable across worktrees).
+
+## 2026-07-03, decisions the spec + ADR-0031 didn't fully pin down
+
+- **`## Design` is a NEW top-level section, not a rename of `### Architecture (diagram if it
+  helps)` in place.** ADR-0031 §1 says "the spec MUST carry a `## Design` block"; it does not
+  say whether that reuses the existing sub-heading or adds a new one. Chose new-section
+  (DEC-002 in the spec) because the `obvious: <why>` collapse needs to be checkable in
+  isolation from `## Solution`'s own (advisory) Reviewer 5 pass. The old `### Architecture`
+  line now just points at `## Design` rather than duplicating content.
+
+- **Reviewer 6's finding is the ONE blocking check in `/kit:spec-validate`; Reviewers 1-5 stay
+  advisory.** This is the sharpest deviation from the kit's own established pattern (every
+  prior spec-validate reviewer, including SPEC-008's Reviewer 5, is advisory-only,
+  "Detect, don't dictate"). ADR-0031 §1 is explicit ("refuses VALIDATED"), so this spec treats
+  it as a deliberate, scoped exception rather than softening the ADR's language to match the
+  kit's usual advisory posture. The blast radius is narrow and reversible: it can only
+  withhold a `VALIDATED` flip, never block a build, and only fires on a spec that is BOTH
+  above-tiny AND design-bearing.
+
+- **`WORKFLOW.md`'s Lane×phase depth matrix gained a REAL row** ("Design record
+  (design-bearing, ADR-0031 §1)"), not a documentation-only note beside the Validate row. This
+  had a load-bearing consequence I did not anticipate at spec time: `lib/gate-ledger.sh`
+  dynamically PARSES that matrix at runtime to build `plan`/`progress`'s phase checklist and
+  `required`'s ship-gate list. Adding a row with `run-lite` (normal) / `measure-twice` (full)
+  cells changed the normal-lane plan from 8 steps to 9 (a new step lands between `spec` and
+  `test-plan`) and made the phase a REQUIRED ship-gate item for the full lane. This broke 7
+  hardcoded step-count/phase-list assertions across `tests/test-hooks.sh` (the `spec-p`
+  progress fixture, the `full-noui`/`full-gap` shipped-incomplete detector fixtures) and 3 in
+  `tests/test-e2e.sh` (the golden run). Fixed by renumbering the expected `step k/n` values and
+  adding a `design-record ran` ledger line to the fixtures that are supposed to represent a
+  fully-disposed run, rather than by pulling the row out of the parsed table. Kept it IN the
+  table (not a side-note) because that is what makes `Design (opt-in)` (the existing,
+  different, opt-in `/kit:design` facilitator row) and the new gate consistent: both are real,
+  trackable phases with a real per-lane depth, not narrative.
+
+- **`test-meta.sh`'s reviewer-count assertions bumped 5 -> 6** (the header string and a new
+  "Reviewer 6" presence check), plus the existing "no stale N reviewer" count-drift guard
+  extended to also catch a stale "5 reviewer" reference, mirroring the guard SPEC-008 already
+  added for "4 reviewer" drift. Both are structural-presence checks, same style as the rest of
+  the file; no new test dialect introduced.
+
+- **`commands/design.md`'s Step 4/5 wiring is additive, gated on design-bearing.** The
+  interactive lane only asks for a diagram + ADR link(s) when the design IS design-bearing; it
+  does not add a mandatory extra beat to every `/kit:design` run, matching the proportionality
+  rule the rest of this feature holds to.
+
+## Test-harness honesty note (not a deviation, a named limitation)
+
+`/kit:spec-validate` is prompt text, not executable code, so `tests/test-design-record.sh`
+cannot drive the live LLM reviewer. Each fixture pre-declares its own design-bearing ground
+truth (`Design-bearing (fixture declaration): yes/no`), which stands in for the step the real
+Reviewer 6 would do by judgment. The harness then proves the STRUCTURAL contract only:
+given that declaration and the `## Design` section's actual content, does the pass/refuse call
+match what Reviewer 6 is specified to do? This is the same boundary SPEC-008 already accepted
+for Reviewers 1-5 (structural presence, not live judgment quality); named in SPEC-122's Test
+plan COVERAGE-DELTA row rather than hidden.
+
+## Verification
+`bash tests/test-design-record.sh` (26/26) + `bash tests/test-meta.sh` (663/663) +
+`bash tests/test-hooks.sh` (452/452) + `bash tests/test-e2e.sh` (20/20), all green after the
+renumbering fix above. `bash tests/test-classify-md-inert.sh` has one pre-existing failure
+(`stripped lib should reproduce the stateful bug`, a `/tmp`-relative-sourcing fragility in a
+lib/proof-ledger.sh test unrelated to this change) confirmed present on master before this
+branch touched anything; left alone as out of scope.

--- a/docs/specs/SPEC-122-design-record.md
+++ b/docs/specs/SPEC-122-design-record.md
@@ -1,0 +1,218 @@
+# Spec: Design record before build (understanding gate, before-half)
+Generated: 2026-07-03
+Status: VALIDATED
+Lane: normal (touches `commands/spec.md`, `commands/spec-validate.md`, `commands/design.md`,
+one `WORKFLOW.md` matrix row, tests/fixtures; no auth/data/hook/migration risk , same surface
+class as SPEC-008, which used `normal` for the same two command files).
+
+## Problem
+
+ADR-0031 §1 ("The understanding gate", accepted 2026-07-03) names a gap the kit's own
+retro surfaced: the pipeline runs `/kit:think` -> `/kit:spec` -> `/kit:spec-validate` ->
+`/kit:execute`, and the only architecture-shaped content in a spec is a one-line hint --
+`### Architecture (diagram if it helps)` under `## Solution` (SPEC-008's template). Nothing
+requires the hint to be filled, nothing requires a diagram, and nothing stops a spec from
+reaching `VALIDATED` with an empty architecture note even when the spec adds a new component,
+changes a schema, or makes an irreversible call. The human ends up gating a diff, not a
+diagram , exactly the failure ADR-0031 names ("does the human understand the change enough
+to shape the next loop?").
+
+This is the BEFORE half of the understanding gate (ADR-0031 §1). The AFTER half
+(`/kit:explain` + quiz) is out of scope; SG-03/04 own it.
+
+## Solution
+
+### Approaches considered
+1. **A new top-level `## Design` section in the SPEC.md template, required (non-empty) only
+   when the spec is design-bearing, enforced by a new `/kit:spec-validate` reviewer.**
+   Promotes the existing `### Architecture` hint out of `## Solution` into its own gated
+   block. Mirrors SPEC-008's own A+B split (template scaffold + advisory reviewer), except
+   this reviewer's finding is BLOCKING (per ADR-0031, `/kit:spec-validate` "refuses"
+   VALIDATED), not merely advisory like Reviewers 1-5.
+2. **Fold the diagram+ADR-link requirement into the existing `### Architecture` line, no new
+   section.** Rejected: a sub-heading buried inside `## Solution` cannot carry its own
+   proportionality collapse (`obvious: <why>`) or its own blocking check without conflating
+   it with the Solution reviewer's (advisory) verdict; ADR-0031 names `## Design` as its own
+   block explicitly.
+3. **A new `/kit:design-check` command that runs standalone.** Rejected: adds a 14th command
+   for a check that belongs inside the phase that already exists to gate the spec
+   (`/kit:spec-validate`); duplicates the existing per-reviewer idiom for no benefit.
+
+### Chosen approach + why
+Approach 1. It reuses the exact scaffold-plus-reviewer shape SPEC-008 already proved works
+for solution depth, adds one heading and one reviewer, and keeps the ADR's "refuses VALIDATED"
+language literal (only Reviewer 6 in `/kit:spec-validate` can withhold the flip; Reviewers 1-5
+stay advisory, unchanged). Approach 2 was rejected because the proportionality collapse
+(`obvious: <why>`) needs its own top-level block to be checkable in isolation; approach 3 was
+rejected as needless command sprawl.
+
+### Extensibility & boundaries
+- Load-bearing dimension: the design-bearing TRIGGER LIST (new component, non-obvious control
+  flow, schema change, external integration, irreversible choice, 2+ approaches). Adding a
+  new trigger is a one-line edit to the reviewer's checklist and the template comment; it does
+  not touch the block's shape.
+- Unit boundaries: the template edit (`commands/spec.md`) is pure scaffold (no enforcement
+  logic); the enforcement (`commands/spec-validate.md` Reviewer 6) is the only place that can
+  block; `commands/design.md` only SEEDS the block's content (diagram + ADR links) for specs
+  that opt into the interactive lane. Each piece is independently readable without the others.
+
+## Design
+<!-- Dogfooding ADR-0031 §1: this spec is itself design-bearing (it changes a template's
+     required structure, adds a blocking reviewer, and wires a downstream command , new
+     control flow in /kit:spec-validate's decision path). -->
+
+### Approaches considered + chosen
+Same as `## Solution` above (approach 1, the scaffold + a blocking reviewer). Not
+re-litigated here; the design view below is the CONTROL-FLOW shape of the new check itself.
+
+### Diagram (flowchart , the reviewer's decision path)
+
+```mermaid
+flowchart TD
+    A[spec-validate reads the spec] --> B{Above tiny lane?}
+    B -- no --> Z[Reviewer 6 not applicable]
+    B -- yes --> C{Design-bearing?<br/>new component / non-obvious<br/>control flow / schema change /<br/>external integration /<br/>irreversible choice / 2+ approaches}
+    C -- no --> D{"## Design collapses to<br/>'obvious: &lt;why&gt;'?"}
+    D -- yes --> E[PASS: proportional, no diagram required]
+    D -- no, heavy Design block anyway --> F[WARNING: proportionality , compliance theater, non-blocking]
+    C -- yes --> G{"## Design non-empty?<br/>diagram + chosen approach present"}
+    G -- yes --> H[PASS: feeds the existing report]
+    G -- no / missing / bare obvious-collapse --> I[CRITICAL, BLOCKING:<br/>Verdict cannot be APPROVED;<br/>Status stays VALIDATED-refused]
+```
+
+### ADR link(s)
+- ADR-0031 (`docs/decisions/0031-understanding-gate.md`) §1 is the decision this spec
+  implements; §3 ("Firing modes") and the explainer/quiz half are out of scope here (SG-03/04).
+- No new lasting/irreversible decision is introduced beyond what ADR-0031 already records;
+  this spec is the implementation, not a new decision.
+
+### Boundaries & failure modes
+Touches the spec-authoring contract every downstream spec inherits (same blast radius as
+SPEC-008), not data or an external integration, so a full failure-modes table is not owed.
+Two boundaries worth naming:
+- **Reviewer 6 only blocks on design-bearing + empty Design.** It never blocks on quality of
+  the diagram, or on a non-design-bearing spec's Design content (that stays advisory, same as
+  Reviewers 1-5). Blast radius: refusing a `VALIDATED` flip is reversible , the spec author
+  fills the block and re-runs `/kit:spec-validate`.
+- **A misclassified "design-bearing" call (false positive or false negative) is a calibration
+  bug in Reviewer 6's own judgment, not a hard failure of the mechanism.** The PROPORTIONALITY
+  CONTROL fixture (below) is the regression guard against the reviewer over-firing on
+  genuinely obvious work.
+
+## Technical Design
+
+### Interfaces (I/O contract)
+- **Consumes:** the spec's own `## Design` section text (present/absent/collapsed), plus the
+  spec's `Lane:` header (to gate "above tiny").
+- **Produces:** the existing `Spec Validation Report` gains a Reviewer 6 finding; the
+  `VALIDATED` flip is conditioned on Reviewer 6 having no blocking finding, in addition to the
+  existing report-approval step.
+- **Invariant:** Reviewers 1-5 remain advisory (SPEC-008's contract, unchanged); only Reviewer
+  6 can withhold `VALIDATED`. A tiny-lane spec never reaches this reviewer (no spec is written
+  for tiny).
+
+### Data model changes
+None (markdown template + prompt-text changes only).
+
+### API changes
+None.
+
+### UI changes
+None.
+
+### Infrastructure changes
+None.
+
+## After state
+- [ ] `commands/spec.md`'s SPEC.md template carries a `## Design` section between `## Solution`
+  and `## Technical Design`, with the design-bearing trigger list, a diagram-by-fit menu
+      (sequence/state/ER/flowchart/C4-lite), an ADR-link sub-heading, and a
+      boundaries/failure-modes sub-heading, plus the `obvious: <why>` collapse instruction.
+      (Today: only a one-line `### Architecture (diagram if it helps)` hint exists, unenforced.)
+- [ ] `commands/spec-validate.md` has a 6th reviewer ("Design Record Auditor") whose finding is
+      explicitly BLOCKING (unlike Reviewers 1-5): a design-bearing spec with an empty/missing
+      `## Design` cannot reach `VALIDATED`. (Today: 5 reviewers, all advisory.)
+- [ ] `commands/design.md` (the opt-in `/kit:design` facilitator) asks for + records a diagram
+      pick and ADR link(s) when the design is design-bearing, and appends them as a `## Design`
+      section to `docs/specs/DECISION-BRIEF.md` alongside its existing `## Solution` append;
+      `/kit:spec`'s Step 1 folds both into the new spec. (Today: `/kit:design` only ever writes
+      `## Solution`.)
+- [ ] `WORKFLOW.md`'s Lane×phase depth matrix carries one new row ("Design record
+      (design-bearing, ADR-0031 §1)") naming the ceremony per lane, distinct from the existing
+      "Design (opt-in)" row (the different, interactive `/kit:design` facilitator lane).
+      (Today: no row names this gate's depth.)
+- [ ] `bash tests/test-design-record.sh` passes all three named controls (below) plus the
+      dotfiles `Design:` field diff is captured.
+- [ ] `bash tests/test-meta.sh` stays green with the documented count delta.
+
+## Acceptance Criteria (global)
+- [ ] All tasks pass their individual acceptance criteria
+- [ ] The 3 fixtures (refuse-empty NC, pass-with-diagram, obvious-collapse) are all green
+- [ ] No regressions in `tests/test-meta.sh` or `tests/test-hooks.sh`
+- [ ] Reviewers 1-5 in `/kit:spec-validate` are untouched (byte-diff limited to the new
+      Reviewer 6 section + the Output-format note)
+
+## Verification
+```
+bash tests/test-design-record.sh
+bash tests/test-meta.sh
+```
+
+## Test plan
+
+Coverage matrix (per ADR-0031 §1's three load-bearing claims):
+
+| # | AC / claim | Fixture | Expected | Covers |
+|---|---|---|---|---|
+| 1 | a design-bearing spec with NO `## Design` block is refused `VALIDATED` | `tests/fixtures/design-record/design-bearing-empty.md` | reviewer-6 check FAILS (refusal marker present in spec-validate.md's own logic, asserted via a scripted grep+heuristic in the test harness since spec-validate is a prompt, not code) | NEGATIVE CONTROL (AC1) |
+| 2 | a design-bearing spec WITH a mermaid diagram + chosen approach PASSES | `tests/fixtures/design-record/design-bearing-filled.md` | reviewer-6 check PASSES | AC1 (positive) |
+| 3 | an obvious/tiny-shaped spec collapses `## Design` to one line and is NOT required to diagram | `tests/fixtures/design-record/obvious-collapse.md` | reviewer-6 check PASSES, no diagram demanded | PROPORTIONALITY CONTROL (AC2) |
+| 4 | `commands/spec.md` template carries the new `## Design` section shape | structural grep on `commands/spec.md` | heading + sub-headings present | AC (template) |
+| 5 | `commands/spec-validate.md` carries Reviewer 6 + the blocking language | structural grep on `commands/spec-validate.md` | Reviewer 6 heading + "refuses"/"blocking" language present | AC (enforcement) |
+| 6 | `commands/design.md` wires diagram + ADR-link capture | structural grep on `commands/design.md` | diagram/ADR-link language present in Step 4/5 | AC (design lane wiring) |
+| 7 | `WORKFLOW.md` carries the new Design-record row | structural grep on `WORKFLOW.md`'s depth matrix | row present, distinct from "Design (opt-in)" | AC (workflow row) |
+| 8 | dotfiles subgoal-template gains a `Design:` field | manual diff captured in the report | field present | AC (dotfiles half) |
+
+**COVERAGE-DELTA:** rows 1-3 exercise the actual DECISION the reviewer makes (real spec text
+in, pass/refuse out) via a lightweight harness script since `/kit:spec-validate` is a prompt
+command, not executable code, so the test asserts the STRUCTURAL contract (the section exists,
+is non-empty, collapses correctly) rather than driving the LLM reviewer live , that is the
+honest boundary of testing a prompt-based command, named rather than hidden. Deliberately NOT
+covered: the reviewer's live LLM judgment quality (same limitation SPEC-008 already accepted
+for Reviewers 1-5); a live run is review-verified in use, not unit-tested.
+
+## Edge Cases
+1. A spec predates this template (no `## Design` heading at all, like SPEC-001..121 pre-dating
+   this change). Reviewer 6 treats a MISSING section the same as an EMPTY one for a
+   design-bearing spec (blocking); for a non-design-bearing legacy spec, its absence is not
+   penalized (mirrors SPEC-008's Reviewer 5 legacy-grace clause).
+2. A spec is design-bearing but the author writes a heavy `## Design` block on genuinely
+   obvious work. Non-blocking PROPORTIONALITY warning (compliance-theater flag), not critical.
+3. `/kit:design` (the opt-in lane) was never run, and the author fills `## Design` directly in
+   `/kit:spec`. Fully supported; `/kit:design` only ever seeds it, the spec's own `## Design`
+   is what Reviewer 6 checks, regardless of how it was filled.
+
+## Out of Scope
+- The AFTER-gate explainer + quiz (`/kit:explain`), the significance classifier, the debt
+  ledger, and the weekend-batch mechanics , all SG-02/03/04/ops-toolkit-side per ADR-0031.
+- Making design record a HARD build-block (`/kit:execute` refusing to run) , ADR-0031 keeps
+  this advisory-at-validate, never a build halt.
+- Four-level C4 diagrams , C4 is LITE (one level) or not used at all.
+- Rewriting the understanding-axis narrative in `WORKFLOW.md`/`AGENTS.md` , reserved for SG-06
+  (docs-last); this spec adds only the one Design-record row the matrix needs.
+
+## Decision Log
+- DEC-001: Reviewer 6's finding is the ONE blocking check in `/kit:spec-validate`; Reviewers
+  1-5 stay advisory (SPEC-008's contract). Rationale: ADR-0031 explicitly says "refuses
+  VALIDATED"; conflating it with the advisory reviewers would silently soften the ADR's intent.
+- DEC-002: the `## Design` block is a NEW top-level section (not a rename of the existing
+  `### Architecture` sub-heading in place). Rationale: a top-level section can carry its own
+  `obvious: <why>` collapse and be checked in isolation from `## Solution`'s advisory reviewer.
+- DEC-003: `WORKFLOW.md` gets exactly one new depth-matrix row, not a new phase in the cycle
+  table. Rationale: this is enforcement inside the existing Spec/Validate phases, not a new
+  command/phase; adding a cycle-table row would cascade into the V-model lens per the file's
+  own "when a new phase is added" rule, which is out of this sub-goal's scope (SG-06 owns the
+  narrative).
+
+## Open questions
+(none)

--- a/docs/verification/design-record.md
+++ b/docs/verification/design-record.md
@@ -1,0 +1,89 @@
+# Proof of done: design record before build (SPEC-122 / ADR-0031 §1)
+
+Behavioral change: `commands/spec.md`'s SPEC.md template gains a required `## Design` block;
+`commands/spec-validate.md` gains a BLOCKING Reviewer 6 that refuses `VALIDATED` on a
+design-bearing spec with an empty Design block; `commands/design.md` seeds the block's diagram
++ ADR link(s) when the design is design-bearing; `WORKFLOW.md`'s Lane×phase depth matrix gains
+one row naming the ceremony per lane.
+
+## Green run
+
+Command: `bash tests/test-design-record.sh`
+Exit: 0
+Output (tail):
+```
+Passed: 26 / 26
+All design-record tests passed.
+```
+
+Command: `bash tests/test-meta.sh`
+Exit: 0
+Output (tail):
+```
+Passed: 663 / 663
+All meta tests passed.
+```
+
+## The 3 named controls (SPEC-122 Test plan)
+
+1. **NEGATIVE CONTROL** -- `tests/fixtures/design-record/design-bearing-empty.md`: declared
+   design-bearing, `## Design` section empty. Reviewer 6's structural logic (reproduced as a
+   pure function in the test harness) returns `REFUSE`. Assertion: `Reviewer 6 REFUSES a
+   design-bearing spec with an empty Design block` -- PASS (i.e. the refusal fires correctly).
+2. **POSITIVE** -- `tests/fixtures/design-record/design-bearing-filled.md`: declared
+   design-bearing, `## Design` carries a mermaid sequence diagram + chosen approach. Verdict
+   `PASS`. Assertion: `Reviewer 6 PASSES a design-bearing spec with a filled Design block`.
+3. **PROPORTIONALITY CONTROL** -- `tests/fixtures/design-record/obvious-collapse.md`: declared
+   NOT design-bearing, `## Design` collapses to a bare `obvious: <why>` line, no diagram.
+   Verdict `PASS` with no diagram required. Assertion: `Reviewer 6 PASSES an obvious spec with
+   no diagram (proportionality)`.
+
+All three, plus the fixtures' own emptiness/diagram/collapse sub-assertions, are green (9/9 in
+that section of the 26).
+
+## NEGATIVE CONTROL (regression class): the depth-matrix ripple
+
+Adding the WORKFLOW.md row is parsed at runtime by `lib/gate-ledger.sh` (the single source for
+"which gates a lane requires"), which changed the normal-lane plan from 8 steps to 9 and made
+the phase a required ship-gate item for the full lane. This broke 7 hardcoded assertions in
+`tests/test-hooks.sh` and 3 in `tests/test-e2e.sh` on first full-suite run (real regression,
+not test flakiness). Fixed by renumbering the expected `step k/n` values and adding a
+`design-record ran` ledger line to the "fully disposed run" fixtures. Detail in
+`docs/implementation-notes/design-record.md`.
+
+Re-verified the coupling directly: with the renumbered tests in place, deleting the WORKFLOW.md
+row (line 358) and re-running turned both suites RED again (`test-hooks.sh` 446/452, 6 failed;
+`test-e2e.sh` 17/20, 3 failed) -- confirming the tests are actually sensitive to the matrix row,
+not coincidentally green. Restoring the row (`git diff WORKFLOW.md` clean, 9 insertions, 0
+deletions) returned both to green.
+
+```
+bash tests/test-hooks.sh   # 452/452 (446/452 with the row removed)
+bash tests/test-e2e.sh     # 20/20  (17/20 with the row removed)
+```
+
+## Dotfiles half
+
+`~/workspace/tieubao/dotfiles` branch `feat/ug-01-design-record` (commit `27a21e1`, off
+`main`, NOT merged/pushed): `home/dot_claude/skills/plan-for-mega-goal/references/
+subgoal-template.md` gains a `**Design:** <bearing | obvious>` top-level field plus a matching
+bullet in the "Deltas from `plan-for-goal`" section.
+
+## Known pre-existing failure (out of scope, confirmed on master)
+
+`bash tests/test-classify-md-inert.sh` -- 1 failure (`stripped lib should reproduce the
+stateful bug`), a `/tmp`-relative-path sourcing fragility in a `lib/proof-ledger.sh` test,
+unrelated to anything this spec touches. Reproduced identically on the unmodified master
+checkout before this branch existed; left alone.
+
+## Reproduce
+
+```bash
+cd dwarves-kit   # or the ug-01 worktree
+bash tests/test-design-record.sh   # 26/26
+bash tests/test-meta.sh            # 663/663
+bash tests/test-hooks.sh           # 452/452
+bash tests/test-e2e.sh             # 20/20
+```
+
+VERDICT: PASS

--- a/tests/fixtures/design-record/design-bearing-empty.md
+++ b/tests/fixtures/design-record/design-bearing-empty.md
@@ -1,0 +1,61 @@
+# Spec: fixture -- design-bearing spec with an EMPTY Design block
+Generated: 2026-07-03
+Status: DRAFT
+Lane: normal
+Design-bearing (fixture declaration): yes
+
+## Problem
+
+Adds a brand-new webhook-ingestion component that receives Stripe payment events over a new
+external integration, validates the signature, and enqueues them for async processing. This is
+a new component, a new external integration, and an irreversible choice (the queue's message
+schema), so it is design-bearing by every trigger in ADR-0031 §1.
+
+## Solution
+
+### Approaches considered
+1. A synchronous handler that processes the webhook inline. Tradeoff: Stripe's retry timeout
+   is tighter than our downstream processing time.
+2. An async queue-backed handler: validate + enqueue, process later. Tradeoff: adds a queue
+   dependency but decouples Stripe's timeout from our processing time. Chosen.
+
+### Chosen approach + why
+Approach 2, because Stripe's webhook timeout is shorter than our worst-case processing time.
+
+### Extensibility & boundaries
+- Load-bearing dimension: event volume. The queue absorbs bursts; a new event TYPE is a new
+  handler, not a schema change.
+- Unit boundaries: the signature-validation step and the enqueue step are independently
+  testable.
+
+### Architecture
+See `## Design` below.
+
+## Design
+
+## Technical Design
+
+### Interfaces (I/O contract)
+- Consumes: Stripe webhook POST body + signature header.
+- Produces: a queued message for the async processor.
+
+## After state
+- [ ] Webhook events are validated and enqueued instead of processed inline.
+
+## Acceptance Criteria (global)
+- [ ] All tasks pass their individual acceptance criteria
+
+## Verification
+`echo fixture-only, no real command`
+
+## Edge Cases
+1. An invalid Stripe signature is rejected with a 400, never enqueued.
+
+## Out of Scope
+- Nothing; this is a test fixture for `tests/test-design-record.sh`, not a real spec.
+
+## Decision Log
+- DEC-001: fixture only.
+
+## Open questions
+(none)

--- a/tests/fixtures/design-record/design-bearing-filled.md
+++ b/tests/fixtures/design-record/design-bearing-filled.md
@@ -1,0 +1,87 @@
+# Spec: fixture -- design-bearing spec with a FILLED Design block
+Generated: 2026-07-03
+Status: DRAFT
+Lane: normal
+Design-bearing (fixture declaration): yes
+
+## Problem
+
+Adds a brand-new webhook-ingestion component that receives Stripe payment events over a new
+external integration, validates the signature, and enqueues them for async processing. This is
+a new component, a new external integration, and an irreversible choice (the queue's message
+schema), so it is design-bearing by every trigger in ADR-0031 §1.
+
+## Solution
+
+### Approaches considered
+1. A synchronous handler that processes the webhook inline. Tradeoff: Stripe's retry timeout
+   is tighter than our downstream processing time.
+2. An async queue-backed handler: validate + enqueue, process later. Tradeoff: adds a queue
+   dependency but decouples Stripe's timeout from our processing time. Chosen.
+
+### Chosen approach + why
+Approach 2, because Stripe's webhook timeout is shorter than our worst-case processing time.
+
+### Extensibility & boundaries
+- Load-bearing dimension: event volume. The queue absorbs bursts; a new event TYPE is a new
+  handler, not a schema change.
+- Unit boundaries: the signature-validation step and the enqueue step are independently
+  testable.
+
+### Architecture
+See `## Design` below.
+
+## Design
+
+### Approaches considered + chosen
+Same as `## Solution` above: approach 2 (async queue-backed handler), chosen because Stripe's
+webhook timeout is tighter than worst-case downstream processing time.
+
+### Diagram (pick by fit, mermaid-first)
+```mermaid
+sequenceDiagram
+    participant Stripe
+    participant Webhook as Webhook handler
+    participant Queue
+    Stripe->>Webhook: POST /webhooks/stripe (signed)
+    Webhook->>Webhook: verify signature
+    Webhook->>Queue: enqueue(event)
+    Webhook-->>Stripe: 200 OK
+    Queue->>Queue: async processor consumes
+```
+
+### ADR link(s)
+Fixture only -- would link `docs/decisions/0031-understanding-gate.md` in a real spec.
+
+### Boundaries & failure modes
+| Failure class | Detection signal | Mitigation / recovery |
+|---|---|---|
+| Invalid signature | 400 response, no enqueue | Stripe's own retry/backoff; alert on rate spike |
+| Queue unavailable | enqueue raises | 500 to Stripe, triggers Stripe's built-in retry |
+
+## Technical Design
+
+### Interfaces (I/O contract)
+- Consumes: Stripe webhook POST body + signature header.
+- Produces: a queued message for the async processor.
+
+## After state
+- [ ] Webhook events are validated and enqueued instead of processed inline.
+
+## Acceptance Criteria (global)
+- [ ] All tasks pass their individual acceptance criteria
+
+## Verification
+`echo fixture-only, no real command`
+
+## Edge Cases
+1. An invalid Stripe signature is rejected with a 400, never enqueued.
+
+## Out of Scope
+- Nothing; this is a test fixture for `tests/test-design-record.sh`, not a real spec.
+
+## Decision Log
+- DEC-001: fixture only.
+
+## Open questions
+(none)

--- a/tests/fixtures/design-record/obvious-collapse.md
+++ b/tests/fixtures/design-record/obvious-collapse.md
@@ -1,0 +1,57 @@
+# Spec: fixture -- obvious (non design-bearing) spec, Design block collapses
+Generated: 2026-07-03
+Status: DRAFT
+Lane: normal
+Design-bearing (fixture declaration): no
+
+## Problem
+
+Rename the `--dry-run` CLI flag to `--plan` across the `spec-to-cli` tool for consistency with
+its sibling tools. No new component, no control-flow change, no schema, no external
+integration, no irreversible choice, and only one obvious way to do it.
+
+## Solution
+
+### Approaches considered
+Only one viable approach: a find-and-replace of the flag name across the CLI parser, its help
+text, and its tests. There is no second reasonable way to rename a flag.
+
+### Chosen approach + why
+The only approach: rename in place. Rejected alternatives: none exist, this is a pure rename.
+
+### Extensibility & boundaries
+N/A -- a flag rename does not change what happens when any dimension grows.
+
+### Architecture
+See `## Design` below.
+
+## Design
+obvious: pure rename of an existing CLI flag, no new component/control-flow/schema/
+integration/irreversible choice, and no second viable approach -- collapses per ADR-0031 §1.
+
+## Technical Design
+
+### API changes
+`--dry-run` -> `--plan` (same behavior, new name; old name kept as a deprecated alias for one
+release).
+
+## After state
+- [ ] `--plan` is the documented flag name; `--dry-run` still works but warns it is deprecated.
+
+## Acceptance Criteria (global)
+- [ ] All tasks pass their individual acceptance criteria
+
+## Verification
+`echo fixture-only, no real command`
+
+## Edge Cases
+1. A user passes both `--dry-run` and `--plan`: the tool errors, naming the conflict.
+
+## Out of Scope
+- Nothing; this is a test fixture for `tests/test-design-record.sh`, not a real spec.
+
+## Decision Log
+- DEC-001: fixture only.
+
+## Open questions
+(none)

--- a/tests/test-design-record.sh
+++ b/tests/test-design-record.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# test-design-record.sh -- Proves the ADR-0031 §1 design record (BEFORE gate).
+#
+# /kit:spec-validate's Reviewer 6 is prompt text, not code, so this harness cannot drive the
+# live LLM judgment. What it CAN prove, honestly, is the STRUCTURAL contract Reviewer 6 is
+# specified to enforce: given a spec's own declared design-bearing status (the fixture's
+# "Design-bearing (fixture declaration):" line stands in for the reviewer's classification
+# step, which is unit-tested-out-of-scope, same limitation SPEC-008 already accepted for its
+# advisory reviewers) and its `## Design` section body, does the pass/refuse call match what
+# ADR-0031 §1 / Reviewer 6 specify? This is the COVERAGE-DELTA named in SPEC-122's Test plan.
+#
+# Run: bash tests/test-design-record.sh
+# Exit 0 = all tests pass. Exit 1 = failures found.
+
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURES="$KIT_DIR/tests/fixtures/design-record"
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+assert_eq() {
+  local NAME="$1" EXPECTED="$2" ACTUAL="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$ACTUAL" = "$EXPECTED" ]; then
+    echo -e "  ${GREEN}PASS${NC} $NAME"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} $NAME (expected '$EXPECTED', got '$ACTUAL')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ------------------------------------------------------------------
+# Reviewer 6's structural contract, reproduced as a pure function.
+# ------------------------------------------------------------------
+
+is_design_bearing() {
+  # The fixture's declared ground truth (stands in for the reviewer's own judgment call --
+  # named, not hidden: see the file header).
+  grep -qE '^Design-bearing \(fixture declaration\): yes$' "$1" && echo yes || echo no
+}
+
+design_section_body() {
+  # Everything between the literal "## Design" heading and the next "## " heading.
+  awk '
+    /^## Design$/ { flag=1; next }
+    /^## /        { flag=0 }
+    flag          { print }
+  ' "$1"
+}
+
+design_section_body_nonblank() {
+  design_section_body "$1" | sed '/^[[:space:]]*$/d'
+}
+
+has_mermaid_diagram() {
+  design_section_body "$1" | grep -qF '```mermaid' && echo yes || echo no
+}
+
+is_obvious_collapse() {
+  # A bare `obvious: <why>` one-liner with nothing else load-bearing (no diagram).
+  local body
+  body="$(design_section_body_nonblank "$1")"
+  [ "$(echo "$body" | grep -cE '^obvious:')" -ge 1 ] && [ "$(has_mermaid_diagram "$1")" = "no" ] && echo yes || echo no
+}
+
+reviewer6_verdict() {
+  # Returns PASS or REFUSE, mirroring commands/spec-validate.md Reviewer 6 steps 2-3.
+  local f="$1" bearing body
+  bearing="$(is_design_bearing "$f")"
+  body="$(design_section_body_nonblank "$f")"
+  if [ "$bearing" = "yes" ]; then
+    if [ -z "$body" ]; then
+      echo REFUSE   # missing/empty Design block on a design-bearing spec
+      return
+    fi
+    if [ "$(is_obvious_collapse "$f")" = "yes" ]; then
+      echo REFUSE   # a bare obvious-collapse on a spec that IS design-bearing
+      return
+    fi
+    if [ "$(has_mermaid_diagram "$f")" = "yes" ]; then
+      echo PASS
+      return
+    fi
+    echo REFUSE     # non-empty but no diagram + no obvious-collapse: still incomplete
+    return
+  fi
+  # not design-bearing: obvious-collapse (no diagram) is the correct, proportional PASS
+  echo PASS
+}
+
+# ============================================================
+echo "=== ADR-0031 §1: design record fixtures (SPEC-122) ==="
+# ============================================================
+
+EMPTY_FIX="$FIXTURES/design-bearing-empty.md"
+FILLED_FIX="$FIXTURES/design-bearing-filled.md"
+OBVIOUS_FIX="$FIXTURES/obvious-collapse.md"
+
+for f in "$EMPTY_FIX" "$FILLED_FIX" "$OBVIOUS_FIX"; do
+  [ -f "$f" ] || { echo "FIXTURE MISSING: $f"; exit 1; }
+done
+
+echo ""
+echo "--- NEGATIVE CONTROL: design-bearing spec with an EMPTY Design block ---"
+BEARING_1="$(is_design_bearing "$EMPTY_FIX")"
+VERDICT_1="$(reviewer6_verdict "$EMPTY_FIX")"
+assert_eq "fixture 1 is declared design-bearing" "yes" "$BEARING_1"
+assert_eq "fixture 1's Design section is empty" "" "$(design_section_body_nonblank "$EMPTY_FIX")"
+assert_eq "Reviewer 6 REFUSES a design-bearing spec with an empty Design block" "REFUSE" "$VERDICT_1"
+
+echo ""
+echo "--- POSITIVE: design-bearing spec WITH a mermaid diagram + chosen approach ---"
+BEARING_2="$(is_design_bearing "$FILLED_FIX")"
+DIAGRAM_2="$(has_mermaid_diagram "$FILLED_FIX")"
+VERDICT_2="$(reviewer6_verdict "$FILLED_FIX")"
+assert_eq "fixture 2 is declared design-bearing" "yes" "$BEARING_2"
+assert_eq "fixture 2's Design section carries a mermaid diagram" "yes" "$DIAGRAM_2"
+assert_eq "Reviewer 6 PASSES a design-bearing spec with a filled Design block" "PASS" "$VERDICT_2"
+
+echo ""
+echo "--- PROPORTIONALITY CONTROL: obvious spec collapses Design, no diagram required ---"
+BEARING_3="$(is_design_bearing "$OBVIOUS_FIX")"
+DIAGRAM_3="$(has_mermaid_diagram "$OBVIOUS_FIX")"
+COLLAPSE_3="$(is_obvious_collapse "$OBVIOUS_FIX")"
+VERDICT_3="$(reviewer6_verdict "$OBVIOUS_FIX")"
+assert_eq "fixture 3 is declared NOT design-bearing" "no" "$BEARING_3"
+assert_eq "fixture 3 carries NO diagram (none required for obvious work)" "no" "$DIAGRAM_3"
+assert_eq "fixture 3's Design section is a bare obvious-collapse" "yes" "$COLLAPSE_3"
+assert_eq "Reviewer 6 PASSES an obvious spec with no diagram (proportionality)" "PASS" "$VERDICT_3"
+
+# ============================================================
+echo ""
+echo "=== Structural wiring: the 4 surfaces SPEC-122 touches ==="
+# ============================================================
+
+SPEC_MD="$KIT_DIR/commands/spec.md"
+VALIDATE_MD="$KIT_DIR/commands/spec-validate.md"
+DESIGN_MD="$KIT_DIR/commands/design.md"
+WORKFLOW_MD="$KIT_DIR/WORKFLOW.md"
+
+RC=0; grep -qE '^## Design$' "$SPEC_MD" || RC=1
+assert_eq "commands/spec.md template has a top-level ## Design heading" 0 $RC
+
+RC=0; grep -qF 'design-bearing' "$SPEC_MD" || RC=1
+assert_eq "commands/spec.md names the design-bearing trigger" 0 $RC
+
+RC=0; grep -qF 'obvious: <why>' "$SPEC_MD" || RC=1
+assert_eq "commands/spec.md names the obvious: <why> collapse" 0 $RC
+
+RC=0; grep -qE 'Reviewer 6' "$VALIDATE_MD" || RC=1
+assert_eq "commands/spec-validate.md has a Reviewer 6" 0 $RC
+
+RC=0; grep -qiE 'BLOCKING' "$VALIDATE_MD" || RC=1
+assert_eq "commands/spec-validate.md Reviewer 6 is marked blocking (unlike 1-5)" 0 $RC
+
+RC=0; grep -qiE 'refus(e|es|ed)' "$VALIDATE_MD" || RC=1
+assert_eq "commands/spec-validate.md uses ADR-0031's 'refuses' language" 0 $RC
+
+RC=0; grep -qiE 'PROPORTIONALITY' "$VALIDATE_MD" || RC=1
+assert_eq "commands/spec-validate.md Reviewer 6 carries the proportionality warning path" 0 $RC
+
+# NEGATIVE CONTROL on the reviewer roster itself: Reviewers 1-5 present verbatim, unchanged.
+for R in "Reviewer 1: Security Auditor" "Reviewer 2: Failure Mode Analyst" "Reviewer 3: Assumption Destroyer" "Reviewer 4: Scope Critic" "Reviewer 5: Solution-Design & Extensibility Critic"; do
+  RC=0; grep -qF "$R" "$VALIDATE_MD" || RC=1
+  assert_eq "commands/spec-validate.md: '$R' present unchanged" 0 $RC
+done
+
+RC=0; grep -qiE 'diagram' "$DESIGN_MD" || RC=1
+assert_eq "commands/design.md's interactive lane asks about a diagram" 0 $RC
+
+RC=0; grep -qiE 'ADR link' "$DESIGN_MD" || RC=1
+assert_eq "commands/design.md's interactive lane records ADR link(s)" 0 $RC
+
+RC=0; grep -qE '^\| Design record \(design-bearing, ADR-0031' "$WORKFLOW_MD" || RC=1
+assert_eq "WORKFLOW.md depth matrix has a Design record row" 0 $RC
+
+RC=0; grep -qF '| Design (opt-in) |' "$WORKFLOW_MD" || RC=1
+assert_eq "WORKFLOW.md's new row is distinct from the existing 'Design (opt-in)' row" 0 $RC
+
+# ============================================================
+echo ""
+echo "=== Results ==="
+# ============================================================
+echo -e "Passed: ${GREEN}${PASS}${NC} / ${TOTAL}"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed: ${RED}${FAIL}${NC}"
+  exit 1
+else
+  echo -e "${GREEN}All design-record tests passed.${NC}"
+  exit 0
+fi

--- a/tests/test-e2e.sh
+++ b/tests/test-e2e.sh
@@ -66,13 +66,16 @@ LANE="normal"   # chosen (a flag still wants a spec + tests in this demo)
 # --- 3. START + the road ---
 GL start e2e-demo "$LANE" "$LANE" "$TYPE" "$TYPE" e2e-repo >/dev/null || { bad "GL start failed"; exit 1; }
 expect "plan: announces the road" "grill" "$(GL plan "$LANE")"
-expect "progress: opens at step 1" "step 1/8 (grill)" "$(GL progress e2e-demo "$LANE")"
+expect "progress: opens at step 1" "step 1/9 (grill)" "$(GL progress e2e-demo "$LANE")"
 
 # --- 4. walk the phases ---
+# (SPEC-122 adds a "Design record" row, run-lite for normal lane, between spec and
+# test-plan in plan order -- the normal-lane plan grows from 8 to 9 steps)
 GL record e2e-demo grill ran "2 questions resolved" >/dev/null
 GL record e2e-demo think ran "intent confirmed" >/dev/null
 GL record e2e-demo spec ran "spec written" >/dev/null
-expect "progress: mid-run pointer" "step 4/8 (test-plan)" "$(GL progress e2e-demo "$LANE")"
+GL record e2e-demo design-record ran "obvious: <why> collapse noted (SPEC-122)" >/dev/null
+expect "progress: mid-run pointer" "step 5/9 (test-plan)" "$(GL progress e2e-demo "$LANE")"
 GL record e2e-demo test-plan skipped "lite; matrix in spec" >/dev/null
 GL record e2e-demo build ran "flag implemented, tests green" >/dev/null
 GL record e2e-demo review ran "SHIP findings=0" >/dev/null
@@ -81,7 +84,7 @@ GL record e2e-demo ship ran "shipping pr=#1" >/dev/null
 
 # --- 5. the three surfaces agree ---
 if GL check "$LANE" e2e-demo >/dev/null 2>&1; then ok "gate-ledger: check passes"; else bad "gate-ledger: check failed"; fi
-expect "progress: complete" "complete (8/8)" "$(GL progress e2e-demo "$LANE")"
+expect "progress: complete" "complete (9/9)" "$(GL progress e2e-demo "$LANE")"
 REPORT=$(LT report)
 expect "telemetry: the run is counted" "runs: 1" "$REPORT"
 expect "telemetry: the ship is counted" "shipped: 1" "$REPORT"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -257,14 +257,14 @@ assert_output_contains "detector 9a: genuinely boardless run still flagged (nega
 # 9b shipped-incomplete-false-flag-now-clean: a full-lane NON-UI run with every REQUIRED gate
 # disposed but the lite ui-design un-disposed is NOT flagged.
 printf '2026-06-10T07:00:00Z | START | lane=full classified=full type=spec-feature repo=%s\n' "$REPO_BASE" > "$BD_DIR/logs/runs/full-noui.log"
-for PH in think design design-critique spec validate test-plan build review docs ship reflect; do
+for PH in think design design-critique spec validate design-record test-plan build review docs ship reflect; do
   printf '2026-06-10T08:00:00Z | GATE | %s | ran | done\n' "$PH" >> "$BD_DIR/logs/runs/full-noui.log"
 done
 printf '| ID-008 | full non-ui work | shipped [run full-noui] |\n' >> "$BD_DIR/repo/_meta/BACKLOG.md"
 assert_output_not_contains "detector 9b: full non-UI run (ui-design lite un-disposed) not flagged" "full-noui" "$(BDT misfires)"
 # 9b negative control: a full-lane run missing a REQUIRED gate (review) still flags.
 printf '2026-06-10T07:00:00Z | START | lane=full classified=full type=spec-feature repo=%s\n' "$REPO_BASE" > "$BD_DIR/logs/runs/full-gap.log"
-for PH in think design design-critique spec validate test-plan build docs ship reflect; do
+for PH in think design design-critique spec validate design-record test-plan build docs ship reflect; do
   printf '2026-06-10T08:00:00Z | GATE | %s | ran | done\n' "$PH" >> "$BD_DIR/logs/runs/full-gap.log"   # note: no `review`
 done
 printf '| ID-009 | full run missing review | shipped [run full-gap] |\n' >> "$BD_DIR/repo/_meta/BACKLOG.md"
@@ -1061,16 +1061,19 @@ assert_output_contains "plan: normal carries required spec" "3. spec            
 assert_output_contains "plan: normal prepends grill intake" "1. grill" "$(GL plan normal)"
 PLAN_TINY="$(GL plan tiny)"
 assert_output_not_contains "plan: tiny has no grill row" "grill" "$PLAN_TINY"
-# progress: plan x ledger; spec-p has grill+spec recorded -> step points at test-plan
+# progress: plan x ledger; spec-p has grill+spec(+design-record) recorded -> step points at test-plan
+# (SPEC-122 adds a "Design record" row to the matrix, run-lite for normal lane, sitting
+# between spec and test-plan in plan order -- bumping the normal-lane plan from 8 to 9 steps)
 printf '2026-06-10T07:00:00Z | START | lane=normal classified=normal type=spec-feature ctype=spec-feature repo=kitA\n' > "$LT2_DIR/runs/spec-p.log"
 GL record spec-p grill ran "4 branches resolved"
 GL record spec-p think ran "intent confirmed"
 GL record spec-p spec ran "spec written"
-assert_output_contains "progress: step k/n line" "spec-p · normal · step 4/8 (test-plan)" "$(GL progress spec-p normal)"
-assert_output_contains "progress: checklist marks" "✓grill ✓think ✓spec ▶test-plan" "$(GL progress spec-p normal)"
+GL record spec-p design-record ran "obvious: <why> collapse noted (SPEC-122)"
+assert_output_contains "progress: step k/n line" "spec-p · normal · step 5/9 (test-plan)" "$(GL progress spec-p normal)"
+assert_output_contains "progress: checklist marks" "✓grill ✓think ✓spec ✓design-record ▶test-plan" "$(GL progress spec-p normal)"
 # a skipped-with-reason phase counts as disposed (not blocking the pointer)
 GL record spec-p test-plan skipped "lite lane, matrix in spec"
-assert_output_contains "progress: skipped-with-reason advances" "step 5/8 (build)" "$(GL progress spec-p normal)"
+assert_output_contains "progress: skipped-with-reason advances" "step 6/9 (build)" "$(GL progress spec-p normal)"
 # trace: header flags + humanized lines
 TRACE_OUT="$(DWARVES_KIT_LOG_DIR="$LT2_DIR" bash "$KIT_DIR/lib/lane-telemetry.sh" trace bug-stampede 2>/dev/null)"
 assert_output_contains "trace: escaped-from indictment flagged" "<< indicts a shipped spec test plan" "$TRACE_OUT"
@@ -1078,12 +1081,12 @@ TRACE_MIS="$(DWARVES_KIT_LOG_DIR="$LT2_DIR" bash "$KIT_DIR/lib/lane-telemetry.sh
 assert_output_contains "trace: type misfire flag survives ctype strip negative? no: clean run shows no flag" "type: spec-feature (classified: ?)" "$TRACE_MIS"
 # negative control: remove the spec record -> the pointer falls back to spec
 grep -v '| spec |' "$LT2_DIR/runs/spec-p.log" > "$LT2_DIR/runs/spec-p.log.tmp" && mv -f "$LT2_DIR/runs/spec-p.log.tmp" "$LT2_DIR/runs/spec-p.log"
-assert_output_contains "progress: negative control (spec record removed -> pointer moves back)" "step 3/8 (spec)" "$(GL progress spec-p normal)"
+assert_output_contains "progress: negative control (spec record removed -> pointer moves back)" "step 3/9 (spec)" "$(GL progress spec-p normal)"
 # a bare skip (no reason) does NOT dispose: the pointer stays (spec-faithful, review F1)
 GL record spec-p spec skipped
-assert_output_contains "progress: bare skip stays a gap" "step 3/8 (spec)" "$(GL progress spec-p normal)"
+assert_output_contains "progress: bare skip stays a gap" "step 3/9 (spec)" "$(GL progress spec-p normal)"
 GL record spec-p spec skipped "matrix in spec body"
-assert_output_contains "progress: reasoned skip disposes" "step 5/8 (build)" "$(GL progress spec-p normal)"
+assert_output_contains "progress: reasoned skip disposes" "step 6/9 (build)" "$(GL progress spec-p normal)"
 # trace: first START wins + multi-start advisory (review F2)
 printf '2026-06-10T06:00:00Z | START | lane=normal classified=full type=doc repo=kitA\n2026-06-10T06:05:00Z | START | lane=tiny classified=tiny type=doc repo=kitA\n' > "$LT2_DIR/runs/spec-2s.log"
 TRACE_2S="$(DWARVES_KIT_LOG_DIR="$LT2_DIR" bash "$KIT_DIR/lib/lane-telemetry.sh" trace spec-2s 2>/dev/null)"

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -976,20 +976,29 @@ else
 fi
 
 TOTAL=$((TOTAL + 1))
-if grep -qF "## The 5 reviewers" "$VALIDATE_CMD" 2>/dev/null; then
-  echo -e "  ${GREEN}PASS${NC} spec-validate.md header says 5 reviewers"
+if grep -qF "## The 6 reviewers" "$VALIDATE_CMD" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC} spec-validate.md header says 6 reviewers"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}FAIL${NC} spec-validate.md header not updated to 5 reviewers"
+  echo -e "  ${RED}FAIL${NC} spec-validate.md header not updated to 6 reviewers"
   FAIL=$((FAIL + 1))
 fi
 
-# Count-drift guard: no live "4 reviewer(s)" reference may remain in the command
-# (the heading, frontmatter, and output-format intro must all agree). Historical
-# "4 reviewers run <date>" lines live in docs/specs/, not here, so this file is safe
-# to assert clean. Caught a real regression in the SPEC-008 review.
-STALE_COUNT=$(grep "4 reviewer" "$VALIDATE_CMD" 2>/dev/null | wc -l | tr -d ' ')
-assert_eq "spec-validate.md has no stale '4 reviewer' references" "0" "$STALE_COUNT"
+TOTAL=$((TOTAL + 1))
+if grep -qE "^### Reviewer 6:" "$VALIDATE_CMD" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC} spec-validate.md has Reviewer 6 (design record, ADR-0031 §1, blocking)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC} spec-validate.md missing Reviewer 6"
+  FAIL=$((FAIL + 1))
+fi
+
+# Count-drift guard: no live "4 reviewer(s)" / "5 reviewer(s)" reference may remain in the
+# command (the heading, frontmatter, and output-format intro must all agree). Historical
+# "N reviewers run <date>" lines live in docs/specs/, not here, so this file is safe
+# to assert clean. Caught a real regression in the SPEC-008 review; SPEC-122 bumps 5 -> 6.
+STALE_COUNT=$(grep -E "4 reviewer|5 reviewer" "$VALIDATE_CMD" 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "spec-validate.md has no stale '4 reviewer' / '5 reviewer' references" "0" "$STALE_COUNT"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
Design record (ADR-0031 §1): design-bearing specs carry a `## Design` block (diagram/ADR/C4-lite, proportional) enforced by spec-validate before VALIDATED; `Design:` field added to the mega-goal subgoal template. Verify: three fixtures (refuse-empty NC, pass-with-diagram, obvious-collapse) + test-meta. Roadmap: ops-toolkit `_meta/megagoals/understanding-gate/ROADMAP.md`.
