### PR TITLE
feat(ship): record the debt-ledger classifier line at ship

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -472,8 +472,9 @@ loop?" Advisory by construction -- nothing below ever blocks a correct build.
   prose-ordered (not alphabetical) diff, a diagram -- composing `narrate-log` +
   `svg-knowledge-diagram`, grounded in the actual diff + recorded tests, never the agent's
   narrative. Human-invoked, on demand; no auto-fire. On a `gate`/gated-final PR, `/kit:ship`'s
-  Step 8 runs `lib/quiz-gate.sh tap`, which asks `lib/significance-classify.sh classify` for the
-  verdict (two signals: significance x understanding-worthiness) and, ONLY on a `tap` (high x
+  Step 8 first runs `lib/significance-classify.sh record` (SPEC-136, below), persisting the
+  `significance=`/`worthiness=`/`verdict=` marker to the debt ledger; then Step 8 runs `lib/quiz-gate.sh tap`, which asks `lib/significance-classify.sh classify` for the
+  same verdict (two signals: significance x understanding-worthiness) and, ONLY on a `tap` (high x
   high), prints the ★-tap nudge: a one-line "worth understanding: <why>" plus a 5-question quiz
   grounded in the diff+tests, routed through `deep-understand`'s mastery gate.
 - **The conscious debt-budget model (ADR-0031 Refinement).** The goal is CONSCIOUS debt, not zero
@@ -488,16 +489,20 @@ loop?" Advisory by construction -- nothing below ever blocks a correct build.
   items into the operator's existing learning skills (`learning-day-process`, `learning-ledger`,
   `deep-understand`, `knowledge-capture`) rather than reinventing a second batching engine;
   `weekend-batch.sh mark-paid <rid>` closes an item so it is never re-collected.
-- **Known wiring gap, stated honestly (not papered over).** `significance-classify.sh record` --
-  the verb that PERSISTS a raw `significance=/worthiness=/verdict=` `| DEBT |` marker independent
-  of the quiz nudge -- has no invoking command anywhere in this repo today; only its `classify`
-  verb (transient, no ledger write) is live, called from `lib/quiz-gate.sh`'s `tap`. Practical
-  consequence: a significant-but-low-worthiness (`wave`) or `not-significant` change that is NEVER
-  part of a `gate`/gated-final PR (so `quiz-gate.sh tap` never runs) is not yet logged to the debt
-  ledger at all -- only changes that at least reach the tap decision are. This does not weaken any
-  hard gate (the axis is advisory either way); it is tracked as a follow-up in
-  `docs/implementation-notes/significance-classify.md` and this sub-goal's own impl-notes, not
-  silently claimed as working.
+- **`significance-classify.sh record` wired at Ship (SPEC-136).** The verb that PERSISTS a raw
+  `significance=`/`worthiness=`/`verdict=` `| DEBT |` marker independent of the quiz nudge --
+  previously an honestly-documented gap with no invoking command -- is now called by
+  `/kit:ship` Step 8, immediately before `quiz-gate.sh tap`, using the same files/description
+  (advisory, guarded so a `record` failure never blocks the ship). Practical effect: EVERY
+  gate/gated-final ship now logs its classifier verdict, including the SILENT-WAVE case
+  (significant-but-low-worthiness, `verdict=wave`, no human response ever follows) -- the exact
+  gap ADR-0031 Refinement §2/§4 names as needing to be tracked, not silently dropped. A later
+  human `debt-response` (engage/defer/wave) forward-carries this recorded marker automatically
+  (the TIER-4-close seam fix, `docs/verification/debt-ledger-response-seam.md`). Remaining,
+  honestly-scoped limit: `record` fires only on `gate`/gated-final PRs (the same scope
+  `quiz-gate.sh tap` has always had, per ADR-0031 §2); a non-gate ship still writes no debt-ledger
+  marker at all -- that scope was never widened by this change, see SPEC-136 "Approaches
+  considered" (D).
 
 ## The spine
 How a committed backlog item becomes shipped work, end to end:

--- a/commands/quiz-gate.md
+++ b/commands/quiz-gate.md
@@ -28,7 +28,8 @@ three responses are recorded.
 
 Only a `tap` verdict (significant AND understanding-worthy) on a `gate`/gated-final PR is ever nudged , the
 anti-fatigue guard. A significant-but-low-worthiness change (`wave`) or a `not-significant` change is NEVER
