### PR TITLE
fix(security): confine proof-table-gen paths + align ledger neutering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,5 +116,8 @@ jobs:
       - name: Run generated proof-table tests (SPEC-132, kit-run-integrity SG-05)
         run: bash tests/test-proof-table-gen.sh
 
+      - name: Run security-hardening tests (SPEC-134, kit-run-integrity TIER-4)
+        run: bash tests/test-security-hardening.sh
+
       - name: Run coverage-delta gate tests (SPEC-130, advisory)
         run: bash tests/test-coverage-delta.sh

--- a/docs/implementation-notes/kri-security-hardening.md
+++ b/docs/implementation-notes/kri-security-hardening.md
@@ -50,3 +50,24 @@ Also from the review: softened the `_normalize_rid` docstring's "EXACTLY" claim 
 never a path-escape, only a multibyte-filename correctness edge), and documented that
 `gate_ledger_sh`'s `_kit_root` param is vestigial (also closes a latent KIT_ROOT script-hijack).
 Impact: proof-table-gen.py write path + two doc-comments; new H6 assertion (20/20).
+
+## 2026-07-04 HIGH negative control was CI-fragile (origin/master ref)
+
+Context: PR #161 CI went RED on both platforms , `FAIL H-NEG: expected the reverted generator to
+leak but it did not`. Root cause: the negctl built its reverted generator via
+`git show origin/master:lib/proof-table-gen.py`, but GitHub's `actions/checkout@v4` defaults to
+`fetch-depth: 1` (shallow, single branch), so `origin/master` is not a ref in CI. `git show` failed,
+the redirect (`2>/dev/null`) swallowed it, the reverted-generator file was EMPTY, `python3 <empty>`
+wrote nothing, and the "should leak" assertion failed. Reproduced deterministically in a
+`git clone --depth 1 --single-branch` (master ref ABSENT -> identical RED).
+Decision: build the reverted generator by TRANSFORMING THE CURRENT FILE (`str.replace` on a stable
+string anchor), never a git ref. `mk_reverted` disables sanitization and/or confinement and ASSERTS
+the anchor was found (a drifted anchor fails loudly instead of a silent no-op leak-that-never-fires).
+Split into three per-guard controls (defense-in-depth honesty): NEG-1 confinement-off -> explicit
+out-of-tree path leaks; NEG-2 same generator but an absolute rid via default path stays confined by
+sanitization; NEG-3 both-off -> the rid escape returns.
+Why: the negctl must be self-contained (no repo-history dependency) and each guard proven load-bearing
+on the vector it uniquely owns. Verified the fixed test passes 22/22 in a ref-less shallow clone.
+Lesson: a negative control that reverts via a git ref is only as reliable as that ref's presence in
+CI; prefer an in-file transform with a found-anchor assertion.
+Impact: tests/test-security-hardening.sh negctl section (22/22); proof file negctl section updated.

--- a/docs/implementation-notes/kri-security-hardening.md
+++ b/docs/implementation-notes/kri-security-hardening.md
@@ -33,3 +33,20 @@ any argument (confirmed: `rid "../../victim/pwned"` returns the branch slug), so
 normalize an arbitrary caller-supplied rid. Shelling out would not do the job; a charset-exact
 Python port is the correct reuse.
 Impact: one small pure function; unit-covered against the `../../` and absolute-path PoCs.
+
+## 2026-07-04 TOCTOU hardening (from fresh-context security review)
+
+Context: a `kit:security-reviewer` pass on the diff found no HIGH but flagged a MEDIUM TOCTOU in
+the NEW confinement code: the check validated `realpath(out_path)` but the write used the
+unresolved `open(out_path)`, re-resolving symlink components at write time (a concurrent local
+process could swap a final-component symlink in the check->write gap and escape runs_root).
+Decision: write to the already-resolved `resolved_out` and open the final component with
+`os.O_NOFOLLOW` (via `os.open`+`os.fdopen`); on refusal, fail with a non-zero exit.
+Why: closes the check-vs-use gap for the realistic local-race model; the deterministic
+symlink-target case (symlink pointing outside) is already caught by the realpath confinement (H6),
+and O_NOFOLLOW covers the residual post-check swap.
+Also from the review: softened the `_normalize_rid` docstring's "EXACTLY" claim (GNU `tr`
+`[:alnum:]` is locale-aware, no `LC_ALL=C` pin; the Python port is deliberately stricter ASCII, so
+never a path-escape, only a multibyte-filename correctness edge), and documented that
+`gate_ledger_sh`'s `_kit_root` param is vestigial (also closes a latent KIT_ROOT script-hijack).
+Impact: proof-table-gen.py write path + two doc-comments; new H6 assertion (20/20).

--- a/docs/implementation-notes/kri-security-hardening.md
+++ b/docs/implementation-notes/kri-security-hardening.md
@@ -1,0 +1,35 @@
+# Implementation notes: kri-security-hardening (SPEC-134)
+
+Delta from the spec. References the spec for decisions; records only what the spec did not pin.
+
+## 2026-07-04 Wrapper KIT_ROOT override (test seam)
+
+Context: SPEC-134 §Design confines `proof-table-gen.py`'s output under
+`realpath(KIT_ROOT/docs/runs)`, enforced EVEN for an explicit out-path. The existing
+`tests/test-proof-table-gen.sh` passed explicit out-paths under `$WORK` (outside docs/runs),
+which the new confinement rejects.
+Decision: split `lib/proof-table-gen.sh` into `SCRIPT_ROOT` (where the script lives, used to
+source libs + locate the .py, always the real repo) and `KIT_ROOT` (the LOGICAL root used for
+output confinement + default out-path, defaults to `SCRIPT_ROOT` but honors a pre-set env
+override). Tests set `KIT_ROOT` to a throwaway dir with a `docs/runs/`, so the confinement is
+exercised against a real docs/runs without polluting the repo.
+Why: the confinement is untestable otherwise (either pollute the real repo's docs/runs or can't
+supply a confined explicit path). The split is a minimal, legitimate test seam; libs still load
+from SCRIPT_ROOT so a fake KIT_ROOT can't break sourcing.
+Alternatives: (a) new tests call the .py directly with custom env (kept for the security PoC test,
+but the EXISTING regression test drives the wrapper, so the wrapper still needed the seam);
+(b) leave existing tests writing to the real docs/runs (pollutes repo, rejected).
+Impact: `lib/proof-table-gen.sh` gains a 1-line KIT_ROOT default-with-override; existing test
+setup points KIT_ROOT at a temp dir and writes outputs under its docs/runs.
+
+## 2026-07-04 rid normalizer implemented in Python, not shelled out
+
+Context: §Design (a) says reuse the kit's `runid()` normalizer if practical, else match its
+charset exactly in Python.
+Decision: implement in Python (`_normalize_rid`), matching `runid()`'s two-step transform
+exactly: replace `/` and space with `-`, then drop every char outside `[A-Za-z0-9._-]`.
+Why: the `bash lib/gate-ledger.sh rid` CLI verb derives the rid from the git BRANCH and ignores
+any argument (confirmed: `rid "../../victim/pwned"` returns the branch slug), so it cannot
+normalize an arbitrary caller-supplied rid. Shelling out would not do the job; a charset-exact
+Python port is the correct reuse.
+Impact: one small pure function; unit-covered against the `../../` and absolute-path PoCs.

--- a/docs/specs/SPEC-134-security-hardening.md
+++ b/docs/specs/SPEC-134-security-hardening.md
@@ -1,0 +1,108 @@
+# Spec: Security hardening for proof-table-gen path handling + ledger neutering
+
+Generated: 2026-07-04
+Status: VALIDATED
+Lane: full (a security-remediation lane over PoC-confirmed findings: a HIGH arbitrary-file-write,
+a MEDIUM code/comment invariant mismatch, a LOW symlink-follow. Correctness-critical, so full.)
+
+## Problem
+
+The security review of the merged kit-run-integrity run surfaced three grounded, PoC-confirmed
+findings:
+
+**HIGH , path traversal / arbitrary file write in `lib/proof-table-gen.py`.** The CLI's only
+required arg, `rid`, is used UNSANITIZED to build both the read path
+(`ledger_path = os.path.join(log_dir, "runs", f"{rid}.log")`) and the default write path
+(`out_path = os.path.join(kit_root, "docs", "runs", f"{rid}.md")`). The only guard checks the
+final BASENAME is not literally `proof-of-done.md`; it does NOT confine the resolved path to
+`docs/runs/`. PoC (confirmed): `rid="/tmp/x/pwned"` writes `/tmp/x/pwned.md` (`os.path.join`
+drops the prefix on an absolute component); `rid="../../victim/pwned"` resolves outside
+`docs/runs/`. The file's own docstring claims "the default out-path is always under docs/runs/",
+a provably false contract. Separately, the explicit-`out-path` branch bypasses even the basename
+check.
+
+**MEDIUM , comment/code mismatch in `mutation()` (`lib/gate-ledger.sh`).** The comment claims
+values are sanitized so "a value can never smuggle a second KV" by neutering embedded `=`, but
+the code only does `tr '\n\r' ' ' | tr ' ' '_'`; it never touches `=`. `debt()` already does
+`tr '=' ':'` for exactly this reason. A `file=`/`reason=` value containing `=` therefore smuggles
+a second `KEY=value` token into the emitted `| MUTATION |` line.
+
+**LOW , symlink follow in `lib/mutation-smoke.sh`.** The mutation loop guards with `[ -f "$file" ]`
+(which FOLLOWS symlinks) and then `cp`/rewrites the file, so a tracked symlink is written THROUGH.
+Not exploitable today (candidate files come from the repo's own source list), but belt-and-suspenders.
+
+## Solution
+
+**HIGH , `lib/proof-table-gen.py`:**
+1. Normalize `rid` before it touches ANY path, matching `lib/gate-ledger.sh`'s `runid()` charset
+   exactly: replace `/` and space with `-`, then drop every char outside `[A-Za-z0-9._-]`. Apply to
+   both `ledger_path` (read) and the default `out_path` (write). (The `gate-ledger.sh rid` CLI verb
+   derives from the git branch and ignores an arbitrary arg, so it cannot normalize a caller string;
+   a charset-exact Python port is the correct reuse , see the implementation note.)
+2. Confine the FINAL resolved `out_path`: compute `runs_root = realpath(KIT_ROOT/docs/runs)` and
+   require `realpath(out_path)` to be `runs_root` or under `runs_root + os.sep`. Enforce this EVEN
+   when an explicit `out-path` arg is supplied. Reject with a non-zero exit + stderr if outside.
+3. Keep the existing `proof-of-done.md` basename refusal (run it BEFORE the confinement check so the
+   canonical-file case keeps its specific message).
+
+**MEDIUM , `mutation()`:** add `tr '=' ':'` to the free-text value neutering pipeline, so every
+value (at least `file=`/`reason=`) matches the comment's stated invariant.
+
+**LOW , `lib/mutation-smoke.sh`:** add an explicit `[ -L "$file" ] && continue` so a symlinked
+target is SKIPPED, not written through.
+
+**Test seam (`lib/proof-table-gen.sh`):** split `SCRIPT_ROOT` (where the script lives; sources libs
++ locates the .py) from `KIT_ROOT` (the logical root for confinement + default out-path; defaults to
+`SCRIPT_ROOT`, honors a pre-set env override). Lets tests exercise confinement against a throwaway
+`docs/runs/` without polluting the repo.
+
+**Not changed:** the ledger marker formats (read-only for the .py); the CLI surfaces
+(`proof-table-gen.sh <rid> [out-path]`, `gate-ledger.sh mutation ...`); the mutation-smoke bite logic;
+any acceptance/coverage-delta rendering.
+
+## Design
+
+The sanitization + confinement contract (the pinned invariant this spec is validated against):
+
+- **Charset invariant.** `_normalize_rid(r)` is exactly `re.sub(r'[^A-Za-z0-9._-]', '', r.replace('/', '-').replace(' ', '-'))`.
+  For all inputs the result contains only `[A-Za-z0-9._-]` , no `/`, no `..` path SEGMENT survives as a
+  traversal (a literal `..` collapses to the harmless filename fragment `..` joined by `-`, never a
+  parent-dir step, because every `/` is already gone). An input that normalizes to empty is rejected.
+- **Confinement invariant.** Let `runs_root = os.path.realpath(os.path.join(KIT_ROOT, 'docs', 'runs'))`.
+  The generator writes `out_path` ONLY IF `real = os.path.realpath(out_path)` satisfies
+  `real == runs_root or real.startswith(runs_root + os.sep)`. This holds for BOTH the default path
+  (built from `runs_root` + the normalized rid) AND any explicit `out-path` arg. Otherwise: stderr +
+  non-zero exit, no write. `os.path.realpath` resolves `..` and symlinks, so neither a `../` explicit
+  path nor a symlink pointing outside can escape. Portable (realpath needs no existence).
+- **Ordering.** basename-`proof-of-done.md` refusal runs FIRST, then confinement , the canonical case
+  keeps its specific message; every other out-of-tree path is rejected by confinement.
+
+These two invariants together make the docstring's "only writes under docs/runs/" claim TRUE.
+
+## Verification
+
+Run `bash tests/test-security-hardening.sh` (new), `bash tests/test-proof-table-gen.sh`,
+`bash tests/test-mutation-smoke.sh`, `bash tests/test-meta.sh`. All exit 0.
+
+Acceptance criteria:
+1. `rid="../../victim/pwned"` and an absolute `rid="/tmp/.../pwned"` are CONFINED (write lands under
+   docs/runs) or REJECTED; no file is written outside docs/runs.
+2. An explicit out-path outside docs/runs is REJECTED (non-zero exit, stderr, no write).
+3. A normal rid still writes `docs/runs/<rid>.md`; the `proof-of-done.md` basename is still refused.
+4. NEGATIVE CONTROL: reverting the sanitization+confinement makes the traversal PoC write outside
+   docs/runs again (RED); restoring re-confines (green).
+5. A `file=`/`reason=` value containing `=` no longer adds a second KV to the `| MUTATION |` line
+   (exact KV count asserted). NEGATIVE CONTROL: reverting leaks the `=`.
+6. mutation-smoke skips a symlinked target.
+7. No regression: the three existing suites stay green.
+
+Proof: `docs/verification/kri-security-hardening.md` (table-first).
+
+## After state
+
+- `lib/proof-table-gen.py`: `_normalize_rid` + realpath confinement; docstring contract now true.
+- `lib/proof-table-gen.sh`: SCRIPT_ROOT/KIT_ROOT split.
+- `lib/gate-ledger.sh`: `mutation()` neuters `=`.
+- `lib/mutation-smoke.sh`: symlink skip.
+- `tests/test-security-hardening.sh`: new; wired into `.github/workflows/test.yml`.
+- `tests/test-proof-table-gen.sh`: out-paths moved under a temp KIT_ROOT/docs/runs.

--- a/docs/verification/kri-security-hardening.md
+++ b/docs/verification/kri-security-hardening.md
@@ -15,6 +15,7 @@ symlink-follow in `lib/mutation-smoke.sh` (a symlinked candidate is skipped, not
 | 3 | explicit out-path outside docs/runs -> REJECTED (non-zero exit + stderr, no write) | H3 | PASS |
 | 4 | a normal rid still writes `docs/runs/<rid>.md` (no over-block) | H4 | PASS |
 | 5 | canonical `proof-of-done.md` basename still refused | H5 | PASS |
+| 5b | an out-location symlink pointing OUTSIDE docs/runs is not written through (TOCTOU hardening) | H6 | PASS |
 | 6 | HIGH **negative control**: reverted generator leaks outside docs/runs (RED) | H-NEG | PASS |
 | 7 | `=` in a `file=`/`reason=` value adds no second KV to the `\| MUTATION \|` line | M1 | PASS |
 | 8 | MEDIUM **negative control**: reverted `mutation()` leaks the `=` as extra KVs | M-NEG | PASS |
@@ -24,7 +25,7 @@ symlink-follow in `lib/mutation-smoke.sh` (a symlinked candidate is skipped, not
 
 | Run | Command | Exit | Verdict |
 |---|---|---|---|
-| green | `bash tests/test-security-hardening.sh` | 0 | PASS (18/18) |
+| green | `bash tests/test-security-hardening.sh` | 0 | PASS (20/20) |
 | HIGH neg-control | reverted `proof-table-gen.py` (origin/master) + absolute-rid PoC | n/a | RED-as-expected (writes outside docs/runs) |
 | MEDIUM neg-control | reverted `mutation()` line + `=`-bearing value | n/a | RED-as-expected (4 KV tokens, `=` leaked) |
 | no-regression | `bash tests/test-proof-table-gen.sh` | 0 | PASS (25/25) |
@@ -78,11 +79,22 @@ guard prevents a write-through. L1 asserts the loop's decision (`regular AND not
 symlink but still processes a real file; L2 greps the real source to confirm the guard is wired into
 the candidate loop immediately after the `-f` check (not dead code).
 
