### PR TITLE
feat(spec-next): atomic wavefront SPEC-number reservation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Run spec-index tests
         run: bash tests/test-spec-index.sh
 
+      - name: Run spec-reservation race tests (SPEC-128)
+        run: bash tests/test-spec-reserve.sh
+
       - name: Run role-classify tests (SPEC-089)
         run: bash tests/test-role-classify.sh
 

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -68,7 +68,10 @@ Create `docs/specs/` directory if it doesn't exist. Generate these files:
 **`docs/specs/SPEC-NNN-<slug>.md`** (main spec). Pick NNN with
 `bash lib/spec-next.sh next`, never by eyeballing the specs dir: it also scans branch
 names and recent commit subjects, the two surfaces where a number ages invisibly inside
-an unmerged PR (two collisions in one week before this guard, SPEC-064 / ID-052):
+an unmerged PR (two collisions in one week before this guard, SPEC-064 / ID-052). If a
+wavefront dispatch already RESERVED a number for you (a `RESERVED SPEC NUMBER` block in
+your prompt, SPEC-128), use THAT number instead of re-deriving one: it was claimed
+atomically at dispatch so no sibling wave worker can take it.
 
 ```markdown
 # Spec: [feature name]

--- a/docs/implementation-notes/SPEC-128-spec-reservation-race.md
+++ b/docs/implementation-notes/SPEC-128-spec-reservation-race.md
@@ -1,0 +1,27 @@
+# Implementation notes , SPEC-128 spec-reservation-race
+
+Delta from the spec. Reference SPEC-128 + the kit-run-integrity ROADMAP; do not restate them.
+
+## 2026-07-04 mkdir-mutex instead of flock
+
+**Context:** ROADMAP open-fork 1 + the sub-goal contract both say the reservation is claimed
+"under `flock`".
+**Decision:** use a POSIX `mkdir`-based mutex, not `flock`.
+**Why:** `flock(1)` is absent on stock macOS (verified: not on PATH) and `lib/orchestrate.sh`
+is explicitly bash-3.2 / no-flock by contract (its own comment at the wavefront primitive).
+The binding property is "two concurrent claims serialize , a file + a lock, no daemon".
+`mkdir` is atomic on POSIX (exactly one racer creates the dir), so a lock DIR delivers the
+same mutual exclusion and is strictly more portable.
+**Alternatives:** `flock` (rejected: not portable to the target host); `set -o noclobber` +
+`>` (works but the mkdir form is the idiomatic shell mutex and carries an obvious stale-lock
+reclaim path).
+**Impact:** none to the contract's property; the spec's Design (b) documents the protocol.
+
+## 2026-07-04 repo-scoped reservations
+
+**Decision:** each reservation line carries `repo=<basename>` and the scan filters to the
+current repo.
+**Why:** `spec-next.sh` scans `$ROOT/docs/specs` (repo-local). A single global reservations
+file shared across repos would make repo B skip numbers repo A reserved. Scoping keeps the
+one-file-under-log-dir shape the contract asked for while staying correct across repos.
+**Impact:** `_reservations()` greps `repo=$REPO`.

--- a/docs/implementation-notes/SPEC-128-spec-reservation-race.md
+++ b/docs/implementation-notes/SPEC-128-spec-reservation-race.md
@@ -25,3 +25,32 @@ current repo.
 file shared across repos would make repo B skip numbers repo A reserved. Scoping keeps the
 one-file-under-log-dir shape the contract asked for while staying correct across repos.
 **Impact:** `_reservations()` greps `repo=$REPO`.
+
+## 2026-07-04 concurrency-review fixes (fresh-context reviewer, 6/10 -> addressed)
+
+A dispatched concurrency reviewer found two MAJOR holes the happy-path tests missed
+(they simulate a DEAD holder, never a live-but-slow/signalled one). Fixed all four
+actionable findings:
+
+- **MAJOR #1 , stale-reclaim could drop a LIVE holder's lock.** The mkdir-mutex had no
+  ownership token, so a TTL-stale reclaim (reachable via clock skew / suspend-resume across
+  the TTL window mid-critical-section) could hand a live holder's lock to another process,
+  and both could append the same number. Fix: stamp a per-acquire owner token
+  (`pid.nonce.epoch`) into `$RES_LOCK/owner`; `reserve` RE-VALIDATES ownership after the scan
+  and before the append (discards + retries, up to 5x, if it lost the lock); `_reserve_unlock`
+  only removes a lock it still owns.
+- **MAJOR #2 , `trap ... INT TERM` without `exit` resumed the critical section unprotected.**
+  Bash runs a trapped-signal handler then RESUMES; the old single `trap ... EXIT INT TERM`
+  released the lock but let `reserve` finish appending with the mutex already gone. Fix: split
+  traps , `EXIT` cleans up; `INT`/`TERM` clean up AND `exit 130/143` so the process actually
+  stops.
+- **MEDIUM #3 , expired-prune was repo-scoped, so the machine-global ledger grew unbounded**
+  across repos. Fix: EXPIRED lines are pruned for EVERY repo on any `reserve` (expiry is pure
+  timestamp math); only the REALIZED check stays repo-scoped.
+- **LOW #4 , unanchored `repo=$REPO` substring** matched `foo-bar` for repo `foo`. Fix:
+  anchored end-of-line match (`repo=` is always the trailing field).
+- **LOW #5 , `check()` TAKEN message changed even on an empty ledger** (AC4 says byte-identical).
+  Fix: the reservation clause is appended only when `_reservations` is non-empty.
+
+Regression tests added: T11 (cross-repo expired prune + foreign-live preserved), T12 (anchored
+repo match), T13 (empty-ledger message byte-identical). Suite now 28/28.

--- a/docs/implementation-notes/SPEC-128-spec-reservation-race.md
+++ b/docs/implementation-notes/SPEC-128-spec-reservation-race.md
@@ -54,3 +54,27 @@ actionable findings:
 
 Regression tests added: T11 (cross-repo expired prune + foreign-live preserved), T12 (anchored
 repo match), T13 (empty-ledger message byte-identical). Suite now 28/28.
+
+## 2026-07-04 Linux-only mutex fail-open (CI on ubuntu caught what macOS masked)
+
+**Context:** PR CI went RED on `test (ubuntu-latest)` while `macos-latest` passed. T2 (the CORE
+20-way concurrency test) got 1 distinct instead of 20, and T9 (stale reclaim) failed with the
+lock left held.
+**Root cause:** `_lock_mtime_epoch` tried `stat -f %m` FIRST. On macOS that is the file mtime.
+On **Linux** `stat -f` is `--file-system` format and `%m` is not a valid FS directive, so GNU
+stat prints a NON-numeric token and EXITS 0 , the `|| stat -c %Y` fallback never fired. That
+garbage fed the `lockage = now - mtime` age check, so every FRESH lock looked older-than-TTL and
+every contender RECLAIMED a live sibling's lock , the mutex failed OPEN (all 20 read the same
+max) and left the lock in an inconsistent held state. Pure `mkdir`/`cat`/`rmdir` are portable;
+`stat` was the only platform-divergent call, which is why ONLY T2/T9 broke.
+**Fix:** try GNU `stat -c %Y` FIRST, then BSD `stat -f %m`, and VALIDATE the result is a pure
+integer (`case $v in *[!0-9]*) v="";; esac`). A non-numeric result becomes empty, and the caller
+treats an unreadable mtime as not-yet-stale (waits rather than steals , safe by construction).
+**Why macOS masked it:** on macOS `stat -c %Y` errors to stderr with empty stdout, so the code
+always reached the correct `stat -f %m` , the bug was invisible without a Linux run.
+**Regression tests:** T14 (a normal reserve FREES the lock, no held/owner leak) + T15 (a FRESH
+non-stale foreign lock is RESPECTED, not stolen , the direct fail-open guard, `SPEC_RESERVE_MAX_TRIES`
+env seam added to bound the spin for the test). Suite now 35/35 on macOS; CI confirms on Linux.
+**Lesson:** `stat -f` vs `stat -c` is a classic BSD/GNU trap , `stat -f %m` is not portable and
+silently returns garbage-with-exit-0 on Linux; always GNU-first + validate, or a `|| fallback`
+that keys on exit code is defeated.

--- a/docs/specs/SPEC-128-spec-reservation-race.md
+++ b/docs/specs/SPEC-128-spec-reservation-race.md
@@ -1,0 +1,201 @@
+# Spec: Close the wavefront SPEC-number reservation race
+
+Generated: 2026-07-04
+Status: VALIDATED
+Lane: full (touches `lib/spec-next.sh` , the number source , plus `lib/orchestrate.sh`'s
+wavefront dispatch path and a new concurrency test; the atomic-claim property is
+correctness-critical, so it earns the deep lane even though the diff is small).
+
+## Problem
+
+`lib/spec-next.sh` (SPEC-064 / ID-052) already scans every VISIBLE surface for used SPEC
+numbers , `docs/specs/` filenames, local + remote branch names, and `SPEC-NNN` mentions in
+the last 200 commit subjects , and prints `max + 1`. That scan is correct: SPEC-064 closed
+the STALE-branch case (SPEC-047 / SPEC-041 collided because a number aged inside an unmerged
+branch that a naive `ls docs/specs | max` missed).
+
+The remaining hole is CONCURRENCY, not staleness. A parallel wave (orchestrate.sh's
+`_wave_run`, WAVE_CAP>1, or a hand-dispatched Agent-tool fan-out) spawns N worker sessions
+at once. Each worker, at spec-time, calls `spec-next.sh next` BEFORE any of them has created
+its branch or written its spec file. So all N scan the SAME surfaces, see the SAME max, and
+get the SAME number. The scan is a source of truth for "already realized"; it has no notion
+of "handed out but not yet realized". The reservation happens too LATE , at branch/spec
+creation , when it needs to happen at hand-out.
+
+This is the general orchestrate.sh path. (For a specific Agent-tool run the conductor can
+pre-assign a contiguous block by hand , the belt , but that does not fix the general
+wavefront path , the suspenders , which is this spec.)
+
+## Solution
+
+### Approaches considered
+
+1. **An atomic reservation ledger consulted by `spec-next.sh`, claimed at wavefront
+   dispatch.** Add a `spec-next.sh reserve` subcommand that, under a process-wide lock,
+   computes the next free number (now folding a reservations file into the same scan) AND
+   appends the reserved number to that file , one indivisible critical section, so two
+   concurrent `reserve` calls serialize and get DISTINCT numbers. `_numbers()` folds the
+   live reservations into its union, so a reserved number reads as TAKEN by the very next
+   `next` / `check` / `reserve`. orchestrate.sh's `_wave_run` claims one number per admitted
+   sub-goal at spawn time (before the branch exists) and injects it into the worker prompt.
+   REUSE: the scan is untouched; the reservation is an ADDITIONAL surface it consults.
+   CHOSEN.
+
+2. **Conductor pre-assigns a contiguous number block, no code change.** Rejected as the
+   general fix: it only works for a run the conductor drives by hand (the Agent-tool
+   fan-out). orchestrate.sh's own `_wave_run` path has no conductor in the loop , it spawns
+   workers itself , so the race survives. Pre-assign is the per-run BELT; this spec is the
+   general SUSPENDERS. (Both are kept; they are different surfaces.)
+
+3. **Rewrite the scanner to lock docs/specs and reserve by touching a spec file.** Rejected:
+   creating a placeholder spec file per worker at hand-out pollutes `docs/specs/`, races on
+   the filesystem the same way, and violates the "REUSE the scan, do not rewrite" bar.
+
+### Chosen shape
+
+`spec-next.sh` gains one subcommand (`reserve`) and folds a reservations surface into its
+existing `_numbers()` union. Nothing about `next` / `check`'s output contract changes; with
+an empty reservations file the behavior is byte-identical to today (this is what keeps the
+SPEC-064 tests green). orchestrate.sh's wavefront spawn loop calls `reserve` once per
+admitted sub-goal and hands the number to the worker.
+
+## Design
+
+### (a) The reservation surface + its path
+
+A single append-only reservations ledger under the kit's durable log dir (the same root
+`gate-ledger.sh` writes to, resolved via `lib/kit-log-dir.sh`):
+
+```
+$(kit_resolve_log_dir)/spec-reservations.log
+```
+
+Each line is the kit's canonical additive-marker shape (mirrors gate-ledger's
+`ISO8601 | MARKER | k=v`):
+
+```
+2026-07-04T09:15:03Z | RESERVE | num=128 repo=dwarves-kit
+```
+
+Repo-scoped (`repo=<basename of git toplevel>`) so a reservation in one repo never inflates
+another repo's numbering , `spec-next.sh` scans `$ROOT/docs/specs`, which is already
+repo-local, so the reservation surface must match that scope. The lock is a sibling
+directory `spec-reservations.log.lock/` (see (b)).
+
+### (b) The atomic-claim protocol (portable mutex, NOT flock)
+
+**Deviation from the roadmap's literal "flock":** macOS ships no `flock(1)` (verified: absent
+on PATH) and `lib/orchestrate.sh` is explicitly bash-3.2 / no-flock by contract. The BINDING
+property the roadmap names is "two concurrent claims serialize" via "a file + a lock, no
+daemon". A `mkdir`-based mutex delivers exactly that and is strictly MORE portable than flock
+(POSIX `mkdir` is atomic , exactly one of N racers creates the dir; the rest get EEXIST).
+
+`reserve` critical section:
+
+```
+acquire:  until `mkdir "$LOCK"` succeeds, sleep a short randomized backoff (bounded retries,
+          then fail loud); on acquire, `trap 'rmdir "$LOCK"' EXIT INT TERM` so a crash frees it.
+          A lock older than a bounded TTL is treated as stale and reclaimed (a dead holder
+          must not wedge the wave forever).
+critical: n = next free number (via _numbers, which now includes live reservations)
+          append "ISO | RESERVE | num=$n repo=$REPO" to the ledger
+          prune dead reservation lines (realized OR expired) while holding the lock
+release:  rmdir "$LOCK"  (also via the EXIT trap)
+print:    $n
+```
+
+Because acquire -> compute -> append -> release is indivisible, two concurrent `reserve`
+calls cannot both read the same max: the second blocks on the lock until the first has
+appended, then sees the first's number as taken. This is the load-bearing property the
+concurrency test proves.
+
+### (c) Where the claim moves to in orchestrate.sh
+
+In `_wave_run`'s spawn loop (the `while ... done < <(_wave_gate ...)` block), for each
+admitted sub-goal, AFTER the worktree is stood up and BEFORE `_run_one_session` /
+`_pane_spawn` is called (i.e. before the worker session can run `/kit:spec` ->
+`spec-next next`), call `spec-next.sh reserve` and inject the reserved `SPEC-NNN` into the
+worker prompt (a `RESERVED SPEC NUMBER` block, same injection site as the flip-contract
+block already appended to `$pfile`). The worker is TOLD its number, so it does not race
+`next` at all; even if it did, the reservation is already folded into the scan, so it would
+skip the sibling numbers. The claim is best-effort: a `reserve` failure logs and falls back
+to the worker computing its own number (degrade, never block the wave) , the reservation is
+an optimization on top of a correct scan, not a new hard dependency.
+
+### (d) Reconciliation once the branch/spec exists
+
+A reservation is a bridge between "number handed out" and "number realized in a scannable
+surface" (branch name / spec file / commit subject). Two prune rules, both applied inside the
+`reserve` critical section (so pruning is itself serialized):
+
+- **Realized:** a reservation whose `num` now appears in the real scan surfaces
+  (`_scan_numbers`, the pre-reservation union) is redundant , the branch/spec now covers it ,
+  and is dropped.
+- **Expired:** a reservation older than `SPEC_RESERVE_TTL` (default 24h, env-overridable) is
+  assumed abandoned (worker died before creating its branch) and is dropped, so a crashed
+  worker cannot permanently inflate the max.
+
+`_numbers()` folds in only LIVE reservations (repo-match AND within TTL), so an expired line
+stops counting even before the next `reserve` physically prunes it. This keeps the ledger
+bounded and self-healing without a daemon or a separate GC.
+
+## Acceptance criteria
+
+1. **Atomic distinctness:** N concurrent `spec-next.sh reserve` calls (background subshells)
+   return N DISTINCT numbers, zero collisions.
+2. **Reserved reads as taken:** after `reserve` returns NNN (before any branch/spec exists),
+   `spec-next.sh check NNN` reports TAKEN and `spec-next.sh next` returns > NNN.
+3. **Negative control:** N concurrent `spec-next.sh next` (the OLD, un-reserved path) DO
+   collide (>=2 identical numbers) , proving the test harness can observe a collision.
+4. **SPEC-064 contract intact:** with an EMPTY reservations ledger, `spec-next.sh next` and
+   `spec-next.sh check <NNN>` behave byte-identically to before (existing surfaces still
+   scanned; output + exit codes unchanged).
+5. **Reconciliation:** a realized reservation (its number now in a branch/spec/commit) and an
+   expired reservation (older than TTL) both stop counting toward the max.
+6. **orchestrate wiring:** `_wave_run` calls `reserve` per admitted sub-goal before spawning
+   it and injects the number into the worker prompt; a `reserve` failure degrades (logs,
+   worker self-computes) rather than failing the wave.
+
+## Verification
+
+```
+# Acceptance 1-5 (the spec-next mechanism):
+bash tests/test-spec-reserve.sh
+
+# Acceptance 4 (SPEC-064 contract regression) also covered by the existing suite:
+bash tests/test-meta.sh 2>&1 | tail -5   # (spec-next is exercised there if pinned)
+
+# Acceptance 6 (orchestrate wiring): a unit test in test-spec-reserve.sh drives the
+# reserve-injection helper with a MOCK spec-next and asserts the prompt carries the number.
+```
+
+## Test plan
+
+Coverage matrix (categories x cases), derived from the acceptance criteria:
+
+| # | Category | Case | Asserts |
+|---|---|---|---|
+| T1 | Happy path | single `reserve` on empty ledger | returns 128 (max+1), appends one RESERVE line |
+| T2 | Concurrency (core) | 20 parallel `reserve` | 20 distinct numbers, 0 dup (atomic claim) |
+| T3 | Fold-in | `reserve` NNN then `check` NNN / `next` | NNN reads TAKEN; next > NNN (before branch) |
+| T4 | Negative control | 20 parallel `next` (no reserve) | >=2 identical (harness CAN see a collision) |
+| T5 | Contract regression | empty ledger `next` / `check` | byte-identical to pre-change output + exit |
+| T6 | Reconcile / realized | reservation whose num is now a branch | dropped; does not double-count |
+| T7 | Reconcile / expired | reservation older than TTL | not counted; pruned |
+| T8 | Repo scope | reservation for repo A | does not inflate repo B's next |
+| T9 | Lock crash-safety | holder dies leaving stale lock dir | next `reserve` reclaims after TTL |
+| T10 | orchestrate wiring | reserve-inject helper w/ mock spec-next | prompt carries `SPEC-NNN`; failure degrades |
+
+COVERAGE-DELTA (to be recorded post-build): covered = T1-T10 above; uncovered = a genuine
+kernel-level simultaneity race (the test uses OS process scheduling + a shared barrier, which
+is the strongest portable approximation, not a hardware-simultaneous claim); and the full
+end-to-end `_wave_run` spawn under a real multi-pane tmux wave (covered structurally by the
+mock-injection unit + the existing test-orchestrate-wavefront.sh, not re-run live here).
+
+## Out of scope
+
+- The conductor's manual pre-assign for a specific Agent-tool run (the belt; done outside the
+  kit).
+- Changing the SPEC-064 `next` / `check` output contract (reuse it).
+- A daemon or a lock service (a file + a mutex dir only).
+- A new numbering scheme.

--- a/docs/verification/kri-02-spec-race.md
+++ b/docs/verification/kri-02-spec-race.md
@@ -13,15 +13,20 @@ Spec: `docs/specs/SPEC-128-spec-reservation-race.md`. Branch: `feat/kri-02-spec-
 | 4 | SPEC-064 `next`/`check` contract byte-identical on empty ledger | test T5 + test-hooks 452/452 | PASS |
 | 5 | reconcile: realized + TTL-expired reservations stop counting + pruned | tests T6, T7 | PASS |
 | 6 | orchestrate `_wave_run` reserves + injects; degrades on failure | test T10 | PASS |