-quizzed (it was already logged silently by SPEC-123's `significance-classify record` at Ship).
+quizzed (it is already logged silently by SPEC-123's `significance-classify record`, wired into `/kit:ship`
+Step 8 by SPEC-136, immediately before this tap).
 
 ```bash
 bash lib/quiz-gate.sh tap <rid> --files "<changed files>" --impl-notes docs/implementation-notes/<slug>.md --pr-kind gate "<what changed>"

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -169,7 +169,9 @@ If the current branch is not main/master:
   ```
 - If the spec references issue numbers, link them in the PR.
 - Tell the user the PR is ready.
-- **Understanding-gate nudge (ADR-0031, SPEC-125):** on a `gate`/gated-final PR, after the Understanding-debt marker is recorded, run `bash lib/quiz-gate.sh tap <rid> --files "<files>" --pr-kind gate "<what changed>"`. On a `tap` verdict it prints the ★-tap nudge; present it and route the human's engage/defer/wave via `/kit:quiz-gate` (`lib/quiz-gate.sh respond`). Advisory, never blocks the merge; a `wave`/`not-significant` change prints nothing.
+- **Understanding-gate nudge (ADR-0031 Refinement §4, SPEC-125, SPEC-136):** on a `gate`/gated-final PR, first record the Understanding-debt marker, then decide whether to nudge:
+  1. `bash lib/significance-classify.sh record <rid> --files "<files>" "<what changed>" || true` -- writes the FAT `significance=`/`worthiness=`/`verdict=` line to the debt ledger LIVE, using the same files/description the tap call below uses. Guarded with `|| true`: advisory, a `record` failure must never block the ship. This is what makes the next bullet's "after the Understanding-debt marker is recorded" literally true, and it is what logs the SILENT-WAVE case (significant-but-low-worthiness, `verdict=wave`, no human response) even when the tap below prints nothing.
+  2. `bash lib/quiz-gate.sh tap <rid> --files "<files>" --pr-kind gate "<what changed>"`. On a `tap` verdict it prints the ★-tap nudge; present it and route the human's engage/defer/wave via `/kit:quiz-gate` (`lib/quiz-gate.sh respond`), which forward-carries the marker recorded in step 1 onto the human's response line. Advisory, never blocks the merge; a `wave`/`not-significant` change prints nothing further here (it is already logged by step 1).
 
 If on main: warn that they should have used a feature branch.
 

--- a/docs/implementation-notes/record-at-ship.md
+++ b/docs/implementation-notes/record-at-ship.md
@@ -1,0 +1,69 @@
+## 2026-07-04 04:01 Wired significance-classify record into /kit:ship (SPEC-136)
+
+Context: ADR-0031 Refinement §4 + the understanding-gate mega-goal's TIER-4 close both named the
+same open hole: `significance-classify.sh record` (SPEC-123) has existed since the classifier
+shipped, but nothing ever called it. `tests/test-understanding-wiring.sh` AC3 made this an honest,
+asserted gap (rc=3) rather than a silent over-claim -- correct SG-06 discipline, but it left the
+"silent wave, but LOGGED" half of ADR-0031 Refinement §2 inert: a significant-but-low-worthiness
+change was only ever recorded as a side effect of `quiz-gate.sh tap` running, and `tap` itself only
+calls `classify` (transient), never `record` (persists). This entry is the DELTA from SPEC-136, not
+a restatement of it (see `docs/specs/SPEC-136-record-at-ship.md` for the full Problem/Solution/
+Design).
+
+Decisions not pinned down by the assigning prompt, made here:
+
+1. **Where in ship.md, exactly.** The assigning prompt said "before the `quiz-gate.sh tap` call,
+   using the SAME change description + files the tap already uses." I placed `record` as bullet
+   sub-step 1 and `tap` as sub-step 2 under the SAME "Understanding-gate nudge" bullet (rather than
+   two separate top-level bullets), so the two calls read as one coherent beat with one shared
+   file/desc input, not two independently-timed steps that could drift apart if someone edits one
+   without the other.
+2. **Fire-on-every-gate-ship vs fire-only-when-tap-would-nudge (SPEC-136 Design, Approach C).**
+   Chose unconditional: `record` runs on every `gate`/gated-final ship regardless of what verdict
+   `tap` will compute a moment later. Gating `record` on `tap`'s own verdict would just move the
+   silent-wave hole one line down (a `wave` verdict, by definition, never triggers `tap`'s nudge
+   branch -- so gating record on "tap would nudge" makes `wave` unloggable again, the exact bug this
+   SPEC closes). `record` and `tap` compute the SAME classification independently (both call
+   `significance-classify` with identical inputs) rather than one feeding the other a cached
+   verdict -- kept them decoupled per Approach B's rejection (a future non-ship caller of `tap`
+   should not silently start writing to the ledger as a side effect of asking `tap` a yes/no
+   question).
+3. **The exit-0 guard.** The assigning prompt said "a `record` failure must never block the ship
+   (guard it, exit-0 posture like the rest of the axis)." Implemented as a literal `|| true` on the
+   prose command in `commands/ship.md` (this is a markdown-instruction file executed by an agent,
+   not a real shell script, so the guard is documentation of intent + a copy-pasteable safe form,
+   not an enforced trap). `significance-classify.sh record` itself already exits 0 in the success
+   path (SPEC-123); the only realistic failure mode is a `gate-ledger.sh debt` write error (e.g. a
+   read-only log dir), which `|| true` absorbs.
+4. **Widening the scope was explicitly rejected.** Considered (Approach D) firing `record` on every
+   ship, not only gate/gated-final. Rejected: the Understanding-gate nudge bullet this wiring
+   extends has always been scoped to `gate`/gated-final PRs (SPEC-125); this SPEC fills a gap
+   INSIDE that existing scope, it does not widen it. A non-gate ship still writes zero debt-ledger
+   markers after this change -- documented plainly in WORKFLOW.md's updated bullet so a future
+   reader does not assume otherwise.
+
+Deviation from a literal reading of the assigning prompt: none functionally, but note the AC3 flip
+in `tests/test-understanding-wiring.sh` needed a THIRD assertion beyond "a caller exists somewhere"
+(the prompt's own wording): I added an explicit line-order check (`record`'s line number precedes
+`tap`'s line number in `commands/ship.md`) so the test proves the ORDERING the whole SPEC depends
+on, not just that both strings happen to appear in the file. A grep-only "both exist" check would
+have passed even if I had (incorrectly) put `record` after `tap`.
+
+Impact: every `/kit:ship` run on a `gate`/gated-final PR now writes a FAT `| DEBT |` line
+(`significance=`/`worthiness=`/`verdict=`) to the debt ledger before the quiz-gate tap decision.
+`weekend-batch.sh collect`/`list` show real significance/worthiness for these rids directly (the
+TIER-4-close walk-back logic stays load-bearing only for pre-SPEC-136 rids and non-gate ships). A
+live smoke run (temp `DWARVES_KIT_LOG_DIR`, this branch's real changed-files list) reproduced the
+full loop: `record` (verdict=wave, grounded in the real files/description, full-lane significant but
+no worthiness trigger fired) -> `list` shows it collectible as `waved` with NO human response yet
+recorded (the silent-wave path, live) -> `debt-response defer` forward-carries `significance=high
+worthiness=low verdict=wave` onto the response line -> `collect` digest shows the real values, not
+blanks -> `mark-paid` exits 0, disposed paid, no longer collectible.
+
+New/flipped test coverage: `tests/test-understanding-wiring.sh` AC3 (3 checks: a caller exists,
+specifically in `commands/ship.md`, and precedes the `tap` call by line number) plus AC2's
+`claim_wired` check for `record` now expects rc=0 (WIRED) instead of rc=3 (HONEST GAP).
+`tests/test-weekend-batch.sh` gained AC5 (7 checks: the full record -> forward-carry -> collect ->
+mark-paid payoff loop, driven through the REAL `significance-classify.sh record` verb, not a
+hand-seeded fixture line) and AC6 (4 checks: the silent-wave path, a `record` producing `verdict=wave`
+with no human response ever collected as `waved`).

--- a/docs/specs/SPEC-136-record-at-ship.md
+++ b/docs/specs/SPEC-136-record-at-ship.md
@@ -1,0 +1,192 @@
+# SPEC-136: wire significance-classify record into /kit:ship
+
+Status: VALIDATED
+Lane: full
+Type: spec-feature
+Relates-to: ADR-0031 Refinement §4 (conscious debt budget; impl-notes as the feed), SPEC-123
+(`lib/significance-classify.sh` , the classifier + its `record` verb), SPEC-125
+(`lib/quiz-gate.sh` , the ★-tap nudge that `tap` already calls `classify` for), SPEC-126
+(`lib/weekend-batch.sh` , the debt-ledger reader whose `collect`/`mark-paid` walk-back logic
+exists only because `record` was unwired), SPEC-127/SPEC-135 (`tests/test-understanding-wiring.sh`
+, the no-orphan sweep that AC3 currently asserts `record` has NO live caller), the
+`debt-ledger-response-seam` TIER-4 close (the forward-carry fix in `gate-ledger.sh debt_response`
+that this wiring now exercises for real on its default path)
+
+## Problem
+
+`significance-classify.sh record` (SPEC-123) has existed since the classifier shipped: it runs
+`classify_core`, then writes a FAT `| DEBT |` line (`significance=<low|high> worthiness=<low|high>
+verdict=<tap|wave|not-significant>`) to the debt ledger via `gate-ledger.sh debt`. Nothing has ever
+called it. `commands/ship.md`'s Understanding-gate nudge bullet (Step 8) says the ★-tap runs "after
+the Understanding-debt marker is recorded" -- but no command anywhere records that marker; only
+`quiz-gate.sh tap` calls `significance-classify.sh classify` (a transient classification, no ledger
+write). `tests/test-understanding-wiring.sh` AC3 makes this an EXPLICIT, asserted honest gap (rc=3,
+"HONEST GAP") rather than a silent over-claim -- which is correct SG-06 discipline, but it leaves a
+real hole open:
+
+1. **The silent-wave case is never logged.** ADR-0031 Refinement §2/§4's whole point is that a
+   significant-but-low-worthiness change (`verdict=wave`) is FINE to skip quizzing, as long as it is
+   a RECORDED choice ("the only real failure is UNTRACKED debt"). Today a `wave` is only ever
+   recorded as a side effect of `quiz-gate.sh tap` running (SPEC-125), and `tap` itself only prints a
+   nudge on `verdict=tap` -- it still calls `classify`, not `record`, so **no `| DEBT |` line is ever
+   written for a `wave` or `not-significant` change on a `gate`/gated-final PR either.** The debt
+   ledger stays empty for exactly the changes ADR-0031 exists to track.
+2. **`weekend-batch.sh collect`/`list` show blank significance/worthiness** for any rid whose only
+   ledger activity is a human `response=` line with no prior FAT line (the TIER-4-close default
+   path, per `debt-ledger-response-seam.md`). The forward-carry fix in `gate-ledger.sh
+   debt_response()` (reads back the last FAT line and re-emits it) exists and is tested, but has
+   never fired live because there has never been a live FAT-line writer.
+3. **impl-notes stay write-only.** ADR-0031 Refinement §4 reverses the ID-234 "drop impl-notes"
+   proposal specifically because the classifier reads `docs/implementation-notes/<slug>.md` as a
+   worthiness signal (`_impl_notes_signal`) -- but that signal only ever reaches a ledger write
+   through `record`, which nothing calls. The impl-notes-feed half of the design is inert until
+   `record` is wired somewhere.
+
+## Solution
+
+Wire `significance-classify.sh record` into `/kit:ship` Step 8, immediately BEFORE the existing
+`quiz-gate.sh tap` call, using the SAME `--files`/description the tap call already uses (so the
+recorded marker and the tap decision are computed from identical inputs and can never disagree).
+This is the minimal seam: `record` already does everything needed (classify + write the FAT line);
+`ship.md` already has the exact file list and change description in scope for the nudge bullet it
+already carries. No new lib code, no new verb, no new ledger shape.
+
+- **`commands/ship.md` Step 8** gains one line before the `quiz-gate.sh tap` call:
+  `bash lib/significance-classify.sh record <rid> --files "<files>" "<what changed>" || true`.
+  The `|| true` is the advisory exit-0 posture already used elsewhere on this axis (mirrors
+  `weekend-batch.sh mark-paid`'s "advisory, never a hard failure" framing and SPEC-125's
+  `quiz-gate.sh tap`'s own always-exit-0 contract): a `record` failure (e.g. a ledger-dir write
+  error) must never block the ship. `--impl-notes docs/implementation-notes/<slug>.md` is included
+  when an impl-note exists for the change, completing ADR-0031 Refinement §4's feed.
+- **The prose bullet's own claim becomes true**: "after the Understanding-debt marker is recorded"
+  now names a real, preceding call, not an aspirational description.
+- **`gate-ledger.sh debt_response`'s forward-carry** (already implemented, TIER-4 close) now has a
+  live FAT-line producer: a later human `respond`/`debt-response` call for the same rid picks up
+  this recorded `significance=`/`worthiness=`/`verdict=` automatically, no new code.
+- **`weekend-batch.sh collect`/`list`** show the recorded sig/wor directly (not via walk-back to a
+  hand-seeded fixture) for every rid that reached Ship on a gate/gated-final PR, including waved and
+  not-significant ones.
+
+**Why record fires on EVERY gate/gated-final ship, not only when tap would nudge**: `quiz-gate.sh
+tap` already deliberately prints nothing on `wave`/`not-significant` (the anti-fatigue guard, SPEC-125)
+-- that guard is about the HUMAN NUDGE, not the ledger write. `record`'s own job (SPEC-123) is
+exactly to persist the classifier's verdict "independent of the quiz nudge" (its own doc comment).
+Firing `record` unconditionally before `tap` on every gate/gated-final ship is what actually closes
+the "silent wave, but LOGGED" gap ADR-0031 Refinement §2 names; gating `record` on `tap`'s own
+verdict would just move the silent hole one line down.
+
+## Design
+
+Design-bearing: wires a previously-inert verb into a live pipeline boundary (`/kit:ship`), changing
+what the debt ledger observably contains for every future gate/gated-final ship. Not a new
+component/schema/lib -- the mechanism (`record`, `debt()`, the forward-carry) is unchanged; only the
+CALL SITE is new.
+
+### Approaches considered
+
+- **A (chosen). Call `record` in `ship.md` Step 8, immediately before `quiz-gate.sh tap`, same
+  files/desc.** Minimal: reuses the exact inputs the nudge bullet already computes. Keeps `record`
+  and `tap` as two independent, single-purpose calls (record persists; tap decides whether to nudge)
+  rather than merging their concerns into one call. Advisory (`|| true`), matching the rest of the
+  axis.
+- **B. Fold `record`'s classify+persist into `quiz-gate.sh tap` itself** (have `tap` call `record`
+  instead of `classify`). Rejected: `tap`'s contract (SPEC-125) is "decide whether to nudge", not
+  "persist the ledger line" -- conflating them would mean every FUTURE caller of `tap` (e.g. a
+  non-ship gate boundary, if one is ever added) silently starts writing to the debt ledger as a side
+  effect, a surprising coupling. Keeping `record` a separate, explicit call at the one call site
+  that wants it (`ship.md`) is more legible and matches SPEC-123's own header ("independent of the
+  quiz nudge").
+- **C. Fire `record` only when `tap`'s verdict is `wave` (skip it when `tap` already nudges).**
+  Rejected: this reintroduces exactly the gap ADR-0031 Refinement §2 forbids for the OTHER verdict
+  --a `tap` change that the human then engages/defers/waves would have no independent FAT line if
+  the human's later `debt-response` overwrote it before a `record` line ever existed; worse, it makes
+  `record`'s behavior implicitly depend on `tap`'s verdict, adding a hidden ordering dependency
+  between two calls that should stay independent. Firing `record` unconditionally (before `tap`
+  runs) is simpler and uniform across all three verdicts.
+- **D. Fire `record` on every ship (not gate/gated-final-only).** Considered, but the Understanding-gate
+  nudge bullet this wiring extends is explicitly scoped to "on a `gate`/gated-final PR" (SPEC-125); a
+  non-gate ship was never in scope for this axis (ADR-0031 is about the merge-boundary human attention
+  gate). Kept the existing `gate`/gated-final scoping unchanged -- this SPEC only fills the gap
+  inside that scope, it does not widen the scope.
+
+```mermaid
+sequenceDiagram
+  participant Ship as /kit:ship Step 8
+  participant SC as significance-classify.sh
+  participant GL as gate-ledger.sh
+  participant QG as quiz-gate.sh
+  participant Human as human (merge decision)
+  participant WB as weekend-batch.sh
+
+  Ship->>SC: record <rid> --files F "<desc>"  (NEW call site, this SPEC)
+  SC->>SC: classify_core (significance x worthiness)
+  SC->>GL: debt <rid> significance= worthiness= verdict=  (FAT | DEBT | line)
+  Note over GL: verdict=wave/not-significant now LOGGED live,<br/>not only as a tap side effect
+  Ship->>QG: tap <rid> --files F --pr-kind gate "<desc>"  (unchanged)
+  QG->>SC: classify (transient, no ledger write)
+  alt verdict = tap
+    QG-->>Human: ★ nudge (engage/defer/wave)
+    Human->>QG: respond <rid> <choice>
+    QG->>GL: debt-response <rid> <choice>
+    GL->>GL: forward-carry: re-emit the FAT line's sig/wor/verdict<br/>alongside response= (TIER-4 seam fix, now live)
+  else verdict = wave or not-significant
+    Note over QG: prints nothing (anti-fatigue guard, unchanged)
+  end
+  WB->>GL: collect/list reads the ledger
+  Note over WB: real significance/worthiness shown,<br/>not blank (walk-back rarely needed now)
+```
+
+## Acceptance criteria
+
+1. `commands/ship.md` Step 8 runs `lib/significance-classify.sh record <rid> --files "<files>"
+   "<what changed>"` BEFORE `lib/quiz-gate.sh tap`, guarded so a `record` failure never blocks the
+   ship (advisory, `|| true` posture).
+2. `tests/test-understanding-wiring.sh` AC3 is flipped: it now asserts `record` IS wired, with a
+   live dispatch path at `commands/ship.md` (a real grep-based assertion, not a tautology), and the
+   `claim_wired` check for `significance-classify.sh record` against `WORKFLOW.md` returns WIRED
+   (rc=0), not HONEST GAP (rc=3).
+3. `WORKFLOW.md`'s "Known wiring gap" bullet, `commands/quiz-gate.md` (~line 31), `lib/gate-ledger.sh`
+   (~242 comment), and `lib/weekend-batch.sh` (~221, ~306 comments) are updated to state `record` is
+   wired at Ship (this SPEC), without over-claiming anything that does not actually dispatch.
+4. A new end-to-end test proves the full loop: `record` (fat line) -> `weekend-batch.sh collect`
+   shows real sig/wor -> a human `debt-response` inherits the classification via forward-carry ->
+   `mark-paid` exits 0 and the item is disposed paid (never re-collected).
+5. A new test proves the silent-wave case: a `record` call producing `verdict=wave` (no human
+   response ever follows) IS collected by `weekend-batch.sh collect`/`list` as `waved` -- the
+   newly-live logged-wave path ADR-0031 Refinement §2 names.
+6. Grounded NC: `significance-classify.sh record`'s classification derives from the actual
+   `--files`/description passed at the call site (already deterministic, SPEC-123's own contract);
+   no new narrative channel is introduced by this wiring.
+7. No regression: `tests/test-weekend-batch.sh`, `tests/test-quiz-gate.sh`,
+   `tests/test-significance-classify.sh`, `tests/test-meta.sh`, and the full CI suite stay green.
+
+## Test plan
+
+| # | Check | Type | Where |
+|---|---|---|---|
+| 1 | `commands/ship.md` Step 8 contains the `record` call before `tap` | static grep | test-understanding-wiring.sh |
+| 2 | AC3 `claim_wired` on WORKFLOW.md for `record` returns WIRED (rc=0) | static | test-understanding-wiring.sh |
+| 3 | AC3's old "no caller" assertion is replaced by a "has a caller" assertion | static | test-understanding-wiring.sh |
+| 4 | AC4 negative control (fabricated over-claim still caught) unaffected | static | test-understanding-wiring.sh (unchanged) |
+| 5 | `record` -> `collect` shows real sig/wor (not blank) | live E2E | test-weekend-batch.sh (new) |
+| 6 | `record` -> `debt-response` -> forward-carry -> `mark-paid` exits 0, disposed paid | live E2E | test-weekend-batch.sh (new) |
+| 7 | `record` producing `verdict=wave` with no response IS collected as `waved` | live E2E | test-weekend-batch.sh (new) |
+| 8 | doc updates: no remaining "un-wired"/"no live caller" claim for `record` in the 4 named files | static grep | manual + this spec's Verification |
+| 9 | full CI suite green | regression | Verification section |
+
+Coverage delta: `tests/test-understanding-wiring.sh` flips the AC3 block's assertions (count
+roughly unchanged, content flipped from "honest gap" to "wired"); `tests/test-weekend-batch.sh`
+gains 2 new sections (E2E loop + silent-wave collection), net new assertions > 0.
+
+## Verification
+
+```
+bash tests/test-understanding-wiring.sh
+bash tests/test-weekend-batch.sh
+bash tests/test-quiz-gate.sh
+bash tests/test-significance-classify.sh
+bash tests/test-meta.sh
+for t in $(grep -oE 'bash tests/test-[a-z0-9-]+\.sh' .github/workflows/test.yml | sort -u | sed 's/bash //'); do bash "$t" >/dev/null 2>&1 && echo "PASS $t" || echo "FAIL $t"; done
+```
+All green; see `docs/verification/record-at-ship/` for the run-table and captured before/after
+`weekend-batch collect` output.

--- a/docs/verification/explain-command/sample-explainer.md
+++ b/docs/verification/explain-command/sample-explainer.md
@@ -1,6 +1,6 @@
-# Explainer for `c22a9e2512b8d966355f8e0b120e4144675bd45f`
+# Explainer for `d8e0fb81ea3b99ab4c6ce06344b51a78a6aba129`
 
-> Literate-diff explainer (base `c22a9e2512b8d966355f8e0b120e4144675bd45f^1`). Grounded in the ACTUAL diff + recorded test
+> Literate-diff explainer (base `d8e0fb81ea3b99ab4c6ce06344b51a78a6aba129^1`). Grounded in the ACTUAL diff + recorded test
 > results, NOT any agent/author narrative (ADR-0031 §2). Read top to bottom; the diff below is
 > in READING order, not git's alphabetical order. The commit message is shown as UNVERIFIED
 > metadata only; where it disagrees with the code, the code below is the source of truth.
@@ -105,4 +105,4 @@ flowchart TD
 
 ### Recorded test result
 
-[no recorded test result for c22a9e2512b8d966355f8e0b120e4144675bd45f]
+[no recorded test result for d8e0fb81ea3b99ab4c6ce06344b51a78a6aba129]

--- a/docs/verification/quiz-gate/sample-quiz.md
+++ b/docs/verification/quiz-gate/sample-quiz.md
@@ -1,6 +1,6 @@
-# Sample quiz (fixture A, ref 1856cec6f823d6d9e326a125978310469f07713d)
+# Sample quiz (fixture A, ref c8d53dd4281aa3398433e7db0d41fce89c973864)
 
-# 5-question understanding quiz for `1856cec6f823d6d9e326a125978310469f07713d`
+# 5-question understanding quiz for `c8d53dd4281aa3398433e7db0d41fce89c973864`
 # Grounded in the ACTUAL diff + recorded test results (SPEC-125), NOT any agent narrative.
 # These questions are the payload for the deep-understand mastery gate, they are not scored here.
 

--- a/docs/verification/record-at-ship/proof-of-done.md
+++ b/docs/verification/record-at-ship/proof-of-done.md
@@ -1,0 +1,159 @@
+# Proof of done: record-at-ship (SPEC-136, understanding-gate ADR-0031 Refinement §4)
+
+## Acceptance criteria -> run-table
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| AC1 | `commands/ship.md` Step 8 runs `significance-classify.sh record` BEFORE `quiz-gate.sh tap`, guarded `\|\| true` | PASS | `commands/ship.md` diff; `tests/test-understanding-wiring.sh` AC3 line-order check |
+| AC2 | `tests/test-understanding-wiring.sh` AC3 flipped: `record` is WIRED (rc=0), not an honest gap (rc=3) | PASS (3/3) | AC3 block below |
+| AC3 | `WORKFLOW.md`, `commands/quiz-gate.md`, `lib/gate-ledger.sh` (~242), `lib/weekend-batch.sh` (~221, ~306) updated to state `record` is wired at Ship, no over-claim | PASS | diffs; no remaining "unwired"/"no live caller" claim for `record` in these 4 files |
+| AC4 | End-to-end: `record` (fat line) -> `weekend-batch collect` shows real sig/wor -> human `debt-response` forward-carries -> `mark-paid` exits 0, disposed paid | PASS (7/7) | `tests/test-weekend-batch.sh` AC5 block |
+| AC5 | Silent-wave: a `record` producing `verdict=wave` with NO human response is collected as `waved` | PASS (4/4) | `tests/test-weekend-batch.sh` AC6 block |
+| AC6 | Grounded NC: the recorded classification derives from the real `--files`/description, not a narrative | PASS | AC5a/AC6a below use `significance-classify.sh`'s own deterministic `explain`/`record` verdict, verified against the actual regex triggers (SPEC-123, unchanged) |
+| AC7 | No regression: full CI suite green | PASS (33/33 files) | Regression section below |
+
+**Total: 19/19 PASS in `test-understanding-wiring.sh`, 45/45 PASS in `test-weekend-batch.sh`, 0 FAIL.**
+
+## Implementation
+
+- `commands/ship.md` Step 8: the "Understanding-gate nudge" bullet now runs
+  `bash lib/significance-classify.sh record <rid> --files "<files>" "<what changed>" || true`
+  immediately before the existing `bash lib/quiz-gate.sh tap ...` call, same files/description.
+- `tests/test-understanding-wiring.sh`: AC3 flipped from "record has no live caller" (rc=3, HONEST
+  GAP) to "record IS wired via commands/ship.md" (rc=0, WIRED) for the `claim_wired` sweep against
+  `WORKFLOW.md`; the old raw "no caller" grep replaced with three real assertions (a caller exists,
+  specifically in `commands/ship.md`, and the `record` call's line number precedes the `tap` call's
+  line number).
+- `WORKFLOW.md`: the "AFTER: the explainer + quiz" paragraph now names the `record` call; the
+  "Known wiring gap" bullet replaced with a "wired at Ship (SPEC-136)" bullet stating the practical
+  effect (every gate/gated-final ship logs its verdict, including silent-wave) and the honestly-
+  scoped remaining limit (gate/gated-final only, never widened).
+- `commands/quiz-gate.md` (~line 31): "it was already logged silently ... at Ship" (previously an
+  aspirational claim with no wiring behind it) now correctly cites SPEC-136 as the wiring that makes
+  it true.
+- `lib/gate-ledger.sh` (~242) + `lib/weekend-batch.sh` (~221, ~306): comments describing the
+  forward-carry / walk-back fallback logic updated from "record is unwired today" (past-tense
+  framing that was becoming stale) to "SPEC-136 wired record into /kit:ship; this fallback stays
+  load-bearing for non-gate ships and pre-SPEC-136 rids" -- no behavior change, comments only.
+- `tests/test-weekend-batch.sh`: two new sections. AC5 drives the REAL `significance-classify.sh
+  record` verb (not a hand-seeded fixture line) through record -> (pending, not yet collectible) ->
+  human `debt-response defer` (forward-carry) -> `collect` (shows real sig/wor) -> `mark-paid`
+  (exits 0, disposed). AC6 drives `record` to a `verdict=wave` outcome and proves it is collected as
+  `waved` with zero human response ever recorded.
+- `docs/specs/SPEC-136-record-at-ship.md`, `docs/implementation-notes/record-at-ship.md` (the
+  DELTA: 4 decisions not pinned down by the assigning prompt).
+
+## Confirmation run (green)
+
+```
+$ bash tests/test-understanding-wiring.sh
+=== AC2: no-orphan sweep -- each of the 5 artifacts has a live dispatch path ===
+  PASS significance-classify: 'record' verb is WIRED via commands/ship.md (SPEC-136)
+  ...
+=== AC3: wiring check -- commands/ship.md now calls significance-classify.sh record (SPEC-136) ===
+  PASS commands/*.md or hooks/*.sh calls significance-classify.sh record (live dispatch path)
+  PASS specifically commands/ship.md calls significance-classify.sh record
+  PASS the record call precedes the quiz-gate tap call in commands/ship.md (record line=173, tap line=174)
+=== Results ===
+Passed: 19 / 19
+All understanding-wiring tests passed.
+
+$ bash tests/test-weekend-batch.sh
+=== AC5 (SPEC-136): the payoff loop -- REAL record -> forward-carry -> collect -> mark-paid ===
+  PASS AC5a record's own stdout prints the verdict (tap, per this description's triggers)
+  PASS AC5b record wrote a FAT | DEBT | line grounded in the real classification (significance=high worthiness=high verdict=tap)
+  PASS AC5c before any human response, ug-30-record-e2e-* is PENDING (not yet collectible)
+  PASS AC5d the human's defer response line forward-carries record's significance=high/worthiness=high/verdict=tap
+  PASS AC5e collect shows REAL significance/worthiness for ug-30-record-e2e-* (high / high), not blank
+  PASS AC5f mark-paid on ug-30-record-e2e-* exits 0 (the record->forward-carry->collect->mark-paid loop closes clean)
+  PASS AC5g ug-30-record-e2e-* is disposed paid -- no longer collectible after mark-paid
+
+=== AC6 (SPEC-136): the silent-wave path -- REAL record produces wave, no response ever follows ===
+  PASS AC6a record's own stdout prints the verdict (wave: significant full-lane change, no worthiness trigger)
+  PASS AC6b record wrote a FAT | DEBT | line (significance=high worthiness=low verdict=wave)
+  PASS AC6c [logged-wave path, live] ug-31-record-wave-* IS collected with disposition=waved, with no human response ever recorded
+  PASS AC6d the collect digest shows ug-31-record-wave-*'s real significance/worthiness (high / low), grounded in the actual files/desc
+
+  TOTAL: 45   PASS: 45   FAIL: 0   SKIP: 0
+```
+
+## Before / after (captured)
+
+**Before this SPEC** (from `docs/verification/docs-wiring/proof-of-done.md`, the prior sub-goal's
+own captured run):
+```
+PASS significance-classify: 'record' verb is an HONEST GAP (no silent over-claim)
+PASS no commands/*.md or hooks/*.sh calls significance-classify.sh record (matches the documented gap)
+```
+`weekend-batch.sh collect`/`list` could only ever show real significance/worthiness by walking back
+to a FAT line that a human `debt-response` happened to have inherited from -- and since `record` had
+no live caller, that FAT line only ever existed via the sibling test suite's hand-seeded fixtures, or
+via `quiz-gate.sh tap`'s OWN transient `classify` call, which never wrote to the ledger. A
+significant-but-low-worthiness (`wave`) or `not-significant` change on a `gate`/gated-final PR that
+never separately reached a human response was **not logged at all**.
+
+**After this SPEC** (this run, live smoke against a temp `DWARVES_KIT_LOG_DIR`, this branch's own
+real changed-files list and an honest description of this actual change):
+```
+$ bash lib/significance-classify.sh record "$RID" --files "commands/ship.md lib/significance-classify.sh lib/weekend-batch.sh lib/gate-ledger.sh commands/quiz-gate.md tests/test-understanding-wiring.sh tests/test-weekend-batch.sh" \
+    "wire significance-classify record into ship.md before the quiz-gate tap, closing the silent-wave-but-logged gap"
+wave
+
+$ cat "$DWARVES_KIT_LOG_DIR/runs/$RID.log"
+... | START | lane=full classified=full type=spec-feature ctype=spec-feature repo=dwarves-kit
+... | DEBT  | significance=high worthiness=low verdict=wave reason=sig:full lane wor:none
+
+$ bash lib/weekend-batch.sh list --repo dwarves-kit --days 400
+live-smoke2-*   waved   high   low   ...   <- collected as waved, BEFORE any human response
+
+$ bash lib/gate-ledger.sh debt-response "$RID" defer "live smoke: deferring to weekend batch"
+$ tail -n1 "$DWARVES_KIT_LOG_DIR/runs/$RID.log"
+... | DEBT | significance=high worthiness=low verdict=wave response=defer reason=live smoke: deferring to weekend batch
+
+$ bash lib/weekend-batch.sh collect --repo dwarves-kit --repo-root "$(pwd)"
+## live-smoke2-*
+- disposition: deferred
+- significance: high / worthiness: low
+...
+
+$ bash lib/weekend-batch.sh mark-paid "$RID" --note "live smoke close"
+rc=0
+$ bash lib/weekend-batch.sh list --repo dwarves-kit --days 400
+<empty -- disposed, never re-collected>
+```
+This run's own real description ("wire significance-classify record into ship.md before the
+quiz-gate tap...") happened to classify as significant (full-lane) but low-worthiness -- i.e. this
+SPEC's own change is itself an example of the SILENT-WAVE case ADR-0031 Refinement §2 names: a
+significant, mechanical, well-tested wiring change that is fine to wave without a quiz, as long as
+it is a RECORDED choice. Before this SPEC, that recording would not have happened live.
+
+## Grounded negative control
+
+`significance-classify.sh`'s classification is unchanged by this SPEC (SPEC-123's own deterministic
+regex-trigger contract): the same `--files`/description always produces the same verdict, with no
+narrative channel. This SPEC only adds a new CALL SITE (`commands/ship.md`); it introduces no new
+way for a fabricated story to influence the recorded verdict. AC5a/AC6a above independently verify
+two different descriptions produce two different, trigger-consistent verdicts (`tap` for one that
+matches a worthiness trigger, `wave` for one that does not), proving the grounding held through the
+new wiring.
+
+## Regression
+
+- `bash tests/test-understanding-wiring.sh`: 19/19 PASS.
+- `bash tests/test-weekend-batch.sh`: 45/45 PASS.
+- `bash tests/test-quiz-gate.sh`: 29/29 PASS.
+- `bash tests/test-significance-classify.sh`: 25/25 PASS.
+- `bash tests/test-meta.sh`: 667/667 PASS.
+- Full CI suite (every `bash tests/test-*.sh` referenced in `.github/workflows/test.yml`, 33
+  files): all PASS, run individually.
+
+## Reproduce
+
+```
+cd dwarves-kit
+bash tests/test-understanding-wiring.sh
+bash tests/test-weekend-batch.sh
+bash tests/test-quiz-gate.sh
+bash tests/test-significance-classify.sh
+bash tests/test-meta.sh
+```