+## Security review (fresh-context)
+
+A fresh-context `kit:security-reviewer` audited the diff. Verdict: no CRITICAL/HIGH; the three
+PoC findings + the requested edges (prefix-collision sibling, `..`-after-normalization, empty
+rid, explicit-out-path) all confirmed closed. It surfaced one new MEDIUM **in the new code** , a
+TOCTOU where the confinement checked `realpath(out_path)` but the write used the unresolved
+`out_path`, so a concurrent local process could swap a final-component symlink in the gap. Fixed:
+the write now targets the ALREADY-RESOLVED path and opens with `O_NOFOLLOW` (proof-table-gen.py),
+covered deterministically by H6. LOW (locale caveat on the charset-equivalence claim) and NIT
+(vestigial `_kit_root` param) addressed by softening the docstring + a comment.
+
 ## Reproduce
 
 ```
 cd <repo>                                        # branch fix/kri-security-hardening
-bash tests/test-security-hardening.sh            # 18/18 green (HIGH+MEDIUM+LOW, both neg-controls)
+bash tests/test-security-hardening.sh            # 20/20 green (HIGH+MEDIUM+LOW, both neg-controls, TOCTOU)
 /bin/bash tests/test-security-hardening.sh       # cross-platform, macOS bash 3.2.57
 bash tests/test-proof-table-gen.sh               # 25/25, no regression
 bash tests/test-mutation-smoke.sh                # 33/33, no regression

--- a/docs/verification/kri-security-hardening.md
+++ b/docs/verification/kri-security-hardening.md
@@ -16,7 +16,7 @@ symlink-follow in `lib/mutation-smoke.sh` (a symlinked candidate is skipped, not
 | 4 | a normal rid still writes `docs/runs/<rid>.md` (no over-block) | H4 | PASS |
 | 5 | canonical `proof-of-done.md` basename still refused | H5 | PASS |
 | 5b | an out-location symlink pointing OUTSIDE docs/runs is not written through (TOCTOU hardening) | H6 | PASS |
-| 6 | HIGH **negative control**: reverted generator leaks outside docs/runs (RED) | H-NEG | PASS |
+| 6 | HIGH **negative controls** (per-guard, defense-in-depth): confinement-off -> explicit path leaks; sanitization-off+confinement-off -> rid leaks; confinement-off alone -> sanitization still confines the rid | NEG-1, NEG-2, NEG-3 | PASS |
 | 7 | `=` in a `file=`/`reason=` value adds no second KV to the `\| MUTATION \|` line | M1 | PASS |
 | 8 | MEDIUM **negative control**: reverted `mutation()` leaks the `=` as extra KVs | M-NEG | PASS |
 | 9 | mutation-smoke skips a symlinked candidate; guard wired into the real loop | L1, L2 | PASS |
@@ -25,13 +25,14 @@ symlink-follow in `lib/mutation-smoke.sh` (a symlinked candidate is skipped, not
 
 | Run | Command | Exit | Verdict |
 |---|---|---|---|
-| green | `bash tests/test-security-hardening.sh` | 0 | PASS (20/20) |
-| HIGH neg-control | reverted `proof-table-gen.py` (origin/master) + absolute-rid PoC | n/a | RED-as-expected (writes outside docs/runs) |
+| green | `bash tests/test-security-hardening.sh` | 0 | PASS (22/22) |
+| HIGH neg-control | per-guard reverts of the CURRENT file (NEG-1/2/3) | n/a | RED-as-expected where a guard is removed (leaks) |
+| HIGH neg-control (CI-cond) | fixed test in a ref-less `--depth 1 --single-branch` clone | 0 | PASS (22/22) -- no `origin/master` dependency |
 | MEDIUM neg-control | reverted `mutation()` line + `=`-bearing value | n/a | RED-as-expected (4 KV tokens, `=` leaked) |
 | no-regression | `bash tests/test-proof-table-gen.sh` | 0 | PASS (25/25) |
 | no-regression | `bash tests/test-mutation-smoke.sh` | 0 | PASS (33/33) |
 | no-regression | `bash tests/test-meta.sh` | 0 | PASS (671 assertions) |
-| cross-platform | `/bin/bash tests/test-security-hardening.sh` (bash 3.2.57) | 0 | PASS (18/18) |
+| cross-platform | `/bin/bash tests/test-security-hardening.sh` (bash 3.2.57) | 0 | PASS (22/22) |
 
 ## Run detail
 
@@ -49,13 +50,26 @@ proof-table-gen: refusing to write '.../leakzone/explicit.md': resolves to '...'
 1
 ```
 