+| 7 | (review) expired-prune is cross-repo; foreign live line preserved | test T11 | PASS |
+| 8 | (review) repo match anchored (`foo` != `foo-bar`) | test T12 | PASS |
+| 9 | (review) check message byte-identical to SPEC-064 on empty ledger | test T13 | PASS |
 
 ## Confirmation run-table
 
 Command: bash tests/test-spec-reserve.sh
 Exit: 0
 Verdict: PASS
-Detail: 23/23 assertions green. T2 (core concurrency) = 20 parallel `reserve` -> 20 distinct
+Detail: 28/28 assertions green. T2 (core concurrency) = 20 parallel `reserve` -> 20 distinct
 numbers, zero collisions. T3 fold-in, T5 SPEC-064 contract, T6/T7 reconciliation, T8 repo
-scope, T9 stale-lock reclaim, T10 orchestrate wiring + degrade path all green.
+scope, T9 stale-lock reclaim, T10 orchestrate wiring + degrade path, plus the concurrency-review
+regression tests T11 (cross-repo expired prune), T12 (anchored repo match), T13 (empty-ledger
+message byte-identical) all green.
 
 Command: bash tests/test-hooks.sh
 Exit: 0

--- a/docs/verification/kri-02-spec-race.md
+++ b/docs/verification/kri-02-spec-race.md
@@ -22,11 +22,11 @@ Spec: `docs/specs/SPEC-128-spec-reservation-race.md`. Branch: `feat/kri-02-spec-
 Command: bash tests/test-spec-reserve.sh
 Exit: 0
 Verdict: PASS
-Detail: 28/28 assertions green. T2 (core concurrency) = 20 parallel `reserve` -> 20 distinct
+Detail: 35/35 assertions green. T2 (core concurrency) = 20 parallel `reserve` -> 20 distinct
 numbers, zero collisions. T3 fold-in, T5 SPEC-064 contract, T6/T7 reconciliation, T8 repo
 scope, T9 stale-lock reclaim, T10 orchestrate wiring + degrade path, plus the concurrency-review
-regression tests T11 (cross-repo expired prune), T12 (anchored repo match), T13 (empty-ledger
-message byte-identical) all green.
+regression tests T11-T13 and the Linux-mutex-fix guards T14 (normal reserve frees the lock) +
+T15 (a fresh foreign lock is respected, not stolen) all green. CI green on BOTH ubuntu + macos.
 
 Command: bash tests/test-hooks.sh
 Exit: 0

--- a/docs/verification/kri-02-spec-race.md
+++ b/docs/verification/kri-02-spec-race.md
@@ -1,0 +1,76 @@
+# Proof of done , kri-02-spec-race (SPEC-128 wavefront spec-number reservation)
+
+Behavioral change: `spec-next.sh reserve` + orchestrate `_wave_run` dispatch reservation.
+Spec: `docs/specs/SPEC-128-spec-reservation-race.md`. Branch: `feat/kri-02-spec-race`.
+
+## Acceptance criteria -> confirmation
+
+| # | Acceptance criterion | Evidence | Verdict |
+|---|---|---|---|
+| 1 | N concurrent `reserve` -> N distinct numbers (atomic claim) | test T2: 20 emitted / 20 distinct | PASS |
+| 2 | a reserved number reads as TAKEN before its branch exists | test T3: check says TAKEN, next advances | PASS |
+| 3 | NEGATIVE CONTROL: old `next` path DOES collide | test T4: 20 emitted / 1 distinct | PASS |
+| 4 | SPEC-064 `next`/`check` contract byte-identical on empty ledger | test T5 + test-hooks 452/452 | PASS |
+| 5 | reconcile: realized + TTL-expired reservations stop counting + pruned | tests T6, T7 | PASS |
+| 6 | orchestrate `_wave_run` reserves + injects; degrades on failure | test T10 | PASS |
+
+## Confirmation run-table
+
+Command: bash tests/test-spec-reserve.sh
+Exit: 0
+Verdict: PASS
+Detail: 23/23 assertions green. T2 (core concurrency) = 20 parallel `reserve` -> 20 distinct
+numbers, zero collisions. T3 fold-in, T5 SPEC-064 contract, T6/T7 reconciliation, T8 repo
+scope, T9 stale-lock reclaim, T10 orchestrate wiring + degrade path all green.
+
+Command: bash tests/test-hooks.sh
+Exit: 0
+Verdict: PASS
+Detail: 452/452. The SPEC-064 spec-next contract assertions (check flags a taken number ->
+TAKEN + exit 1; next is a 3-digit number) still pass , the reservation fold-in is additive
+and byte-identical on an empty ledger.
+
+Command: bash tests/test-meta.sh
+Exit: 0
+Verdict: PASS
+Detail: 667/667. No regression across the meta-integrity suite.
+
+Command: bash tests/test-orchestrate-wavefront.sh
+Exit: 0
+Verdict: PASS
+Detail: ALL PASS. The `_wave_run` reserve-injection change did not disturb the wavefront
+scheduling or the flip-contract prompt-injection tests.
+
+## NEGATIVE CONTROL
+
+The proof must be able to observe a FAILURE, or a green run proves nothing. Two independent
+negative controls:
+
+1. **In-test negative control (T4):** the SAME harness that shows `reserve` never collides
+   fires the OLD, un-reserved path , 20 parallel `spec-next.sh next` , and asserts it DOES
+   collide. Observed: 20 emitted, 1 distinct (all identical). This proves the concurrency
+   test can SEE a collision; the distinctness of `reserve` (T2) is therefore meaningful, not
+   vacuous.
+
+   Command: (T4, inside test-spec-reserve.sh) 20x parallel `spec-next.sh next`, no reserve
+   Exit: 0
+   Verdict: PASS (collision observed as designed: 1 distinct < 20)
+
+2. **Revert -> RED -> restore:** removing the `reserve` subcommand's atomic claim (making it
+   a bare `next` + append with no lock) makes T2 FAIL (concurrent claimers read the same max
+   before either appends). Re-applying the mkdir-mutex restores GREEN. Mechanism: the mutex
+   is the load-bearing property; without it the append-after-read is not indivisible.
+
+   Verdict: PASS (the test is sensitive to the fix; the fix is what makes it green)
+
+## Reproduce
+
+```
+cd ~/workspace/tieubao/dwarves-kit
+git switch feat/kri-02-spec-race
+bash tests/test-spec-reserve.sh        # 23/23, incl. T2 concurrency + T4 negative control
+bash tests/test-hooks.sh               # 452/452 (SPEC-064 contract intact)
+bash tests/test-orchestrate-wavefront.sh   # ALL PASS (wiring undisturbed)
+```
+
+Final Verdict: PASS

--- a/lib/orchestrate.sh
+++ b/lib/orchestrate.sh
@@ -734,6 +734,22 @@ _sg_branch() {  # goalfile id
   printf '%s\n' "$branch"
 }
 
+# Atomically reserve ONE SPEC number for a wave sub-goal at dispatch (SPEC-128), so a
+# concurrent wave cannot hand the same number to two workers. Delegates to `spec-next.sh
+# reserve` (mkdir-mutex + reservation ledger folded into the scan). Best-effort by contract:
+# on any failure it echoes nothing and returns nonzero, and the caller degrades to letting
+# the worker compute its own number , the reservation is an optimization over a correct scan,
+# never a new hard dependency that could wedge the wave. `$SPEC_NEXT_CMD` overrides the binary
+# for tests (a mock). Echoes the reserved SPEC number (e.g. 128); empty on failure.
+_wave_reserve_spec() {
+  local sn="${SPEC_NEXT_CMD:-$ORCH_DIR/spec-next.sh}" n
+  [ -x "$sn" ] || [ -r "$sn" ] || return 1
+  n="$(bash "$sn" reserve 2>/dev/null)" || return 1
+  n="$(printf '%s' "$n" | grep -oE '^[0-9]+$' | head -1)"
+  [ -n "$n" ] || return 1
+  printf '%s\n' "$n"
+}
+
 # Create OR reuse a per-sub-goal worktree at <repo>/.claude/worktrees/<id> on <branch> (the repo-wide
 # worktree location, per the global worktree rule). REUSE only on a clean crash-resume (edge 5): the
 # path is already a REGISTERED git worktree, its tree is clean, AND it is on <branch>. Otherwise
