### PR TITLE
Emit sweep: close the RUN_REPORT under-count

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,3 +127,6 @@ jobs:
 
       - name: Run grill-conditioning tests (SPEC-138, kit-absorptions sub-goal 04)
         run: bash tests/test-grill-conditioning.sh
+
+      - name: Run command emit-sweep no-orphan check (SPEC-139, kit-run-integrity sub-goal 05)
+        run: bash tests/test-command-emit-sweep.sh

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -453,6 +453,51 @@ measure a false-positive rate against yet). See ops-toolkit `_meta/megagoals/kit
 "Proposed additions (TIER-4)" for the full recommendation. This section documents the gates as
 they ship; it does not promote them.
 
+## Command emit coverage (SPEC-139)
+
+The gate-ledger's `RUN_REPORT.md` (`/kit:mega`'s per-sub-goal gate matrix) can only show a phase
+as covered if SOME command actually calls `gate-ledger.sh` for it. A 2026-07-04 audit of every
+file under `commands/` found 11 of 29 commands with a real `bash lib/gate-ledger.sh <verb>` call
+and 18 dark, with no distinction between "this phase genuinely has no ledger concern" and "nobody
+wired it yet" -- the RUN_REPORT under-counts silently either way. This section is the single
+source of truth for that distinction (parsed by `tests/test-command-emit-sweep.sh`, no second
+copy): every command in `commands/` either contains a `gate-ledger` call, or is listed below with
+a reason it legitimately does not need one.
+
+**9 commands wired this pass** (SPEC-139): `spec.md`, `spec-validate.md`, `verify.md`,
+`think.md`, `design.md`, `ui-design.md`, `docs.md`, `retro.md`, `explain.md` -- each now records
+one line (`record <rid> <Phase> ran "<summary>"`) at its natural hand-off point, the same
+single-line convention `test-plan.md` / `review.md` / `devs-team.md` already use. `verify` and
+`explain` are not `Lane x phase depth matrix` rows (no lane requires them), so their record is
+pure RUN_REPORT observability, never a new required gate; `think` / `design` / `docs` / `spec` /
+`validate` / `reflect` (the phase `retro.md` records) already ARE matrix rows and this closes
+their record-side gap.
+
+**9 utility commands, exempted (no direct emit by design):**
+
+| Command | Why no direct emit |
+|---|---|
+| `absorb.md` | Maintainer-only external-source absorption audit (SPEC-004); propose-only, approves/merges nothing itself, and runs outside any spec's rid/lane lifecycle. |
+| `adopt.md` | One-time repo-bootstrap into a NEW consumer repo (injects AGENTS.md/CLAUDE.md/WORKFLOW pointer); runs BEFORE any rid or lane exists in that repo. |
+| `next.md` | Pure read-only task dispatcher, own text says "Do NOT execute anything. Just detect and recommend."; hands off to `/kit:execute`, which is the one that emits. |
+| `start.md` | Pure read-only session entry-point detector, own text says "Do NOT execute anything."; same shape as `next.md`. |
+| `kit-health.md` | Self-assessment of the kit's OWN philosophy compliance (file count, hook perf, source citations); not a phase in any run's V-model lifecycle. |
+| `draft-agent.md` | Meta-agent generator (drafts a new subagent or mega-goal sub-goal file); a generator utility, not a V-model phase. |
+| `visual-team.md` | A critique lens invoked FROM `ui-design.md` Step 3, not an independent phase owner; the phase owner (`ui-design.md`) now emits `UI design` itself (SPEC-139), mirroring how `devs-team.md`'s own `review` emit already covers the design-critique lens it is invoked from. |
+| `mega.md` | Already emits via the driver: "The driver emits a `gate-ledger start` per dispatched sub-goal ... (SPEC-101)" (`commands/mega.md`, "Close the run visibly" section) -- the emission is real but happens in the orchestration driver at dispatch time, not as a literal call inside `mega.md`'s own prose. |
+| `dispatch.md` | Each fanned-out worker runs the FULL `/kit:execute` lifecycle (its own `gate-ledger.sh` calls) inside its own isolated worktree (see `commands/dispatch.md`'s worker prompt, "extends the `/kit:execute` worker contract"); `dispatch.md` itself is the fan-out lead, never a phase owner, and never calls `gate-ledger.sh` directly. |
+
+**Known pre-existing gap, NOT closed by this pass (out of scope, flagged honestly):** neither
+`Build` nor `Design record` -- both REQUIRED matrix rows -- has any command that calls
+`gate-ledger.sh record` for them; `execute.md` narrates the escalation/action verbs around a
+build but never records `build ran`, and no command records `design-record ran` (the design-record
+row is enforced statically by `/kit:spec-validate` Reviewer 6, never separately recorded to the
+ledger). SPEC-139 does not touch `execute.md` or add a new record call for either phase (both
+commands were already counted "emitting" in the 2026-07-04 audit and are out of this sub-goal's
+named scope); a run that needs those two gates satisfied records them manually
+(`bash lib/gate-ledger.sh record <rid> build ran "<note>"` / `... design-record ran "<note>"`),
+the same generic escape hatch AGENTS.md already names for any phase gate.
+
 ## The understanding axis (ADR-0031)
 
 A second axis, orthogonal to the verification gates above (ADR-0024/0025 stay the only hard

--- a/commands/design.md
+++ b/commands/design.md
@@ -36,5 +36,8 @@ Once the user approves the design, **append** a `## Solution` section (and `## F
 ### Step 6: Hand off
 Tell the user the design is captured and the next step is `/kit:spec`, which reads the brief and folds the Solution into the spec's `## Solution` (and the Design section, if present, into the spec's `## Design`). Do NOT run `/kit:spec` yourself; this lane only shapes and records the design.
 
+After Step 6, record it for lane telemetry (SPEC-139), one line:
+`bash lib/gate-ledger.sh record <rid> Design ran "approaches=<N> design-bearing=<yes|no>"`.
+
 ## Source
 Forked from `superpowers:brainstorming` (one-question-at-a-time, present-in-sections, per-section approval). Realizes SPEC-008 Part C; see `docs/specs/SPEC-011-design-lane.md`.

--- a/commands/docs.md
+++ b/commands/docs.md
@@ -93,6 +93,9 @@ Create a single commit: `docs: update [list of files] to match current codebase`
 
 This is a docs-only commit. Do NOT mix code changes with doc updates.
 
+After the commit, record it for lane telemetry (SPEC-139), one line:
+`bash lib/gate-ledger.sh record <rid> Docs ran "files=<list>"`.
+
 ## Rules
 
 - Never document features that don't exist in the code (no phantom features).