--- a/docs/verification/weekend-batch/sample-digest.md
+++ b/docs/verification/weekend-batch/sample-digest.md
@@ -1,13 +1,13 @@
 # Weekend batch: debt paydown
 
-Window: since 2026-06-26T18:10:30Z (repo: fixture-repo)
+Window: since 2026-06-27T03:58:39Z (repo: fixture-repo)
 Items: 2 (1 waved, 1 deferred)
 
 ## ug-10-waved-item
 - disposition: waved
 - significance: high / worthiness: low
 - reason: sig:full-lane wor:none
-- recorded: 2026-07-03T18:10:30Z
+- recorded: 2026-07-04T03:58:39Z
 - impl-notes: docs/implementation-notes/ug-10-waved-item.md (found)
 - explainer: docs/verification/explain-command/ug-10-waved-item-explainer.md (absent)
 
@@ -15,6 +15,6 @@ Items: 2 (1 waved, 1 deferred)
 - disposition: deferred
 - significance: high / worthiness: high
 - reason: deferred to weekend batch
-- recorded: 2026-07-03T18:10:30Z
+- recorded: 2026-07-04T03:58:39Z
 - impl-notes: docs/implementation-notes/ug-11-deferred-item.md (absent)
 - explainer: docs/verification/explain-command/deferred-item-explainer.md (found)

