### PR TITLE
fix(lib): carry classification through the debt response line

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run lane-classify rule tests (SPEC-098)
         run: bash tests/test-lane-classify.sh
 
-      - name: Run significance-classify tests (SPEC-122)
+      - name: Run significance-classify tests (SPEC-123)
         run: bash tests/test-significance-classify.sh
 
       - name: Run lane-telemetry render tests (SPEC-099)

--- a/docs/implementation-notes/debt-ledger-response-seam.md
+++ b/docs/implementation-notes/debt-ledger-response-seam.md
@@ -1,0 +1,56 @@
+## 2026-07-03 18:00 Debt-ledger response-writer schema mismatch (TIER-4 close finding)
+
+Context: understanding-gate's TIER-4 close (3 independent review lenses: architecture, security,
+advisor) converged on and reproduced live a cross-sub-goal integration bug. SG-02's classifier
+(`gate-ledger.sh debt`, SPEC-123) writes a FAT `| DEBT |` line (`significance=`/`worthiness=`/
+`verdict=`). SG-04's human-response verb (`gate-ledger.sh debt-response`, used by `quiz-gate.sh
+respond`) wrote a THIN line (`response=` only). The ledger is last-line-wins for readers, so
+`weekend-batch.sh mark-paid` (SG-05) read sig/wor/verdict off the last line and re-emitted them
+through the fat `debt` verb, which validates those fields as required enums -- empty values crashed
+it with exit 64. Because the fat writer (`significance-classify record`) is unwired today, EVERY
+live `debt-response` is thin, making this the default path on any human-responded item, not an edge
+case. `tests/test-weekend-batch.sh` previously only ever hand-seeded fat lines directly into the
+fixture ledger (bypassing `respond`/`debt-response` entirely), which is why the suite never caught
+this.
+
+Decision: implement the fix exactly as prescribed by the assigning prompt (root cause + design were
+already established by the TIER-4 close, not re-derived here):
+
+1. `gate-ledger.sh debt_response()` now forward-carries: it looks back at the ledger for THIS rid's
+   last FAT debt line (one containing `verdict=`) and, if found, re-emits its significance/worthiness/
+   verdict alongside the new `response=`. If no fat line exists (today's live default), it writes the
+   thin line as before -- it never fabricates sig/wor.
+2. `weekend-batch.sh cmd_mark_paid` no longer calls the fat `debt` verb at all. It closes via
+   `debt-response <rid> engage "<reason>"`, which only requires a valid response enum and is safe
+   whether or not a fat line exists upstream (forward-carries when one does).
+3. `weekend-batch.sh cmd_list` / `cmd_collect` walk back to the last FAT debt line for display when
+   the last line lacks significance=/worthiness= (a new `_last_fat_debt_line` helper), so the digest
+   shows real numbers instead of blanks whenever a classifier line exists anywhere in the rid's
+   history. Blank stays blank when none exists -- an honest, documented gap until
+   `significance-classify record` is wired (a separate, out-of-scope decision).
+4. Security LOW (folded in per the assigning prompt): a free-text `reason=` value containing a
+   token shaped like a control field (e.g. `response=engage`) could be misread by a naive
+   whole-line KV-parse. Two layers: (a) writer -- `gate-ledger.sh debt()` and `debt_response()` now
+   replace any `=` inside a `reason` value with `:` before writing, so a reason can never contain a
+   real `KEY=value` token; (b) reader, belt-and-suspenders -- `weekend-batch.sh _kv()` now cuts the
+   line at the first ` reason=` (`struct="${line%% reason=*}"`) and parses control keys only from
+   that prefix, since the writer's field order always puts control keys before `reason=`. `_disposition()`
+   inherits this fix automatically (it calls `_kv`).
+5. Cosmetic: `.github/workflows/test.yml`'s `test-significance-classify.sh` step comment mislabeled
+   `SPEC-122`; corrected to `SPEC-123` (the actual spec `tests/test-significance-classify.sh` and
+   `lib/significance-classify.sh` cite in their own headers).
+
+Alternatives considered (all rejected per the assigning prompt's single-root recommendation):
+wiring `significance-classify record` to make every debt line fat from the start (explicitly out of
+scope, a separate Han decision); having `mark-paid` special-case empty enums inside the fat `debt`
+verb itself (would still leave `debt()`'s required-enum validation doing double duty as both a
+classifier-input guard and a paydown-closer guard -- two callers, one validation, easy to
+re-break); rejecting (rather than stripping) a `reason=` containing `=` (would break the legitimate
+`quiz-gate.sh respond`'s existing `"SG-04 quiz-gate nudge ref=$ref"` reason text, a real feature,
+not an attack).
+
+Impact: `weekend-batch.sh mark-paid` on any human-responded (`defer`/`wave`/`engage`) item now
+closes cleanly regardless of whether a classifier ever ran for that rid. New regression coverage in
+`tests/test-weekend-batch.sh`: a true end-to-end `debt-response` (thin) -> `collect` -> `mark-paid`
+case (the exact bug), a forward-carry case (fat line before a response line), and two reason-
+injection security cases (writer-side neutering + reader-side struct-prefix cut, independently).

--- a/docs/verification/debt-ledger-response-seam.md
+++ b/docs/verification/debt-ledger-response-seam.md
@@ -1,0 +1,139 @@
+# Proof of done: debt-ledger response-writer schema mismatch (TIER-4 close finding)
+
+VERDICT: PASS
+
+## Acceptance criteria
+
+1. The live repro from the assigning prompt (`gate-ledger.sh debt-response ... defer` then
+   `weekend-batch.sh mark-paid`) exits 0 (was exit 64).
+2. `debt_response()` forward-carries significance/worthiness/verdict from the last FAT debt line
+   for the rid, when one exists; never fabricates data when none exists.
+3. `weekend-batch.sh cmd_mark_paid` closes via `debt-response ... engage`, never the raw fat `debt`
+   verb.
+4. Readers (`cmd_list`/`cmd_collect`) walk back to the last FAT line for sig/wor display when the
+   last line lacks them.
+5. A `reason=` free-text value can never smuggle a control token, at both the writer (neutered `=`)
+   and reader (`_kv` struct-prefix cut) layers.
+6. A true end-to-end `respond -> collect -> mark-paid` regression test exists (not a hand-seeded
+   fat line), plus a forward-carry case and two security negative controls.
+7. The full CI suite + the three directly-touched suites (`test-weekend-batch.sh`,
+   `test-quiz-gate.sh`, `test-significance-classify.sh`) + `test-meta.sh` all stay green.
+
+## Implementation
+
+- `lib/gate-ledger.sh` `debt_response()`: looks back at the ledger for the rid's last `| DEBT |`
+  line containing `verdict=` (a "fat" line); if found, re-emits its
+  `significance=`/`worthiness=`/`verdict=` alongside the new `response=`. Also neuters any `=`
+  inside a `reason` value (writer-side smuggle guard), matching the same guard added to `debt()`.
+- `lib/weekend-batch.sh` `cmd_mark_paid()`: no longer calls the fat `debt` verb; closes via
+  `bash "$GATE_LEDGER" debt-response "$rid" engage "$reason"`.
+- `lib/weekend-batch.sh` `_last_fat_debt_line()` (new helper) + walk-back in `cmd_list`/`cmd_collect`:
+  falls back to the last fat line for sig/wor display when the last (possibly thin) line lacks them.
+- `lib/weekend-batch.sh` `_kv()`: cuts the line at the first ` reason=` (`struct="${line%% reason=*}"`)
+  and parses control keys from that prefix only (reader-side smuggle guard, `_disposition()`
+  inherits it automatically since it calls `_kv`).
+- `.github/workflows/test.yml`: cosmetic, `test-significance-classify.sh` step comment corrected
+  `SPEC-122` -> `SPEC-123`.
+- `tests/test-weekend-batch.sh`: added a true end-to-end regression (thin response -> collect ->
+  mark-paid, exits 0), a forward-carry case (fat line before a response line), and two security
+  negative controls (writer-side neutering, reader-side struct-prefix cut against the actual
+  exploitable shape: a silent-wave line with no real `response=` field).
+
+## Confirmation run-table (2026-07-03/04, ug-fix worktree, fixed code)
+
+| # | Command | Exit | Output |
+|---|---------|------|--------|
+| 1 | `bash tests/test-weekend-batch.sh` | 0 | `TOTAL: 34   PASS: 34   FAIL: 0   SKIP: 0` |
+| 2 | `bash tests/test-quiz-gate.sh` | 0 | `TOTAL: 29   PASS: 29   FAIL: 0` |
+| 3 | `bash tests/test-significance-classify.sh` | 0 | `25/25 passed, 0 failed` |
+| 4 | `bash tests/test-meta.sh` | 0 | `Passed: 667 / 667` |
+| 5 | Full CI suite (every `bash tests/test-*.sh` wired in `.github/workflows/test.yml`, 20 files) | 0 (all) | `PASS` for every suite: test-e2e, test-hooks, test-lane-classify, test-lane-telemetry, test-ledger-durability, test-mega-merge, test-meta-agent, test-meta, test-model-routing, test-multiplexer, test-orchestrate-wavefront, test-orchestrate, test-pane-viewer, test-proof-visual-evidence, test-review-team-plants, test-role-classify, test-significance-classify, test-spec-index, test-tier4-close, test-token-capture |
+| 6 | Live repro (assigning prompt, verbatim): `gate-ledger.sh debt-response <rid> defer ...` then `weekend-batch.sh mark-paid <rid>` | 0 | `EXIT=0` (was `debt: significance must be low|high (got '')` / exit 64 before this fix) |
+
+Note: `tests/test-weekend-batch.sh` and `tests/test-quiz-gate.sh` are not currently wired into
+`.github/workflows/test.yml` (a pre-existing gap, out of scope for this fix); both were run
+directly (rows 1-2) and are green.
+
+## NEGATIVE CONTROL (revert -> RED -> restore)
+
+The fix (and its own regression tests) is falsifiable, not a rubber stamp. The pre-fix code
+(commit `77815c2`, the parent of this fix) was extracted via `git archive 77815c2 | tar -x` into a
+scratch directory (no working-tree mutation, no `git worktree add`), then:
+
+**1. The exact live repro from the assigning prompt, run against the pre-fix code:**
+```
+$ cd <scratch-pre-fix-checkout>
+$ export DWARVES_KIT_LOG_DIR=$(mktemp -d); rid="repro-negctrl-$$"
+$ bash lib/gate-ledger.sh debt-response "$rid" defer "deferred to weekend"
+$ bash lib/weekend-batch.sh mark-paid "$rid"
+debt: significance must be low|high (got '')
+Exit: 64
+```
+RED, confirming the bug is real and reproducible on the pre-fix code.
+
+**2. The same repro against the fixed code (this branch):**
+```
+$ cd <ug-fix worktree>
+$ export DWARVES_KIT_LOG_DIR=$(mktemp -d); rid="repro-$$"
+$ bash lib/gate-ledger.sh debt-response "$rid" defer "deferred to weekend"
+$ bash lib/weekend-batch.sh mark-paid "$rid"
+Exit: 0
+```
+GREEN, confirming the fix closes the exact reported bug.
+
+**3. The NEW test file (this branch's `tests/test-weekend-batch.sh`, with all new regression +
+forward-carry + security cases) copied onto the pre-fix `lib/` and run there:**
+```
+$ cp <ug-fix worktree>/tests/test-weekend-batch.sh <scratch-pre-fix-checkout>/tests/
+$ cd <scratch-pre-fix-checkout>
+$ bash tests/test-weekend-batch.sh
+...
+FAIL regression: mark-paid on a THIN response-only item exits 0 (was exit 64 before this fix)
+FAIL regression: ug-20-thin-response-* is no longer collectible after mark-paid (disposed paid, never re-collected)
+FAIL forward-carry: the response line carries significance=high from the earlier classifier line
+FAIL forward-carry: the response line carries worthiness=high from the earlier classifier line
+FAIL forward-carry: the response line carries verdict=tap from the earlier classifier line
+FAIL forward-carry: the digest shows real sig/wor for ug-21-fat-then-response-* (high / high), not blanks
+FAIL security [writer]: only ONE 'response=<word>' token survives on the line (the real control field; the embedded one was neutered)
+FAIL security [reader]: a silent-wave line (no real response= field) with 'response=engage' smuggled in reason= still reads disposition=waved, NOT paid (struct-prefix cut)
+TOTAL: 34   PASS: 26   FAIL: 8   SKIP: 0
+```
+8 of the new checks correctly FAIL against the pre-fix code (proving the new tests actually
+exercise the seam, not a tautology), and the SAME test file run against the fixed code (row 1 of the
+run-table above) is 34/34 green.
+
+**4. Why the OLD test suite never caught this:** `tests/test-weekend-batch.sh`'s pre-existing `AC3a`
+case seeded a hand-written FAT debt line directly into the fixture file (`seed()`, bypassing
+`respond`/`debt-response` entirely) before calling `mark-paid` -- so `mark-paid`'s re-emit through
+the fat `debt` verb always had real sig/wor/verdict to re-emit and never crashed in that fixture.
+The new regression case instead calls the REAL `gate-ledger.sh debt-response` codepath with no
+prior classifier line, which is the actual default live shape (the fat writer,
+`significance-classify record`, is unwired today) -- that is the seam the old suite masked.
+
+No restore step was needed: the pre-fix code was read from a disposable `git archive` extraction in
+a scratch temp directory, never the working tree.
+
+## Reproduce
+
+```
+cd <dwarves-kit>/.claude/worktrees/ug-fix   # or the merged master
+bash tests/test-weekend-batch.sh
+bash tests/test-quiz-gate.sh
+bash tests/test-significance-classify.sh
+bash tests/test-meta.sh
+for t in $(grep -oE 'bash tests/test-[a-z0-9-]+\.sh' .github/workflows/test.yml | sort -u | sed 's/bash //'); do
+  bash "$t" >/dev/null 2>&1 && echo "PASS $t" || echo "FAIL $t"
+done
+
+# live repro
+export DWARVES_KIT_LOG_DIR=$(mktemp -d); rid="repro-$$"
+bash lib/gate-ledger.sh debt-response "$rid" defer "deferred to weekend"
+bash lib/weekend-batch.sh mark-paid "$rid"; echo "EXIT=$?"   # expect EXIT=0
+
+# negative control (pre-fix code, disposable)
+TMPD="$(mktemp -d)"; git archive 77815c2 | tar -x -C "$TMPD"
+cd "$TMPD"
+export DWARVES_KIT_LOG_DIR=$(mktemp -d); rid="repro-negctrl-$$"
+bash lib/gate-ledger.sh debt-response "$rid" defer "deferred to weekend"
+bash lib/weekend-batch.sh mark-paid "$rid"; echo "EXIT=$?"   # expect EXIT=64 (RED)
+```

--- a/docs/verification/quiz-gate/sample-quiz.md
+++ b/docs/verification/quiz-gate/sample-quiz.md
@@ -1,6 +1,6 @@
-# Sample quiz (fixture A, ref 00eb4bda92da818a918431207341696c2be42901)
+# Sample quiz (fixture A, ref 1856cec6f823d6d9e326a125978310469f07713d)
 
-# 5-question understanding quiz for `00eb4bda92da818a918431207341696c2be42901`
+# 5-question understanding quiz for `1856cec6f823d6d9e326a125978310469f07713d`
 # Grounded in the ACTUAL diff + recorded test results (SPEC-125), NOT any agent narrative.
 # These questions are the payload for the deep-understand mastery gate, they are not scored here.
 

--- a/docs/verification/weekend-batch/sample-digest.md
+++ b/docs/verification/weekend-batch/sample-digest.md
@@ -1,13 +1,13 @@
 # Weekend batch: debt paydown
 
-Window: since 2026-06-26T17:16:03Z (repo: fixture-repo)
+Window: since 2026-06-26T18:02:50Z (repo: fixture-repo)
 Items: 2 (1 waved, 1 deferred)
 
 ## ug-10-waved-item
 - disposition: waved
 - significance: high / worthiness: low
 - reason: sig:full-lane wor:none
-- recorded: 2026-07-03T17:16:02Z
+- recorded: 2026-07-03T18:02:50Z
 - impl-notes: docs/implementation-notes/ug-10-waved-item.md (found)
 - explainer: docs/verification/explain-command/ug-10-waved-item-explainer.md (absent)
 
@@ -15,6 +15,6 @@ Items: 2 (1 waved, 1 deferred)
 - disposition: deferred
 - significance: high / worthiness: high
 - reason: deferred to weekend batch
-- recorded: 2026-07-03T17:16:03Z
+- recorded: 2026-07-03T18:02:50Z
 - impl-notes: docs/implementation-notes/ug-11-deferred-item.md (absent)
 - explainer: docs/verification/explain-command/deferred-item-explainer.md (found)

--- a/docs/verification/weekend-batch/sample-digest.md
+++ b/docs/verification/weekend-batch/sample-digest.md
@@ -1,13 +1,13 @@
 # Weekend batch: debt paydown
 
-Window: since 2026-06-26T18:02:50Z (repo: fixture-repo)
+Window: since 2026-06-26T18:10:30Z (repo: fixture-repo)
 Items: 2 (1 waved, 1 deferred)
 
 ## ug-10-waved-item
 - disposition: waved
 - significance: high / worthiness: low
 - reason: sig:full-lane wor:none
-- recorded: 2026-07-03T18:02:50Z
+- recorded: 2026-07-03T18:10:30Z
 - impl-notes: docs/implementation-notes/ug-10-waved-item.md (found)
 - explainer: docs/verification/explain-command/ug-10-waved-item-explainer.md (absent)
 
@@ -15,6 +15,6 @@ Items: 2 (1 waved, 1 deferred)
 - disposition: deferred
 - significance: high / worthiness: high
 - reason: deferred to weekend batch
-- recorded: 2026-07-03T18:02:50Z
+- recorded: 2026-07-03T18:10:30Z
 - impl-notes: docs/implementation-notes/ug-11-deferred-item.md (absent)
 - explainer: docs/verification/explain-command/deferred-item-explainer.md (found)

--- a/lib/gate-ledger.sh
+++ b/lib/gate-ledger.sh
@@ -196,7 +196,13 @@ debt() {
       worthiness)   wor="$v" ;;
       verdict)      verdict="$v" ;;
       response)     response="$v" ;;
-      reason)       reason="$(oneline "$v")" ;;
+      # Security LOW (TIER-4 close): a reason value containing a literal "=" can smuggle a
+      # fake control token (e.g. "reason=response=engage") past a naive downstream KV-parse
+      # (weekend-batch.sh's _kv, which greps the whole line). Belt-and-suspenders alongside
+      # the struct-prefix cut in weekend-batch.sh: neuter it here at the source by replacing
+      # "=" with ":" (matches the pre-existing "sig:full-lane" reason-text convention), so a
+      # reason can never contain a real KEY=value control token.
+      reason)       reason="$(oneline "$v" | tr '=' ':')" ;;
     esac
   done
   case "$sig" in low|high) ;; *) echo "debt: significance must be low|high (got '$sig')" >&2; return 64;; esac
@@ -218,16 +224,44 @@ debt() {
 # SG-05) / wave (accept the debt knowingly). All three are logged , the only real failure is UNTRACKED
 # debt, so waving is a first-class RECORDED choice, never a hard block. Same additive shape: check()/
 # override()/descent()/_rows() ignore `| DEBT |`, so a response line can never fake or mask a gate.
+#
+# FORWARD-CARRY (TIER-4 close finding): SG-02's classifier (`debt()`) writes a FAT line
+# (significance=/worthiness=/verdict=); this command historically wrote a THIN line (response= only,
+# no sig/wor/verdict). The ledger is last-line-wins for readers, so any consumer that re-emits the
+# LAST debt line's sig/wor/verdict through the fat `debt` verb (e.g. weekend-batch.sh mark-paid) saw
+# empty enums and crashed -- and because `significance-classify record` (the fat writer) is unwired
+# today, EVERY live debt-response is thin, making this the DEFAULT path, not an edge case. Fix: look
+# back at the ledger for THIS rid's last FAT line (one carrying verdict=) and, if found, re-emit its
+# sig/wor/verdict alongside response= -- making the response line self-describing without inventing
+# data. If no fat line exists (the live today-flow), write the thin line as before; blank stays blank.
 # Usage: debt-response <rid> <engage|defer|wave> [reason]
 debt_response() {
   local rid="${1:-}" response="${2:-}"; shift 2 2>/dev/null || { echo "usage: debt-response <rid> <engage|defer|wave> [reason]" >&2; return 64; }
   [ -n "$rid" ] || { echo "debt-response requires a rid" >&2; return 64; }
   case "$response" in engage|defer|wave) ;; *) echo "debt-response: response must be engage|defer|wave (got '$response')" >&2; return 64;; esac
-  local reason; reason="$(oneline "$@")"
+  # Security LOW (TIER-4 close), same guard as debt(): neuter a "=" in reason so it can never
+  # smuggle a control token past a naive downstream KV-parse.
+  local reason; reason="$(oneline "$@" | tr '=' ':')"
   mkdir -p "$RUNS_DIR"
-  local line; line="response=$response"
+  local f; f="$(ledger_file "$rid")" || return 1
+  local sig="" wor="" verdict="" last_fat
+  if [ -f "$f" ]; then
+    last_fat="$(grep '| DEBT |' "$f" 2>/dev/null | grep 'verdict=' | tail -n1)" || true
+    if [ -n "$last_fat" ]; then
+      sig="$(printf '%s' "$last_fat" | grep -oE 'significance=[^ ]+' | head -n1 | cut -d= -f2-)" || true
+      wor="$(printf '%s' "$last_fat" | grep -oE 'worthiness=[^ ]+' | head -n1 | cut -d= -f2-)" || true
+      verdict="$(printf '%s' "$last_fat" | grep -oE 'verdict=[^ ]+' | head -n1 | cut -d= -f2-)" || true
+    fi
+  fi
+  local line
+  if [ -n "$verdict" ]; then
+    line="$(printf 'significance=%s worthiness=%s verdict=%s response=%s' "$sig" "$wor" "$verdict" "$response")"
+  else
+    line="response=$response"
+  fi
   [ -n "$reason" ] && line="$line reason=$reason"
-  printf '%s | DEBT | %s\n' "$(now)" "$line" >> "$(ledger_file "$rid")"
+  mkdir -p "$RUNS_DIR"
+  printf '%s | DEBT | %s\n' "$(now)" "$line" >> "$f"
 }
 
 override() {

--- a/lib/weekend-batch.sh
+++ b/lib/weekend-batch.sh
@@ -120,12 +120,28 @@ _last_debt_line() {
   grep '| DEBT |' "$1" 2>/dev/null | tail -n1 || true
 }
 
+# _last_fat_debt_line <ledger-file> -- the last `| DEBT |` line carrying significance= (a "fat"
+# line: SG-02's classifier via gate-ledger.sh debt(), or a forward-carried debt-response()). Readers
+# use this to walk back past a THIN response-only line (pre-forward-carry history, or the classifier
+# genuinely never ran) so significance/worthiness still display instead of going blank. Returns ""
+# (via `|| true`) when no fat line exists at all -- an honest gap, not fabricated data.
+_last_fat_debt_line() {
+  grep '| DEBT |' "$1" 2>/dev/null | grep 'significance=' | tail -n1 || true
+}
+
 # _kv <line> <key> -- extract KEY=value (no embedded spaces in the value) from a ledger line.
-# Safe even when a later `reason=...` field embeds spaces, because the regex stops at the first
-# space. `|| true`: a key that is not present (e.g. `response=` on a silent SG-02 wave) is an
-# expected empty result, never a script-aborting failure.
+# Security LOW (TIER-4 close): a free-text `reason=...` value can itself contain a token shaped
+# like a control field (e.g. `reason=response=engage`); grepping the WHOLE line would misread that
+# as the real control key. The writer (gate-ledger.sh debt()/debt_response()) always emits control
+# keys BEFORE `reason=` and now also neuters any `=` inside the reason value itself (belt-and-
+# suspenders) -- so cutting the line at the first ` reason=` and parsing control keys from that
+# prefix ONLY is both correct (real control fields never appear after `reason=`) and sufficient.
+# `|| true`: a key that is not present (e.g. `response=` on a silent SG-02 wave) is an expected
+# empty result, never a script-aborting failure.
 _kv() {
-  printf '%s' "$1" | grep -oE "$2=[^ ]+" | head -n1 | cut -d= -f2- || true
+  local line="$1" key="$2" struct
+  struct="${line%% reason=*}"
+  printf '%s' "$struct" | grep -oE "$key=[^ ]+" | head -n1 | cut -d= -f2- || true
 }
 
 # _disposition <debt-line> -- prints "waved"|"deferred"|"pending"|"paid"|"not-significant" for the
@@ -192,13 +208,23 @@ _strip_ug_prefix() {
 
 cmd_list() {
   _parse_common "$@" || return $?
-  local f disp rid last sig wor ts
+  local f disp rid last sig wor ts fat
   _collectible_files | while IFS=$'\t' read -r f disp; do
     [ -n "$f" ] || continue
     rid="$(basename "$f" .log)"
     last="$(_last_debt_line "$f")"
     sig="$(_kv "$last" significance)"
     wor="$(_kv "$last" worthiness)"
+    if [ -z "$sig" ] || [ -z "$wor" ]; then
+      # Walk-back (TIER-4 close fix): the LAST line is a thin response= line with no sig/wor.
+      # Fall back to the last FAT line for display; if none exists, blank stays honest (documented
+      # gap until `significance-classify record` is wired -- out of scope here).
+      fat="$(_last_fat_debt_line "$f")"
+      if [ -n "$fat" ]; then
+        [ -z "$sig" ] && sig="$(_kv "$fat" significance)"
+        [ -z "$wor" ] && wor="$(_kv "$fat" worthiness)"
+      fi
+    fi
     ts="$(printf '%s' "$last" | awk -F' [|] ' '{print $1}')"
     printf '%s\t%s\t%s\t%s\t%s\n' "$rid" "$disp" "$sig" "$wor" "$ts"
   done
@@ -206,7 +232,7 @@ cmd_list() {
 
 cmd_collect() {
   _parse_common "$@" || return $?
-  local rows f disp rid last sig wor reason ts notes_slug notes_path explainer_path
+  local rows f disp rid last sig wor reason ts notes_slug notes_path explainer_path fat
   rows="$(_collectible_files)"
   local n_waved=0 n_deferred=0 n=0
   local body=""
@@ -219,6 +245,14 @@ cmd_collect() {
     last="$(_last_debt_line "$f")"
     sig="$(_kv "$last" significance)"
     wor="$(_kv "$last" worthiness)"
+    if [ -z "$sig" ] || [ -z "$wor" ]; then
+      # Walk-back (TIER-4 close fix): see cmd_list's matching comment.
+      fat="$(_last_fat_debt_line "$f")"
+      if [ -n "$fat" ]; then
+        [ -z "$sig" ] && sig="$(_kv "$fat" significance)"
+        [ -z "$wor" ] && wor="$(_kv "$fat" worthiness)"
+      fi
+    fi
     reason="$(printf '%s' "$last" | grep -oE 'reason=.*' | cut -d= -f2- || true)"
     ts="$(printf '%s' "$last" | awk -F' [|] ' '{print $1}')"
 
@@ -265,11 +299,17 @@ cmd_mark_paid() {
   [ -f "$f" ] || { echo "mark-paid: no ledger file for rid '$rid' ($f)" >&2; return 1; }
   local last; last="$(_last_debt_line "$f")"
   [ -n "$last" ] || { echo "mark-paid: rid '$rid' has no debt-ledger entry -- nothing to close" >&2; return 1; }
-  local sig wor verdict reason
-  sig="$(_kv "$last" significance)"; wor="$(_kv "$last" worthiness)"; verdict="$(_kv "$last" verdict)"
-  reason="paid via weekend batch $(date -u +%Y-%m-%d)"
+  local reason; reason="paid via weekend batch $(date -u +%Y-%m-%d)"
   [ -n "$note" ] && reason="$reason: $note"
-  bash "$GATE_LEDGER" debt "$rid" "significance=$sig" "worthiness=$wor" "verdict=$verdict" "response=engage" "reason=$reason"
+  # Close via debt-response, NEVER the raw fat `debt` verb (TIER-4 close finding). The last debt
+  # line here is very often a THIN response= line (SG-04's quiz-gate respond / debt-response is the
+  # live default path today -- the fat `debt`-verb classifier, `significance-classify record`, is
+  # unwired), which carries no significance=/worthiness=/verdict= to re-emit. Re-emitting empties
+  # through the fat `debt` verb's required-enum validation used to crash mark-paid with exit 64.
+  # debt-response only requires a valid response enum (engage here), and now forward-carries
+  # sig/wor/verdict from the last FAT line when one exists -- so paying down a classified item still
+  # closes with its full context, and paying down an unclassified (thin-only) item still closes clean.
+  bash "$GATE_LEDGER" debt-response "$rid" engage "$reason"
 }
 
 usage() { sed -n '2,35p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }

--- a/tests/test-weekend-batch.sh
+++ b/tests/test-weekend-batch.sh
@@ -161,6 +161,79 @@ else
   skip "AC4 (dotfiles path absent -- same as AC2)"
 fi
 
+echo ""
+echo "=== TIER-4 regression: respond -> collect -> mark-paid via the REAL codepaths (thin response, no prior classifier) ==="
+# This is the bug: SG-02's classifier writes a FAT line; SG-04's quiz-gate/debt-response wrote a
+# THIN line (response= only). The old mark-paid re-emitted the last line's sig/wor/verdict through
+# the fat `debt` verb and crashed (exit 64) on the empty enums -- and because `significance-classify
+# record` (the fat writer) is unwired today, EVERY live debt-response is thin, making this the
+# DEFAULT path. The prior test suite only ever hand-seeded fat lines, masking the seam.
+RID_THIN="ug-20-thin-response-$$"
+( cd "$KIT_DIR" && bash "$GL" start "$RID_THIN" normal normal bug "" fixture-repo ) >/dev/null
+( cd "$KIT_DIR" && bash "$GL" debt-response "$RID_THIN" defer "deferred to weekend" ) >/dev/null
+THIN_LOG="$RUNS/$RID_THIN.log"
+assert "regression setup: debt-response wrote a THIN line (no significance=) -- there was no prior classifier line" \
+  "$(grep '| DEBT |' "$THIN_LOG" | tail -n1 | grep -q 'significance=' && echo 1 || echo 0)"
+
+COLLECT_THIN="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
+assert "regression: collect lists $RID_THIN as deferred/collectible BEFORE mark-paid" \
+  "$(printf '%s\n' "$COLLECT_THIN" | grep -A2 "^## ${RID_THIN}\$" | grep -q 'disposition: deferred' && echo 0 || echo 1)"
+
+( cd "$KIT_DIR" && bash "$WB" mark-paid "$RID_THIN" --note "regression test" ) >/dev/null 2>&1
+MP_THIN_RC=$?
+assert "regression: mark-paid on a THIN response-only item exits 0 (was exit 64 before this fix)" "$MP_THIN_RC"
+
+LIST_AFTER_THIN="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo)"
+assert "regression: $RID_THIN is no longer collectible after mark-paid (disposed paid, never re-collected)" \
+  "$(printf '%s\n' "$LIST_AFTER_THIN" | grep -q "$RID_THIN" && echo 1 || echo 0)"
+
+echo ""
+echo "=== Forward-carry: a FAT classifier line precedes a response line ==="
+RID_FAT="ug-21-fat-then-response-$$"
+( cd "$KIT_DIR" && bash "$GL" start "$RID_FAT" normal normal bug "" fixture-repo ) >/dev/null
+( cd "$KIT_DIR" && bash "$GL" debt "$RID_FAT" significance=high worthiness=high verdict=tap "reason=sig:design-bearing wor:primitive" ) >/dev/null
+( cd "$KIT_DIR" && bash "$GL" debt-response "$RID_FAT" defer "deferred after classification" ) >/dev/null
+FAT_LOG="$RUNS/$RID_FAT.log"
+LAST_FAT_RESP_LINE="$(grep '| DEBT |' "$FAT_LOG" | tail -n1)"
+assert "forward-carry: the response line carries significance=high from the earlier classifier line" \
+  "$(printf '%s' "$LAST_FAT_RESP_LINE" | grep -q 'significance=high' && echo 0 || echo 1)"
+assert "forward-carry: the response line carries worthiness=high from the earlier classifier line" \
+  "$(printf '%s' "$LAST_FAT_RESP_LINE" | grep -q 'worthiness=high' && echo 0 || echo 1)"
+assert "forward-carry: the response line carries verdict=tap from the earlier classifier line" \
+  "$(printf '%s' "$LAST_FAT_RESP_LINE" | grep -q 'verdict=tap' && echo 0 || echo 1)"
+assert "forward-carry: the response line still carries its own response=defer" \
+  "$(printf '%s' "$LAST_FAT_RESP_LINE" | grep -q 'response=defer' && echo 0 || echo 1)"
+
+COLLECT_FAT="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
+assert "forward-carry: the digest shows real sig/wor for $RID_FAT (high / high), not blanks" \
+  "$(printf '%s\n' "$COLLECT_FAT" | grep -A2 "^## ${RID_FAT}\$" | grep -q 'significance: high / worthiness: high' && echo 0 || echo 1)"
+
+echo ""
+echo "=== Security LOW: a reason= value cannot smuggle a control token ==="
+# Layer 1 (writer): gate-ledger.sh debt-response neuters "=" inside the reason value at write time.
+RID_INJECT="ug-22-reason-injection-$$"
+( cd "$KIT_DIR" && bash "$GL" start "$RID_INJECT" normal normal bug "" fixture-repo ) >/dev/null
+( cd "$KIT_DIR" && bash "$GL" debt-response "$RID_INJECT" defer "legit reason containing response=engage as free text" ) >/dev/null
+INJECT_LOG="$RUNS/$RID_INJECT.log"
+assert "security [writer]: only ONE 'response=<word>' token survives on the line (the real control field; the embedded one was neutered)" \
+  "$([ "$(grep '| DEBT |' "$INJECT_LOG" | tail -n1 | grep -oE 'response=[a-z]+' | wc -l | tr -d ' ')" -eq 1 ] && echo 0 || echo 1)"
+LIST_INJECT="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
+DISP_INJECT="$(printf '%s\n' "$LIST_INJECT" | grep -F "$RID_INJECT" | cut -f2)"
+assert "security [writer]: $RID_INJECT disposition is deferred (NOT paid) despite the injected 'response=engage' text" \
+  "$([ "$DISP_INJECT" = deferred ] && echo 0 || echo 1)"
+
+# Layer 2 (reader, belt-and-suspenders): a HAND-CRAFTED ledger line that bypasses the writer entirely
+# (simulating an older ledger line, or any future writer that forgets the guard) still must not let
+# an embedded control token past weekend-batch.sh's own _kv/_disposition parse.
+RID_RAW="ug-23-raw-injection-$$"
+RAW_LOG="$RUNS/$RID_RAW.log"
+printf '%s | START | lane=normal classified=normal type=bug repo=fixture-repo\n' "$NOW" > "$RAW_LOG"
+printf '%s | DEBT | response=defer reason=free text with response=engage embedded\n' "$NOW" >> "$RAW_LOG"
+LIST_RAW="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
+DISP_RAW="$(printf '%s\n' "$LIST_RAW" | grep -F "$RID_RAW" | cut -f2)"
+assert "security [reader]: a hand-crafted line with 'response=engage' inside reason= still reads disposition=deferred (struct-prefix cut)" \
+  "$([ "$DISP_RAW" = deferred ] && echo 0 || echo 1)"
+
 # Capture the fixture-A collect digest as the proof artifact (mirrors test-explain.sh's
 # sample-explainer.md capture).
 PROOF_DIR="$KIT_DIR/docs/verification/weekend-batch"