@@ -1076,6 +1092,25 @@ _wave_run() {  # megadir roadmap
       printf 'It flips your box in the SHARED ROADMAP under a lock. The orchestrator advances only\n'
       printf 'once your box is flipped there (grounded completion; no self-claim).\n'
     } >> "$pfile"
+
+    # Reserved SPEC number injection (SPEC-128). Claim a number atomically at DISPATCH , before
+    # this worker (and its siblings) can race `spec-next next` at spec-time , and tell the worker
+    # to use exactly it. Best-effort: a reserve failure leaves no block, and the worker falls back
+    # to computing its own number (the reservation ledger it would then scan already folds in any
+    # sibling claims, so even the fallback is collision-safe). Appended AFTER the flip-contract so
+    # the serial path's prompt stays byte-identical (this whole block is WAVE-only).
+    local reserved_spec
+    if reserved_spec="$(_wave_reserve_spec)"; then
+      {
+        printf '\n\n---\nRESERVED SPEC NUMBER (SPEC-128 wavefront reservation)\n'
+        printf 'This wave dispatch reserved SPEC-%s for your sub-goal. When you run /kit:spec (or\n' "$reserved_spec"
+        printf 'call lib/spec-next.sh), USE SPEC-%s , it is already claimed for you under a lock, so\n' "$reserved_spec"
+        printf 'no sibling wave worker can take it. Do NOT re-derive a different number.\n'
+      } >> "$pfile"
+      _say "[orchestrate] [wave] $id reserved SPEC-$reserved_spec"
+    else
+      _say "[orchestrate] [wave] $id: SPEC reservation unavailable; worker will self-compute (degraded, still scan-safe)."
+    fi
     _emit_event "$megadir" "$id" executing "wave (worktree $wt)"
 
     if [ "$MULTIPLEXER" = 1 ]; then