--- a/lib/gate-ledger.sh
+++ b/lib/gate-ledger.sh
@@ -239,11 +239,15 @@ debt() {
 # (significance=/worthiness=/verdict=); this command historically wrote a THIN line (response= only,
 # no sig/wor/verdict). The ledger is last-line-wins for readers, so any consumer that re-emits the
 # LAST debt line's sig/wor/verdict through the fat `debt` verb (e.g. weekend-batch.sh mark-paid) saw
-# empty enums and crashed -- and because `significance-classify record` (the fat writer) is unwired
-# today, EVERY live debt-response is thin, making this the DEFAULT path, not an edge case. Fix: look
-# back at the ledger for THIS rid's last FAT line (one carrying verdict=) and, if found, re-emit its
-# sig/wor/verdict alongside response= -- making the response line self-describing without inventing
-# data. If no fat line exists (the live today-flow), write the thin line as before; blank stays blank.
+# empty enums and crashed -- and at the time this fix landed, `significance-classify record` (the
+# fat writer) was unwired anywhere, making a thin-only debt-response the DEFAULT path, not an edge
+# case. SPEC-136 later wired `record` into `/kit:ship` Step 8 (before the quiz-gate tap), so a live
+# gate/gated-final ship now writes the fat line first; this forward-carry stays load-bearing for
+# any rid predating that wiring and for non-gate ships (record's scope is gate/gated-final only,
+# unchanged by SPEC-136). Fix: look back at the ledger for THIS rid's last FAT line (one carrying
+# verdict=) and, if found, re-emit its sig/wor/verdict alongside response= -- making the response
+# line self-describing without inventing data. If no fat line exists (a non-gate ship, or a rid
+# from before SPEC-136), write the thin line as before; blank stays blank.
 # Usage: debt-response <rid> <engage|defer|wave> [reason]
 debt_response() {
   local rid="${1:-}" response="${2:-}"; shift 2 2>/dev/null || { echo "usage: debt-response <rid> <engage|defer|wave> [reason]" >&2; return 64; }

--- a/lib/weekend-batch.sh
+++ b/lib/weekend-batch.sh
@@ -217,8 +217,10 @@ cmd_list() {
     wor="$(_kv "$last" worthiness)"
     if [ -z "$sig" ] || [ -z "$wor" ]; then
       # Walk-back (TIER-4 close fix): the LAST line is a thin response= line with no sig/wor.
-      # Fall back to the last FAT line for display; if none exists, blank stays honest (documented
-      # gap until `significance-classify record` is wired -- out of scope here).
+      # Fall back to the last FAT line for display; if none exists, blank stays honest. Since
+      # SPEC-136 wired `significance-classify record` into /kit:ship (before the quiz-gate tap),
+      # a live gate/gated-final rid almost always has a FAT line to walk back to; this stays the
+      # fallback for a non-gate ship or a rid predating that wiring.
       fat="$(_last_fat_debt_line "$f")"
       if [ -n "$fat" ]; then
         [ -z "$sig" ] && sig="$(_kv "$fat" significance)"
@@ -302,13 +304,16 @@ cmd_mark_paid() {
   local reason; reason="paid via weekend batch $(date -u +%Y-%m-%d)"
   [ -n "$note" ] && reason="$reason: $note"
   # Close via debt-response, NEVER the raw fat `debt` verb (TIER-4 close finding). The last debt
-  # line here is very often a THIN response= line (SG-04's quiz-gate respond / debt-response is the
-  # live default path today -- the fat `debt`-verb classifier, `significance-classify record`, is
-  # unwired), which carries no significance=/worthiness=/verdict= to re-emit. Re-emitting empties
-  # through the fat `debt` verb's required-enum validation used to crash mark-paid with exit 64.
-  # debt-response only requires a valid response enum (engage here), and now forward-carries
-  # sig/wor/verdict from the last FAT line when one exists -- so paying down a classified item still
-  # closes with its full context, and paying down an unclassified (thin-only) item still closes clean.
+  # line here CAN be a THIN response= line (SG-04's quiz-gate respond / debt-response), which
+  # carries no significance=/worthiness=/verdict= to re-emit on its own -- historically the
+  # default path, since the fat `debt`-verb classifier, `significance-classify record`, had no
+  # live caller anywhere; SPEC-136 wired it into /kit:ship (before the quiz-gate tap), so a live
+  # gate/gated-final rid now has a FAT line first, and this stays the fallback shape for a
+  # non-gate ship or a rid predating that wiring. Re-emitting empties through the fat `debt`
+  # verb's required-enum validation used to crash mark-paid with exit 64. debt-response only
+  # requires a valid response enum (engage here), and now forward-carries sig/wor/verdict from
+  # the last FAT line when one exists -- so paying down a classified item still closes with its
+  # full context, and paying down an unclassified (thin-only) item still closes clean.
   bash "$GATE_LEDGER" debt-response "$rid" engage "$reason"
 }
 

--- a/tests/test-understanding-wiring.sh
+++ b/tests/test-understanding-wiring.sh
@@ -9,8 +9,10 @@
 #
 #   AC1  WORKFLOW.md + AGENTS.md declare the understanding axis; README notes /kit:explain
 #   AC2  no-orphan sweep: each of the 5 artifacts has a LIVE dispatch/invocation path
-#   AC3  the one honest exception (significance-classify.sh's `record` verb has no live caller)
-#        is stated as a gap, not silently claimed as wired
+#   AC3  significance-classify.sh's `record` verb, once the one honest exception with no live
+#        caller, is now WIRED into /kit:ship Step 8 (SPEC-136, before the quiz-gate tap); this
+#        AC proves the live dispatch path exists and precedes the tap call, not just that a
+#        string matches somewhere
 #   AC4  NEGATIVE CONTROL: a fabricated over-claim (a fake lib call, no caller, no honesty
 #        marker) is CAUGHT by the same sweep mechanism used for AC2/AC3 -- proving the sweep can
 #        actually catch the c6fbd99 bug class, not just that nothing untested exists
@@ -113,7 +115,8 @@ grep -qiE 'BLOCKING' "$KIT_DIR/commands/spec-validate.md" || RC=1
 assert "Design record: /kit:spec-validate Reviewer 6 is a BLOCKING enforcer (WIRED)" $RC
 
 # 2. significance-classify: the `classify` verb is live (called by lib/quiz-gate.sh); the
-#    `record` verb (the ledger-persisting one) is a KNOWN, HONESTLY-DOCUMENTED gap, not a claim.
+#    `record` verb (the ledger-persisting one) is now ALSO live -- wired into /kit:ship Step 8
+#    (SPEC-136), immediately before the quiz-gate tap, closing the "silent wave, but LOGGED" gap.
 claim_wired "$WORKFLOW" \
   'significance-classify\.sh classify' \
   'SIG_CLASSIFY.*classify|significance-classify\.sh"? *classify' \
@@ -126,7 +129,7 @@ claim_wired "$WORKFLOW" \
   'significance-classify\.sh"? *record' \
   "$KIT_DIR/commands" "$KIT_DIR/hooks"
 RC=$?
-assert "significance-classify: 'record' verb is an HONEST GAP (no silent over-claim)" $RC 3
+assert "significance-classify: 'record' verb is WIRED via commands/ship.md (SPEC-136)" $RC 0
 
 # 3. /kit:explain: the command file exists (plugin auto-registration, same convention as every
 #    other /kit:* command -- no central manifest lists commands, see .claude-plugin/plugin.json).
@@ -160,13 +163,32 @@ grep -A60 -E '^## The understanding axis' "$WORKFLOW" | grep -qiE 'weekend-debt-
 assert "weekend-batch: WORKFLOW.md honestly scopes it Han-invoked (no scheduled job), names the ops-toolkit skill" $RC
 
 echo ""
-echo "=== AC3: honesty check -- no command actually calls significance-classify.sh record today ==="
+echo "=== AC3: wiring check -- commands/ship.md now calls significance-classify.sh record (SPEC-136) ==="
+
+# Flipped from the prior "honest gap" assertion: SPEC-136 wired significance-classify.sh record
+# into /kit:ship Step 8, immediately before the quiz-gate tap call. This is a genuine grep-based
+# assertion against the real command file (mirrors how quiz-gate's own "Step 8 invokes tap" claim
+# is asserted above), not a tautology restating claim_wired's own regex.
+RC=0
+if ! grep -rlE 'significance-classify\.sh"? *record' "$KIT_DIR/commands" "$KIT_DIR/hooks" 2>/dev/null | grep -q .; then
+  RC=1  # no caller anywhere -- the gap would be back, and WORKFLOW.md's "wired" wording would be false
+fi
+assert "commands/*.md or hooks/*.sh calls significance-classify.sh record (live dispatch path)" $RC
 
 RC=0
-if grep -rlE 'significance-classify\.sh"? *record' "$KIT_DIR/commands" "$KIT_DIR/hooks" 2>/dev/null | grep -q .; then
-  RC=1  # a caller exists now -- the WORKFLOW.md "known gap" wording would be STALE/false
+SHIP_MD="$KIT_DIR/commands/ship.md"
+grep -qE 'significance-classify\.sh"? *record' "$SHIP_MD" || RC=1
+assert "specifically commands/ship.md calls significance-classify.sh record" $RC
+
+RC=0
+# Ordering: the record call's line number must be BEFORE the quiz-gate tap call's line number,
+# so the ledger marker really is written before the tap decision (not after, not unrelated).
+RECORD_LINE="$(grep -nE 'significance-classify\.sh"? *record' "$SHIP_MD" | head -n1 | cut -d: -f1)"
+TAP_LINE="$(grep -nE 'quiz-gate\.sh"? *tap' "$SHIP_MD" | head -n1 | cut -d: -f1)"
+if [ -z "$RECORD_LINE" ] || [ -z "$TAP_LINE" ] || [ "$RECORD_LINE" -ge "$TAP_LINE" ]; then
+  RC=1
 fi
-assert "no commands/*.md or hooks/*.sh calls significance-classify.sh record (matches the documented gap)" $RC
+assert "the record call precedes the quiz-gate tap call in commands/ship.md (record line=$RECORD_LINE, tap line=$TAP_LINE)" $RC
 
 echo ""
 echo "=== AC4: NEGATIVE CONTROL -- a fabricated over-claim IS caught by the sweep ==="

--- a/tests/test-weekend-batch.sh
+++ b/tests/test-weekend-batch.sh
@@ -9,6 +9,11 @@
 #   AC3c window scoping: an item older than --days is excluded
 #   AC3d repo scoping: a different-repo item is excluded by default, included with --all-repos
 #   AC4  NEGATIVE CONTROL (reuse): the skill invokes, does not fork a second engine
+#   AC5  SPEC-136 payoff loop: a REAL `significance-classify.sh record` call (grounded in actual
+#        --files/desc, not a hand-seeded fixture line) -> a human debt-response forward-carries the
+#        classification -> collect shows real sig/wor -> mark-paid exits 0, disposed paid
+#   AC6  SPEC-136 silent-wave path: a REAL `record` call producing verdict=wave with NO human
+#        response ever following IS collected as waved -- the newly-live logged-wave path
 #
 # AC2/AC4 read a file in the SIBLING dotfiles repo (~/workspace/tieubao/dotfiles). That path is
 # ABSENT in CI (same precedent as SPEC-107's dotfiles-half check in tests/test-meta.sh: "its path
@@ -21,6 +26,7 @@ set -uo pipefail
 KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WB="$KIT_DIR/lib/weekend-batch.sh"
 GL="$KIT_DIR/lib/gate-ledger.sh"
+SC="$KIT_DIR/lib/significance-classify.sh"
 
 PASS=0; FAIL=0; SKIP=0; TOTAL=0
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; NC='\033[0m'
@@ -239,6 +245,77 @@ LIST_RAW="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
 DISP_RAW="$(printf '%s\n' "$LIST_RAW" | grep -F "$RID_RAW" | cut -f2)"
 assert "security [reader]: a silent-wave line (no real response= field) with 'response=engage' smuggled in reason= still reads disposition=waved, NOT paid (struct-prefix cut)" \
   "$([ "$DISP_RAW" = waved ] && echo 0 || echo 1)"
+
+echo ""
+echo "=== AC5 (SPEC-136): the payoff loop -- REAL record -> forward-carry -> collect -> mark-paid ==="
+# Unlike the forward-carry section above (which hand-calls the fat gate-ledger.sh debt verb
+# directly), this drives the ACTUAL /kit:ship call site verb, lib/significance-classify.sh record,
+# with real --files/description input -- the exact call SPEC-136 wired into commands/ship.md Step 8.
+# significance-classify.sh's classification is deterministic (SPEC-123): this is the GROUNDED-NC
+# assertion (AC6 of SPEC-136) that the recorded verdict traces to the real files/desc, not a
+# narrative.
+RID_E2E="ug-30-record-e2e-$$"
+( cd "$KIT_DIR" && bash "$GL" start "$RID_E2E" normal normal bug "" fixture-repo ) >/dev/null
+E2E_DESC="add a new data model migration that introduces a primitive future work will build on"
+E2E_VERDICT="$(cd "$KIT_DIR" && bash "$SC" record "$RID_E2E" --files "lib/x.sh" "$E2E_DESC")"
+assert "AC5a record's own stdout prints the verdict (tap, per this description's triggers)" \
+  "$([ "$E2E_VERDICT" = "tap" ] && echo 0 || echo 1)"
+E2E_LOG="$RUNS/$RID_E2E.log"
+FIRST_DEBT_LINE="$(grep '| DEBT |' "$E2E_LOG" | head -n1)"
+assert "AC5b record wrote a FAT | DEBT | line grounded in the real classification (significance=high worthiness=high verdict=tap)" \
+  "$(printf '%s' "$FIRST_DEBT_LINE" | grep -q 'significance=high worthiness=high verdict=tap' && echo 0 || echo 1)"
+
+# An open tap with no human response yet is PENDING -- not yet collectible (still Flow A's to
+# resolve; matches AC3b's bonus check on ug-16-pending-item above).
+LIST_E2E_PRE="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
+assert "AC5c before any human response, $RID_E2E is PENDING (not yet collectible)" \
+  "$(printf '%s\n' "$LIST_E2E_PRE" | grep -F "$RID_E2E" | grep -q . && echo 1 || echo 0)"
+
+# The human defers it (SG-04's live response path) -- this is what makes it collectible AND is
+# where the TIER-4-close forward-carry fires, using the FAT line record() just wrote.
+( cd "$KIT_DIR" && bash "$GL" debt-response "$RID_E2E" defer "deferred to weekend batch" ) >/dev/null
+LAST_E2E_LINE="$(grep '| DEBT |' "$E2E_LOG" | tail -n1)"
+assert "AC5d the human's defer response line forward-carries record's significance=high/worthiness=high/verdict=tap" \
+  "$(printf '%s' "$LAST_E2E_LINE" | grep -q 'significance=high worthiness=high verdict=tap response=defer' && echo 0 || echo 1)"
+
+COLLECT_E2E="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
+assert "AC5e collect shows REAL significance/worthiness for $RID_E2E (high / high), not blank" \
+  "$(printf '%s\n' "$COLLECT_E2E" | grep -A2 "^## ${RID_E2E}\$" | grep -q 'significance: high / worthiness: high' && echo 0 || echo 1)"
+
+( cd "$KIT_DIR" && bash "$WB" mark-paid "$RID_E2E" --note "paid via AC5 e2e test" ) >/dev/null 2>&1
+MARKPAID_E2E_RC=$?
+assert "AC5f mark-paid on $RID_E2E exits 0 (the record->forward-carry->collect->mark-paid loop closes clean)" "$MARKPAID_E2E_RC"
+
+LIST_E2E_POST="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
+assert "AC5g $RID_E2E is disposed paid -- no longer collectible after mark-paid" \
+  "$(printf '%s\n' "$LIST_E2E_POST" | grep -F "$RID_E2E" | grep -q . && echo 1 || echo 0)"
+
+echo ""
+echo "=== AC6 (SPEC-136): the silent-wave path -- REAL record produces wave, no response ever follows ==="
+# ADR-0031 Refinement's whole point: a significant-but-low-worthiness change is fine to wave
+# WITHOUT a human ever responding, as long as it is a RECORDED (not silently dropped) choice. Before
+# SPEC-136, nothing ever called record, so this case was never logged at all unless quiz-gate.sh
+# tap happened to run (and even then, tap itself never writes the ledger -- record does). This is
+# the newly-live logged-wave path.
+RID_WAVE="ug-31-record-wave-$$"
+( cd "$KIT_DIR" && bash "$GL" start "$RID_WAVE" normal normal bug "" fixture-repo ) >/dev/null
+WAVE_DESC="add a mechanical, reversible, fully test-covered guard clause"
+WAVE_VERDICT="$(cd "$KIT_DIR" && bash "$SC" record "$RID_WAVE" --files "lib/orchestrate.sh lib/foo.sh" "$WAVE_DESC")"
+assert "AC6a record's own stdout prints the verdict (wave: significant full-lane change, no worthiness trigger)" \
+  "$([ "$WAVE_VERDICT" = "wave" ] && echo 0 || echo 1)"
+WAVE_LOG="$RUNS/$RID_WAVE.log"
+assert "AC6b record wrote a FAT | DEBT | line (significance=high worthiness=low verdict=wave)" \
+  "$(grep '| DEBT |' "$WAVE_LOG" | tail -n1 | grep -q 'significance=high worthiness=low verdict=wave' && echo 0 || echo 1)"
+
+# No human response EVER follows for this rid -- this is the point of the test.
+LIST_WAVE="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
+DISP_WAVE="$(printf '%s\n' "$LIST_WAVE" | grep -F "$RID_WAVE" | cut -f2)"
+assert "AC6c [logged-wave path, live] $RID_WAVE IS collected with disposition=waved, with no human response ever recorded" \
+  "$([ "$DISP_WAVE" = waved ] && echo 0 || echo 1)"
+
+COLLECT_WAVE="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
+assert "AC6d the collect digest shows $RID_WAVE's real significance/worthiness (high / low), grounded in the actual files/desc" \
+  "$(printf '%s\n' "$COLLECT_WAVE" | grep -A2 "^## ${RID_WAVE}\$" | grep -q 'significance: high / worthiness: low' && echo 0 || echo 1)"
 
 # Capture the fixture-A collect digest as the proof artifact (mirrors test-explain.sh's
 # sample-explainer.md capture).


### PR DESCRIPTION
Completes ADR-0031 Refinement §4: wires `significance-classify record` into `/kit:ship` before the quiz-gate tap, so the FAT classifier line (significance/worthiness/verdict) is written to the debt ledger live. Closes the "silent wave, but LOGGED" gap — low-worthiness significant changes are now recorded (not just human-responded taps); `weekend-batch collect` shows real sig/wor; the seam fix's forward-carry means a later human response inherits the classification. Advisory, never blocks the ship. Flips test-understanding-wiring AC3 (record is now wired, not an honest gap) + updates the gap-docs. Verify: wiring + weekend-batch + the live record->collect->mark-paid end-to-end. HELD for review — this completes a design decision the understanding gate deferred to the human.