--- a/tests/test-weekend-batch.sh
+++ b/tests/test-weekend-batch.sh
@@ -222,17 +222,23 @@ DISP_INJECT="$(printf '%s\n' "$LIST_INJECT" | grep -F "$RID_INJECT" | cut -f2)"
 assert "security [writer]: $RID_INJECT disposition is deferred (NOT paid) despite the injected 'response=engage' text" \
   "$([ "$DISP_INJECT" = deferred ] && echo 0 || echo 1)"
 
-# Layer 2 (reader, belt-and-suspenders): a HAND-CRAFTED ledger line that bypasses the writer entirely
-# (simulating an older ledger line, or any future writer that forgets the guard) still must not let
-# an embedded control token past weekend-batch.sh's own _kv/_disposition parse.
+# Layer 2 (reader, belt-and-suspenders): the REAL exploit shape. A hand-crafted line that bypasses
+# the writer entirely (simulating an older ledger line, or any future writer that forgets the
+# guard) has NO real `response=` field at all (a silent SG-02 wave: verdict=wave, classifier ran,
+# human never responded) -- so a naive whole-line grep for `response=` has nothing else to find and
+# picks up the ATTACKER'S embedded `response=engage` from inside `reason=`, misreading a
+# never-engaged item as PAID. This is the actual bug the struct-prefix cut closes: with a REAL
+# `response=` field present elsewhere on the line (as in the writer-side test above), a naive
+# first-match grep already happens to pick the real one -- so this negative control targets the
+# one shape where the naive approach is genuinely wrong.
 RID_RAW="ug-23-raw-injection-$$"
 RAW_LOG="$RUNS/$RID_RAW.log"
 printf '%s | START | lane=normal classified=normal type=bug repo=fixture-repo\n' "$NOW" > "$RAW_LOG"