--- a/lib/spec-next.sh
+++ b/lib/spec-next.sh
@@ -151,9 +151,20 @@ _prune_reservations() {
   mv -f "$tmp" "$RES_FILE" 2>/dev/null || rm -f "$tmp"
 }
 
+# Lock-dir mtime as epoch seconds, portable + POISON-PROOF. GNU coreutils (`stat -c %Y`)
+# FIRST, then BSD/macOS (`stat -f %m`). Critical: on Linux `stat -f %m` is the
+# `--file-system` format and prints a NON-numeric token with EXIT 0 (not an error), so a
+# BSD-first `stat -f %m || stat -c %Y` never reaches the fallback and returns garbage. That
+# garbage poisons the `lockage` arithmetic in `_reserve_lock`, making every fresh lock look
+# older-than-TTL -> every contender spuriously RECLAIMS a live sibling's lock -> the mutex
+# fails OPEN (the Linux-only T2/T9 failure the macOS CI masked). Only a pure-integer result
+# is accepted; anything else -> empty -> the caller treats the lock as not-yet-stale (safe:
+# it waits rather than steals). GNU-first so Linux hits the numeric path directly.
 _lock_mtime_epoch() {
-  local d="$1"
-  stat -f %m "$d" 2>/dev/null || stat -c %Y "$d" 2>/dev/null || printf ''
+  local d="$1" v=""
+  v="$(stat -c %Y "$d" 2>/dev/null)"; case "$v" in ''|*[!0-9]*) v="";; esac
+  if [ -z "$v" ]; then v="$(stat -f %m "$d" 2>/dev/null)"; case "$v" in ''|*[!0-9]*) v="";; esac; fi
+  printf '%s' "$v"
 }
 
 # Release the lock ONLY if we still own it (review MAJOR #1). The owner token guards against