-NEGATIVE CONTROL , the reverted generator (origin/master's `proof-table-gen.py`, no
-normalization + no confinement) DOES leak, proving H1-H3 bite:
+NEGATIVE CONTROLS , the two guards are defense-in-depth, so the negctl **builds a reverted
+generator by transforming the CURRENT file** (a `str.replace` on a stable anchor, asserting the
+anchor was found so a drift fails loudly), NOT by fetching `origin/master` , CI's shallow
+`actions/checkout` (fetch-depth 1) has no `master` ref, and the old `git show origin/master:...`
+negctl silently produced an empty file that wrote nothing (the exact RED that this fix addresses;
+reproduced deterministically in a `--depth 1 --single-branch` clone). Each guard is proven
+load-bearing on the vector it uniquely owns:
 ```
-$ KIT_ROOT=... KIT_LOG_DIR=... python3 <origin/master proof-table-gen.py> "$LEAKZONE/neg-abs-pwned"
-wrote .../leakzone/neg-abs-pwned.md   (rid=/.../leakzone/neg-abs-pwned, ...)   <-- arbitrary write OUTSIDE docs/runs
+# NEG-1  confinement is the SOLE guard on an explicit out-of-tree path (sanitization never sees it)
+$ python3 <confinement-disabled> somerid "$LEAKZONE/neg1-explicit"
+   -> writes $LEAKZONE/neg1-explicit(.md)   <-- LEAK (confinement load-bearing here)
+# NEG-2  same reverted generator, but an ABSOLUTE rid via the DEFAULT out-path stays confined:
+$ python3 <confinement-disabled> "$LEAKZONE/neg2-absrid"
+   -> writes docs/runs/-...-neg2-absrid.md  ; no file at $LEAKZONE/neg2-absrid.md  (sanitization load-bearing here)
+# NEG-3  remove BOTH guards -> the rid escape returns:
+$ python3 <sanitization+confinement disabled> "$LEAKZONE/neg3-absrid"
+   -> writes $LEAKZONE/neg3-absrid.md        <-- LEAK outside docs/runs
 ```
-Restoring the fixed generator re-confines every case (18/18 green).
+The real (fixed) generator confines/rejects every case above (H1-H3), and the fixed test passes
+22/22 in a ref-less shallow clone (no `origin/master`), i.e. under CI conditions.
 
 ### MEDIUM , `=` neutered both ways (real ledger line)
 