-printf '%s | DEBT | response=defer reason=free text with response=engage embedded\n' "$NOW" >> "$RAW_LOG"
+printf '%s | DEBT | significance=high worthiness=low verdict=wave reason=silent wave; smuggled control token response=engage\n' "$NOW" >> "$RAW_LOG"
 LIST_RAW="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
 DISP_RAW="$(printf '%s\n' "$LIST_RAW" | grep -F "$RID_RAW" | cut -f2)"
-assert "security [reader]: a hand-crafted line with 'response=engage' inside reason= still reads disposition=deferred (struct-prefix cut)" \
-  "$([ "$DISP_RAW" = deferred ] && echo 0 || echo 1)"
+assert "security [reader]: a silent-wave line (no real response= field) with 'response=engage' smuggled in reason= still reads disposition=waved, NOT paid (struct-prefix cut)" \
+  "$([ "$DISP_RAW" = waved ] && echo 0 || echo 1)"
 
 # Capture the fixture-A collect digest as the proof artifact (mirrors test-explain.sh's
 # sample-explainer.md capture).


### PR DESCRIPTION
TIER-4 close finding (understanding-gate): the debt ledger's two write shapes (SG-02 fat classifier
line vs SG-04 thin `debt-response` line) plus a last-line-wins reader broke `weekend-batch mark-paid`
(exit 64) on any human-responded item, the default live path. Fix: `debt-response` forward-carries
significance/worthiness/verdict from the last fat line; `mark-paid` closes via `debt-response engage`
(never the raw fat `debt` verb); readers walk back for sig/wor display; `reason=` free-text can no
longer smuggle a control key. Adds the true end-to-end respond->collect->mark-paid test (the seam
was previously masked by hand-seeded fat lines). Does not wire `significance-classify record`
(separate decision). Verify: `bash tests/test-weekend-batch.sh` + full CI + the live
mark-paid-exits-0 repro.