@@ -174,7 +185,8 @@ _reserve_lock() {
   mkdir -p "$RES_DIR" 2>/dev/null || true
   # Per-acquire unique token: pid + a random nonce + epoch defeats pid-reuse aliasing.
   _LOCK_TOKEN="$$.${RANDOM}.$(now_epoch)"
-  local tries=0 max=600   # ~ up to 30s; ample for a wave of a few workers
+  # Bounded spin so a live contender never wedges forever; env-overridable for tests.
+  local tries=0 max="${SPEC_RESERVE_MAX_TRIES:-600}"   # ~ up to 30s; ample for a wave of a few workers
   while ! mkdir "$RES_LOCK" 2>/dev/null; do
     # stale-lock reclaim: if the lock dir is older than TTL, a prior holder died with it held.
     if [ -d "$RES_LOCK" ]; then

--- a/lib/spec-next.sh
+++ b/lib/spec-next.sh
@@ -10,16 +10,83 @@
 # Usage:
 #   spec-next.sh next         -> the next free number (e.g. "064")
 #   spec-next.sh check <NNN>  -> exit 0 if free, exit 1 (+ where seen) if taken
+#   spec-next.sh reserve      -> atomically claim + print the next free number (SPEC-128)
+#
+# SPEC-128 closes the CONCURRENCY case SPEC-064 did not: a parallel wave that each calls
+# `next` BEFORE any branch/spec exists all scan the same surfaces and get the SAME number.
+# The scan is correct; the reservation happens too late. `reserve` claims a number under a
+# portable mkdir-mutex and records it in a reservations ledger that `_numbers()` folds in, so
+# a reserved number reads as TAKEN by the very next caller. `next`/`check` are unchanged in
+# contract: with an empty ledger they behave byte-identically to before.
 set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+REPO="$(basename "$ROOT")"
 
-_numbers() {
+# Durable reservations ledger under the kit log dir (same root gate-ledger.sh writes to).
+# Sourced best-effort: if kit-log-dir.sh is missing (e.g. spec-next copied standalone), fall
+# back to a temp-dir ledger so `next`/`check` still work; only `reserve` needs the durable path.
+_SPEC_NEXT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -r "$_SPEC_NEXT_DIR/kit-log-dir.sh" ]; then
+  # shellcheck source=lib/kit-log-dir.sh
+  source "$_SPEC_NEXT_DIR/kit-log-dir.sh" 2>/dev/null || true
+fi
+if command -v kit_resolve_log_dir >/dev/null 2>&1; then
+  RES_DIR="$(kit_resolve_log_dir)"
+else
+  RES_DIR="${TMPDIR:-/tmp}/dwarves-kit-spec-reserve"
+fi
+RES_FILE="${SPEC_RESERVE_FILE:-$RES_DIR/spec-reservations.log}"
+RES_LOCK="$RES_FILE.lock"
+# Abandoned-reservation TTL: a reservation older than this (worker died before creating its
+# branch) stops counting and gets pruned. A stale LOCK dir older than this is reclaimed.
+SPEC_RESERVE_TTL="${SPEC_RESERVE_TTL:-86400}"   # 24h in seconds
+
+now_epoch() { date -u +%s; }
+
+# ISO8601 -> epoch seconds, portable across BSD (macOS) and GNU date. Empty on parse failure.
+_iso_to_epoch() {
+  local iso="$1" e
+  e="$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null)" \
+    || e="$(date -u -d "$iso" +%s 2>/dev/null)" || e=""
+  printf '%s' "$e"
+}
+
+# The REAL scan surfaces (specs + branches + commits) , the SPEC-064 union, unchanged. Split
+# out so reconciliation can tell a REALIZED reservation (its number now here) from a live one.
+_scan_numbers() {
   {
     ls "$ROOT/docs/specs" 2>/dev/null | grep -oE 'SPEC-[0-9]+' || true
     git -C "$ROOT" branch -a --format='%(refname:short)' 2>/dev/null | grep -oE 'SPEC-[0-9]+' || true
     git -C "$ROOT" log --all --format='%s' -200 2>/dev/null | grep -oE 'SPEC-[0-9]+' || true
   } | grep -oE '[0-9]+' | sort -n | uniq
+}
+
+# LIVE reservation numbers for THIS repo: repo-scoped AND within TTL (an expired line stops
+# counting even before it is physically pruned). Empty when no ledger exists (the common case,
+# which keeps `next`/`check` byte-identical to SPEC-064).
+_reservations() {
+  [ -f "$RES_FILE" ] || return 0
+  local cutoff; cutoff=$(( $(now_epoch) - SPEC_RESERVE_TTL ))
+  while IFS= read -r line; do
+    case "$line" in *"| RESERVE |"*) ;; *) continue;; esac
+    case "$line" in *"repo=$REPO"*) ;; *) continue;; esac
+    local iso num e
+    iso="${line%% | *}"
+    num="$(printf '%s' "$line" | grep -oE 'num=[0-9]+' | head -1 | cut -d= -f2)"
+    [ -n "$num" ] || continue
+    e="$(_iso_to_epoch "$iso")"
+    # A line whose timestamp we cannot parse is kept (fail-safe: better to over-reserve than
+    # to hand out a number a live sibling may hold).
+    if [ -n "$e" ] && [ "$e" -lt "$cutoff" ]; then continue; fi
+    printf '%s\n' "$num"
+  done < "$RES_FILE"
+}
+
+# The full union readers see: the real scan PLUS live reservations. `_scan_numbers` is the
+# SPEC-064 body verbatim; folding reservations in is purely additive.
+_numbers() {
+  { _scan_numbers; _reservations; } | sort -n | uniq
 }
 
 next() {
@@ -33,18 +100,101 @@ check() {
   local n="${1:-}"; [ -n "$n" ] || { echo "usage: check <NNN>" >&2; return 64; }
   n="$(printf '%03d' "$((10#$n))")"
   if _numbers | grep -qx "$((10#$n))" || _numbers | grep -qx "$n"; then
-    echo "SPEC-$n is TAKEN (seen in specs/, a branch, or a recent commit subject)" >&2
+    echo "SPEC-$n is TAKEN (seen in specs/, a branch, a recent commit subject, or a live reservation)" >&2
     return 1
   fi
   echo "SPEC-$n is free"
 }
 
+# ---- SPEC-128: atomic reservation ---------------------------------------------------------
+# Prune dead reservation lines IN PLACE (called only while the lock is held, so the rewrite
+# is serialized). Drops lines that are REALIZED (number now in the real scan) or EXPIRED
+# (older than TTL). Repo-scoped: lines for OTHER repos are always kept verbatim.
+_prune_reservations() {
+  [ -f "$RES_FILE" ] || return 0
+  local realized cutoff tmp
+  realized="$(_scan_numbers)"
+  cutoff=$(( $(now_epoch) - SPEC_RESERVE_TTL ))
+  tmp="$RES_FILE.tmp.$$"
+  : > "$tmp"
+  local line iso num e keep
+  while IFS= read -r line; do
+    keep=1
+    if printf '%s' "$line" | grep -q "| RESERVE |" && printf '%s' "$line" | grep -q "repo=$REPO"; then
+      iso="${line%% | *}"
+      num="$(printf '%s' "$line" | grep -oE 'num=[0-9]+' | head -1 | cut -d= -f2)"
+      if [ -n "$num" ]; then
+        # realized? (match both the zero-padded and the bare-integer form, as check() does:
+        # _scan_numbers emits zero-padded "006" while $((10#$num)) is "6").
+        if printf '%s\n' "$realized" | grep -qx "$num" || printf '%s\n' "$realized" | grep -qx "$((10#$num))"; then keep=0; fi
+        # expired?
+        e="$(_iso_to_epoch "$iso")"
+        if [ -n "$e" ] && [ "$e" -lt "$cutoff" ]; then keep=0; fi
+      fi
+    fi
+    [ "$keep" = 1 ] && printf '%s\n' "$line" >> "$tmp"
+  done < "$RES_FILE"
+  mv -f "$tmp" "$RES_FILE" 2>/dev/null || rm -f "$tmp"
+}
+
+# Acquire the mkdir-mutex (portable; macOS has no flock, orchestrate.sh is no-flock by
+# contract). Exactly one racer creates the dir; the rest retry with a randomized backoff.
+# A lock DIR older than TTL is reclaimed (a dead holder must not wedge the wave). Loud fail
+# after a bounded number of tries so a live contender never spins forever silently.
+_reserve_lock() {
+  mkdir -p "$RES_DIR" 2>/dev/null || true
+  local tries=0 max=600   # ~ up to 30s at 50ms; ample for a wave of a few workers
+  while ! mkdir "$RES_LOCK" 2>/dev/null; do
+    # stale-lock reclaim: if the lock dir is older than TTL, a prior holder died with it held.
+    if [ -d "$RES_LOCK" ]; then
+      local lockage e
+      e="$(_lock_mtime_epoch "$RES_LOCK")"
+      if [ -n "$e" ]; then
+        lockage=$(( $(now_epoch) - e ))
+        if [ "$lockage" -gt "$SPEC_RESERVE_TTL" ]; then
+          rmdir "$RES_LOCK" 2>/dev/null || true
+          continue
+        fi
+      fi
+    fi
+    tries=$((tries + 1))
+    [ "$tries" -ge "$max" ] && { echo "spec-next reserve: could not acquire lock after $max tries ($RES_LOCK)" >&2; return 1; }
+    # randomized sub-100ms backoff to desynchronize racers
+    sleep "0.0$(( (RANDOM % 9) + 1 ))"
+  done
+  return 0
+}
+
+_lock_mtime_epoch() {
+  local d="$1"
+  stat -f %m "$d" 2>/dev/null || stat -c %Y "$d" 2>/dev/null || printf ''
+}
+
+# reserve: atomically claim + print the next free number. acquire -> compute next (folding
+# live reservations) -> append the claim -> prune dead lines -> release. Indivisible, so two
+# concurrent `reserve` calls serialize and get DISTINCT numbers.
+reserve() {
+  _reserve_lock || return 1
+  # Free the lock on any exit from here (crash-safety: a killed reserve must not wedge).
+  trap 'rmdir "$RES_LOCK" 2>/dev/null || true' EXIT INT TERM
+  local n
+  n="$(next)"
+  mkdir -p "$RES_DIR" 2>/dev/null || true
+  printf '%s | RESERVE | num=%s repo=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$n" "$REPO" >> "$RES_FILE"
+  _prune_reservations
+  rmdir "$RES_LOCK" 2>/dev/null || true
+  trap - EXIT INT TERM
+  printf '%s\n' "$n"
+}
+
 main() {
   local sub="${1:-next}"; shift || true
   case "$sub" in
-    next)  next ;;
-    check) check "$@" ;;
-    *) echo "usage: spec-next.sh {next|check <NNN>}" >&2; return 64 ;;
+    next)    next ;;
+    check)   check "$@" ;;
+    reserve) reserve ;;
+    *) echo "usage: spec-next.sh {next|check <NNN>|reserve}" >&2; return 64 ;;
   esac
 }
 

--- a/lib/spec-next.sh
+++ b/lib/spec-next.sh
@@ -70,7 +70,9 @@ _reservations() {
   local cutoff; cutoff=$(( $(now_epoch) - SPEC_RESERVE_TTL ))
   while IFS= read -r line; do
     case "$line" in *"| RESERVE |"*) ;; *) continue;; esac
-    case "$line" in *"repo=$REPO"*) ;; *) continue;; esac
+    # Anchored to end-of-line (review LOW #4): `repo=` is always the trailing field, so this
+    # exact-suffix match stops repo `foo` from also matching a line for `foo-bar`.
+    case "$line" in *"repo=$REPO") ;; *) continue;; esac
     local iso num e
     iso="${line%% | *}"
     num="$(printf '%s' "$line" | grep -oE 'num=[0-9]+' | head -1 | cut -d= -f2)"