@@ -94,7 +108,7 @@ covered deterministically by H6. LOW (locale caveat on the charset-equivalence c
 
 ```
 cd <repo>                                        # branch fix/kri-security-hardening
-bash tests/test-security-hardening.sh            # 20/20 green (HIGH+MEDIUM+LOW, both neg-controls, TOCTOU)
+bash tests/test-security-hardening.sh            # 22/22 green (HIGH+MEDIUM+LOW, per-guard neg-controls, TOCTOU)
 /bin/bash tests/test-security-hardening.sh       # cross-platform, macOS bash 3.2.57
 bash tests/test-proof-table-gen.sh               # 25/25, no regression
 bash tests/test-mutation-smoke.sh                # 33/33, no regression

--- a/docs/verification/kri-security-hardening.md
+++ b/docs/verification/kri-security-hardening.md
@@ -1,0 +1,90 @@
+# Proof of done: security hardening (SPEC-134, kit-run-integrity TIER-4)
+
+Three PoC-confirmed findings remediated: HIGH path-traversal / arbitrary-file-write in
+`lib/proof-table-gen.py` (rid sanitized to `runid()` charset + final out-path realpath-confined
+under `docs/runs/`, enforced even for an explicit out-path), MEDIUM `mutation()` comment/code
+mismatch in `lib/gate-ledger.sh` (`=` now neutered so a value cannot smuggle a second KV), LOW
+symlink-follow in `lib/mutation-smoke.sh` (a symlinked candidate is skipped, not written through).
+
+## Acceptance criteria -> confirmation
+
+| # | Acceptance criterion | Test | Result |
+|---|---|---|---|
+| 1 | traversal rid (`../../victim`) default out-path -> CONFINED under docs/runs, no escape | H1 | PASS |
+| 2 | absolute rid (`/leakzone/abs-pwned`) -> no arbitrary absolute write | H2 | PASS |
+| 3 | explicit out-path outside docs/runs -> REJECTED (non-zero exit + stderr, no write) | H3 | PASS |
+| 4 | a normal rid still writes `docs/runs/<rid>.md` (no over-block) | H4 | PASS |
+| 5 | canonical `proof-of-done.md` basename still refused | H5 | PASS |
+| 6 | HIGH **negative control**: reverted generator leaks outside docs/runs (RED) | H-NEG | PASS |
+| 7 | `=` in a `file=`/`reason=` value adds no second KV to the `\| MUTATION \|` line | M1 | PASS |
+| 8 | MEDIUM **negative control**: reverted `mutation()` leaks the `=` as extra KVs | M-NEG | PASS |
+| 9 | mutation-smoke skips a symlinked candidate; guard wired into the real loop | L1, L2 | PASS |
+
+## Confirmation run-table
+
+| Run | Command | Exit | Verdict |
+|---|---|---|---|
+| green | `bash tests/test-security-hardening.sh` | 0 | PASS (18/18) |
+| HIGH neg-control | reverted `proof-table-gen.py` (origin/master) + absolute-rid PoC | n/a | RED-as-expected (writes outside docs/runs) |
+| MEDIUM neg-control | reverted `mutation()` line + `=`-bearing value | n/a | RED-as-expected (4 KV tokens, `=` leaked) |
+| no-regression | `bash tests/test-proof-table-gen.sh` | 0 | PASS (25/25) |
+| no-regression | `bash tests/test-mutation-smoke.sh` | 0 | PASS (33/33) |
+| no-regression | `bash tests/test-meta.sh` | 0 | PASS (671 assertions) |
+| cross-platform | `/bin/bash tests/test-security-hardening.sh` (bash 3.2.57) | 0 | PASS (18/18) |
+
+## Run detail
+
+### HIGH , confined both ways (real PoC output)
+
+FIXED (traversal + absolute rid confined; explicit out-of-tree rejected):
+```
+$ bash lib/proof-table-gen.sh "../../victim-escapee"
+wrote .../dwarves-kit-kri-sec/docs/runs/..-..-victim-escapee.md   # confined, no escape
+$ bash lib/proof-table-gen.sh "$LEAKZONE/abs-pwned"
+wrote .../dwarves-kit-kri-sec/docs/runs/-...-leakzone-abs-pwned.md ; no file at $LEAKZONE/abs-pwned.md
+$ bash lib/proof-table-gen.sh somerid "$LEAKZONE/explicit.md" ; echo $?
+proof-table-gen: refusing to write '.../leakzone/explicit.md': resolves to '...', outside the
+  allowed run-table tree '.../docs/runs' (this generator only writes under docs/runs/)
+1
+```
+
+NEGATIVE CONTROL , the reverted generator (origin/master's `proof-table-gen.py`, no
+normalization + no confinement) DOES leak, proving H1-H3 bite:
+```
+$ KIT_ROOT=... KIT_LOG_DIR=... python3 <origin/master proof-table-gen.py> "$LEAKZONE/neg-abs-pwned"
+wrote .../leakzone/neg-abs-pwned.md   (rid=/.../leakzone/neg-abs-pwned, ...)   <-- arbitrary write OUTSIDE docs/runs
+```
+Restoring the fixed generator re-confines every case (18/18 green).
+
+### MEDIUM , `=` neutered both ways (real ledger line)
+
+FIXED , a `reason` value carrying `=` is rewritten to `:`, so the emitted line has exactly the
+two intended KVs (`verdict=`, `reason=`):
+```
+$ bash lib/gate-ledger.sh mutation med-rid verdict=flag 'reason=smuggled=second=kv'
+<TS> | MUTATION | verdict=flag reason=smuggled:second:kv          # 2 KEY= tokens
+```
+NEGATIVE CONTROL , reverting the `| tr '=' ':'` step (throwaway copy of gate-ledger.sh, sourced
+from the real lib so deps resolve) leaks the `=` as extra KVs:
+```
+$ bash <reverted gate-ledger.sh> mutation negmed-rid verdict=flag 'reason=smuggled=second=kv'
+<TS> | MUTATION | verdict=flag reason=smuggled=second=kv          # 4 KEY= tokens (smuggled=, second= now parse as KVs)
+```
+
+### LOW , symlink skip
+
+`[ -f "$file" ]` follows a symlink-to-regular (true), so only the added `[ -L "$file" ] && continue`
+guard prevents a write-through. L1 asserts the loop's decision (`regular AND not symlink`) skips a
+symlink but still processes a real file; L2 greps the real source to confirm the guard is wired into
+the candidate loop immediately after the `-f` check (not dead code).
+
+## Reproduce
+
+```
+cd <repo>                                        # branch fix/kri-security-hardening
+bash tests/test-security-hardening.sh            # 18/18 green (HIGH+MEDIUM+LOW, both neg-controls)
+/bin/bash tests/test-security-hardening.sh       # cross-platform, macOS bash 3.2.57
+bash tests/test-proof-table-gen.sh               # 25/25, no regression
+bash tests/test-mutation-smoke.sh                # 33/33, no regression
+bash tests/test-meta.sh                          # 671, no regression
+```

--- a/lib/gate-ledger.sh
+++ b/lib/gate-ledger.sh
@@ -534,8 +534,9 @@ mutation() {
   for kv in "$@"; do
     k="${kv%%=*}"; v="${kv#*=}"
     # every value is single-token (space-split read-side); collapse spaces + neuter embedded "="
-    # in free text so a value can never smuggle a second KV or split the ledger line.
-    v="$(printf '%s' "$v" | tr '\n\r' '  ' | tr ' ' '_')"
+    # in free text so a value can never smuggle a second KV or split the ledger line. The "="->":"
+    # step (SPEC-134) matches debt()'s pre-existing neutering and makes this line's comment true.
+    v="$(printf '%s' "$v" | tr '\n\r' '  ' | tr ' ' '_' | tr '=' ':')"
     case "$k" in
       verdict) verdict="$v" ;;
       *)       rest="$rest $k=$v" ;;

--- a/lib/mutation-smoke.sh
+++ b/lib/mutation-smoke.sh
@@ -214,6 +214,7 @@ run() {  # [<base>]
   while IFS="$(printf '\t')" read -r file lineno orig mut; do
     [ "$attempts" -ge "$MAX" ] && break
     [ -f "$file" ] || continue
+    [ -L "$file" ] && continue   # SPEC-134: never mutate through a symlink (defense-in-depth)
     attempts=$((attempts+1))
 
     CUR_FILE="$file"; CUR_BK="$(mktemp)"; cp "$file" "$CUR_BK"

--- a/lib/proof-table-gen.py
+++ b/lib/proof-table-gen.py
@@ -5,8 +5,14 @@ regenerate.
 
 Hard rule (docs/verification/README.md: "Generators write run ledgers, never the
 canonical"): this script refuses to write to any out-path whose basename is literally
-`proof-of-done.md`, the exact filename `lib/proof-ledger.sh` keys the ship-gate on. The
-default out-path is always under `docs/runs/`.
+`proof-of-done.md`, the exact filename `lib/proof-ledger.sh` keys the ship-gate on.
+
+Path safety (SPEC-134): `rid` is CALLER-controlled, so it is normalized to
+`lib/gate-ledger.sh`'s `runid()` charset before it touches ANY path (read ledger + default
+write), and the FINAL resolved out-path is confined under `realpath(KIT_ROOT/docs/runs)` --
+enforced EVEN for an explicit out-path arg. So the default out-path is always under
+`docs/runs/`, and no `rid` or explicit path can escape it (the guarantee this docstring
+makes is now enforced, not merely asserted).
 
 Parses three ledger line shapes (space-pipe-split, the same convention
 `lib/gate-ledger.sh`'s own awk uses):
@@ -33,6 +39,16 @@ import subprocess
 import sys
 
 CANONICAL_BASENAME = "proof-of-done.md"
+
+
+def _normalize_rid(raw):
+    """Normalize a caller-supplied rid to lib/gate-ledger.sh's runid() charset EXACTLY
+    (SPEC-134). runid() is `tr '/ ' '--' | tr -cd '[:alnum:]._-'`: replace '/' and space
+    with '-', then drop every char outside [A-Za-z0-9._-]. This strips path separators (no
+    '/' survives, so no `..` can act as a parent-dir step) before the rid is ever joined
+    into a filesystem path. ASCII [:alnum:] to match tr's C-locale behavior."""
+    swapped = raw.replace("/", "-").replace(" ", "-")
+    return re.sub(r"[^A-Za-z0-9._-]", "", swapped)
 
 
 def fail(msg, code=1):
@@ -110,8 +126,17 @@ def parse_ledger(ledger_path):
     return lane, gate_rows, outcomes
 
 
-def gate_ledger_sh(kit_root):
-    return os.path.join(kit_root, "lib", "gate-ledger.sh")
+def _kit_lib_root():
+    """The REAL repo root (parent of this module's lib/ dir). SPEC-134 decouples helper-script
+    location from KIT_ROOT: gate-ledger.sh is a sibling of this module and always lives in the
+    real repo, whereas KIT_ROOT is now purely the output-confinement anchor (which a test may
+    point at a throwaway dir). Resolving the helper via __file__ keeps `required`/`check` reading
+    the real WORKFLOW.md even when KIT_ROOT is overridden."""
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def gate_ledger_sh(_kit_root=None):
+    return os.path.join(_kit_lib_root(), "lib", "gate-ledger.sh")
 
 
 def required_phases(kit_root, lane):
@@ -119,7 +144,7 @@ def required_phases(kit_root, lane):
     try:
         res = subprocess.run(
             ["bash", gate_ledger_sh(kit_root), "required", lane],
-            capture_output=True, text=True, cwd=kit_root, check=False,
+            capture_output=True, text=True, cwd=_kit_lib_root(), check=False,
         )
     except OSError:
         return None
@@ -133,7 +158,7 @@ def acceptance_status(kit_root, lane, rid):
     try:
         res = subprocess.run(
             ["bash", gate_ledger_sh(kit_root), "check", lane, rid],
-            capture_output=True, text=True, cwd=kit_root, check=False,
+            capture_output=True, text=True, cwd=_kit_lib_root(), check=False,
         )
     except OSError:
         return "n/a (gate-ledger.sh unavailable)"
@@ -215,7 +240,11 @@ def render(rid, ledger_path, kit_root, lane, gate_rows, outcomes):
 def main(argv):
     if len(argv) < 2:
         fail("usage: proof-table-gen.py <rid> [out-path]", 64)
-    rid = argv[1]
+    # SPEC-134: rid is caller-controlled; normalize it before it touches ANY path.
+    raw_rid = argv[1]
+    rid = _normalize_rid(raw_rid)
+    if not rid:
+        fail(f"rid {raw_rid!r} normalizes to empty (no [A-Za-z0-9._-] chars); refusing", 64)
 
     kit_root = os.environ.get("KIT_ROOT")
     log_dir = os.environ.get("KIT_LOG_DIR")
@@ -226,15 +255,29 @@ def main(argv):
             64,
         )
 
-    out_path = argv[2] if len(argv) > 2 else os.path.join(kit_root, "docs", "runs", f"{rid}.md")
+    # SPEC-134: the ONLY tree this generator may write into. realpath resolves symlinks +
+    # `..`, and needs no existence, so it is a portable confinement anchor.
+    runs_root = os.path.realpath(os.path.join(kit_root, "docs", "runs"))
+    out_path = argv[2] if len(argv) > 2 else os.path.join(runs_root, f"{rid}.md")
 
     # Hard backstop (SPEC-016 / SPEC-132 AC5): refuse the canonical filename regardless of
     # caller intent -- a code-level guard, not just a convention followed by discipline.
+    # Runs BEFORE the confinement check so the canonical-file case keeps its specific message.
     if os.path.basename(out_path) == CANONICAL_BASENAME:
         fail(
             f"refusing to write '{out_path}': basename is the canonical "
             f"'{CANONICAL_BASENAME}' (see docs/verification/README.md); this generator "
             "only writes run-table companions under docs/runs/",
+            1,
+        )
+
+    # SPEC-134: confine the FINAL resolved out-path under docs/runs/. Enforced for BOTH the
+    # default path and an explicit out-path arg -- the explicit branch no longer bypasses this.
+    resolved_out = os.path.realpath(out_path)
+    if resolved_out != runs_root and not resolved_out.startswith(runs_root + os.sep):
+        fail(
+            f"refusing to write '{out_path}': resolves to '{resolved_out}', outside the "
+            f"allowed run-table tree '{runs_root}' (this generator only writes under docs/runs/)",
             1,
         )
 

--- a/lib/proof-table-gen.py
+++ b/lib/proof-table-gen.py
@@ -42,11 +42,15 @@ CANONICAL_BASENAME = "proof-of-done.md"
 
 
 def _normalize_rid(raw):
-    """Normalize a caller-supplied rid to lib/gate-ledger.sh's runid() charset EXACTLY
-    (SPEC-134). runid() is `tr '/ ' '--' | tr -cd '[:alnum:]._-'`: replace '/' and space
-    with '-', then drop every char outside [A-Za-z0-9._-]. This strips path separators (no
-    '/' survives, so no `..` can act as a parent-dir step) before the rid is ever joined
-    into a filesystem path. ASCII [:alnum:] to match tr's C-locale behavior."""
+    """Normalize a caller-supplied rid to lib/gate-ledger.sh's runid() charset (SPEC-134).
+    runid() is `tr '/ ' '--' | tr -cd '[:alnum:]._-'`: replace '/' and space with '-', then
+    drop every char outside [A-Za-z0-9._-]. This strips path separators (no '/' survives, so
+    no `..` can act as a parent-dir step) before the rid is ever joined into a filesystem path.
+    We match runid()'s ASCII intent but are DELIBERATELY STRICTER: this port is pure ASCII,
+    whereas GNU tr's `[:alnum:]` is locale-aware and MAY admit multibyte alnums under a UTF-8
+    locale (runid() pins no LC_ALL=C). The Python side only ever strips MORE, so this is never
+    a path-escape; on an exotic multibyte rid the two could disagree on the exact filename (a
+    correctness edge, not a security one). Real rids are ASCII branch slugs, so they agree."""
     swapped = raw.replace("/", "-").replace(" ", "-")
     return re.sub(r"[^A-Za-z0-9._-]", "", swapped)
 
@@ -136,6 +140,10 @@ def _kit_lib_root():
 
 
 def gate_ledger_sh(_kit_root=None):
+    # `_kit_root` is VESTIGIAL (SPEC-134): callers still pass kit_root, but it is intentionally
+    # ignored -- the helper is resolved via __file__, never via the (now caller-influenceable)
+    # KIT_ROOT. This also closes a latent path-hijack: the old `os.path.join(kit_root, "lib",
+    # "gate-ledger.sh")` would have exec'd whatever script sat at an attacker-set KIT_ROOT/lib.
     return os.path.join(_kit_lib_root(), "lib", "gate-ledger.sh")
 
 
@@ -285,14 +293,25 @@ def main(argv):
     lane, gate_rows, outcomes = parse_ledger(ledger_path)
     content = render(rid, ledger_path, kit_root, lane, gate_rows, outcomes)
 
-    out_dir = os.path.dirname(out_path)
+    # SPEC-134: write to the ALREADY-RESOLVED path (not the unresolved out_path), and open the
+    # final component with O_NOFOLLOW. The confinement check above validated `resolved_out`; using
+    # a bare `open(out_path)` would re-resolve symlink components at write time, so a concurrent
+    # local process could swap a final-component symlink in the check->write gap (TOCTOU) and land
+    # the write outside runs_root. Writing `resolved_out` + refusing to follow a final-component
+    # symlink closes that gap for the realistic local-race model.
+    out_dir = os.path.dirname(resolved_out)
     if out_dir:
         os.makedirs(out_dir, exist_ok=True)
-    with open(out_path, "w", encoding="utf-8") as f:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(resolved_out, flags, 0o644)
+    except OSError as e:
+        fail(f"refusing to write '{resolved_out}': {e.strerror} (final component may be a symlink)", 1)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(content)
 
     print(
-        f"wrote {out_path} (rid={rid}, lane={lane or 'unknown'}, "
+        f"wrote {resolved_out} (rid={rid}, lane={lane or 'unknown'}, "
         f"gates={len(gate_rows)}, outcomes={len(outcomes)})"
     )
     return 0

--- a/lib/proof-table-gen.sh
+++ b/lib/proof-table-gen.sh
@@ -13,13 +13,20 @@
 #   [out-path]  default: docs/runs/<rid>.md (a generated path; refuses proof-of-done.md)
 set -euo pipefail
 
-KIT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# SCRIPT_ROOT = where this script + its libs live (always the real repo); used to source
+# libs and locate the .py. KIT_ROOT = the LOGICAL kit root the generator confines output
+# under (docs/runs) and derives the default out-path from. KIT_ROOT defaults to SCRIPT_ROOT
+# but honors a pre-set env override (SPEC-134 test seam), so the SPEC-134 path confinement
+# can be exercised against a throwaway docs/runs without polluting the real repo. Libs are
+# always sourced from SCRIPT_ROOT, so a fake KIT_ROOT can never break sourcing.
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KIT_ROOT="${KIT_ROOT:-$SCRIPT_ROOT}"
 # shellcheck source=lib/kit-log-dir.sh
-source "$KIT_ROOT/lib/kit-log-dir.sh" || { echo "FATAL: lib/kit-log-dir.sh missing or unreadable" >&2; exit 1; }
+source "$SCRIPT_ROOT/lib/kit-log-dir.sh" || { echo "FATAL: lib/kit-log-dir.sh missing or unreadable" >&2; exit 1; }
 kit_migrate_log_dir || true
 
 export KIT_ROOT
 export KIT_LOG_DIR
 KIT_LOG_DIR="$(kit_resolve_log_dir)"
 
-exec python3 "$KIT_ROOT/lib/proof-table-gen.py" "$@"
+exec python3 "$SCRIPT_ROOT/lib/proof-table-gen.py" "$@"

--- a/tests/test-proof-table-gen.sh
+++ b/tests/test-proof-table-gen.sh
@@ -27,6 +27,12 @@ WORK="$(mktemp -d "${TMPDIR:-/tmp}/kit-proof-table-gen.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 export DWARVES_KIT_LOG_DIR="$WORK/logs"
 mkdir -p "$DWARVES_KIT_LOG_DIR/runs"
+# SPEC-134: the generator now confines its output under realpath(KIT_ROOT/docs/runs). Point
+# KIT_ROOT at a throwaway root so explicit out-paths land in a real docs/runs (exercising the
+# confinement) without polluting the actual repo. The wrapper honors this env override.
+export KIT_ROOT="$WORK/kitroot"
+RUNS="$KIT_ROOT/docs/runs"
+mkdir -p "$RUNS"
 
 # ============================================================
 echo "=== T1/T6: round-trip + coverage-delta (lane known) ==="
@@ -38,7 +44,7 @@ cat > "$DWARVES_KIT_LOG_DIR/runs/$RID1.log" <<'EOF'
 2026-07-04T09:00:02Z | GATE | build | ran | implemented
 2026-07-04T09:00:03Z | GATE | ship | skipped | held for review
 EOF
-OUT1="$WORK/out1.md"
+OUT1="$RUNS/out1.md"
 RES1="$(bash "$GEN" "$RID1" "$OUT1" 2>&1)"; RC1=$?
 assert_eq "T1: generator exits 0 on a populated fixture" "$RC1" "0"
 BODY1="$(cat "$OUT1" 2>/dev/null)"
@@ -64,7 +70,7 @@ cat > "$DWARVES_KIT_LOG_DIR/runs/$RID2.log" <<'EOF'
 2026-07-04T09:00:02Z | OUTCOME | build | start | at=2000
 2026-07-04T09:00:02Z | OUTCOME | build | end | at=2043 caught=true dur_s=43
 EOF
-OUT2="$WORK/out2.md"
+OUT2="$RUNS/out2.md"
 bash "$GEN" "$RID2" "$OUT2" >/dev/null 2>&1
 BODY2="$(cat "$OUT2" 2>/dev/null)"
 expect "T2: Caught/Duration columns appear when OUTCOME lines exist" "Caught | Duration (s)" "$BODY2"
@@ -80,7 +86,7 @@ cat > "$DWARVES_KIT_LOG_DIR/runs/$RID2B.log" <<'EOF'
 2026-07-04T09:00:01Z | OUTCOME | spec | start | at=500
 2026-07-04T09:00:01Z | OUTCOME | spec | end | at=509 caught=false dur_s=9
 EOF
-OUT2B="$WORK/out2b.md"
+OUT2B="$RUNS/out2b.md"
 bash "$GEN" "$RID2B" "$OUT2B" >/dev/null 2>&1
 BODY2B="$(cat "$OUT2B" 2>/dev/null)"
 expect "T2: spec row still populates in the partial fixture" "| 1 | spec | 2026-07-04T09:00:01Z | ran | spec authored | false | 9 |" "$BODY2B"
@@ -95,7 +101,7 @@ cat > "$DWARVES_KIT_LOG_DIR/runs/$RID2C.log" <<'EOF'
 2026-07-04T09:00:01Z | OUTCOME | spec | start | at=100
 2026-07-04T09:00:01Z | OUTCOME | spec | end | at=145 caught=true
 EOF
-OUT2C="$WORK/out2c.md"
+OUT2C="$RUNS/out2c.md"
 bash "$GEN" "$RID2C" "$OUT2C" >/dev/null 2>&1
 BODY2C="$(cat "$OUT2C" 2>/dev/null)"
 expect "T2: dur_s= absent -> duration derived from end.at - start.at epoch delta (45)" "| 1 | spec | 2026-07-04T09:00:01Z | ran | spec authored | true | 45 |" "$BODY2C"
@@ -123,7 +129,7 @@ assert_eq "T4: canonical file content is untouched after the refused call" "$CAN
 
 DEFAULT_OUT_LINE="$(bash "$GEN" "$RID1" 2>&1 | grep -oE 'wrote [^ ]+' | cut -d' ' -f2)"
 expect "T5: default out-path lands under docs/runs/" "docs/runs/$RID1.md" "$DEFAULT_OUT_LINE"
-rm -f "$KIT_DIR/docs/runs/$RID1.md" 2>/dev/null || true   # generated artifact, not part of this test's fixture
+rm -f "$RUNS/$RID1.md" 2>/dev/null || true   # generated artifact, not part of this test's fixture
 
 # ============================================================
 echo ""
@@ -133,7 +139,7 @@ RID7="fixture-no-start"
 cat > "$DWARVES_KIT_LOG_DIR/runs/$RID7.log" <<'EOF'
 2026-07-04T09:00:01Z | GATE | spec | ran | spec authored
 EOF
-OUT7="$WORK/out7.md"
+OUT7="$RUNS/out7.md"
 bash "$GEN" "$RID7" "$OUT7" >/dev/null 2>&1
 RC7=$?
 assert_eq "T7: generator exits 0 even with no START line" "$RC7" "0"
@@ -145,7 +151,7 @@ expect "T7: coverage-delta uncovered degrades to lane-unknown text" "Uncovered: 
 echo ""
 echo "=== T8: fully empty ledger (rid has no ledger file at all) ==="
 # ============================================================
-OUT8="$WORK/out8.md"
+OUT8="$RUNS/out8.md"
 bash "$GEN" "no-such-rid-ever" "$OUT8" >/dev/null 2>&1
 RC8=$?
 assert_eq "T8: generator exits 0 on a rid with no ledger file" "$RC8" "0"

--- a/tests/test-security-hardening.sh
+++ b/tests/test-security-hardening.sh
@@ -74,6 +74,15 @@ bash "$GEN" "normal-rid" "$CANON" >/dev/null 2>&1; RC_H5=$?
 eq "H5: proof-of-done.md basename still refused" "$RC_H5" "1"
 if [ ! -f "$CANON" ]; then ok "H5: canonical file not created by the refused call"; else bad "H5: canonical file was written"; fi
 
+# H6: a symlink sitting AT the (confined) output location, pointing OUTSIDE docs/runs, must not be
+# written through -- realpath follows it, the confinement sees the outside target, and rejects. The
+# generator writes the RESOLVED path + opens with O_NOFOLLOW, so no data lands on the symlink target.
+SENTINEL="$LEAKZONE/toctou-target.md"; printf 'ORIGINAL\n' > "$SENTINEL"
+ln -s "$SENTINEL" "$RUNS/evil-symlink.md"     # a symlink inside docs/runs -> outside
+bash "$GEN" evil-symlink >/dev/null 2>&1; RC_H6=$?   # default out-path resolves to the symlink
+eq "H6: write through an out->outside symlink is refused (non-zero exit)" "$RC_H6" "1"
+eq "H6: the symlink's outside target is untouched (no write-through)" "$(cat "$SENTINEL")" "ORIGINAL"
+
 # H-NEG: revert BOTH the normalization + confinement (use origin/master's generator) and show the
 # same absolute-rid PoC leaks. Proves H1-H3 actually bite.
 echo "--- HIGH negative control (reverted generator leaks) ---"

--- a/tests/test-security-hardening.sh
+++ b/tests/test-security-hardening.sh
@@ -83,14 +83,50 @@ bash "$GEN" evil-symlink >/dev/null 2>&1; RC_H6=$?   # default out-path resolves
 eq "H6: write through an out->outside symlink is refused (non-zero exit)" "$RC_H6" "1"
 eq "H6: the symlink's outside target is untouched (no write-through)" "$(cat "$SENTINEL")" "ORIGINAL"
 
-# H-NEG: revert BOTH the normalization + confinement (use origin/master's generator) and show the
-# same absolute-rid PoC leaks. Proves H1-H3 actually bite.
-echo "--- HIGH negative control (reverted generator leaks) ---"
-ORIG_PY="$WORK/orig-proof-table-gen.py"
-git -C "$KIT_DIR" show origin/master:lib/proof-table-gen.py > "$ORIG_PY" 2>/dev/null
-NEG_ABS="$LEAKZONE/neg-abs-pwned"
-KIT_ROOT="$KIT_ROOT" KIT_LOG_DIR="$DWARVES_KIT_LOG_DIR" python3 "$ORIG_PY" "$NEG_ABS" >/dev/null 2>&1
-if [ -f "$NEG_ABS.md" ]; then ok "H-NEG: reverted generator DOES leak (writes $NEG_ABS.md outside docs/runs)"; else bad "H-NEG: expected the reverted generator to leak but it did not"; fi
+# HIGH negative controls: build a REVERTED generator by transforming the CURRENT file (NOT
+# origin/master -- CI's shallow checkout has no such ref, which silently made the old negctl a
+# no-op). mk_reverted disables one or both guards via STABLE STRING ANCHORS and asserts the anchor
+# was actually found (a drifted anchor fails loudly instead of a silent no-op leak-that-never-fires).
+# The two guards are defense-in-depth, so each is proven load-bearing on the vector it uniquely
+# owns, and the full escape is shown to return only when BOTH are removed.
+echo "--- HIGH negative controls (per-guard, reverting the CURRENT file) ---"
+mk_reverted() {  # <sanitize_off 0|1> <confine_off 0|1> <outfile>
+  python3 - "$PY" "$1" "$2" "$3" <<'PY'
+import sys
+src, san_off, conf_off, out = sys.argv[1], sys.argv[2] == "1", sys.argv[3] == "1", sys.argv[4]
+s = open(src).read()
+if san_off:
+    s2 = s.replace("rid = _normalize_rid(raw_rid)", "rid = raw_rid", 1)
+    assert s2 != s, "sanitize anchor not found (drifted); negctl would be a silent no-op"
+    s = s2
+if conf_off:
+    s2 = s.replace(
+        "if resolved_out != runs_root and not resolved_out.startswith(runs_root + os.sep):",
+        "if False:", 1)
+    assert s2 != s, "confine anchor not found (drifted); negctl would be a silent no-op"
+    s = s2
+open(out, "w").write(s)
+PY
+}
+run_rev() { KIT_ROOT="$KIT_ROOT" KIT_LOG_DIR="$DWARVES_KIT_LOG_DIR" python3 "$@" >/dev/null 2>&1; }
+
+# NEG-1: confinement is the SOLE guard on an explicit out-of-tree path (sanitization never touches an
+# explicit out-path). Disable confinement -> the explicit path MUST leak (RED-on-revert).
+REV_CONF="$WORK/rev-confine-off.py"; mk_reverted 0 1 "$REV_CONF" || bad "NEG setup: mk_reverted (confine-off) failed"
+run_rev "$REV_CONF" somerid "$LEAKZONE/neg1-explicit"
+if [ -f "$LEAKZONE/neg1-explicit" ] || [ -f "$LEAKZONE/neg1-explicit.md" ]; then ok "NEG-1 (confinement load-bearing): confinement-off -> explicit out-of-tree path LEAKS"; else bad "NEG-1: expected a leak with confinement removed, none occurred"; fi
+
+# NEG-2: with confinement OFF, sanitization ALONE still confines the rid vector (an absolute rid via
+# the DEFAULT out-path normalizes to a filename inside docs/runs). Proves sanitization is load-bearing
+# on the rid vector independently -- NO leak expected here.
+run_rev "$REV_CONF" "$LEAKZONE/neg2-absrid"
+present "NEG-2 (sanitization load-bearing): confinement-off but sanitization still confines the rid vector" "$LEAKZONE/neg2-absrid.md"
+
+# NEG-3: the full escape returns only when BOTH guards are removed. Disable sanitization AND
+# confinement -> an absolute rid via the default out-path MUST leak (RED-on-revert).
+REV_BOTH="$WORK/rev-both-off.py"; mk_reverted 1 1 "$REV_BOTH" || bad "NEG setup: mk_reverted (both-off) failed"
+run_rev "$REV_BOTH" "$LEAKZONE/neg3-absrid"
+if [ -f "$LEAKZONE/neg3-absrid.md" ]; then ok "NEG-3 (rid-vector guard load-bearing): both-off -> absolute rid LEAKS outside docs/runs"; else bad "NEG-3: expected a leak with both guards removed, none occurred"; fi
 
 # ============================================================
 echo ""

--- a/tests/test-security-hardening.sh
+++ b/tests/test-security-hardening.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# test-security-hardening.sh -- SPEC-134 security remediation for the kit-run-integrity run.
+#
+# Pins three PoC-confirmed findings + their negative controls:
+#   HIGH  : lib/proof-table-gen.py path traversal / arbitrary file write. rid is normalized
+#           (runid() charset) before any path, and the FINAL resolved out-path is confined
+#           under realpath(KIT_ROOT/docs/runs) EVEN for an explicit out-path arg.
+#   MEDIUM: lib/gate-ledger.sh mutation() now neuters embedded "=" in free-text values, so a
+#           value can never smuggle a second KEY=value token into the | MUTATION | line.
+#   LOW   : lib/mutation-smoke.sh skips a symlinked candidate ([ -L ] guard) instead of writing
+#           through it.
+# Each finding carries a negative control that REVERTS the fix (in a throwaway copy) and shows the
+# original behavior leaks -- proving the assertion actually bites.
+#
+# Run: bash tests/test-security-hardening.sh
+# Exit 0 = all pass. Exit 1 = failures.
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GEN="$KIT_DIR/lib/proof-table-gen.sh"
+PY="$KIT_DIR/lib/proof-table-gen.py"
+LEDGER="$KIT_DIR/lib/gate-ledger.sh"
+SMOKE="$KIT_DIR/lib/mutation-smoke.sh"
+GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+PASS=0; FAIL=0; TOTAL=0
+ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
+bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
+eq()      { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
+present() { if [ -e "$2" ]; then bad "$1 (LEAK: '$2' exists outside docs/runs)"; else ok "$1"; fi; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/kit-sec-harden.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+export DWARVES_KIT_LOG_DIR="$WORK/logs"; mkdir -p "$DWARVES_KIT_LOG_DIR/runs"
+
+# Throwaway confinement anchor (the wrapper honors a pre-set KIT_ROOT); a real docs/runs so the
+# confinement targets it, never the real repo.
+export KIT_ROOT="$WORK/kitroot"; RUNS="$KIT_ROOT/docs/runs"; mkdir -p "$RUNS"
+# A world-outside-docs/runs zone the PoC tries (and must fail) to write into.
+LEAKZONE="$WORK/leakzone"; mkdir -p "$LEAKZONE"
+
+# ============================================================
+echo "=== HIGH: proof-table-gen path confinement ==="
+# ============================================================
+# H1: a traversal rid, default out-path -> normalized + confined under docs/runs, nothing escapes.
+# Compare via realpath (python3) so a symlinked /var -> /private/var prefix does not fool the check.
+OUT_H1="$(bash "$GEN" "../../victim-escapee" 2>&1 | grep -oE 'wrote [^ ]+' | cut -d' ' -f2)"
+under_runs() { python3 - "$1" "$2" <<'PY'
+import os, sys
+child = os.path.realpath(sys.argv[1]); root = os.path.realpath(sys.argv[2])
+sys.exit(0 if child == root or child.startswith(root + os.sep) else 1)
+PY
+}
+if under_runs "$OUT_H1" "$RUNS"; then ok "H1: traversal rid lands inside docs/runs ($OUT_H1)"; else bad "H1: traversal rid escaped docs/runs (wrote '$OUT_H1')"; fi
+present "H1: no file written at the clone-root escape target" "$KIT_ROOT/victim-escapee.md"
+
+# H2: an absolute rid -> normalized (leading '/' becomes '-'), confined; no arbitrary abs write.
+ABS_TARGET="$LEAKZONE/abs-pwned"
+bash "$GEN" "$ABS_TARGET" >/dev/null 2>&1
+present "H2: absolute rid does NOT write the arbitrary absolute path" "$ABS_TARGET.md"
+
+# H3: an explicit out-path OUTSIDE docs/runs -> rejected (non-zero exit, stderr), no write.
+ERR_H3="$(bash "$GEN" somerid "$LEAKZONE/explicit.md" 2>&1)"; RC_H3=$?
+eq "H3: explicit out-of-tree out-path is rejected (non-zero exit)" "$RC_H3" "1"
+present "H3: explicit out-of-tree path is not written" "$LEAKZONE/explicit.md"
+case "$ERR_H3" in *"outside"*|*"docs/runs"*) ok "H3: rejection names the confinement reason";; *) bad "H3: rejection message unclear: $ERR_H3";; esac
+
+# H4: a normal rid still writes docs/runs/<rid>.md (no over-blocking).
+bash "$GEN" "normal-rid" >/dev/null 2>&1
+if [ -f "$RUNS/normal-rid.md" ]; then ok "H4: a normal rid still writes docs/runs/normal-rid.md"; else bad "H4: normal rid did not write its run-table"; fi
+
+# H5: the canonical proof-of-done.md basename is still refused (basename guard preserved).
+CANON="$RUNS/proof-of-done.md"
+bash "$GEN" "normal-rid" "$CANON" >/dev/null 2>&1; RC_H5=$?
+eq "H5: proof-of-done.md basename still refused" "$RC_H5" "1"
+if [ ! -f "$CANON" ]; then ok "H5: canonical file not created by the refused call"; else bad "H5: canonical file was written"; fi
+
+# H-NEG: revert BOTH the normalization + confinement (use origin/master's generator) and show the
+# same absolute-rid PoC leaks. Proves H1-H3 actually bite.
+echo "--- HIGH negative control (reverted generator leaks) ---"
+ORIG_PY="$WORK/orig-proof-table-gen.py"
+git -C "$KIT_DIR" show origin/master:lib/proof-table-gen.py > "$ORIG_PY" 2>/dev/null
+NEG_ABS="$LEAKZONE/neg-abs-pwned"
+KIT_ROOT="$KIT_ROOT" KIT_LOG_DIR="$DWARVES_KIT_LOG_DIR" python3 "$ORIG_PY" "$NEG_ABS" >/dev/null 2>&1
+if [ -f "$NEG_ABS.md" ]; then ok "H-NEG: reverted generator DOES leak (writes $NEG_ABS.md outside docs/runs)"; else bad "H-NEG: expected the reverted generator to leak but it did not"; fi
+
+# ============================================================
+echo ""
+echo "=== MEDIUM: mutation() '=' neutering ==="
+# ============================================================
+# M1: a free-text value carrying '=' must NOT add extra KEY=value tokens to the | MUTATION | line.
+kv_count() { printf '%s' "$1" | grep -oE '[A-Za-z_]+=' | wc -l | tr -d ' '; }
+bash "$LEDGER" mutation med-rid verdict=flag 'reason=smuggled=second=kv' >/dev/null 2>&1
+LINE_M1="$(grep MUTATION "$DWARVES_KIT_LOG_DIR/runs/med-rid.log")"
+eq "M1: exactly 2 KEY= tokens (verdict= + reason=), '=' neutered" "$(kv_count "$LINE_M1")" "2"
+case "$LINE_M1" in *"reason=smuggled:second:kv"*) ok "M1: '=' in the value rewritten to ':'";; *) bad "M1: value not neutered: $LINE_M1";; esac
+
+# M-NEG: revert the fix in a throwaway copy of gate-ledger.sh (sourced from the real lib so deps
+# resolve) and show the '=' leaks a second KV.
+echo "--- MEDIUM negative control (reverted mutation leaks) ---"
+NEG_GL="$KIT_DIR/lib/.neg-gate-ledger.sh"   # inside lib/ so its `source ...kit-log-dir.sh` resolves
+sed "s#tr ' ' '_' | tr '=' ':'#tr ' ' '_'#" "$LEDGER" > "$NEG_GL"
+trap 'rm -rf "$WORK"; rm -f "$NEG_GL"' EXIT
+bash "$NEG_GL" mutation negmed-rid verdict=flag 'reason=smuggled=second=kv' >/dev/null 2>&1
+LINE_MNEG="$(grep MUTATION "$DWARVES_KIT_LOG_DIR/runs/negmed-rid.log")"
+if [ "$(kv_count "$LINE_MNEG")" -gt 2 ]; then ok "M-NEG: reverted mutation leaks extra KV ($(kv_count "$LINE_MNEG") tokens: $LINE_MNEG)"; else bad "M-NEG: expected the '=' to leak a second KV, got: $LINE_MNEG"; fi
+
+# ============================================================
+echo ""
+echo "=== LOW: mutation-smoke symlink skip ==="
+# ============================================================
+# L1: the guard's exact predicate skips a symlink. `[ -f ]` FOLLOWS a symlink-to-regular (true),
+# so only the `[ -L ]` guard prevents a write-through. Assert both the follow and the skip.
+TARGET="$WORK/l-target"; printf 'sentinel\n' > "$TARGET"
+LINKF="$WORK/l-link"; ln -s "$TARGET" "$LINKF"
+if [ -f "$LINKF" ]; then ok "L1: [ -f link ] is true (symlink-to-regular is followed -- why the -L guard is needed)"; else bad "L1: [ -f link ] unexpectedly false"; fi
+# The loop's decision: process iff regular AND not a symlink.
+if { [ -f "$LINKF" ] && [ ! -L "$LINKF" ]; }; then bad "L1: loop would PROCESS the symlink (guard not effective)"; else ok "L1: loop skips the symlink (regular-and-not-symlink is false)"; fi
+if { [ -f "$TARGET" ] && [ ! -L "$TARGET" ]; }; then ok "L1: a real regular file is still processed (no over-skip)"; else bad "L1: real file wrongly skipped"; fi
+
+# L2: the guard is actually WIRED into the real mutation loop, immediately after the `-f` check
+# (not dead code elsewhere). Grep the source for the two adjacent guard lines.
+if grep -qF '[ -L "$file" ] && continue' "$SMOKE"; then ok "L2: symlink-skip guard present in lib/mutation-smoke.sh"; else bad "L2: symlink-skip guard missing from lib/mutation-smoke.sh"; fi
+if awk '/\[ -f "\$file" \] \|\| continue/{f=1;next} f&&/\[ -L "\$file" \] && continue/{print "ok";exit}' "$SMOKE" | grep -q ok; then
+  ok "L2: guard sits immediately after the [ -f ] check in the candidate loop"; else bad "L2: guard not adjacent to the [ -f ] check"; fi
+
+echo ""
+echo "=== Results ==="
+echo -e "Passed: ${GREEN}$PASS${NC} / $TOTAL"
+if [ "$FAIL" -gt 0 ]; then echo -e "${RED}$FAIL assertions failed.${NC}"; exit 1; fi
+echo -e "${GREEN}security-hardening green.${NC}"