--- a/commands/explain.md
+++ b/commands/explain.md
@@ -85,6 +85,10 @@ Save the enriched explainer under `docs/verification/explain-command/` (or along
 Tell the user it is ready and that the quiz built on it is `deep-understand` (SG-04). Do NOT merge, do NOT
 gate the merge; the explainer is advisory (ADR-0031: engage / defer / wave, never must-pass).
 
+Record the run for lane telemetry (SPEC-139), one line (`explain` carries no matrix row of its
+own, same as `verify` -- RUN_REPORT observability, never a new required gate):
+`bash lib/gate-ledger.sh record <rid> explain ran "ref=<commit|PR|spec>"`.
+
 ## Rules
 
 - Ground every claim in the diff or a recorded verdict. The diff wins over the commit message and over memory.

--- a/commands/retro.md
+++ b/commands/retro.md
@@ -123,3 +123,7 @@ Check if any action items should become:
 - Adjustments to hook configuration
 
 Ask: "Any of these action items worth adding to the project CLAUDE.md or kit config?"
+
+After the retro document is written, record it for lane telemetry (SPEC-139), one line
+(the matrix row this command owns is `Reflect`, not `retro`):
+`bash lib/gate-ledger.sh record <rid> Reflect ran "action-items=<N>"`.

--- a/commands/spec-validate.md
+++ b/commands/spec-validate.md
@@ -107,3 +107,6 @@ Spec: [spec name]
 If NEEDS REVISION, update `docs/specs/SPEC-NNN-<slug>.md` with the fixes and mark the Decision Log with entries for each change made.
 
 If APPROVED, update the Status line in SPEC.md to `VALIDATED`. **Exception (ADR-0031 §1):** if Reviewer 6 raised a CRITICAL, BLOCKING finding (a design-bearing spec with an empty/missing `## Design` block), the Verdict is NEEDS REVISION regardless of Reviewers 1-5's outcome, and Status does NOT flip to `VALIDATED` until the Design block is filled and this reviewer re-runs clean.
+
+After the verdict, record it for lane telemetry (SPEC-139), one line:
+`bash lib/gate-ledger.sh record <rid> Validate ran "<APPROVED|NEEDS REVISION> critical=<N> warnings=<K>"`.

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -247,3 +247,6 @@ Ask: "Approve this spec, or do you want to adjust anything?"
 When approved, update the Status line in SPEC.md to `APPROVED`.
 
 Remind the user they can run `/kit:spec-validate` for adversarial review before implementation.
+
+After approval, record it for lane telemetry (SPEC-139), one line:
+`bash lib/gate-ledger.sh record <rid> Spec ran "SPEC-NNN-<slug> approved, tasks=<N>"`.

--- a/commands/think.md
+++ b/commands/think.md
@@ -48,3 +48,6 @@ Do NOT be a yes-man. Do NOT validate the idea by default. Push hard on weak poin
 5. If BUILD (so the brief now exists on disk), dispatch the **brief-reviewer** subagent (read-only) against `docs/specs/DECISION-BRIEF.md` to independently judge it for clarity, completeness, and testability -- the writer of the brief is not the right judge of its own output. Report its verdict (PASS / FAIL:fixable / FAIL:escalate) to the user alongside the brief. This is advisory only: never block on it, and never edit the brief yourself to satisfy it. If it finds gaps, surface them so the user can decide whether to patch the brief before moving on. If the verdict is RETHINK or KILL, there is no saved brief to review -- skip this step.
 
 6. If BUILD, suggest (optional) `/kit:design` to shape the solution interactively before `/kit:spec`. It is opt-in; the user may go straight to `/kit:spec`.
+
+After the verdict, record it for lane telemetry (SPEC-139), one line:
+`bash lib/gate-ledger.sh record <rid> Think ran "<verdict> <one-line thesis>"`.

--- a/commands/ui-design.md
+++ b/commands/ui-design.md
@@ -125,6 +125,10 @@ the ACCEPTED fixes (the per-round approval Phase B already has) -> re-render -> 
 - Terminate exactly as Phase B otherwise does on `SOLID` / `RECONSIDER` / a `frontend-design` error;
   the quiescence stop + cap 3 are the additional terminations. Final acceptance stays a `gate`.
 
+After the loop terminates (Phase A SOLID, or Phase B/quiescence's SOLID / RECONSIDER / cap), record
+it for lane telemetry (SPEC-139), one line:
+`bash lib/gate-ledger.sh record <rid> "UI design" ran "<verdict> rounds=<N>"`.
+
 ## Notes
 - Opt-in, report-only; never hard-gates `/kit:spec` or any build. The maintainer decides whether to proceed.
 - Under bypassPermissions the per-iteration `AskUserQuestion` approvals auto-resolve; the loop still terminates structurally (SOLID / RECONSIDER / max-2 cap). It delivers its full value in non-bypass mode.

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -107,9 +107,14 @@ means design a better measurement, not ship.
 Append one entry to `docs/verification/<spec-slug>.md` (create the file if missing),
 shape per `docs/verification/README.md`: the captured `Command:` the verifiers ran, its
 `Exit:` code, an `Output (excerpt):`, and the `Verdict:`. If nothing runnable existed,
-record `[NO EXECUTABLE CHECK: <reason>]` rather than a fake pass. This append is the only
-thing `/kit:verify` writes; it never touches the code under test. The recorded
-`Command:` line is what a later reader re-runs to regression-check this verdict.
+record `[NO EXECUTABLE CHECK: <reason>]` rather than a fake pass. This append (plus the
+lane-telemetry ledger line below) is the only thing `/kit:verify` writes; it never touches
+the code under test. The recorded `Command:` line is what a later reader re-runs to
+regression-check this verdict.
+
+Also record the verdict for lane telemetry (SPEC-139), one line (`verify` carries no matrix
+row of its own -- this is RUN_REPORT observability, never a new required gate):
+`bash lib/gate-ledger.sh record <rid> verify ran "<PASS|FAIL|INCONCLUSIVE>"`.
 
 Gate what the proof needs by the spec's **proof class** (`lib/proof-gate.sh class
 "<spec title or task>"`):

--- a/docs/implementation-notes/kit-emit-sweep.md
+++ b/docs/implementation-notes/kit-emit-sweep.md
@@ -1,0 +1,84 @@
+# Implementation notes: kit-emit-sweep (SPEC-139)
+
+Delta from the spec only; see `docs/specs/SPEC-139-kit-emit-sweep.md` for the full design and
+its own `## Decision Log` for the three design decisions pinned there (DEC-001/002/003). This
+file covers what came up DURING implementation that the spec did not (or could not) anticipate.
+
+## 2026-07-04 08:00 the sweep's positive check had to be loosened from a strict regex to a loose substring
+
+**Decision:** the sweep's "does this command emit" check is `grep -qi 'gate-ledger'` (any
+mention, case-insensitive), not a stricter invocation-shape regex.
+
+**Why:** the first draft used `` `bash lib/gate-ledger\.sh <verb>` `` (mirroring the exact
+phrasing convention `spec.md`/`review.md`/etc. use). Running it against the real repo before
+trusting it surfaced a false negative: `commands/quiz-gate.md`'s real emit is phrased
+`` `gate-ledger.sh debt-response` `` (no `bash lib/` prefix in the same backtick span, since its
+prose describes the underlying `lib/quiz-gate.sh`'s own internal call rather than instructing
+the reading agent to run gate-ledger.sh directly). A strict regex would have wrongly flagged a
+genuinely-wired command an orphan. The loose substring check trades false-negative risk for a
+coarser signal, matching what the sub-goal's own contract actually asks for ("either contains a
+gate-ledger call OR is listed in the exemption table" -- not "contains a call in exactly this
+shape").
+
+**Impact:** the sweep is deliberately not a strict wiring-shape verifier; AC3 (per-newly-wired-
+command phase check) supplies the STRICT proof (a phase-specific regex) for exactly the 9 files
+this SPEC wired, while AC1's loose check covers the other 20 without needing to hand-tune a
+regex per file's prose style.
+
+## 2026-07-04 08:05 the WORKFLOW.md table parser had to anchor on the first column only
+
+**Decision:** `exemption_list()` parses ONLY lines matching `^\| *`name.md`...`, ignoring any
+other backtick-wrapped `.md` mention in the section.
+
+**Why:** the first draft grepped the WHOLE "## Command emit coverage" section for any
+backtick-`.md` token, which over-matched: the prose paragraph above the table mentions
+`test-plan.md`/`review.md`/`devs-team.md` as convention examples, and several table rows'
+OWN rationale text re-mentions their own filename (the `mega.md` row explains itself twice --
+"the emission is real... not as a literal call inside `mega.md`'s own prose" -- and `dispatch.md`
+similarly). Both produced duplicate/spurious entries in the parsed exemption list, breaking
+AC2's exact-set assertion. Anchoring to the table's FIRST COLUMN (line-start `| \`name.md\``)
+fixed it cleanly without having to avoid re-mentioning a filename in the prose (which would have
+made the rationale text stilted).
+
+**Impact:** none outside the test file; this is purely a parsing-robustness fix, not a design
+change. Documents a reusable lesson for the THREE prior sibling no-orphan sweeps (not applied to
+them, out of scope): a section-wide grep for a marker string is fragile once the section's own
+prose legitimately re-mentions that marker.
+
+## 2026-07-04 08:05 a negative-control fixture almost defeated its own purpose
+
+**Decision:** the AC4 fixture's description text avoids the literal substring "gate-ledger"
+entirely, with a comment inside the fixture explaining why.
+
+**Why:** the first fixture's frontmatter description read "a command with no gate-ledger
+mention and no exemption entry" -- which itself contains the substring "gate-ledger", so the
+sweep's own `grep -qi gate-ledger` check matched the fixture's SELF-DESCRIPTION and wrongly
+counted it as wired. A classic self-referential test-fixture trap (the same shape as a
+fixture that says "this file has no secrets" and thereby trips a secret-scanner on the word
+"secrets"). Caught immediately by actually running the test rather than trusting the design on
+paper.
+
+**Impact:** none outside the test file. Recorded as SPEC-139's Test plan case 8 (the "security/
+abuse" category row) so it is not lost as tribal knowledge.
+
+## 2026-07-04 08:10 `Build` and design-record stay unrecorded -- named, not fixed
+
+**Decision:** `execute.md` is untouched; no new `record <rid> build ran` or
+`record <rid> design-record ran` call was added anywhere.
+
+**Why:** both are genuine pre-existing gaps (confirmed: `execute.md` narrates escalation/action
+verbs around a build but never calls `record` for the `Build` phase itself; no command anywhere
+calls `record <rid> design-record ran`, since that row is enforced statically by
+`/kit:spec-validate` Reviewer 6 rather than separately recorded). Neither is in this sub-goal's
+named 9-command list, and `execute.md` was already counted among the mega-goal's own "11
+emitting" commands (it DOES call gate-ledger.sh, just not for the `Build` phase specifically) --
+touching it would be scope creep against the explicit DO-NOT-add-new-gates /
+DO-NOT-change-lane-matrix-cells constraint, and against the "surgical changes" discipline (only
+touch what the task requires).
+
+**Impact:** for THIS sub-goal's own ship, both gates were satisfied by a MANUAL
+`bash lib/gate-ledger.sh record <rid> build ran "..."` / `... design-record ran "..."` call
+(the same generic escape hatch AGENTS.md already names for any phase gate with no dedicated
+command instruction), not by editing any kit source file. WORKFLOW.md's new section names both
+gaps honestly as out of scope, with a candidate backlog note in
+`docs/retro/RETRO-2026-07-04-kit-emit-sweep.md`.

--- a/docs/retro/RETRO-2026-07-04-kit-emit-sweep.md
+++ b/docs/retro/RETRO-2026-07-04-kit-emit-sweep.md
@@ -1,0 +1,52 @@
+# Retro: kit-emit-sweep (SPEC-139, kit-run-integrity sub-goal 05)
+
+Date: 2026-07-04
+Sprint: single-session sub-goal, dispatched as ID-256's fifth of six sub-goals
+
+## Metrics
+- Tasks planned: 3 (wire 9 dark commands, exemption table, no-orphan sweep test), completed: 3, deferred: 0
+- Commits: 1 (planned, at ship)
+- Files changed: 13 (9 commands, WORKFLOW.md, CI workflow, spec, new test file)
+- Time span: one continuous session, spec through ship
+
+## What worked
+- **The 3 prior no-orphan-sweep siblings (`test-understanding-wiring.sh`, `test-kri-wiring.sh`,
+  `test-docs-wiring.sh`) made this fast to design correctly.** Reusing their exact shape
+  (PASS/FAIL counters, a load-bearing negative control, WORKFLOW.md as the parsed single
+  source of truth) meant the only genuinely new design work was the generic per-file sweep
+  loop itself, not the whole test harness.
+- **Dogfooding the newly-wired commands against this very sub-goal's own SPEC/ship caught real
+  bugs before they shipped.** Writing SPEC-139's own `## Design`/`## Test plan` sections and
+  running `spec-validate`'s adversarial pass live (not just describing it) is what surfaced the
+  design decisions now in the Decision Log.
+
+## What hurt
+- **The first sweep-check regex was too strict and produced a false negative.** A first draft
+  keyed on the literal invocation shape `` `bash lib/gate-ledger\.sh <verb>` `` and would have
+  wrongly flagged `commands/quiz-gate.md` an orphan, because that file's real emit is phrased
+  as `` `gate-ledger.sh debt-response` `` (no `bash lib/` prefix in the same backtick span).
+  Caught only by actually running the check against the real repo before trusting it.
+- **The exemption-table parser initially over-matched.** `exemption_list()`'s first version
+  grepped for ANY backtick-wrapped `.md` mention anywhere in the new WORKFLOW.md section,
+  which picked up self-referential mentions inside the table's own rationale prose (e.g. the
+  `mega.md` row explaining itself twice) and prose from the paragraph ABOVE the table (e.g.
+  "the same convention `test-plan.md` / `review.md` already use"). Fixed by anchoring the
+  parser to the table's FIRST COLUMN only (`^\| *`name.md`...`), not any backtick mention in
+  the section.
+- **A negative-control fixture almost defeated itself.** The first fixture command's own
+  description text said "no gate-ledger mention" -- which itself matched the sweep's
+  `grep -qi gate-ledger` check, making the fixture accidentally pass as "wired." A classic
+  self-referential test-fixture trap; fixed by rephrasing the fixture to avoid the substring
+  entirely (and noting the trap explicitly in the Test plan's case 8).
+
+## Action items
+- [ ] None owed back to the kit itself from this pass; the pre-existing `Build`/design-record
+      gap (no command records either phase) is named honestly in WORKFLOW.md and left as a
+      backlog candidate for a future sub-goal, not fixed here (out of this sub-goal's scope).
+
+## Kit feedback
+The no-orphan-sweep pattern (this is now the fourth instance in this repo) is mature enough
+that a future generalization -- a single reusable `lib/no-orphan-sweep.sh` shared by all four
+callers instead of four independently-written `_wired`/`sweep_check` functions -- might be
+worth a future sub-goal's time. Not done here (surgical-change discipline; each of the four
+existing files works and touching the other three is out of this sub-goal's scope).

--- a/docs/specs/SPEC-139-kit-emit-sweep.md
+++ b/docs/specs/SPEC-139-kit-emit-sweep.md
@@ -1,0 +1,170 @@
+# Spec: Command emit sweep -- close the RUN_REPORT under-count (kit-run-integrity sub-goal 05)
+
+Generated: 2026-07-04
+Status: VALIDATED
+Lane: full (touches the operate-contract's own gate-recording convention across 9 command
+files plus a new invariant test that must hold forever; treated as full per the mega-goal's
+own framing, not because any single edit is architecturally deep).
+
+## Problem
+
+`RUN_REPORT.md` (`/kit:mega`'s per-sub-goal gate matrix, `commands/mega.md` "Close the run
+visibly") can only show a phase as covered if SOME command actually calls `gate-ledger.sh`
+for it. A 2026-07-04 audit of every file under `commands/` (re-verified against the current
+`master`-based tree on this branch, since sub-goals 03+04 landed after the mega-goal's
+original count) found the SAME split the mega-goal's framing named: **11 of 29 commands emit
+directly, 18 are dark**, with no distinction anywhere between "this phase genuinely has no
+ledger concern" and "nobody wired it yet." RUN_REPORT under-counts silently either way, and a
+new command added later with neither an emit nor a documented reason would silently join the
+dark 18 with zero test coverage noticing.
+
+Of the 18 dark commands, 9 are **phase-owning** (`spec.md`, `spec-validate.md`, `verify.md`,
+`think.md`, `design.md`, `ui-design.md`, `docs.md`, `retro.md`, `explain.md` -- each maps to a
+real V-model phase or an established RUN_REPORT-observability phase like `grill`), and 9 are
+**utility commands** (`absorb.md`, `adopt.md`, `next.md`, `start.md`, `kit-health.md`,
+`draft-agent.md`, `visual-team.md`, `mega.md`, `dispatch.md`) that genuinely have no phase of
+their own to record against -- but until now that distinction lived only in a conductor's head,
+never in the repo.
+
+## Solution
+
+Two-part close-out, plus the forever-invariant test the mega-goal's over-test framing demands:
+
+1. **Wire the 9 phase-owning dark commands.** Each gains ONE line, at its natural hand-off
+   point, in the SAME single-line convention `test-plan.md` / `review.md` / `devs-team.md`
+   already use (`bash lib/gate-ledger.sh record <rid> <Phase> ran "<summary>"`):
+   - `spec.md` -> `Spec` (a real `Lane x phase depth matrix` row)
+   - `spec-validate.md` -> `Validate` (a real matrix row)
+   - `think.md` -> `Think` (a real matrix row)
+   - `design.md` -> `Design` (a real matrix row, "Design (opt-in)")
+   - `ui-design.md` -> `UI design` (a real matrix row, "UI design (opt-in)")
+   - `docs.md` -> `Docs` (a real matrix row)
+   - `retro.md` -> `Reflect` (a real matrix row -- the command is `/kit:retro` but the phase
+     it owns is named `Reflect` in the matrix, so the record call uses that name, not `retro`)
+   - `verify.md` -> `verify` (bespoke; `/kit:verify` is on-demand and carries no matrix row of
+     its own, same precedent as `grill`'s own non-matrix phase -- pure RUN_REPORT
+     observability, never a new required gate)
+   - `explain.md` -> `explain` (bespoke, same non-matrix reasoning as `verify`)
+
+   No lane-matrix cell changes: a command that ran unrecorded yesterday becomes VISIBLE today,
+   never newly-blocking (`required()`/`check()` are keyed on the SAME matrix rows they already
+   were; only 6 of the 9 phases above are matrix rows at all, and none of those 6 gain a new
+   `measure-twice` cell -- they already had one, it just had no live emitter).
+
+2. **Document the 9 utility commands as an exemption table**, in `WORKFLOW.md`'s new
+   "## Command emit coverage (SPEC-139)" section (single source of truth, parsed by the new
+   test, no second copy -- mirrors `matrix_for_lane()`'s own precedent of parsing WORKFLOW.md
+   at runtime): `next.md` / `start.md` are read-only detectors that say so in their own text
+   ("Do NOT execute anything"); `kit-health.md` / `absorb.md` / `adopt.md` / `draft-agent.md`
+   are self-assessment, maintainer-audit, one-time-bootstrap, and meta-generation utilities
+   that sit outside any spec's rid/lane lifecycle; `visual-team.md` is a nested critique lens
+   invoked FROM `ui-design.md` (whose own new emit now covers that phase); `mega.md` /
+   `dispatch.md` already emit, just not as a literal call inside their own prose --
+   `mega.md`'s own text says the driver emits `gate-ledger start` per dispatched sub-goal
+   (SPEC-101), and `dispatch.md`'s fanned-out workers each run the full `/kit:execute`
+   lifecycle (their own gate-ledger calls) inside their isolated worktrees.
+
+3. **A no-orphan sweep test, `tests/test-command-emit-sweep.sh`**, that asserts the invariant
+   FOREVER: every command in `commands/` either mentions `gate-ledger` (a real emit) or is
+   named in WORKFLOW.md's exemption table. Mirrors the established pattern
+   (`tests/test-understanding-wiring.sh` / `tests/test-kri-wiring.sh` /
+   `tests/test-docs-wiring.sh`): a generic sweep function, a load-bearing NEGATIVE CONTROL
+   (a fixture command with neither an emit nor an exemption entry IS flagged), plus a specific
+   proof that the exemption table is load-bearing for `dispatch.md` (which has ZERO
+   gate-ledger mentions of its own -- removing its exemption row alone must turn it into the
+   ONE new orphan the sweep flags).
+
+**Not changed:** no new gate, no lane-matrix cell, no new required phase. `execute.md`
+(`Build`) and the design-record gate are pre-existing gaps (neither is recorded by ANY
+command today, `execute.md` narrates escalation/action verbs but never `record`s `build ran`,
+and design-record is enforced statically by Reviewer 6 rather than separately recorded) --
+both are flagged honestly in WORKFLOW.md's new section as OUT OF SCOPE for this sub-goal
+(`execute.md` was already counted among the 11 "emitting" commands in the mega-goal's own
+framing, and touching it is not in this sub-goal's named list), with the generic manual-record
+escape hatch named for a run that needs either gate satisfied.
+
+## Design
+
+`obvious: not design-bearing`. No new component, no schema change, no external integration, no
+irreversible choice: nine markdown edits reusing an established single-line convention, one
+new markdown table reusing an established parse-at-runtime pattern, and one new test file
+reusing an established no-orphan-sweep shape (three prior siblings in this exact repo). A
+diagram would restate the file list above without adding information.
+
+## Acceptance criteria
+
+1. Each of the 9 phase-owning dark commands (`spec.md`, `spec-validate.md`, `verify.md`,
+   `think.md`, `design.md`, `ui-design.md`, `docs.md`, `retro.md`, `explain.md`) contains a
+   real `bash lib/gate-ledger.sh record <rid> <Phase> ran "..."` call at its natural hand-off
+   point, using the phase name given in the Solution section above.
+2. `WORKFLOW.md` carries a "## Command emit coverage (SPEC-139)" section naming exactly the 9
+   utility commands (`absorb.md`, `adopt.md`, `next.md`, `start.md`, `kit-health.md`,
+   `draft-agent.md`, `visual-team.md`, `mega.md`, `dispatch.md`) with a grounded, per-command
+   reason, plus an honest note on the pre-existing `Build`/design-record gap (out of scope).
+3. `tests/test-command-emit-sweep.sh` passes: every one of the 29 real `commands/*.md` files
+   either mentions `gate-ledger` or is named in the exemption table (0 orphans); the exemption
+   table names exactly the 9 expected commands, no more no less; each of the 9 newly-wired
+   commands is independently verified to carry its specific phase's record call (not just a
+   loose pass on AC1's coarser check).
+4. NEGATIVE CONTROL (load-bearing): a fixture command with neither a `gate-ledger` mention nor
+   an exemption entry IS flagged an orphan by the same sweep function used for AC3, proving the
+   sweep catches the bug class, not just that the real repo happens to be clean.
+5. A second, narrower negative control proves the exemption table is load-bearing for
+   `dispatch.md` specifically (it has zero `gate-ledger` mentions of its own): removing its
+   exemption-table row alone makes the sweep flag exactly one new orphan, `dispatch.md`.
+6. No regression: the full CI suite (every `bash tests/test-*.sh` referenced in
+   `.github/workflows/test.yml`, 33 files after this SPEC adds one) stays green.
+
+## Verification
+
+```
+bash tests/test-command-emit-sweep.sh
+bash tests/test-understanding-wiring.sh
+bash tests/test-kri-wiring.sh
+bash tests/test-docs-wiring.sh
+bash tests/test-meta.sh
+for t in $(grep -oE 'bash tests/test-[a-z0-9-]+\.sh' .github/workflows/test.yml | sort -u | sed 's/bash //'); do bash "$t" >/dev/null 2>&1 && echo "PASS $t" || echo "FAIL $t"; done
+```
+All green; see `docs/verification/kit-emit-sweep/proof-of-done.md` for the full run-table, the
+committed 29-row emit-coverage table, and the live-capture ledger lines.
+
+## Test plan
+Date: 2026-07-04
+Source: this spec's Acceptance criteria
+
+| # | Case | Category | Covers (AC) | Expected | Proof |
+|---|------|----------|-------------|----------|-------|
+| 1 | each of the 9 phase-owning commands carries its exact `record <rid> <Phase> ran` call | happy-path | AC1 | 9/9 grep matches, one per command/phase pair | `tests/test-command-emit-sweep.sh` AC3 block |
+| 2 | WORKFLOW.md's exemption table names exactly the 9 expected utility commands | happy-path | AC2 | sorted actual list == sorted expected list, no more no less | `tests/test-command-emit-sweep.sh` AC2 block |
+| 3 | the full sweep over real `commands/*.md` reports 0 orphans | happy-path | AC3 | sweep_check return code 0, no `ORPHAN:` lines | `tests/test-command-emit-sweep.sh` AC1 block |
+| 4 | commands/ has exactly 29 files (pin, catches silent drift) | boundary/edge | AC3 | count == 29 | `tests/test-command-emit-sweep.sh` AC1 block |
+| 5 | a fixture command with neither an emit nor an exemption entry | boundary/edge + failure-injection | AC4 | flagged as exactly 1 orphan, named precisely | `tests/test-command-emit-sweep.sh` AC4 block |
+| 6 | the two legit fixture copies (an emitter, an exempt) are NOT flagged alongside the bad fixture | regression | AC4 | 0 false positives on the legit copies | `tests/test-command-emit-sweep.sh` AC4 block |
+| 7 | removing dispatch.md's exemption row alone (leaving its zero gate-ledger mentions unchanged) | failure-injection | AC5 | sweep flags exactly 1 NEW orphan, `dispatch.md` | `tests/test-command-emit-sweep.sh` AC5 block; also manually demonstrated live (see proof-of-done RED capture) |
+| 8 | a fixture description that names "gate-ledger" while explaining it has none (self-referential false-negative trap) | security/abuse | AC4 | the fixture avoids the substring by design; caught once during authoring, fixed | proof-of-done "Grounded negative control" section |
+| 9 | full existing CI suite (32 pre-existing files) stays green after all 9 command edits + the WORKFLOW.md table | regression | AC6 | 32/32 PASS, 0 FAIL | Verification section; proof-of-done "Regression" |
+
+### Coverage notes
+- Categories skipped: none -- all 5 categories (happy-path, boundary/edge, failure-injection, security/abuse, regression) are represented across cases 1-9 above.
+- This is a coverage TARGET across the enumerated categories, not an exhaustive test list.
+
+## Decision Log
+- DEC-001: the loose "mentions `gate-ledger`" check (rather than a per-file invocation-shape
+  regex) is the sweep's positive-coverage test, because a stricter regex that tries to
+  distinguish "a real call" from "a prose mention" turned out to be brittle in practice (the
+  first draft's strict `` `bash lib/gate-ledger\.sh <verb>` `` pattern missed `quiz-gate.md`'s
+  legitimate `` `gate-ledger.sh debt-response` `` shorthand and would have wrongly flagged it
+  an orphan); alternatives rejected: a strict per-file regex (too fragile to phrasing drift), a
+  hand-maintained allow/deny list with no grep at all (loses the "did someone actually touch
+  the ledger" signal entirely).
+- DEC-002: `verify` and `explain` record bespoke, non-matrix phase names (lowercase, no Title
+  Case) rather than being shoehorned into an existing matrix row, mirroring `grill`'s own
+  established precedent (`lib/gate-ledger.sh`'s `record()` accepts any phase string; only
+  `required()`/`plan()`/`progress()` consult the matrix). Alternative rejected: inventing a
+  `Verify (opt-in)` / `Explain (opt-in)` matrix row, which the sub-goal's explicit "no
+  lane-matrix cell changes" constraint forbids.
+- DEC-003: `retro.md` records phase `Reflect` (the matrix's own name for that row), not
+  `retro` (the command's own name), because `record()`'s phase argument is what RUN_REPORT and
+  `required()`/`check()` key on -- recording `retro` would silently create a SECOND, unmatched
+  phase name that never satisfies the real `Reflect` gate. Rejected: recording both `Reflect`
+  and `retro` (redundant, and invites drift between the two).

--- a/docs/verification/kit-emit-sweep/proof-of-done.md
+++ b/docs/verification/kit-emit-sweep/proof-of-done.md
@@ -1,0 +1,244 @@
+# Proof of done: kit-emit-sweep (SPEC-139, kit-run-integrity mega-goal sub-goal 05, ID-256)
+
+## Acceptance criteria -> run-table
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| AC1 | Each of the 9 phase-owning dark commands carries a real `record <rid> <Phase> ran "..."` call at its natural hand-off point | PASS (9/9) | AC3 block below; `tests/test-command-emit-sweep.sh` AC3 |
+| AC2 | `WORKFLOW.md` carries a "## Command emit coverage (SPEC-139)" section naming exactly the 9 utility commands with a grounded reason, plus the honest pre-existing-gap note | PASS | WORKFLOW.md diff (below); `tests/test-command-emit-sweep.sh` AC2 |
+| AC3 | `tests/test-command-emit-sweep.sh` passes: 0 orphans across the real 29, exemption table exact-matches the 9 expected, each of the 9 newly-wired commands independently verified | PASS (19/19) | Confirmation run below |
+| AC4 | NEGATIVE CONTROL: a fixture command with neither an emit nor an exemption entry IS flagged an orphan | PASS | Confirmation run below; also proven at the WHOLE-DIFF level via a real revert (see "Grounded negative control") |
+| AC5 | A second, narrower NC proves the exemption table load-bearing for `dispatch.md` specifically | PASS | Confirmation run below |
+| AC6 | No regression: full CI suite (33 files) stays green | PASS (33/33) | Regression section below |
+
+**Total: 19/19 PASS in `tests/test-command-emit-sweep.sh`, 0 FAIL.**
+
+## The emit-coverage table (29 rows, committed)
+
+Before this sub-goal: 11/29 commands emitted directly, 18/29 were dark with no distinction
+between "genuinely no ledger concern" and "nobody wired it." After: 20/29 emit directly (9
+newly wired this pass), 9/29 explicitly exempted with a documented, grounded reason, **0/29
+silently dark**.
+
+| Command | Status | Phase / reason |
+|---|---|---|
+| `absorb.md` | EXEMPT | Maintainer-only external-source audit; propose-only, outside any rid/lane lifecycle |
+| `adopt.md` | EXEMPT | One-time repo-bootstrap, runs before any rid/lane exists in the target repo |
+| `assign.md` | EMITS (pre-existing) | `START` routing facts (SPEC-061/062) |
+| `debug.md` | EMITS (pre-existing) | `action` escalation marker |
+| `design.md` | **EMITS (NEW, SPEC-139)** | `Design` |
+| `devs-team.md` | EMITS (pre-existing) | `review` |
+| `dispatch.md` | EXEMPT | Fanned-out workers each run the full `/kit:execute` lifecycle (own gate-ledger calls); dispatch.md itself never calls gate-ledger.sh |
+| `docs.md` | **EMITS (NEW, SPEC-139)** | `Docs` |
+| `draft-agent.md` | EXEMPT | Meta-agent generator, not a V-model phase |
+| `execute.md` | EMITS (pre-existing) | `start --amend` / `action` escalation (NOTE: never records `build ran` -- pre-existing gap, out of scope, see WORKFLOW.md) |
+| `explain.md` | **EMITS (NEW, SPEC-139)** | `explain` (bespoke, no matrix row) |
+| `grill.md` | EMITS (pre-existing) | `grill` ran/skipped (SPEC-138 reason enum) |
+| `kit-health.md` | EXEMPT | Self-assessment of the kit's own philosophy, not a run phase |
+| `mega.md` | EXEMPT | Driver emits `gate-ledger start` per dispatched sub-goal (SPEC-101), not a literal call in mega.md's own prose |
+| `next.md` | EXEMPT | Pure read-only dispatcher ("Do NOT execute anything") |
+| `quiz-gate.md` | EMITS (pre-existing) | `debt-response` |
+| `retro.md` | **EMITS (NEW, SPEC-139)** | `Reflect` (the matrix's name for this row, not `retro`) |
+| `review.md` | EMITS (pre-existing) | `review` |
+| `review-team.md` | EMITS (pre-existing) | `review` + `coverage-delta.sh check` |
+| `ship.md` | EMITS (pre-existing) | `Ship` (+ significance-classify record + quiz-gate tap, SPEC-136) |
+| `spec.md` | **EMITS (NEW, SPEC-139)** | `Spec` |
+| `spec-validate.md` | **EMITS (NEW, SPEC-139)** | `Validate` |
+| `start.md` | EXEMPT | Pure read-only entry-point detector ("Do NOT execute anything") |
+| `test-plan.md` | EMITS (pre-existing) | `test-plan` |
+| `test-plan-review-team.md` | EMITS (pre-existing) | `test-plan` |
+| `think.md` | **EMITS (NEW, SPEC-139)** | `Think` |
+| `ui-design.md` | **EMITS (NEW, SPEC-139)** | `UI design` |
+| `verify.md` | **EMITS (NEW, SPEC-139)** | `verify` (bespoke, no matrix row) |
+| `visual-team.md` | EXEMPT | Nested critique lens invoked from `ui-design.md` Step 3, not an independent phase owner |
+
+**COVERAGE-DELTA:** 9 new emit call sites added (0 -> 9 for the phase-owning dark set); the
+no-orphan sweep test is entirely new (0 -> 19 assertions covering the full-repo invariant); the
+exemption table is entirely new (0 -> 9 documented rows, closing what was previously an
+undocumented, tribal-knowledge distinction). Net: RUN_REPORT's per-sub-goal gate matrix can now
+account for 29/29 commands with an explicit status, versus 11/29 before.
+
+## Implementation
+
+- 9 command files (`spec.md`, `spec-validate.md`, `verify.md`, `think.md`, `design.md`,
+  `ui-design.md`, `docs.md`, `retro.md`, `explain.md`) each gain one `gate-ledger.sh record`
+  line at their natural hand-off point, reusing the exact single-line convention
+  `test-plan.md`/`review.md`/`devs-team.md` already use.
+- `WORKFLOW.md` gains a new "## Command emit coverage (SPEC-139)" section: the audit framing,
+  the 9-command exemption table with per-command rationale, and an honest note on the
+  pre-existing `Build`/design-record gap (named, not fixed -- out of scope).
+- `tests/test-command-emit-sweep.sh` (new): a generic no-orphan sweep over all of `commands/*.md`,
+  parsing the exemption list from WORKFLOW.md's table (single source of truth, anchored to the
+  table's first column only so a rationale sentence re-mentioning a filename is never
+  double-counted), plus a load-bearing negative control and a `dispatch.md`-specific
+  load-bearing-exemption proof.
+- `.github/workflows/test.yml` gains one new CI step running the sweep test.
+- `docs/specs/SPEC-139-kit-emit-sweep.md` (new spec, VALIDATED, with a `## Test plan` section)
+  and `docs/implementation-notes/kit-emit-sweep.md` (the delta from the spec: 3 decisions the
+  assigning prompt did not pin down).
+
+## Confirmation run (green)
+
+```
+$ bash tests/test-command-emit-sweep.sh
+=== AC1: no-orphan sweep -- every real commands/*.md either emits or is exempted ===
+  PASS every command in commands/ mentions gate-ledger OR is exempted (0 orphans)
+  PASS commands/ has 29 command files (the 2026-07-04 count; update this pin if it legitimately changes)
+
+=== AC2: the exemption table names exactly the 9 expected utility commands ===
+  PASS exemption table = {absorb,adopt,dispatch,draft-agent,kit-health,mega,next,start,visual-team}, no more no less
+
+=== AC3: each of the 9 newly-wired commands genuinely records its own phase ===
+  PASS commands/ui-design.md records 'UI design ran' via gate-ledger.sh (real call, not a loose match)
+  PASS commands/spec-validate.md records 'Validate ran' via gate-ledger.sh (real call, not a loose match)
+  PASS commands/docs.md records 'Docs ran' via gate-ledger.sh (real call, not a loose match)
+  PASS commands/explain.md records 'explain ran' via gate-ledger.sh (real call, not a loose match)
+  PASS commands/verify.md records 'verify ran' via gate-ledger.sh (real call, not a loose match)
+  PASS commands/think.md records 'Think ran' via gate-ledger.sh (real call, not a loose match)
+  PASS commands/spec.md records 'Spec ran' via gate-ledger.sh (real call, not a loose match)
+  PASS commands/design.md records 'Design ran' via gate-ledger.sh (real call, not a loose match)
+  PASS commands/retro.md records 'Reflect ran' via gate-ledger.sh (real call, not a loose match)
+
+=== AC4: NEGATIVE CONTROL -- a fixture command with neither emit nor exemption IS caught ===
+  PASS the sweep flags exactly 1 orphan in the fixture dir (the fabricated bad command)
+  PASS the flagged orphan is specifically fixture-bad-command.md (not a false hit on the legit copies)
+  PASS the legit 'emits' copy (review.md) is NOT flagged
+  PASS the legit 'exempt' copy (next.md) is NOT flagged
+
+=== AC5: the exemption table is load-bearing for dispatch.md (not decorative) ===
+  PASS dispatch.md has ZERO gate-ledger mentions of its own (the exemption entry is the ONLY thing keeping it non-orphan)
+  PASS removing dispatch's exemption entry alone makes the sweep flag exactly 1 new orphan (dispatch.md)
+  PASS ...and that orphan is specifically dispatch.md
+
+=== Results ===
+Passed: 19 / 19
+All command-emit-sweep tests passed.
+```
+
+## Grounded negative control (whole-diff level, load-bearing)
+
+Beyond the in-test AC4/AC5 fixtures, the sweep was proven against the REAL diff by reverting it
+and re-running the same command (the RED-as-expected proof the `verify` gate above records):
+
+```
+$ git stash push -- commands/ WORKFLOW.md
+ok stashed
+
+$ bash tests/test-command-emit-sweep.sh
+  ORPHAN: absorb.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: adopt.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: design.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: dispatch.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: docs.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: draft-agent.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: explain.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: kit-health.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: next.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: retro.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: spec-validate.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: spec.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: start.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: think.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: ui-design.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: verify.md (no gate-ledger mention, not in the exemption table)
+  ORPHAN: visual-team.md (no gate-ledger mention, not in the exemption table)
+  FAIL every command in commands/ mentions gate-ledger OR is exempted (0 orphans)
+  ... (14 FAIL total)
+=== Results ===
+Passed: 5 / 19
+Failed: 14
+
+$ git stash pop
+ok stash pop
+```
+(17 real orphans surface once the WORKFLOW.md exemption table itself is also reverted, since the
+9 exempted-utility rows disappear along with the 9 newly-wired commands -- both halves of the
+change are proven load-bearing together.) Re-running the sweep after `stash pop` confirmed 19/19
+green again (see the Confirmation run above, captured after restore).
+
+## Live captures (one per phase family, real ledger lines from the real run log)
+
+Ledger file: `~/.local/state/dwarves-kit/logs/runs/kit-emit-sweep.log` (via `bash lib/gate-ledger.sh show kit-emit-sweep`):
+
+```
+2026-07-04T07:46:49Z | START | lane=full classified=full type=spec-feature ctype=spec-feature repo=dwarves-kit
+2026-07-04T08:02:20Z | GATE | spec | ran | SPEC-139-kit-emit-sweep approved, tasks=3 ...
+2026-07-04T08:03:13Z | GATE | validate | ran | APPROVED critical=0 warnings=0 ...
+2026-07-04T08:03:19Z | GATE | design-record | ran | SPEC-139 Design section: obvious collapse ...
+2026-07-04T08:03:27Z | GATE | grill | skipped | reason=operator-wave: TIER1+3 framing done upstream ...
+2026-07-04T08:03:27Z | GATE | think | override | TIER1+3 framing done upstream ...
+2026-07-04T08:03:27Z | GATE | design | override | explicitly skipped per sub-goal framing (TIER1+3) ...
+2026-07-04T08:03:27Z | GATE | design-critique | override | single-worker mechanical wiring task ...
+2026-07-04T08:03:54Z | GATE | test-plan | ran | matrix rows=9 categories=happy-path,boundary/edge,...
+2026-07-04T08:03:58Z | GATE | build | ran | 9 dark commands wired ...
+2026-07-04T08:04:28Z | GATE | review | ran | SHIP findings=0 ...
+2026-07-04T08:04:42Z | GATE | docs | ran | files=WORKFLOW.md ...
+2026-07-04T08:05:17Z | GATE | reflect | ran | action-items=0 ...
+2026-07-04T08:05:56Z | GATE | verify | ran | PASS 19/19 test-command-emit-sweep.sh + negative control ...
+2026-07-04T08:06:16Z | GATE | explain | ran | ref=HEAD (mechanical proof only) ...
+```
+
+- **Spec-lifecycle family** (`spec.md` / `spec-validate.md`): dogfooded FOR REAL against this
+  very sub-goal's own SPEC-139 -- the `Spec ran` and `Validate ran` lines above are this SPEC's
+  actual authorship and adversarial-review pass, not a fixture.
+- **Docs/Reflect family** (`docs.md` / `retro.md` / `explain.md`): `Docs ran` and `Reflect ran`
+  are dogfooded for real (this diff's own doc-drift check, and this file's own retro at
+  `docs/retro/RETRO-2026-07-04-kit-emit-sweep.md`); `explain ran` is a mechanical proof
+  (`lib/explain.sh render HEAD --out ...` exited 0, real engine invocation, not a fixture),
+  labeled honestly in its own ledger reason as "mechanical proof only."
+- **Verify family** (`verify.md`): `verify ran` is dogfooded for real -- the actual
+  `test-command-emit-sweep.sh` run (19/19) plus the actual `git stash`/`pop` negative control
+  above.
+- **Product-framing family** (`think.md` / `design.md` / `ui-design.md`): legitimately SKIPPED
+  this run (TIER1+3 framing was already resolved upstream by the mega-goal conductor before
+  dispatch, per the sub-goal's own instructions), recorded honestly as `override`, never
+  fabricated as `ran`. To still prove the three new call strings are syntactically valid and
+  produce well-formed lines, a throwaway dry-run against a SCRATCH log dir (never touching the
+  real `kit-emit-sweep` ledger) confirms all three execute cleanly:
+  ```
+  $ DWARVES_KIT_LOG_DIR="$(mktemp -d)" bash lib/gate-ledger.sh record smoke-rid Think ran "..."
+  $ DWARVES_KIT_LOG_DIR="$(mktemp -d)" bash lib/gate-ledger.sh record smoke-rid Design ran "..."
+  $ DWARVES_KIT_LOG_DIR="$(mktemp -d)" bash lib/gate-ledger.sh record smoke-rid "UI design" ran "..."
+  $ cat "$TESTDIR/runs/smoke-rid.log"
+  2026-07-04T08:06:38Z | GATE | think | ran | BUILD one-line thesis: mechanical dry-run only ...
+  2026-07-04T08:06:38Z | GATE | design | ran | approaches=2 design-bearing=no (mechanical dry-run only)
+  2026-07-04T08:06:38Z | GATE | ui-design | ran | SOLID rounds=1 (mechanical dry-run only)
+  ```
+  (Confirms in particular that the quoted phase `"UI design"` normalizes correctly to `ui-design`,
+  matching the matrix row and the sweep test's AC3 expectation.)
+
+## Cross-check: the sibling observatory's parser ingests the new lines
+
+The harness-observatory sibling's `adapters.read_kit_gates` parser (per its DECISIONS.md
+"01-kit-gates-lens", 2026-07-04) reads `| GATE |` / `| OUTCOME |` lines, splitting on `" | "`
+with a per-line tolerance grammar (>=4 fields required; field[4] = reason when present). Every
+new line this sub-goal emits (`record()`'s own `printf '%s | GATE | %s | %s | %s\n' ...`) is
+byte-identical in shape to the pre-existing `| GATE | <phase> | ran | <reason> |` lines the
+sibling already ingests (e.g. `review`/`test-plan`/`Ship`) -- no new field, no new marker type,
+same 5-field pipe format the sibling's own grammar note documents. No sibling code change is
+needed; this sub-goal introduces zero new grammar. Confirmed by inspection of the actual
+captured lines above against `gate-ledger.sh`'s `record()` function (unchanged by this SPEC) and
+the sibling's own documented tolerance rule.
+
+## Regression
+
+- `bash tests/test-command-emit-sweep.sh`: 19/19 PASS (new).
+- `bash tests/test-understanding-wiring.sh`: 19/19 PASS.
+- `bash tests/test-kri-wiring.sh`: 31/31 PASS.
+- `bash tests/test-docs-wiring.sh`: 22/22 PASS.
+- `bash tests/test-hooks.sh`: 452/452 PASS.
+- `bash tests/test-grill-conditioning.sh`: 23/23 PASS.
+- `bash tests/test-meta.sh`: 667/667 PASS.
+- Full CI suite (every `bash tests/test-*.sh` referenced in `.github/workflows/test.yml`, 33
+  files after this SPEC adds one): all PASS, run individually.
+
+## Reproduce
+
+```
+cd dwarves-kit
+bash tests/test-command-emit-sweep.sh
+bash tests/test-understanding-wiring.sh
+bash tests/test-kri-wiring.sh
+bash tests/test-docs-wiring.sh
+bash tests/test-meta.sh
+```

--- a/tests/test-command-emit-sweep.sh
+++ b/tests/test-command-emit-sweep.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# test-command-emit-sweep.sh -- SPEC-139, kit-run-integrity mega-goal sub-goal 05 (ID-256).
+#
+# RUN_REPORT.md (`/kit:mega`'s per-sub-goal gate matrix) can only show a phase as covered if
+# SOME command actually calls `gate-ledger.sh` for it. A 2026-07-04 audit of every file under
+# commands/ found 11 of 29 with a real gate-ledger call and 18 dark, with no distinction
+# between "this phase genuinely has no ledger concern" and "nobody wired it yet" -- the
+# RUN_REPORT under-counts silently either way. This sub-goal wires 9 of the 18 (the
+# phase-owning ones: spec, spec-validate, verify, think, design, ui-design, docs, retro,
+# explain) and documents the other 9 (utility commands) as an explicit exemption table in
+# WORKFLOW.md's "## Command emit coverage (SPEC-139)" section -- the single source of truth,
+# parsed here, no second copy.
+#
+# This file proves the FOREVER invariant, mirroring the no-orphan sweep pattern already
+# established by tests/test-understanding-wiring.sh / tests/test-kri-wiring.sh /
+# tests/test-docs-wiring.sh: every command in commands/ either mentions `gate-ledger` (a real
+# emit) OR is named in WORKFLOW.md's exemption table (a documented, reasoned no-emit). A new
+# command added later with neither is an ORPHAN -- caught by this test, not discovered months
+# later when RUN_REPORT quietly under-counts it.
+#
+#   AC1  every command in commands/ (a) mentions gate-ledger, or (b) is in the exemption table
+#   AC2  the exemption table names exactly the 9 expected utility commands (no silent drift)
+#   AC3  each of the 9 newly-wired commands genuinely contains a gate-ledger record call
+#        (not just present-by-coincidence in the loose AC1 check)
+#   AC4  NEGATIVE CONTROL: a fixture command with NEITHER an emit NOR an exemption entry IS
+#        flagged an orphan by the same sweep function, proving it actually catches the bug
+#        class, not just that the real repo happens to be clean
+#   AC5  the exemption table is load-bearing for `dispatch.md` specifically: dispatch.md has
+#        ZERO gate-ledger mentions of its own, so removing its exemption-table entry would
+#        turn it into an orphan -- proving the table is not decorative
+#
+# Run: bash tests/test-command-emit-sweep.sh   (exit 0 = all AC green)
+
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COMMANDS_DIR="$KIT_DIR/commands"
+WORKFLOW="$KIT_DIR/WORKFLOW.md"
+
+PASS=0; FAIL=0; TOTAL=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 ${3:-}"; FAIL=$((FAIL+1)); fi; }
+assert_eq() { TOTAL=$((TOTAL+1)); if [ "$2" = "$3" ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 (expected '$3', got '$2')"; FAIL=$((FAIL+1)); fi; }
+
+# ---------------------------------------------------------------------------------------
+# exemption_list <workflow-md>: prints one bare command-name (no .md) per line, parsed from
+# WORKFLOW.md's "## Command emit coverage" section table (single source of truth; the
+# matrix_for_lane() precedent in lib/gate-ledger.sh parses WORKFLOW.md the same way, no
+# second copy of the mapping). A row is `| \`<name>.md\` | <reason> |` -- ANCHORED at the
+# line start (the FIRST column only), so a rationale sentence that re-mentions its own or
+# another command's filename in backticks (e.g. mega's/dispatch's own rows do, explaining
+# themselves) is never double-counted or mistaken for a second exemption.
+# ---------------------------------------------------------------------------------------
+exemption_list() {
+  local doc="$1"
+  awk '/^## Command emit coverage/{f=1;next} f&&/^## /{exit} f' "$doc" \
+    | grep -E '^\| *`[a-z][a-z0-9-]*\.md` *\|' \
+    | sed -E 's/^\| *`([a-z][a-z0-9-]*)\.md`.*/\1/'
+}
+
+# sweep_check <commands-dir> <exemption-list-string>: prints one "ORPHAN: <name>.md" line per
+# command with neither a gate-ledger mention nor an exemption entry; return code = orphan count.
+sweep_check() {
+  local dir="$1" exempt="$2" f base orphans=0
+  for f in "$dir"/*.md; do
+    [ -f "$f" ] || continue
+    base="$(basename "$f" .md)"
+    grep -qi 'gate-ledger' "$f" && continue
+    printf '%s\n' "$exempt" | grep -qxF "$base" && continue
+    echo "  ORPHAN: $base.md (no gate-ledger mention, not in the exemption table)"
+    orphans=$((orphans + 1))
+  done
+  return "$orphans"
+}
+
+EXEMPT="$(exemption_list "$WORKFLOW")"
+
+echo "=== AC1: no-orphan sweep -- every real commands/*.md either emits or is exempted ==="
+
+ORPHAN_OUT="$(sweep_check "$COMMANDS_DIR" "$EXEMPT")"
+ORPHAN_RC=$?
+[ -n "$ORPHAN_OUT" ] && echo "$ORPHAN_OUT" >&2
+if [ "$ORPHAN_RC" -eq 0 ]; then RC=0; else RC=1; fi
+assert "every command in commands/ mentions gate-ledger OR is exempted (0 orphans)" $RC
+
+TOTAL_COMMANDS=$(find "$COMMANDS_DIR" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')
+assert_eq "commands/ has 29 command files (the 2026-07-04 count; update this pin if it legitimately changes)" "$TOTAL_COMMANDS" "29"
+
+echo ""
+echo "=== AC2: the exemption table names exactly the 9 expected utility commands ==="
+
+EXPECTED_EXEMPT="absorb
+adopt
+dispatch
+draft-agent
+kit-health
+mega
+next
+start
+visual-team"
+
+SORTED_EXPECTED="$(printf '%s\n' "$EXPECTED_EXEMPT" | sort)"
+SORTED_ACTUAL="$(printf '%s\n' "$EXEMPT" | sort)"
+assert_eq "exemption table = {absorb,adopt,dispatch,draft-agent,kit-health,mega,next,start,visual-team}, no more no less" "$SORTED_ACTUAL" "$SORTED_EXPECTED"
+
+echo ""
+echo "=== AC3: each of the 9 newly-wired commands genuinely records its own phase ==="
+
+declare -A NEW_PHASE=(
+  [spec]='Spec'
+  [spec-validate]='Validate'
+  [verify]='verify'
+  [think]='Think'
+  [design]='Design'
+  [ui-design]='UI design'
+  [docs]='Docs'
+  [retro]='Reflect'
+  [explain]='explain'
+)
+for cmd in "${!NEW_PHASE[@]}"; do
+  phase="${NEW_PHASE[$cmd]}"
+  RC=0
+  grep -qE "gate-ledger\.sh\"? *record <rid> [\"\`]?${phase}[\"\`]? ran" "$COMMANDS_DIR/$cmd.md" || RC=1
+  assert "commands/$cmd.md records '$phase ran' via gate-ledger.sh (real call, not a loose match)" $RC
+done
+
+echo ""
+echo "=== AC4: NEGATIVE CONTROL -- a fixture command with neither emit nor exemption IS caught ==="
+
+FIXTURE_DIR="$(mktemp -d -t command-emit-sweep-fixture.XXXXXX)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# one legit "emits" copy, one legit "exempt" copy, one fabricated bad command (SPEC-139's own
+# c6fbd99-class bug: a new command lands with no emit and no exemption entry).
+cp "$COMMANDS_DIR/review.md" "$FIXTURE_DIR/review.md"
+cp "$COMMANDS_DIR/next.md" "$FIXTURE_DIR/next.md"
+cat > "$FIXTURE_DIR/fixture-bad-command.md" <<'EOF'
+---
+description: "TEST FIXTURE ONLY: proves the sweep catches an unrecorded, unlisted command."
+---
+This fixture exists only to prove test-command-emit-sweep.sh's sweep function catches an
+orphaned command. It must never appear in the real commands directory. It deliberately says
+nothing about the audit ledger tool this whole test suite is about, by name, anywhere in this
+file -- that omission is the point of the fixture.
+EOF
+
+FIXTURE_OUT="$(sweep_check "$FIXTURE_DIR" "$EXEMPT")"
+FIXTURE_RC=$?
+assert_eq "the sweep flags exactly 1 orphan in the fixture dir (the fabricated bad command)" "$FIXTURE_RC" "1"
+
+if printf '%s\n' "$FIXTURE_OUT" | grep -qF "ORPHAN: fixture-bad-command.md"; then RC=0; else RC=1; fi
+assert "the flagged orphan is specifically fixture-bad-command.md (not a false hit on the legit copies)" $RC
+
+if printf '%s\n' "$FIXTURE_OUT" | grep -q "ORPHAN: review.md"; then RC=1; else RC=0; fi
+assert "the legit 'emits' copy (review.md) is NOT flagged" $RC
+
+if printf '%s\n' "$FIXTURE_OUT" | grep -q "ORPHAN: next.md"; then RC=1; else RC=0; fi
+assert "the legit 'exempt' copy (next.md) is NOT flagged" $RC
+
+echo ""
+echo "=== AC5: the exemption table is load-bearing for dispatch.md (not decorative) ==="
+
+RC=0
+grep -qi 'gate-ledger' "$COMMANDS_DIR/dispatch.md" && RC=1
+assert "dispatch.md has ZERO gate-ledger mentions of its own (the exemption entry is the ONLY thing keeping it non-orphan)" $RC
+
+EXEMPT_WITHOUT_DISPATCH="$(printf '%s\n' "$EXEMPT" | grep -vxF 'dispatch')"
+WITHOUT_OUT="$(sweep_check "$COMMANDS_DIR" "$EXEMPT_WITHOUT_DISPATCH")"
+WITHOUT_RC=$?
+assert_eq "removing dispatch's exemption entry alone makes the sweep flag exactly 1 new orphan (dispatch.md)" "$WITHOUT_RC" "1"
+
+if printf '%s\n' "$WITHOUT_OUT" | grep -qF "ORPHAN: dispatch.md"; then RC=0; else RC=1; fi
+assert "...and that orphan is specifically dispatch.md" $RC
+
+echo ""
+echo "=== Results ==="
+echo -e "Passed: ${GREEN}${PASS}${NC} / ${TOTAL}"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed: ${RED}${FAIL}${NC}"
+  exit 1
+else
+  echo -e "${GREEN}All command-emit-sweep tests passed.${NC}"
+  exit 0
+fi


### PR DESCRIPTION
## What

Emit sweep: 18 dark commands classified emit-owed vs exempt, no-orphan sweep test locks the
invariant, RUN_REPORT now reflects the full matrix. Covers ID-256 (kit-run-integrity mega-goal,
sub-goal 05 of 6).

A 2026-07-04 audit of every `commands/*.md` file found 11/29 commands with a real
`gate-ledger.sh` call and 18/29 dark, with no distinction between "genuinely no ledger concern"
and "nobody wired it yet." This PR closes that gap:

1. **9 phase-owning dark commands wired**: `spec.md`, `spec-validate.md`, `verify.md`,
   `think.md`, `design.md`, `ui-design.md`, `docs.md`, `retro.md`, `explain.md` each now record
   one line at their natural hand-off point, reusing the exact single-line convention
   `test-plan.md`/`review.md`/`devs-team.md` already use. No new gate, no lane-matrix cell
   change: a command that ran unrecorded yesterday becomes VISIBLE, never newly-blocking.
2. **9 utility commands documented as an explicit exemption table** in a new WORKFLOW.md
   section ("## Command emit coverage"): `absorb.md`, `adopt.md`, `next.md`, `start.md`,
   `kit-health.md`, `draft-agent.md`, `visual-team.md`, `mega.md`, `dispatch.md`, each with a
   grounded, per-command rationale.
3. **A no-orphan sweep test** (`tests/test-command-emit-sweep.sh`, new CI step) that locks the
   invariant forever: every command in `commands/` either emits or is exempted, with a
   load-bearing negative control (a fixture command with neither IS flagged) plus a second,
   narrower proof that the exemption table is load-bearing for `dispatch.md` specifically.

## Why

See `docs/specs/SPEC-139-kit-emit-sweep.md` for the full spec (VALIDATED, adversarially
self-reviewed against all 6 spec-validate lenses, zero critical/warning findings) and
`docs/verification/kit-emit-sweep/proof-of-done.md` for the full over-test proof.

## Review

SHIP, findings=0 (self-reviewed; no lib/hooks touched so a single reviewer is proportionate per
SPEC-069's escalation rule).

## Testing

- `tests/test-command-emit-sweep.sh`: 19/19 PASS (new).
- Full CI suite (33 files after this PR adds one): all green, including a real negative control
  via `git stash`/`pop` proving the sweep goes RED (5/19) against the reverted diff.
- Live ledger captures for every phase family (spec/validate dogfooded on this SPEC itself,
  docs/reflect/verify dogfooded for real, explain mechanically proven, think/design/ui-design
  proven via a scratch-log dry-run since they were legitimately skipped this run per the
  sub-goal's own TIER1+3 framing).

## Checklist
- [x] Tests pass (19/19 new suite; 33/33 full CI)
- [x] Docs updated (WORKFLOW.md new section)
- [x] Review: SHIP (self-reviewed, no lib/hooks touched)
- [x] No regressions (full suite green before and after)

Not merged by this PR (mega-goal orchestration merges bottom-up on green across all 6
sub-goals).