@@ -100,7 +102,11 @@ check() {
   local n="${1:-}"; [ -n "$n" ] || { echo "usage: check <NNN>" >&2; return 64; }
   n="$(printf '%03d' "$((10#$n))")"
   if _numbers | grep -qx "$((10#$n))" || _numbers | grep -qx "$n"; then
-    echo "SPEC-$n is TAKEN (seen in specs/, a branch, a recent commit subject, or a live reservation)" >&2
+    # Byte-identical to SPEC-064 when no reservations exist (Acceptance 4): the reservation
+    # clause is appended ONLY when the ledger actually contributed a live number (review LOW #5).
+    local src="seen in specs/, a branch, or a recent commit subject"
+    [ -n "$(_reservations)" ] && src="seen in specs/, a branch, a recent commit subject, or a live reservation"
+    echo "SPEC-$n is TAKEN ($src)" >&2
     return 1
   fi
   echo "SPEC-$n is free"
@@ -108,8 +114,14 @@ check() {
 
 # ---- SPEC-128: atomic reservation ---------------------------------------------------------
 # Prune dead reservation lines IN PLACE (called only while the lock is held, so the rewrite
-# is serialized). Drops lines that are REALIZED (number now in the real scan) or EXPIRED
-# (older than TTL). Repo-scoped: lines for OTHER repos are always kept verbatim.
+# is serialized). Two independent rules:
+#   * EXPIRED (older than TTL) -> dropped for EVERY repo. Expiry is pure timestamp math and
+#     does not need the calling repo's git state, so a one-shot / archived repo's abandoned
+#     lines are cleaned up by ANY later reserve -- the machine-global ledger stays bounded
+#     (review MEDIUM #3). Non-RESERVE lines and unparseable timestamps are always kept.
+#   * REALIZED (number now in the real scan) -> dropped only for THIS repo, because "realized"
+#     is scoped to this repo's branches/specs/commits. Other repos' realized-ness is theirs
+#     to prune when they next reserve.
 _prune_reservations() {
   [ -f "$RES_FILE" ] || return 0
   local realized cutoff tmp
@@ -117,19 +129,21 @@ _prune_reservations() {
   cutoff=$(( $(now_epoch) - SPEC_RESERVE_TTL ))
   tmp="$RES_FILE.tmp.$$"
   : > "$tmp"
-  local line iso num e keep
+  local line iso num e keep is_res is_repo
   while IFS= read -r line; do
     keep=1
-    if printf '%s' "$line" | grep -q "| RESERVE |" && printf '%s' "$line" | grep -q "repo=$REPO"; then
+    is_res=0; case "$line" in *"| RESERVE |"*) is_res=1;; esac
+    if [ "$is_res" = 1 ]; then
       iso="${line%% | *}"
       num="$(printf '%s' "$line" | grep -oE 'num=[0-9]+' | head -1 | cut -d= -f2)"
-      if [ -n "$num" ]; then
-        # realized? (match both the zero-padded and the bare-integer form, as check() does:
-        # _scan_numbers emits zero-padded "006" while $((10#$num)) is "6").
+      # EXPIRED, cross-repo: drop any RESERVE line older than the TTL.
+      e="$(_iso_to_epoch "$iso")"
+      if [ -n "$e" ] && [ "$e" -lt "$cutoff" ]; then keep=0; fi
+      # REALIZED, this-repo only (anchored repo match, review LOW #4): drop if the number is
+      # now in this repo's real scan. Match both zero-padded and bare-int, as check() does.
+      is_repo=0; case "$line" in *"repo=$REPO") is_repo=1;; esac
+      if [ "$keep" = 1 ] && [ "$is_repo" = 1 ] && [ -n "$num" ]; then
         if printf '%s\n' "$realized" | grep -qx "$num" || printf '%s\n' "$realized" | grep -qx "$((10#$num))"; then keep=0; fi
-        # expired?
-        e="$(_iso_to_epoch "$iso")"
-        if [ -n "$e" ] && [ "$e" -lt "$cutoff" ]; then keep=0; fi
       fi
     fi
     [ "$keep" = 1 ] && printf '%s\n' "$line" >> "$tmp"
@@ -137,13 +151,30 @@ _prune_reservations() {
   mv -f "$tmp" "$RES_FILE" 2>/dev/null || rm -f "$tmp"
 }
 
+_lock_mtime_epoch() {
+  local d="$1"
+  stat -f %m "$d" 2>/dev/null || stat -c %Y "$d" 2>/dev/null || printf ''
+}
+
+# Release the lock ONLY if we still own it (review MAJOR #1). The owner token guards against
+# deleting a lock a stale-reclaim already handed to another process: a reserve that lost the
+# lock mid-flight must never rmdir the new holder's lock. Idempotent + best-effort.
+_reserve_unlock() {
+  [ "$(cat "$RES_LOCK/owner" 2>/dev/null)" = "${_LOCK_TOKEN:-}" ] || return 0
+  rm -f "$RES_LOCK/owner" 2>/dev/null || true
+  rmdir "$RES_LOCK" 2>/dev/null || true
+}
+
 # Acquire the mkdir-mutex (portable; macOS has no flock, orchestrate.sh is no-flock by
-# contract). Exactly one racer creates the dir; the rest retry with a randomized backoff.
-# A lock DIR older than TTL is reclaimed (a dead holder must not wedge the wave). Loud fail
-# after a bounded number of tries so a live contender never spins forever silently.
+# contract). Exactly one racer creates the dir; the winner stamps an OWNER TOKEN inside so a
+# later reclaim + the release path can tell a live holder from a dead one. A lock DIR older
+# than TTL is reclaimed (a dead holder must not wedge the wave). Loud fail after a bounded
+# number of tries so a live contender never spins forever silently.
 _reserve_lock() {
   mkdir -p "$RES_DIR" 2>/dev/null || true
-  local tries=0 max=600   # ~ up to 30s at 50ms; ample for a wave of a few workers
+  # Per-acquire unique token: pid + a random nonce + epoch defeats pid-reuse aliasing.
+  _LOCK_TOKEN="$$.${RANDOM}.$(now_epoch)"
+  local tries=0 max=600   # ~ up to 30s; ample for a wave of a few workers
   while ! mkdir "$RES_LOCK" 2>/dev/null; do
     # stale-lock reclaim: if the lock dir is older than TTL, a prior holder died with it held.
     if [ -d "$RES_LOCK" ]; then
@@ -152,6 +183,9 @@ _reserve_lock() {
       if [ -n "$e" ]; then
         lockage=$(( $(now_epoch) - e ))
         if [ "$lockage" -gt "$SPEC_RESERVE_TTL" ]; then
+          # Reclaim a genuinely-old lock: remove its owner stamp then the dir (rmdir refuses a
+          # non-empty dir, so the owner file must go first). Never a recursive rm.
+          rm -f "$RES_LOCK/owner" 2>/dev/null || true
           rmdir "$RES_LOCK" 2>/dev/null || true
           continue
         fi
@@ -162,30 +196,44 @@ _reserve_lock() {
     # randomized sub-100ms backoff to desynchronize racers
     sleep "0.0$(( (RANDOM % 9) + 1 ))"
   done
+  printf '%s' "$_LOCK_TOKEN" > "$RES_LOCK/owner" 2>/dev/null || true
   return 0
 }
 
-_lock_mtime_epoch() {
-  local d="$1"
-  stat -f %m "$d" 2>/dev/null || stat -c %Y "$d" 2>/dev/null || printf ''
-}
-
 # reserve: atomically claim + print the next free number. acquire -> compute next (folding
-# live reservations) -> append the claim -> prune dead lines -> release. Indivisible, so two
-# concurrent `reserve` calls serialize and get DISTINCT numbers.
+# live reservations) -> RE-VALIDATE ownership -> append the claim -> prune dead lines ->
+# release. Indivisible, so two concurrent `reserve` calls serialize and get DISTINCT numbers.
+# The ownership re-check (review MAJOR #1) closes the window where a TTL-stale reclaim could
+# hand our lock to another process WHILE we were still scanning: if we no longer own the
+# lock, discard this attempt and retry rather than append under a lock we lost.
 reserve() {
-  _reserve_lock || return 1
-  # Free the lock on any exit from here (crash-safety: a killed reserve must not wedge).
-  trap 'rmdir "$RES_LOCK" 2>/dev/null || true' EXIT INT TERM
-  local n
-  n="$(next)"
-  mkdir -p "$RES_DIR" 2>/dev/null || true
-  printf '%s | RESERVE | num=%s repo=%s\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$n" "$REPO" >> "$RES_FILE"
-  _prune_reservations
-  rmdir "$RES_LOCK" 2>/dev/null || true
-  trap - EXIT INT TERM
-  printf '%s\n' "$n"
+  local attempt=0 n
+  while [ "$attempt" -lt 5 ]; do
+    attempt=$((attempt + 1))
+    _reserve_lock || return 1
+    # Split traps (review MAJOR #2): a bare `trap ... INT TERM` releases the lock but bash then
+    # RESUMES the critical section unprotected. On a signal we must actually EXIT after cleanup.
+    trap '_reserve_unlock' EXIT
+    trap '_reserve_unlock; exit 130' INT
+    trap '_reserve_unlock; exit 143' TERM
+    n="$(next)"
+    if [ "$(cat "$RES_LOCK/owner" 2>/dev/null)" != "$_LOCK_TOKEN" ]; then
+      # Lost the lock to a stale-reclaim mid-scan. We do NOT own it, so do NOT unlock
+      # (that is the new holder's lock); clear the trap and retry from scratch.
+      trap - EXIT INT TERM
+      continue
+    fi
+    mkdir -p "$RES_DIR" 2>/dev/null || true
+    printf '%s | RESERVE | num=%s repo=%s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$n" "$REPO" >> "$RES_FILE"
+    _prune_reservations
+    _reserve_unlock
+    trap - EXIT INT TERM
+    printf '%s\n' "$n"
+    return 0
+  done
+  echo "spec-next reserve: lost the lock to a stale-reclaim race ${attempt}x; giving up" >&2
+  return 1
 }
 
 main() {

--- a/tests/test-spec-reserve.sh
+++ b/tests/test-spec-reserve.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# test-spec-reserve.sh -- SPEC-128: atomic wavefront SPEC-number reservation.
+#
+# Proves the CONCURRENCY case SPEC-064 did not: a parallel wave that each calls `next` before
+# any branch/spec exists all get the SAME number. `reserve` claims a number under a portable
+# mkdir-mutex + a reservations ledger folded into the scan, so N concurrent claims yield N
+# DISTINCT numbers. Includes the required negative control (the OLD `next` path DOES collide),
+# the SPEC-064 contract regression, reconciliation (realized + expired), repo-scope, lock
+# crash-safety, and the orchestrate.sh reserve-inject wiring.
+#
+# Run: bash tests/test-spec-reserve.sh
+# Exit 0 = all pass. Exit 1 = failures.
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SN="$KIT_DIR/lib/spec-next.sh"
+GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+PASS=0; FAIL=0; TOTAL=0
+ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
+bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
+expect() { if printf '%s' "$3" | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+# grep -c prints "0" AND exits 1 on no match, so `grep -c || echo 0` double-prints. This
+# returns a single clean integer whether or not the file exists / the pattern matches.
+count() { local c; c="$(grep -c "$1" "$2" 2>/dev/null)"; printf '%s' "${c:-0}"; }
+
+# A temp git repo whose only spec is SPEC-005 => next free is 006. `cd` into it so spec-next's
+# `git rev-parse --show-toplevel` resolves here; SPEC_RESERVE_FILE isolates the ledger.
+mk_repo() {
+  local r; r="$(mktemp -d "${TMPDIR:-/tmp}/kit-spec-reserve.XXXXXX")"
+  git -C "$r" init -q; git -C "$r" config user.email t@t.t; git -C "$r" config user.name t
+  mkdir -p "$r/docs/specs"; : > "$r/docs/specs/SPEC-005-x.md"
+  git -C "$r" add -A; git -C "$r" commit -qm init >/dev/null 2>&1
+  printf '%s\n' "$r"
+}
+
+# ============================================================
+echo "=== T1: single reserve on empty ledger ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"
+OUT="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve)"
+eq "T1 reserve returns max+1 (006)" "$OUT" "006"
+LINES="$(count '| RESERVE |' "$RES")"
+eq "T1 exactly one RESERVE line appended" "$LINES" "1"
+expect "T1 line is repo-scoped + carries num" "num=006 repo=$(basename "$R")" "$(cat "$RES")"
+
+# ============================================================
+echo "=== T2: 20 parallel reserve -> 20 distinct (atomic claim, CORE) ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"; ACC="$R/acc"; : > "$ACC"
+( cd "$R"
+  for _ in $(seq 1 20); do ( SPEC_RESERVE_FILE="$RES" bash "$SN" reserve >> "$ACC" 2>/dev/null ) & done
+  wait )
+T2_TOTAL="$(grep -c . "$ACC" | tr -d ' ')"
+T2_DISTINCT="$(sort -u "$ACC" | grep -c . | tr -d ' ')"
+eq "T2 emitted 20 numbers" "$T2_TOTAL" "20"
+eq "T2 all 20 distinct (zero collisions)" "$T2_DISTINCT" "20"
+
+# ============================================================
+echo "=== T3: a reserved number reads as TAKEN before its branch exists ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"
+N="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve)"       # 006
+CHK="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" check "$N" 2>&1; echo "rc=$?")"
+expect "T3 check <reserved> says TAKEN" "TAKEN" "$CHK"
+expect "T3 check <reserved> exits 1"    "rc=1"  "$CHK"
+NEXT="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" next)"
+eq "T3 next advances past the reservation (007)" "$NEXT" "007"
+
+# ============================================================
+echo "=== T4: NEGATIVE CONTROL -- 20 parallel next (old path) DOES collide ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"; ACC="$R/acc"; : > "$ACC"    # empty ledger: `next` has no reservation
+( cd "$R"
+  for _ in $(seq 1 20); do ( SPEC_RESERVE_FILE="$RES" bash "$SN" next >> "$ACC" 2>/dev/null ) & done
+  wait )
+NC_TOTAL="$(grep -c . "$ACC" | tr -d ' ')"
+NC_DISTINCT="$(sort -u "$ACC" | grep -c . | tr -d ' ')"
+if [ "$NC_DISTINCT" -lt "$NC_TOTAL" ]; then
+  ok "T4 old next path collides ($NC_DISTINCT distinct < $NC_TOTAL) -- harness CAN see a collision"
+else
+  bad "T4 expected a collision from the un-reserved path, got $NC_DISTINCT distinct of $NC_TOTAL"
+fi
+
+# ============================================================
+echo "=== T5: SPEC-064 contract intact with an empty ledger ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"
+# SPEC-005 present + SPEC-041 in a branch name => check 041 TAKEN (branch scan), next numeric.
+git -C "$R" branch "feat/SPEC-041-x" >/dev/null 2>&1
+N5="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" next)"
+expect "T5 next is a 3-digit number" "^[0-9][0-9][0-9]$" "$N5"
+CHK5="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" check 041 2>&1; echo "rc=$?")"
+expect "T5 check sees a branch-only number as TAKEN (SPEC-064 scan)" "TAKEN" "$CHK5"
+expect "T5 taken exits 1" "rc=1" "$CHK5"
+CHK5F="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" check 999 2>&1; echo "rc=$?")"
+expect "T5 a free number reports free + exits 0" "rc=0" "$CHK5F"
+eq "T5 no ledger file created by next/check (contract untouched)" "$([ -f "$RES" ] && echo yes || echo no)" "no"
+
+# ============================================================
+echo "=== T6: reconcile -- a REALIZED reservation (now a branch) stops counting ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"
+N6="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve)"   # 006 reserved
+# Realize it: create a branch carrying SPEC-006 (the worker made its branch).
+git -C "$R" branch "feat/SPEC-006-done" >/dev/null 2>&1
+# Next reserve must prune the now-redundant 006 line and still not double-count it.
+N6B="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve)"  # should be 007 (006 realized)
+eq "T6 next reserve after realization is 007" "$N6B" "007"
+REALIZED_LINES="$(count 'num=006' "$RES")"
+eq "T6 the realized 006 reservation line was pruned" "$REALIZED_LINES" "0"
+
+# ============================================================
+echo "=== T7: reconcile -- an EXPIRED reservation stops counting ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"
+# Hand-write a reservation dated in 1970 (definitely older than any TTL).
+printf '1970-01-01T00:00:00Z | RESERVE | num=006 repo=%s\n' "$(basename "$R")" > "$RES"
+# With TTL default 24h, the ancient 006 is expired => not counted => next free is still 006.
+N7="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" next)"
+eq "T7 expired reservation does not inflate next (still 006)" "$N7" "006"
+# A fresh reserve prunes the expired line.
+(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve >/dev/null)
+EXP_LINES="$(count '1970-01-01' "$RES")"
+eq "T7 expired line pruned on next reserve" "$EXP_LINES" "0"
+
+# ============================================================
+echo "=== T8: reservations are REPO-SCOPED (repo A does not inflate repo B) ==="
+# ============================================================
+RA="$(mk_repo)"; RB="$(mk_repo)"; RES="$RA/shared.log"    # one shared ledger file, two repos
+(cd "$RA" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve >/dev/null)   # reserves 006 for repo A
+(cd "$RA" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve >/dev/null)   # 007 for repo A
+N8B="$(cd "$RB" && SPEC_RESERVE_FILE="$RES" bash "$SN" next)"          # repo B ignores A's lines
+eq "T8 repo B's next ignores repo A's reservations (006)" "$N8B" "006"
+
+# ============================================================
+echo "=== T9: stale LOCK dir older than TTL is reclaimed ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"
+mkdir -p "$(dirname "$RES")"; mkdir "$RES.lock"          # simulate a dead holder's leftover lock
+# Backdate the lock dir well past the TTL so the reclaim path fires.
+touch -t 200001010000 "$RES.lock" 2>/dev/null || true
+N9="$(cd "$R" && SPEC_RESERVE_TTL=1 SPEC_RESERVE_FILE="$RES" bash "$SN" reserve 2>/dev/null)"
+eq "T9 reserve reclaims a stale lock and still claims (006)" "$N9" "006"
+eq "T9 lock released after reserve" "$([ -d "$RES.lock" ] && echo held || echo free)" "free"
+
+# ============================================================
+echo "=== T10: orchestrate _wave_reserve_spec wiring (mock spec-next) ==="
+# ============================================================
+# Source orchestrate.sh (its source-guard skips main) and drive the helper with a mock.
+# shellcheck disable=SC1090
+( source "$KIT_DIR/lib/orchestrate.sh" 2>/dev/null
+  MOCK="$(mktemp)"; printf '#!/usr/bin/env bash\necho 128\n' > "$MOCK"; chmod +x "$MOCK"
+  got="$(SPEC_NEXT_CMD="$MOCK" _wave_reserve_spec)"
+  [ "$got" = "128" ] && echo "T10A-OK" || echo "T10A-BAD:$got"
+  # degrade path: a mock that fails (nonzero, no output) => helper returns nonzero, empty
+  BADMOCK="$(mktemp)"; printf '#!/usr/bin/env bash\nexit 1\n' > "$BADMOCK"; chmod +x "$BADMOCK"
+  if got2="$(SPEC_NEXT_CMD="$BADMOCK" _wave_reserve_spec)"; then echo "T10B-BAD:nonempty:$got2"; else
+    [ -z "$got2" ] && echo "T10B-OK" || echo "T10B-BAD:$got2"; fi
+) > "${TMPDIR:-/tmp}/t10.$$" 2>/dev/null
+T10="$(cat "${TMPDIR:-/tmp}/t10.$$" 2>/dev/null)"
+expect "T10 helper returns the reserved number from spec-next" "T10A-OK" "$T10"
+expect "T10 helper degrades (nonzero+empty) on reserve failure" "T10B-OK" "$T10"
+
+# ============================================================
+echo ""
+echo "=== Results ==="
+echo -e "Passed: ${GREEN}$PASS${NC} / $TOTAL"
+if [ "$FAIL" -gt 0 ]; then echo -e "${RED}$FAIL assertions failed.${NC}"; exit 1; fi
+echo -e "${GREEN}spec-reserve green.${NC}"

--- a/tests/test-spec-reserve.sh
+++ b/tests/test-spec-reserve.sh
@@ -207,6 +207,30 @@ expect "T13 empty-ledger TAKEN message has NO reservation clause" "seen in specs
 if printf '%s' "$MSG13" | grep -q 'reservation'; then bad "T13 empty-ledger message leaked a reservation clause"; else ok "T13 no reservation clause on empty ledger"; fi
 
 # ============================================================
+echo "=== T14: a normal reserve FREES the lock (no held lock, no owner leak) ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"
+N14="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve)"
+eq "T14 normal reserve returns a number" "$N14" "006"
+eq "T14 lock dir freed after a normal reserve" "$([ -d "$RES.lock" ] && echo held || echo free)" "free"
+eq "T14 no owner file left behind" "$([ -e "$RES.lock/owner" ] && echo leak || echo clean)" "clean"
+
+# ============================================================
+echo "=== T15: a FRESH (non-stale) foreign lock is RESPECTED, not stolen ==="
+# ============================================================
+# This is the direct guard for the mutex fail-open the macOS CI masked: if lock-mtime reads
+# garbage (Linux `stat -f %m` = --file-system format), a FRESH lock looks older-than-TTL and
+# gets reclaimed -> the number is stolen. With correct mtime the fresh lock is respected, so a
+# bounded reserve times out (empty, nonzero) and the foreign lock is still held.
+R="$(mk_repo)"; RES="$R/res.log"
+mkdir -p "$(dirname "$RES")"; mkdir "$RES.lock"; printf 'foreign.owner.token' > "$RES.lock/owner"   # current mtime, foreign owner
+OUT15="$(cd "$R" && SPEC_RESERVE_MAX_TRIES=3 SPEC_RESERVE_FILE="$RES" bash "$SN" reserve 2>/dev/null; echo "rc=$?")"
+if printf '%s' "$OUT15" | grep -qE '^[0-9]{3}$'; then bad "T15 reserve STOLE a fresh foreign lock (fail-open: $OUT15)"; else ok "T15 reserve did not steal a fresh foreign lock"; fi
+expect "T15 bounded reserve fails loudly rather than fail-open" "rc=1" "$OUT15"
+eq "T15 the fresh foreign lock is still held" "$([ -d "$RES.lock" ] && echo held || echo free)" "held"
+eq "T15 the foreign owner token is untouched" "$(cat "$RES.lock/owner" 2>/dev/null)" "foreign.owner.token"
+
+# ============================================================
 echo ""
 echo "=== Results ==="
 echo -e "Passed: ${GREEN}$PASS${NC} / $TOTAL"

--- a/tests/test-spec-reserve.sh
+++ b/tests/test-spec-reserve.sh
@@ -163,6 +163,50 @@ expect "T10 helper returns the reserved number from spec-next" "T10A-OK" "$T10"
 expect "T10 helper degrades (nonzero+empty) on reserve failure" "T10B-OK" "$T10"
 
 # ============================================================
+echo "=== T11: EXPIRED prune is cross-repo (review #3, bounded shared ledger) ==="
+# ============================================================
+# An expired reservation for repo B must be cleaned up by repo A's reserve, or the
+# machine-global ledger grows unbounded across repos.
+RA="$(mk_repo)"; RES="$RA/shared.log"
+printf '1970-01-01T00:00:00Z | RESERVE | num=006 repo=some-other-repo\n' > "$RES"   # expired, foreign repo
+(cd "$RA" && SPEC_RESERVE_FILE="$RES" bash "$SN" reserve >/dev/null)
+FOREIGN_EXPIRED="$(count 'some-other-repo' "$RES")"
+eq "T11 a foreign repo's EXPIRED line is pruned by any reserve" "$FOREIGN_EXPIRED" "0"
+# But a foreign repo's LIVE (non-expired) line is left alone (realized-prune stays repo-scoped).
+RB2="$(mk_repo)"; RES2="$RB2/shared.log"
+printf '%s | RESERVE | num=006 repo=some-other-repo\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$RES2"
+(cd "$RB2" && SPEC_RESERVE_FILE="$RES2" bash "$SN" reserve >/dev/null)
+FOREIGN_LIVE="$(count 'some-other-repo' "$RES2")"
+eq "T11 a foreign repo's LIVE line is preserved" "$FOREIGN_LIVE" "1"
+
+# ============================================================
+echo "=== T12: repo match is anchored (review #4: 'foo' != 'foo-bar') ==="
+# ============================================================
+# Reserve under a repo whose name is a prefix of the ledger line's repo; it must NOT count.
+R="$(mktemp -d "${TMPDIR:-/tmp}/kit-spec-reserve.XXXXXX")"; mv "$R" "$R-bar"; R="$R-bar"
+git -C "$R" init -q; git -C "$R" config user.email t@t.t; git -C "$R" config user.name t
+mkdir -p "$R/docs/specs"; : > "$R/docs/specs/SPEC-005-x.md"
+git -C "$R" add -A; git -C "$R" commit -qm init >/dev/null 2>&1
+RES="$R/res.log"
+# A live reservation for repo "<base>-bar" (this repo). A DIFFERENT repo whose name is the
+# bare prefix must not fold this in. Simulate by writing a line for this repo, then asking a
+# would-be prefix repo... simpler: assert the anchored fold only matches the exact repo.
+BASE="$(basename "$R")"                 # e.g. kit-spec-reserve.xxx-bar
+PREFIX="${BASE%-bar}"                    # the bare prefix, kit-spec-reserve.xxx
+printf '%s | RESERVE | num=006 repo=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PREFIX" > "$RES"
+# This repo is "<...>-bar"; a line for the PREFIX repo must NOT be folded in, so next is 006.
+N12="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" next)"
+eq "T12 a prefix-repo reservation is NOT folded into this repo (006)" "$N12" "006"
+
+# ============================================================
+echo "=== T13: check message byte-identical to SPEC-064 on empty ledger (review #5) ==="
+# ============================================================
+R="$(mk_repo)"; RES="$R/res.log"
+MSG13="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" check 005 2>&1)"
+expect "T13 empty-ledger TAKEN message has NO reservation clause" "seen in specs/, a branch, or a recent commit subject)" "$MSG13"
+if printf '%s' "$MSG13" | grep -q 'reservation'; then bad "T13 empty-ledger message leaked a reservation clause"; else ok "T13 no reservation clause on empty ledger"; fi
+
+# ============================================================
 echo ""
 echo "=== Results ==="
 echo -e "Passed: ${GREEN}$PASS${NC} / $TOTAL"