### PR DESCRIPTION
## Security hardening (kit-run-integrity TIER-4)

Remediates three PoC-confirmed findings from the security review of the merged kit-run-integrity run. Spec: `docs/specs/SPEC-134-security-hardening.md`. Proof: `docs/verification/kri-security-hardening.md`.

### HIGH , path traversal / arbitrary file write in `lib/proof-table-gen.py`
The caller-controlled `rid` (the CLI's only required arg) was used **unsanitized** to build both the read path (`docs/runs/<rid>.log`) and the default write path (`docs/runs/<rid>.md`), guarded only by a basename check that did **not** confine the resolved path to `docs/runs/`. Confirmed PoC: `rid="/tmp/x/pwned"` wrote `/tmp/x/pwned.md` (`os.path.join` drops the prefix on an absolute component); `rid="../../victim/pwned"` escaped `docs/runs/`. The explicit-`out-path` branch bypassed even the basename check.

Fix (both required):
- **Normalize** `rid` to `lib/gate-ledger.sh`'s `runid()` charset exactly (`/` and space -> `-`, then drop everything outside `[A-Za-z0-9._-]`) before it touches **any** path. No `/` survives, so no `..` can act as a parent-dir step.
- **Confine** the final resolved out-path under `os.path.realpath(KIT_ROOT/docs/runs)` (prefix check uses `runs_root + os.sep`, so a sibling like `docs/runs-evil/` is rejected too). Enforced **even for an explicit out-path arg**. The `proof-of-done.md` basename refusal is preserved and runs first.
- Decoupled helper-script location (`gate-ledger.sh` via `__file__`) from `KIT_ROOT`, so `KIT_ROOT` is purely the confinement anchor and a test can redirect it without breaking the coverage-delta subprocess.

### MEDIUM , `mutation()` comment/code mismatch in `lib/gate-ledger.sh`
The comment claimed embedded `=` was neutered so a value "can never smuggle a second KV", but the code only collapsed whitespace. A `file=`/`reason=` value containing `=` therefore added extra `KEY=value` tokens to the `| MUTATION |` line. Fix: apply the same `tr '=' ':'` that `debt()` already uses.

### LOW , symlink follow in `lib/mutation-smoke.sh`
The candidate loop guarded with `[ -f "$file" ]` (which follows symlinks) then wrote through the file. Added `[ -L "$file" ] && continue` to skip a symlinked target (defense-in-depth; not exploitable today).

### Tests / proof
- New `tests/test-security-hardening.sh` (18 assertions): HIGH confinement (traversal + absolute + explicit-out-of-tree reject + normal-still-writes + basename-refused), MEDIUM `=`-neutering, LOW symlink-skip , **each with a reverting negative control** (the reverted code demonstrably leaks). Wired into `.github/workflows/test.yml`.
- Existing `tests/test-proof-table-gen.sh` updated to write under a throwaway `KIT_ROOT/docs/runs` so it exercises the new confinement.
- No regression: `test-proof-table-gen` 25/25, `test-mutation-smoke` 33/33, `test-meta` green (671), cross-platform on macOS bash 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
