### PR TITLE
fix(kit): reconcile proof-table-gen OUTCOME reader to real 01 marker

### DIFF
--- a/docs/specs/SPEC-133-proof-table-outcome-reconcile.md
+++ b/docs/specs/SPEC-133-proof-table-outcome-reconcile.md
@@ -1,0 +1,98 @@
+# Spec: Reconcile proof-table-gen's OUTCOME reader to the real gate-outcome marker
+
+Generated: 2026-07-04
+Status: VALIDATED
+Lane: normal (a parser fix over a known, now-merged ledger schema; no new subsystem, no
+correctness-critical concurrency).
+
+## Problem
+
+SPEC-132 (`lib/proof-table-gen.py`, sub-goal 05) shipped an OUTCOME parser against an
+**assumed** single-line marker shape (documented as "ASSUMED shape for sub-goal 01 ... may
+not be merged yet"). SPEC-129 (sub-goal 01, `lib/gate-ledger.sh`'s `outcome()`/`outcome_read()`)
+has since merged with a **different, real** shape: TWO lines per gate bracketing start/end,
+using `dur_s=` (seconds), not the assumed single-line `dur_ms=`.
+
+Concretely, 01's real marker:
+```
+<TS> | OUTCOME | <phase> | start | at=<epoch>
+<TS> | OUTCOME | <phase> | end   | at=<epoch> caught=<true|false> dur_s=<N>
+```
+(field 3 = phase, field 4 = event `start|end`; `caught=`/`dur_s=` appear only on the `end`
+line.)
+
+05's current parser treats `parts[3:]` as one kv blob and regexes for `caught=` and
+`dur_ms=` without modeling the event field. Effect verified against a real-shape fixture:
+`caught=` happens to still match (the regex is unanchored, so it finds `caught=true` inside
+the `end` line's kv blob regardless of the `start|end` token in front of it), but `dur_ms=`
+never matches (01 never emits that key), so the DURATION column is always `n/a`. The
+CAUGHT column's accidental match is not a designed pairing (it doesn't distinguish
+start-line noise from end-line signal), so it is fragile, not correct. Net effect: the
+MEASURABLE-to-HONESTLY-PROVEN link this mega-goal exists to make is broken for duration and
+accidental for caught.
+
+## Solution
+
+Rewrite the OUTCOME branch of `parse_ledger()` in `lib/proof-table-gen.py` to model 01's
+real two-line shape directly:
+
+- Recognize `parts[3]` as the event (`start`|`end`).
+- On a `start` line: record the phase's `at=` epoch (for the duration fallback only); do
+  not populate `outcomes[phase]` yet (avoids a start-only phase reading as "has an
+  outcome").
+- On an `end` line: read `caught=` and `dur_s=` from its kv blob. If `dur_s=` is absent but
+  a matching `start` epoch was seen, fall back to `end.at - start.at`. Populate
+  `outcomes[phase] = {"caught": ..., "dur_s": ...}` (last end-line-per-phase wins, matching
+  `outcome_read()`'s own semantics).
+- Rename the rendered column from `Duration (ms)` to `Duration (s)` and print `dur_s`
+  directly (no unit conversion; 01 already emits whole seconds).
+- Update the stale doc comment (the "ASSUMED shape ... may not be merged yet" note) to the
+  real, merged shape, referencing SPEC-129.
+- Preserve every additive-tolerance property SPEC-132 already established: an entirely
+  absent OUTCOME marker still renders the 5-column table (no Caught/Duration header, no
+  crash); a phase with a GATE row but no OUTCOME end-line still renders `n/a` in both
+  columns without crashing the row.
+
+**Not changed:** 01's marker format (read-only consumer), 05's output file location/naming,
+the acceptance/coverage-delta sections, the CLI surface (`proof-table-gen.sh <rid>
+[out-path]`).
+
+### Test fixture correction
+
+`tests/test-proof-table-gen.sh`'s T2/T2B fixtures encode the **assumed** (now known
+incorrect) single-line shape from SPEC-132's original write. They are updated in place to
+the real 01 two-line shape (start/end pair, `dur_s=`), preserving the exact behavioral
+properties they test (round-trip population, per-row degrade-to-n/a, whole-table
+degrade-to-absent) -- these fixtures were pinning a hypothesis that has since been falsified
+by the real merged marker, not a still-valid contract to protect verbatim.
+
+## Design
+
+`obvious: not design-bearing`. No new component, no schema change, no external
+integration, no irreversible choice, and exactly one viable approach (read the marker
+format that already exists in merged code). This is a like-for-like parser correction
+inside an existing function (`parse_ledger()`'s `OUTCOME` branch) against an existing,
+now-fixed wire format (SPEC-129's `outcome()`/`outcome_read()`); the "before/after" is
+fully captured by the two marker-shape blocks in `## Problem` and `## Solution` above, so a
+diagram would restate them without adding information.
+
+## Acceptance criteria
+
+1. A real-01-format OUTCOME pair (`start` + `end` with `caught=true dur_s=N`) round-trips:
+   the generated table's Caught column shows the caught value and the Duration (s) column
+   shows `N`.
+2. A phase with GATE coverage but no OUTCOME lines at all still renders `n/a`/`n/a` for that
+   row (per-row degrade, unchanged from SPEC-132).
+3. A ledger with zero OUTCOME lines anywhere still renders the plain 5-column table (no
+   Caught/Duration header), unchanged from SPEC-132.
+4. `bash tests/test-proof-table-gen.sh` is green after the fixture correction.
+5. A negative control (parser reverted to the pre-fix regex) turns the real-01-format
+   assertion RED, proving the fix is load-bearing.
+
+## Verification
+
+```
+bash tests/test-proof-table-gen.sh
+```
+All assertions PASS; see `docs/verification/kri-outcome-reader.md` for the full run-table
+including the negative control.

--- a/docs/verification/kri-outcome-reader.md
+++ b/docs/verification/kri-outcome-reader.md
@@ -1,0 +1,109 @@
+# Proof of done: reconcile proof-table-gen's OUTCOME reader to the real 01 marker (SPEC-133)
+
+`lib/proof-table-gen.py` (SPEC-132, sub-goal 05) parsed an **assumed** single-line OUTCOME
+shape (`caught=<bool> [dur_ms=<N>]`). `lib/gate-ledger.sh`'s `outcome()`/`outcome_read()`
+(SPEC-129, sub-goal 01) merged with a **different, real** shape: a `start`/`end` line pair
+per phase, duration in seconds as `dur_s=`. The DURATION column never populated from real
+01 data (`dur_ms=` never emitted); the CAUGHT column's match was an unmodeled regex
+coincidence, not a designed pairing. This closes the gap: the parser now models the real
+`start`/`end` event field, reads `caught=`/`dur_s=` off the `end` line, and falls back to an
+`end.at - start.at` epoch delta if `dur_s=` is ever absent.
+
+## Acceptance criteria -> confirmation
+
+| # | Acceptance criterion | Test | Result |
+|---|---|---|---|
+| 1 | Real-01-format OUTCOME pair (`start`+`end`, `caught=true dur_s=N`) round-trips into the Caught + Duration (s) columns | T2 | PASS |
+| 2 | A GATE-covered phase with no OUTCOME lines still renders `n/a`/`n/a` per row (unchanged) | T2 (partial fixture) | PASS |
+| 3 | Zero OUTCOME lines anywhere still renders the plain 5-column table (unchanged) | T1/T3 | PASS |
+| 4 | `dur_s=` absent on the end line falls back to the `at=` epoch delta | T2C (new) | PASS |
+| 5 | `tests/test-proof-table-gen.sh` green after the fixture correction | full suite | PASS (25/25) |
+| 6 | Negative control: reverting the parser turns the real-format assertions RED | manual revert run | PASS (5 assertions RED, all in T2/T2C) |
+| 7 | No regression in the wider meta-suite | `tests/test-meta.sh` | PASS (667/667) |
+
+## Confirmation run-table
+
+| Run | Command | Exit | Verdict |
+|---|---|---|---|
+| green | `bash tests/test-proof-table-gen.sh` | 0 | PASS (25/25 assertions) |
+| negative control | `lib/proof-table-gen.py` stashed back to the pre-fix parser, re-run | 1 | RED-as-expected (5 assertions failed, all real-01-format: T2 Caught/Duration header, T2 spec row, T2 build row, T2C fallback-duration row, plus the derived acceptance FAIL row printed on stderr/stdout) |
+| restore | `git stash pop` then `bash tests/test-proof-table-gen.sh` | 0 | PASS (25/25, back to green) |
+| cross-platform | `/bin/bash tests/test-proof-table-gen.sh` (bash 3.2.57, macOS system bash) | 0 | PASS (25/25) |
+| no-regression | `bash tests/test-meta.sh` | 0 | PASS (667/667) |
+| standalone parser check | `python3 -c "..."` importing `parse_ledger()` directly against a hand-built real-01-format fixture | n/a | `outcomes = {'spec': {'caught': 'true', 'dur_s': '42'}}` (both fields populated) |
+
+## Run detail
+
+### Green (25/25)
+
+```
+Command: bash tests/test-proof-table-gen.sh
+Exit: 0
+Verdict: proof-table-gen green.
+Passed: 25 / 25
+```
+All 25 assertions pass, including the corrected T2 (real 01 start/end pair, both phases
+populate Caught + Duration (s)), T2's partial-fixture per-row degrade, the new T2C
+(dur_s= absent -> epoch-delta fallback), and the unchanged T1/T3/T4/T5/T7/T8 additive-
+tolerance and canonical-file-protection assertions.
+
+### Negative control (revert -> RED -> restore)
+
+To prove the fix is load-bearing (not decorative), the parser fix in
+`lib/proof-table-gen.py` was stashed (`git stash push -- lib/proof-table-gen.py`),
+restoring the pre-fix regex-only OUTCOME reader, and the suite re-run against the
+now-updated (real-01-format) fixtures:
+
+```
+Command: bash tests/test-proof-table-gen.sh   (with the pre-fix parser)
+Exit: 1
+Verdict: 5 assertions failed
+```
+The failures were exactly the real-01-format assertions:
+- T2: "Caught/Duration columns appear when OUTCOME lines exist" (label mismatch:
+  pre-fix still emits `Duration (ms)`)
+- T2: "spec row populates caught=false dur=12 ..." (dur column stayed `n/a`, since
+  pre-fix never reads `dur_s=`)
+- T2: "build row populates caught=true dur=43 ..." (same)
+- T2: "spec row still populates in the partial fixture" (same)
+- T2C: "dur_s= absent -> duration derived from end.at - start.at epoch delta (45)"
+  (pre-fix has no fallback path at all)
+
+`git stash pop` restored the fix; re-running returned the suite to 25/25 green (Exit 0).
+The fix is load-bearing: without it, a genuinely real-format OUTCOME pair still renders
+`n/a` for Duration and carries the stale `(ms)` label.
+
+### Cross-platform
+
+```
+Command: /bin/bash tests/test-proof-table-gen.sh
+bash version: GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
+Exit: 0
+Verdict: PASS (25/25)
+```
+The change is pure Python (portable) plus bash-heredoc test fixtures with no BSD-sensitive
+constructs (no `date -d`/`-r`, no `stat -f`, no `sed -i ''`), so no cross-platform risk.
+
+### No-regression (wider meta-suite)
+
+```
+Command: bash tests/test-meta.sh
+Exit: 0
+Verdict: All meta tests passed.
+Passed: 667 / 667
+```
+
+## Reproduce
+
+```
+cd <repo>
+bash tests/test-proof-table-gen.sh                 # 25/25 green
+/bin/bash tests/test-proof-table-gen.sh            # cross-platform (macOS bash 3.2)
+bash tests/test-meta.sh                            # 667/667, no regression
+
+# negative control
+git stash push -- lib/proof-table-gen.py
+bash tests/test-proof-table-gen.sh                 # 20/25, 5 real-01-format assertions RED
+git stash pop
+bash tests/test-proof-table-gen.sh                 # 25/25 green again
+```

--- a/lib/proof-table-gen.py
+++ b/lib/proof-table-gen.py
@@ -12,11 +12,15 @@ Parses three ledger line shapes (space-pipe-split, the same convention
 `lib/gate-ledger.sh`'s own awk uses):
   TS | START | lane=<l> classified=<c> type=<t> [ctype=<ct>] repo=<r>
   TS | GATE | <phase> | ran|skipped|override | [reason]
-  TS | OUTCOME | <phase> | caught=<true|false> [dur_ms=<N>] [start=<ISO>] [end=<ISO>]
+  TS | OUTCOME | <phase> | start | at=<epoch>
+  TS | OUTCOME | <phase> | end | at=<epoch> caught=<true|false> dur_s=<N>
 
-The OUTCOME line is an ASSUMED shape for sub-goal 01 (gate-outcome-emit), which may not
-be merged yet -- see SPEC-132 "Assumed 01 marker shape". Additive-tolerant: an entirely
-absent OUTCOME marker degrades the table (fewer columns), never crashes.
+The OUTCOME line is sub-goal 01's REAL, now-merged marker shape (gate-outcome-emit,
+SPEC-129's `outcome()`/`outcome_read()` in lib/gate-ledger.sh): a start/end pair per
+phase (field 3 = phase, field 4 = event `start|end`); `caught=`/`dur_s=` appear only on
+the `end` line, duration in SECONDS (not the `dur_ms` this parser assumed before
+SPEC-129 merged). Additive-tolerant: an entirely absent OUTCOME marker degrades the
+table (fewer columns), never crashes.
 
 Usage: proof-table-gen.py <rid> [out-path]
 Env (set by the lib/proof-table-gen.sh wrapper, not re-derived here):
@@ -39,7 +43,8 @@ def fail(msg, code=1):
 def parse_ledger(ledger_path):
     lane = None
     gate_rows = []       # ordered list of dict(ts, phase, state, reason)
-    outcomes = {}        # phase -> dict(caught, dur_ms)  (last OUTCOME line per phase wins)
+    outcomes = {}        # phase -> dict(caught, dur_s)  (last END line per phase wins)
+    starts = {}          # phase -> start epoch (from the `start` line's at=), fallback-only
 
     if not os.path.isfile(ledger_path):
         return lane, gate_rows, outcomes
@@ -66,19 +71,41 @@ def parse_ledger(ledger_path):
             reason = " | ".join(parts[4:]) if len(parts) > 4 else ""
             gate_rows.append({"ts": ts, "phase": phase, "state": state, "reason": reason})
 
-        elif marker == "OUTCOME" and len(parts) >= 3:
+        elif marker == "OUTCOME" and len(parts) >= 4:
+            # Real shape (SPEC-129): field 3 = phase, field 4 = event (start|end); the
+            # kv blob (caught=/dur_s=) lives only on the end line.
             phase = parts[2]
-            kv_blob = " ".join(parts[3:])
+            event = parts[3]
+            kv_blob = parts[4] if len(parts) > 4 else ""
+
+            if event == "start":
+                m_at = re.search(r"\bat=(\d+)", kv_blob)
+                if m_at:
+                    starts[phase] = m_at.group(1)
+                continue
+
+            if event != "end":
+                continue
+
             caught = None
-            dur_ms = None
+            dur_s = None
             mcaught = re.search(r"caught=(\S+)", kv_blob)
             if mcaught:
                 caught = mcaught.group(1)
-            mdur = re.search(r"dur_ms=(\S+)", kv_blob)
+            mdur = re.search(r"dur_s=(\S+)", kv_blob)
             if mdur:
-                dur_ms = mdur.group(1)
-            if caught is not None or dur_ms is not None:
-                outcomes[phase] = {"caught": caught, "dur_ms": dur_ms}
+                dur_s = mdur.group(1)
+            if dur_s is None:
+                # Fallback: derive duration from this end line's at= minus the matching
+                # start line's at=, same epoch-delta the emitter itself uses.
+                m_end_at = re.search(r"\bat=(\d+)", kv_blob)
+                start_epoch = starts.get(phase)
+                if m_end_at and start_epoch:
+                    delta = int(m_end_at.group(1)) - int(start_epoch)
+                    if delta >= 0:
+                        dur_s = str(delta)
+            if caught is not None or dur_s is not None:
+                outcomes[phase] = {"caught": caught, "dur_s": dur_s}
 
     return lane, gate_rows, outcomes
 
@@ -150,7 +177,7 @@ def render(rid, ledger_path, kit_root, lane, gate_rows, outcomes):
     out.append("## 2. Confirmation (gate runs)")
     out.append("")
     if has_outcomes:
-        out.append("| # | Phase | When (ISO8601) | State | Reason | Caught | Duration (ms) |")
+        out.append("| # | Phase | When (ISO8601) | State | Reason | Caught | Duration (s) |")
         out.append("|---|---|---|---|---|---|---|")
     else:
         out.append("| # | Phase | When (ISO8601) | State | Reason |")
@@ -161,7 +188,7 @@ def render(rid, ledger_path, kit_root, lane, gate_rows, outcomes):
             if has_outcomes:
                 o = outcomes.get(r["phase"])
                 caught = o["caught"] if o and o["caught"] else "n/a"
-                dur = o["dur_ms"] if o and o["dur_ms"] else "n/a"
+                dur = o["dur_s"] if o and o["dur_s"] else "n/a"
                 out.append(f"| {i} | {r['phase']} | {r['ts']} | {r['state']} | {reason} | {caught} | {dur} |")
             else:
                 out.append(f"| {i} | {r['phase']} | {r['ts']} | {r['state']} | {reason} |")

--- a/tests/test-proof-table-gen.sh
+++ b/tests/test-proof-table-gen.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# test-proof-table-gen.sh -- the generated proof-of-done confirmation table (SPEC-132).
+# test-proof-table-gen.sh -- the generated proof-of-done confirmation table (SPEC-132,
+# reconciled to 01's real marker shape per SPEC-133).
 #
-# Pins: round-trip against a fixture ledger, additive-tolerance BOTH ways (01's
-# caught=/dur_ms= marker present vs. entirely absent), the hard "never overwrite the
-# canonical proof-of-done.md" backstop (explicit path + the default path), the
-# coverage-delta row with a known lane and with an unknown lane, and a fully empty
+# Pins: round-trip against a fixture ledger, additive-tolerance BOTH ways (01's real
+# start/end caught=/dur_s= marker pair present vs. entirely absent), the hard "never
+# overwrite the canonical proof-of-done.md" backstop (explicit path + the default path),
+# the coverage-delta row with a known lane and with an unknown lane, and a fully empty
 # ledger (no crash).
 #
 # Run: bash tests/test-proof-table-gen.sh
@@ -44,29 +45,31 @@ BODY1="$(cat "$OUT1" 2>/dev/null)"
 expect "T1: confirmation row for spec (phase/when/state/reason, round-trip)" "| 1 | spec | 2026-07-04T09:00:01Z | ran | spec authored |" "$BODY1"
 expect "T1: confirmation row for build" "| 2 | build | 2026-07-04T09:00:02Z | ran | implemented |" "$BODY1"
 expect "T1: confirmation row for ship (skipped state preserved)" "| 3 | ship | 2026-07-04T09:00:03Z | skipped | held for review |" "$BODY1"
-refute "T1 (implies T3): no Caught/Duration columns when zero OUTCOME lines exist" "Duration (ms)" "$BODY1"
+refute "T1 (implies T3): no Caught/Duration columns when zero OUTCOME lines exist" "Duration (s)" "$BODY1"
 expect "T6: coverage-delta covers spec+build" "Covered: build, spec" "$BODY1"
 expect "T6: coverage-delta names ship as uncovered (required, only skipped)" "Uncovered: ship" "$BODY1"
 expect "T6: acceptance row reflects lane=normal" "lane \`normal\`" "$BODY1"
 
 # ============================================================
 echo ""
-echo "=== T2: additive-tolerance, OUTCOME markers present (assumed 01 shape) ==="
+echo "=== T2: additive-tolerance, OUTCOME markers present (SPEC-129 real 01 shape) ==="
 # ============================================================
 RID2="fixture-outcomes"
 cat > "$DWARVES_KIT_LOG_DIR/runs/$RID2.log" <<'EOF'
 2026-07-04T09:00:00Z | START | lane=normal classified=normal type=spec-feature repo=dwarves-kit
 2026-07-04T09:00:01Z | GATE | spec | ran | spec authored
 2026-07-04T09:00:02Z | GATE | build | ran | implemented
-2026-07-04T09:00:01Z | OUTCOME | spec | caught=false start=2026-07-04T09:00:01Z end=2026-07-04T09:00:01Z dur_ms=1200
-2026-07-04T09:00:02Z | OUTCOME | build | caught=true dur_ms=4300
+2026-07-04T09:00:01Z | OUTCOME | spec | start | at=1000
+2026-07-04T09:00:01Z | OUTCOME | spec | end | at=1012 caught=false dur_s=12
+2026-07-04T09:00:02Z | OUTCOME | build | start | at=2000
+2026-07-04T09:00:02Z | OUTCOME | build | end | at=2043 caught=true dur_s=43
 EOF
 OUT2="$WORK/out2.md"
 bash "$GEN" "$RID2" "$OUT2" >/dev/null 2>&1
 BODY2="$(cat "$OUT2" 2>/dev/null)"
-expect "T2: Caught/Duration columns appear when OUTCOME lines exist" "Caught | Duration (ms)" "$BODY2"
-expect "T2: spec row populates caught=false dur=1200" "| 1 | spec | 2026-07-04T09:00:01Z | ran | spec authored | false | 1200 |" "$BODY2"
-expect "T2: build row populates caught=true dur=4300" "| 2 | build | 2026-07-04T09:00:02Z | ran | implemented | true | 4300 |" "$BODY2"
+expect "T2: Caught/Duration columns appear when OUTCOME lines exist" "Caught | Duration (s)" "$BODY2"
+expect "T2: spec row populates caught=false dur=12 from real 01 start/end pair" "| 1 | spec | 2026-07-04T09:00:01Z | ran | spec authored | false | 12 |" "$BODY2"
+expect "T2: build row populates caught=true dur=43 from real 01 start/end pair" "| 2 | build | 2026-07-04T09:00:02Z | ran | implemented | true | 43 |" "$BODY2"
 
 # same fixture, add a phase with NO outcome line -> that row degrades to n/a per-row
 RID2B="fixture-outcomes-partial"
@@ -74,12 +77,28 @@ cat > "$DWARVES_KIT_LOG_DIR/runs/$RID2B.log" <<'EOF'
 2026-07-04T09:00:00Z | START | lane=normal classified=normal type=spec-feature repo=dwarves-kit
 2026-07-04T09:00:01Z | GATE | spec | ran | spec authored
 2026-07-04T09:00:03Z | GATE | ship | ran | opened PR
-2026-07-04T09:00:01Z | OUTCOME | spec | caught=false dur_ms=900
+2026-07-04T09:00:01Z | OUTCOME | spec | start | at=500
+2026-07-04T09:00:01Z | OUTCOME | spec | end | at=509 caught=false dur_s=9
 EOF
 OUT2B="$WORK/out2b.md"
 bash "$GEN" "$RID2B" "$OUT2B" >/dev/null 2>&1
 BODY2B="$(cat "$OUT2B" 2>/dev/null)"
+expect "T2: spec row still populates in the partial fixture" "| 1 | spec | 2026-07-04T09:00:01Z | ran | spec authored | false | 9 |" "$BODY2B"
 expect "T2: per-row degrade -- a phase with no OUTCOME line gets n/a, not a crash" "| 2 | ship | 2026-07-04T09:00:03Z | ran | opened PR | n/a | n/a |" "$BODY2B"
+
+# same shape, but the end line omits dur_s= (defensive case) -> duration falls back to
+# the end.at - start.at epoch delta, the same arithmetic outcome()'s own emitter uses
+RID2C="fixture-outcomes-fallback-duration"
+cat > "$DWARVES_KIT_LOG_DIR/runs/$RID2C.log" <<'EOF'
+2026-07-04T09:00:00Z | START | lane=normal classified=normal type=spec-feature repo=dwarves-kit
+2026-07-04T09:00:01Z | GATE | spec | ran | spec authored
+2026-07-04T09:00:01Z | OUTCOME | spec | start | at=100
+2026-07-04T09:00:01Z | OUTCOME | spec | end | at=145 caught=true
+EOF
+OUT2C="$WORK/out2c.md"
+bash "$GEN" "$RID2C" "$OUT2C" >/dev/null 2>&1
+BODY2C="$(cat "$OUT2C" 2>/dev/null)"
+expect "T2: dur_s= absent -> duration derived from end.at - start.at epoch delta (45)" "| 1 | spec | 2026-07-04T09:00:01Z | ran | spec authored | true | 45 |" "$BODY2C"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary
- `lib/proof-table-gen.py` (sub-goal 05) parsed an assumed single-line OUTCOME shape (`caught=`/`dur_ms=`) that `lib/gate-ledger.sh`'s real, now-merged `outcome()` marker (sub-goal 01) never emits: 01 writes a `start`/`end` line pair per phase with duration in seconds as `dur_s=`. The DURATION column silently stayed `n/a` on real data; the CAUGHT column's match was an unmodeled regex coincidence, not a designed pairing.
- Rewrote the OUTCOME branch of `parse_ledger()` to model the real `start`/`end` event field, read `caught=`/`dur_s=` off the `end` line, and fall back to an `end.at - start.at` epoch delta if `dur_s=` is ever absent. Renamed the rendered column `Duration (ms)` -> `Duration (s)`. Updated the stale "ASSUMED shape ... may not be merged yet" doc comment to reference the real, merged SPEC-129 shape.
- `tests/test-proof-table-gen.sh`'s T2/T2B fixtures pinned the wrong assumed shape; corrected them to the real 01 format and added a new T2C case for the epoch-delta duration fallback.
- No output-format or 01-marker changes; additive-tolerance preserved (absent OUTCOME still degrades gracefully, no crash).

## Test plan
- [x] `bash tests/test-proof-table-gen.sh` -> 25/25 green
- [x] Negative control: `lib/proof-table-gen.py` reverted to the pre-fix parser -> 5 assertions RED (all real-01-format), restored -> 25/25 green again
- [x] `/bin/bash tests/test-proof-table-gen.sh` (bash 3.2.57, macOS system bash) -> 25/25 green (cross-platform)
- [x] `bash tests/test-meta.sh` -> 667/667, no regression
- [x] Full run-table + negative control detail: `docs/verification/kri-outcome-reader.md`

Spec: `docs/specs/SPEC-133-proof-table-outcome-reconcile.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