### PR DESCRIPTION
Close the wavefront SPEC-number race: a parallel wave that each calls `spec-next next` before any branch exists all get the same number (the scan is correct; the reservation is too late). Reuse spec-next's scan; add a `flock`-guarded reservation claimed atomically at wavefront dispatch, so a number reads as taken the instant it is handed out. Verify: concurrency test (N parallel claims -> N distinct numbers) + negative control (old path collides) + spec-next contract intact + coverage-delta. First of the kit-run-integrity wave (enables the parallel 01/03/04/05). Roadmap: ops-toolkit `_meta/megagoals/kit-run-integrity/ROADMAP.md`.

## What changed

- **`lib/spec-next.sh`** gains a `reserve` subcommand. It claims the next free SPEC number under a portable **mkdir-based mutex** (macOS ships no `flock`; the binding property is "two concurrent claims serialize", which `mkdir`'s POSIX atomicity delivers) and records it in an append-only reservations ledger (`$(kit_resolve_log_dir)/spec-reservations.log`, the same durable root `gate-ledger.sh` uses). `_numbers()` folds live reservations into its existing scan, so a reserved number reads as TAKEN by the very next `next`/`check`/`reserve`.
- **`lib/orchestrate.sh`** `_wave_run` calls `_wave_reserve_spec` per admitted sub-goal at dispatch (before the worker session can race `spec-next next`) and injects the reserved `SPEC-NNN` into the worker prompt. Best-effort: a reserve failure degrades to the worker self-computing (still scan-safe), never wedges the wave.
- Reservations are **repo-scoped** and **self-healing**: realized lines (number now in a branch/spec/commit) and TTL-expired lines (default 24h; abandoned by a crashed worker) are pruned under the lock, so the ledger stays bounded and a dead worker cannot permanently inflate the max.

## Reuse, not rewrite

`spec-next.sh`'s scan (specs + branches + commits, SPEC-064) is untouched. The reservation is an ADDITIONAL surface it consults. With an empty ledger, `next`/`check` behave byte-identically to before, so the SPEC-064 contract holds (verified: existing `test-hooks.sh` 452/452 green).

## Proof

`tests/test-spec-reserve.sh` (23 assertions, registered in CI):

| Check | Result |
|---|---|
| 20 parallel `reserve` -> 20 distinct numbers, 0 collisions (atomic claim) | PASS |
| a reserved number reads as TAKEN before its branch exists | PASS |
| NEGATIVE CONTROL: 20 parallel `next` (old path) DO collide (1 distinct/20) | PASS |
| SPEC-064 `next`/`check` contract byte-identical on empty ledger | PASS |
| reconcile: realized + TTL-expired reservations stop counting + are pruned | PASS |
| repo-scope: repo A's reservations do not inflate repo B | PASS |
| stale lock dir older than TTL is reclaimed | PASS |
| orchestrate `_wave_reserve_spec` wiring + degrade path | PASS |

Full suite: `test-spec-reserve` 23/23, `test-hooks` 452/452, `test-meta` 667/667, `test-orchestrate` + `test-orchestrate-wavefront` ALL PASS.

**COVERAGE-DELTA** , covered: T1-T10 above (atomic distinctness, fold-in, negative control, SPEC-064 contract, realized+expired reconciliation, repo-scope, stale-lock reclaim, orchestrate wiring+degrade). Uncovered: a hardware-simultaneous claim (the test uses OS process scheduling + parallel spawn, the strongest portable approximation, not a single-instant hardware race); and a live end-to-end `_wave_run` under a real multi-pane tmux wave (covered structurally by the mock-injection unit + the existing `test-orchestrate-wavefront.sh`, not re-run live here).

## Notes

- **Deviation from the roadmap's literal "flock":** `flock(1)` is absent on stock macOS and `orchestrate.sh` is bash-3.2 / no-flock by contract. A `mkdir` mutex is the idiomatic, more-portable equivalent; see `docs/implementation-notes/SPEC-128-spec-reservation-race.md`.
- This is the general orchestrate.sh fix (the suspenders). The conductor's manual per-run pre-assign (the belt) is separate and out of scope here.
- First of the kit-run-integrity wave; enables the parallel 01/03/04/05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
