### PR TITLE
docs(mega): mirror tiny-decompose + Consolidate mode + de-escalation nudge

### DIFF
--- a/commands/mega.md
+++ b/commands/mega.md
@@ -9,9 +9,11 @@ whatever activator is present (`/goal`, `ralph-loop`, or the kit's own
 step you never merge a PR whose ship-gate has not passed.
 
 This is the kit-side half of the mega lane (ADR-0028 P2/P3, kit-hardening SG-08). It
-**mirrors** the ops-toolkit `plan-for-mega-goal` skill's authoring beats -- decompose,
-front-load every sub-goal's clarification question ONCE up front, set the per-run
-merge config -- so a bare-kit team gets the same shape without the skill installed.
+**mirrors** the ops-toolkit `plan-for-mega-goal` skill's authoring beats -- decompose
+(including the tiny-item batching rule), front-load every sub-goal's clarification
+question ONCE up front, set the per-run merge config, and (as its own mode) Consolidate
+overlapping same-project megas -- so a bare-kit team gets the same shape without the
+skill installed.
 It does **NOT fork** the skill: the skill stays the deeper authoring reference
 (stacking-tool detection, scaffold-path resolution across arbitrary repos, the full
 pointer-prompt convention, `NOTES.md`/`FEEDBACK.md`); this command is the kit-native
@@ -50,6 +52,15 @@ human-judgment step), and a proof expectation scaled to the sub-goal's complexit
 run-table for CLI/data work, a screenshot/GIF for visual work). Show this as plain
 text; nothing is written to disk until approved -- the wrong decomposition is the
 most expensive failure mode, catch it here.
+
+**Tiny items never earn their own sub-goal (mirrors the skill's tiny-item rule).** A
+one-liner-scale item (a config flip, a doc line, a one-line guard) does not earn a
+dedicated slot in a chain otherwise sized 3-8 substantial items. Batch every tiny item
+into ONE sweep sub-goal, each item keeping its own check line inside that sub-goal's
+`Done =` so it stays individually auditable, or route it as a `/kit:assign` `tiny`-lane
+task outside the mega-goal entirely (`lib/lane-classify.sh classify` will size it
+`tiny` on its own merits). Reserve dedicated sub-goals for work substantial enough to
+need its own PR, proof, and merge gate.
 
 **Deployable terminus (mirrors the skill's "definition of done extends past
 built").** Once real diffs exist, check `lib/proof-ledger.sh deployable <root>
@@ -168,7 +179,20 @@ LANE=$(grep -m1 -iE '^Lane:' docs/specs/SPEC-NNN-<slug>.md \
          | sed -E 's/^[Ll]ane:[[:space:]]*//; s/[[:space:]].*$//')  # per sub-goal
 bash lib/mega-merge.sh gate  "$RID" "$LANE"                        # decision only, no side effects
 bash lib/mega-merge.sh merge <pr> "$RID" "$LANE" [--execute]       # action; refuses on a failing gate
+bash lib/lane-classify.sh deescalate "$LANE" --rid "$RID"          # advisory nudge, mirrors ship.md Step 8
 ```
+
+**Ship-time de-escalation, mirrored here explicitly (SPEC-141).** `mega.md`'s per-sub-goal
+ship/close is this Step -- `gate-ledger` + `mega-merge.sh` -- never a call into
+`commands/ship.md`'s script, so its Step 8 bullets (the significance record, the ★-tap nudge,
+the pitch offer, the SPEC-141 de-escalation nudge) are not guaranteed to fire here just because
+they exist there. Worse, under DELEGATE mode (WORKFLOW.md "Mega-goal delegate execution",
+ADR-0032) each sub-goal runs in a fresh headless session, and the conductor "never reads a
+child's transcript" -- so even a child that happens to invoke `/kit:ship` internally would have
+any nudge it printed swallowed inside that invisible session. The fix reuses the SAME `LANE`
+and `RID` this Step already computes for the `mega-merge.sh gate` call above -- no new
+computation, no new verb, just the existing SPEC-141 `deescalate` call made explicit at the
+one place a human watching the mega run actually sees output.
 
 `lib/mega-merge.sh` is the ship-layer auto-merge ENFORCEMENT: `gate` reuses
 `lib/gate-ledger.sh check` verbatim (the lane's `measure-twice` gates -- the same
@@ -209,6 +233,61 @@ matrix + the callable stack, markdown-only -- and render the timeline + totals i
 chat. The report reads from the rid ledger (`lib/gate-ledger.sh`) and the roadmap
 checkboxes, never from transcripts.
 
+## Consolidate mode (remega, mirrors the skill's mode)
+
+A different input than the normal Step 1-5 flow: **2+ existing `.claude/goals/<slug>/`
+scaffold dirs of the SAME project** whose decompositions overlap because they were
+authored at different times with incomplete information. Given
+`consolidate=<slugA>,<slugB>[,...]`, re-decompose their UNION into ONE new scaffold and
+mark the old ones superseded -- operator-confirmed, never auto. This composes the
+command's OWN existing beats (decompose, front-load-once, `## Touches` authoring,
+spec-number reservation) over a union input; it invents no new scaffold shape and needs
+no new binary or `lib/` file. Full depth + a worked dry-run: the skill's
+`references/GUIDE.md` ("Consolidate mode (remega)") and
+`references/consolidate-dry-run-sample.md`.
+
+**The seven steps, at kit-native scoping:**
+
+1. **Inventory** every candidate mega's `ROADMAP.md` + `goals/NN` files: status, `## Touches`,
+   deps, `Done =`, `Merge policy`. A `- [x] ... -- PR #N` line imports untouched (never
+   re-run, it is history); an in-flight sub-goal finishes under its OLD mega first; a queued
+   one is the raw material the re-decompose actually re-plans.
+2. **Overlap analysis**: pairwise `## Touches` intersection across the megas via
+   `lib/dispatch-gate.sh` -- the SAME disjointness checker Step 4's wave-eligibility already
+   reuses, never a second checker -- plus a semantic pass for dedupe candidates (same outcome
+   authored twice) and merge candidates (same-module sub-goals for related outcomes).
+3. **Re-decompose the union**: write ONE new `ROADMAP.md` applying the dedupe + merge
+   decisions, with the dependency graph re-derived from ACTUAL code/interface dependencies
+   (not the old chains' authoring order), and `## Touches` re-sliced so each new sub-goal owns
+   a disjoint module slice. This re-slicing is what CREATES wave parallelism: sub-goals that
+   only chained because they were authored later, and that touch independent modules, now run
+   as one parallel wave. Pull any file every sub-goal touches (a shared gate, a dispatcher, a
+   VERBS map) into ONE owner sub-goal so the rest go parallel.
+4. **Front-load clarifications ONCE**, over the whole union -- Step 2's beat, reused
+   verbatim, just framed against the union rather than one mega.
+5. **Spec-number block reserve + release.** Reserve via `bash lib/spec-next.sh reserve`
+   (SPEC-128's mkdir-mutex reservations ledger, the same mechanism the wavefront dispatch
+   already uses at Step 4). This kit has no separate `release` verb: an unclaimed reservation
+   self-expires on its own stale-reclaim TTL, so "release the old megas' unused numbers" is a
+   no-op here, not a command to run -- the ledger prunes them without an operator step.
+6. **Provenance per sub-goal.** Every consolidated sub-goal records `from: <mega-A>/SG-03 +
+   <mega-B>/SG-01` on its roadmap line and in its goal file. Done imports keep their own
+   single origin + PR.
+7. **Supersede, never delete.** Old mega `ROADMAP.md` headers gain `superseded_by:
+   <new-slug>`. This kit's nearest archive analog is the goal-draft lifecycle already in
+   `WORKFLOW.md` ("Goal drafts (.claude/goals/)"): `lib/goal-drafts.sh archive` moves a
+   shipped single-goal draft to `.claude/goals/done/`. A superseded MEGA scaffold (a whole
+   `<slug>/` dir, not one file) moves the same way in spirit, to `.claude/goals/done/<slug>/`
+   -- mirroring that convention's intent rather than reusing the verb unchanged (it currently
+   only walks single `.md` drafts). **Never write the markers or move anything without an
+   explicit go from the human**: show the supersede plan first.
+
+**When NOT to consolidate:** any old mega **>=80% done** (just finish it, import nothing);
+**different merge postures or different tenants/repos** (a `full-auto` mega and a
+`gate`-heavy mega, or two different repos, do not share a merge train); **under ~2 megas x 3
+overlapping remaining sub-goals** (the re-planning session costs more than the overlap it
+removes).
+
 ## What this refuses (mirrors `/kit:dispatch`'s "What this command refuses")
 
 - **Merging a PR whose ship-gate has not passed.** `gate` is the only question
@@ -226,10 +305,15 @@ checkboxes, never from transcripts.
 - **Diverging from the skill's checkpoint semantics.** If the ops-toolkit skill is
   installed, this command's Steps 1-3 must produce the same front-load-once,
   same-defaults shape.
+- **Auto-superseding a mega scaffold.** Consolidate mode always shows the supersede plan
+  and waits for an explicit human go before writing a `superseded_by:` marker or moving
+  anything.
 
 Source: ADR-0028 P2/P3 (autonomous-loop hardening, "Where each layer lives" table);
 SPEC-034 (mega-goal lane, ID-037 -- the roadmap conventions + single-chain gate
 this command reuses); SPEC-095 / kit-hardening SG-07 (`lib/proof-ledger.sh
-deployable`, the terminus classifier reused here verbatim); `lib/gate-ledger.sh`
-(the required-gate set this rides on); ops-toolkit `plan-for-mega-goal` SKILL.md
-(the authoring mirror source).
+deployable`, the terminus classifier reused here verbatim); SPEC-141 (ship-time lane
+de-escalation, the `lib/lane-classify.sh deescalate` verb mirrored explicitly at Step 5);
+`lib/gate-ledger.sh` (the required-gate set this rides on); ops-toolkit
+`plan-for-mega-goal` SKILL.md (the authoring mirror source, incl. its tiny-item rule and
+its Consolidate mode).

--- a/docs/specs/SPEC-142-mega-mirror-sync.md
+++ b/docs/specs/SPEC-142-mega-mirror-sync.md
@@ -1,0 +1,169 @@
+# Spec: Mega-mirror-sync (mega-goal sub-goal 09, mirror the tiny/consolidate/de-escalation knobs)
+
+Generated: 2026-07-04
+Status: VALIDATED
+Lane: normal (docs-only projection into `commands/mega.md` plus one candidate
+`lib/lane-classify.sh deescalate` call site addition at an existing invocation point;
+no new lib file, no behavior change to any existing verb)
+Design: obvious (ADR-0031 sec 1 -- a documented mirror of already-shipped upstream
+knobs, not a new architecture decision)
+
+## Problem
+
+`commands/mega.md` (the kit-native `/kit:mega`) carries an explicit never-diverge contract
+with the ops-toolkit `plan-for-mega-goal` skill: "the two must never diverge in checkpoint
+semantics -- a drift here is a bug in this file, not a feature." Three knobs landed on the
+skill side (and, for the third, on the kit's own `ship.md`/`lane-classify.sh`) after
+`mega.md`'s last mirror sync (#164, 2026-07-04 earlier the same day):
+
+1. **The tiny-decompose rule** (sub-goal 02's skill half, dotfiles, already merged upstream):
+   a one-liner-scale item never gets its own sub-goal slot; it batches into one sweep
+   sub-goal or runs as a `/kit:assign` `tiny`-lane task instead.
+2. **Consolidate mode (remega)** (sub-goal 08, dotfiles): `consolidate=<slugA>,<slugB>[,...]`
+   re-decomposes 2+ overlapping same-project mega scaffolds into one new scaffold, marking
+   the old ones superseded.
+3. **The ship-time lane de-escalation nudge** (sub-goal 07, this kit, SPEC-141): an advisory
+   `lib/lane-classify.sh deescalate` call fired from `commands/ship.md` Step 8 when a
+   `normal`/`full` lane shipped a tiny-sized diff.
+
+`mega.md` is silent on all three. (1) and (2) are pure documentation drift: the skill moved,
+the kit-native projection didn't. (3) is more than drift: `mega.md`'s own documented
+per-sub-goal ship/close path (Step 5's `gate-ledger` + `mega-merge.sh` calls) never invokes
+`commands/ship.md` at all, and per `WORKFLOW.md`'s "Mega-goal delegate execution" (ADR-0032),
+a delegated child's session is conductor-invisible by design ("the conductor absorbs one line
+per sub-goal; it never reads a child's transcript"). So even in the case where a delegated
+child's own full-lifecycle run happens to invoke `/kit:ship` internally, any SPEC-141 nudge it
+printed is swallowed inside that invisible child session and never surfaces at the layer a
+human operating the mega-goal actually watches.
+
+## Solution
+
+### Approaches considered
+
+1. **Add three documentation-only mirror paragraphs to `commands/mega.md`, plus one
+   `lib/lane-classify.sh deescalate` call at the point `mega.md`'s Step 5 already derives
+   `LANE`/`RID` for the `mega-merge.sh gate`/`merge` calls. CHOSEN.** Zero new lib files,
+   zero behavior change to any existing verb: the deescalate call reuses the SPEC-141 verb
+   verbatim, at an existing computed-values site. This is a pure projection: mirror the
+   semantics, reference the skill for depth, keep the kit-native scoping already established
+   by #164 (never re-derive the skill's own logic in `mega.md`, only name it).
+2. **Have the delegated child always run `commands/ship.md` and trust its Step 8 to cover
+   the nudge.** Rejected: `mega.md` does not currently document this dependency, the skill's
+   own "Kit-adopted repos route through SDD" guidance for delegate mode says a sub-goal
+   "drives the lane via `lib/` + `gate-ledger` directly" rather than mandating the `/kit:ship`
+   script text, and even if it fired, ADR-0032's own conductor-invisibility rule means the
+   nudge would never reach the human watching the mega run. Assuming coverage here would be
+   the same "never over-claim portable enforcement" mistake AGENTS.md warns against.
+3. **A new `lib/mega-deescalate.sh` or a mega-specific floor.** Rejected: SPEC-141's
+   `deescalate()` already takes `--rid`/`--root`/`--base`/`--floor`; nothing about calling it
+   from a second site needs a new script or a second floor constant.
+
+### Chosen shape
+
+Three `commands/mega.md` edits, no `lib/` behavior change:
+
+- **Step 1 (Decompose):** one paragraph mirroring the skill's tiny-item rule (batch into one
+  sweep sub-goal, keep each item's own check line, or route via `/kit:assign` `tiny` lane
+  outside the mega-goal).
+- **New `## Consolidate mode (remega, mirrors the skill's mode)` section**, placed after
+  Step 5 and before `## What this refuses` (mirroring the skill GUIDE.md's own placement of
+  its Consolidate mode section after the normal produce/use flow). Summarizes the seven steps
+  and the when-NOT table at kit-native scoping: reuses `lib/dispatch-gate.sh` for `## Touches`
+  overlap (the same checker Step 4 already names), reuses `lib/spec-next.sh reserve` for the
+  spec-number step, and notes this kit has no separate `release` verb (an unclaimed
+  reservation self-expires on its own TTL, so "release" here is a no-op, not a new command),
+  and points the archive/supersede step at the kit's own existing goal-draft lifecycle
+  (`lib/goal-drafts.sh archive`, `WORKFLOW.md` "Goal drafts (.claude/goals/)") as the nearest
+  kit-native analog rather than inventing a new archive mechanism or citing ops-toolkit's
+  private `_meta/README.md` (which #164 already declined to mirror for the same reason).
+- **Step 5:** one added prose paragraph + one added `bash` line
+  (`bash lib/lane-classify.sh deescalate "$LANE" --rid "$RID"`) right after the existing
+  `RID=`/`LANE=` derivation, explaining why the mirror needs an explicit call here (conductor-
+  visibility, per ADR-0032) rather than assuming ship.md's own copy already covers it.
+
+## Design
+
+### Why the de-escalation call belongs at mega.md's own Step 5, not left implicit
+
+`mega.md`'s per-sub-goal ship/close is NOT a call into `commands/ship.md`; it is its own
+documented path (`gate-ledger start` at dispatch, `mega-merge.sh gate`/`merge` at close). The
+skill's own delegate-mode guidance ("Kit-adopted repos route through SDD... drive the lane via
+`lib/` + `gate-ledger` directly") and this run's own empirical dispatch prompts (every sub-goal
+in this stack, this one included, was told to `gh pr create` directly, never "run `/kit:ship`")
+confirm the child does not reliably route through `ship.md`'s script text. And even where it
+might, ADR-0032's conductor-invisibility rule means the nudge would be swallowed in a child
+transcript the conductor never reads. The correct, minimal fix is therefore to add the SAME
+advisory call at the ONE place in `mega.md`'s own text where `LANE` and `RID` are already in
+hand for every finished sub-goal (the existing `mega-merge.sh gate` call site) -- zero new
+computation, one more advisory line the conductor's own visible output now carries.
+
+### Why this is documentation-plus-one-call, not a new mechanism
+
+Every piece of machinery named in the Consolidate mode mirror already exists in this kit:
+`lib/dispatch-gate.sh` (disjointness), `lib/spec-next.sh reserve` (SPEC-128), the goal-draft
+archive lifecycle (`lib/goal-drafts.sh`), and `lib/lane-classify.sh deescalate` (SPEC-141).
+Nothing here invents a checker, a scheduler, or a second floor; it names what already runs.
+
+## Acceptance criteria
+
+1. `commands/mega.md` contains a tiny-item-batching paragraph in Step 1.
+2. `commands/mega.md` contains a `## Consolidate mode` section covering all seven steps + the
+   when-NOT table, at kit-native scoping (no re-derivation of the skill's own logic).
+3. `commands/mega.md` Step 5 contains an added `bash lib/lane-classify.sh deescalate ...` line
+   at the existing `LANE`/`RID` derivation site, with prose explaining the conductor-visibility
+   rationale.
+4. A never-diverge checklist (this spec or the PR body) enumerates every mega.md beat against
+   its skill-side (or kit-side, for SPEC-141) counterpart, each marked SYNCED, with a pointer
+   to where each lives on both sides.
+5. No `lib/` file's existing behavior changes; the only new invocation is the added
+   `deescalate` call, which reuses SPEC-141's verb verbatim.
+
+## Review
+
+Self-reviewed (sub-goal worker, no team review requested for this docs-plus-one-call lane;
+`lane_rank(normal)` does not require `/kit:review-team`, only the standard single-lens pass,
+which this run substitutes with the acceptance-criteria grep table below since the change has
+no runtime surface beyond the one added `bash` line, which is unreachable dead prose until an
+operator's copy-paste, per `verify` skill guidance for docs-shaped diffs).
+
+## Verification
+
+```bash
+rg -n 'tiny|consolidat|deescalate|LANE_DEESCALATE' commands/mega.md
+```
+
+Expect: rows in Step 1 (tiny), a `## Consolidate mode` section (consolidat, multiple rows),
+and a `deescalate`/de-escalation row in Step 5.
+
+## Test plan
+
+Docs-only change (plus one dead-until-copy-pasted `bash` line reusing an existing, already-
+tested verb). No new automated test: `SPEC-141-lane-de-escalation.md`'s own test suite already
+covers `deescalate()`'s behavior; this spec adds no second call site with different semantics
+to test, only a second *documented* invocation of the same verb.
+
+## Never-diverge checklist (skill <-> mega.md, beat by beat)
+
+Every beat either side carries, so the NEXT skill change has a diff target.
+
+| Beat | Skill-side location | `mega.md` location | Status |
+|---|---|---|---|
+| Decompose (3-8 items, `Done =`, `Merge policy`, proof expectation) | `references/GUIDE.md` "How to use it" step 3 | Step 1 | SYNCED (pre-existing) |
+| Front-load every clarification ONCE | `references/GUIDE.md` step 3's batched question set | Step 2 | SYNCED (pre-existing) |
+| Merge config (`merge_mode` / `merge_autonomy` / per-sub-goal tag) | `references/GUIDE.md` "Merge policy & autonomy" | Step 3 | SYNCED (pre-existing) |
+| Scaffold fields (`Model:`/`Effort:`/`Design:`/`Done-mode:`, `## Touches`) | `references/subgoal-template.md` | Step 4 | SYNCED (#164) |
+| Run mode (subagent-delegate \| delegate \| inline) | `references/invocation-template.md` "Run mode" | Step 5 | SYNCED (#164) |
+| Close the run visibly (RUN_REPORT / event log) | `references/GUIDE.md` step 9 + `references/notes-template.md` Event log | Step 5 "Close the run visibly" | SYNCED (#164) |
+| Tiny-item batching rule | `references/GUIDE.md` "How to use it" step 3, "Tiny items never become their own sub-goal" | Step 1 (this spec) | SYNCED (this PR) |
+| Consolidate mode (remega) | `references/GUIDE.md` "Consolidate mode (remega)" + `SKILL.md` `argument-hint` | `## Consolidate mode` (this spec) | SYNCED (this PR) |
+| Ship-time lane de-escalation | this kit's own `SPEC-141-lane-de-escalation.md` + `commands/ship.md` Step 8 bullet 4 (no skill-side counterpart -- kit-originated knob) | Step 5, added `deescalate` call (this spec) | SYNCED (this PR, kit-to-kit mirror for conductor visibility) |
+| OPERATE.md RUN CONTRACT pointer | `references/OPERATE.md` | (none) | DELIBERATELY NOT MIRRORED -- private ops-toolkit path, parked on portability re-apply (ID-246), per #164 |
+
+## Out of scope
+
+- Any change to `lib/lane-classify.sh`, `lib/mega-merge.sh`, `lib/orchestrate.sh`,
+  `lib/spec-next.sh`, or `lib/goal-drafts.sh` behavior.
+- Building the optional `lib/` overlap-report helper the skill's Consolidate mode section
+  calls out as "not required" (judgment-driven procedure, no daemon).
+- Re-applying the OPERATE.md RUN CONTRACT pointer #164 deliberately left unmirrored (still
+  parked on the ops-toolkit portability re-apply, ID-246).


### PR DESCRIPTION
## What

Mirror the tiny-decompose rule + Consolidate mode into `/kit:mega`, plus a
never-diverge checklist. Closes the mirror contract for this run. Covers ID
(mega mirror of 02/07/08 knobs).

Three knobs landed on the `plan-for-mega-goal` skill / kit side since the last
mirror sync (`commands/mega.md` #164, same day):

1. **Tiny-decompose rule** (sub-goal 02's skill half, dotfiles): a one-liner
   item never gets its own sub-goal, batch into one sweep sub-goal or route
   via `/kit:assign` `tiny` lane.
2. **Consolidate mode / remega** (sub-goal 08, dotfiles): `consolidate=<slugA>,
   <slugB>[,...]` re-decomposes 2+ overlapping same-project mega scaffolds
   into one, marking the old ones superseded.
3. **Ship-time lane de-escalation** (sub-goal 07, this kit, SPEC-141): an
   advisory `lib/lane-classify.sh deescalate` nudge, currently only wired
   into `commands/ship.md` Step 8.

`commands/mega.md` carries its own "the two must never diverge" contract, so
all three needed a mirror pass here.

## Why

`mega.md`'s per-sub-goal ship/close is its OWN path (`gate-ledger` +
`mega-merge.sh`), never a call into `commands/ship.md`'s script. Per
`WORKFLOW.md`'s "Mega-goal delegate execution" (ADR-0032), each sub-goal also
runs in a fresh headless session the conductor "never reads... the
transcript" of. So even if a delegated child happens to invoke `/kit:ship`
internally, any SPEC-141 de-escalation nudge it printed is swallowed inside
that invisible session and never reaches the human watching the mega run.
The fix adds the SAME `deescalate` call explicitly at the point `mega.md`'s
Step 5 already derives `LANE`/`RID` for the `mega-merge.sh gate` call, zero
new computation, zero new verb.

## Grep proof

```
$ rg -n 'tiny|consolidat|deescalate|LANE_DEESCALATE' commands/mega.md
13:(including the tiny-item batching rule), front-load every sub-goal's clarification
56:**Tiny items never earn their own sub-goal (mirrors the skill's tiny-item rule).** A
58:dedicated slot in a chain otherwise sized 3-8 substantial items. Batch every tiny item
60:`Done =` so it stays individually auditable, or route it as a `/kit:assign` `tiny`-lane
62:`tiny` on its own merits). Reserve dedicated sub-goals for work substantial enough to
182:bash lib/lane-classify.sh deescalate "$LANE" --rid "$RID"          # advisory nudge, mirrors ship.md Step 8
194:computation, no new verb, just the existing SPEC-141 `deescalate` call made explicit at the
241:`consolidate=<slugA>,<slugB>[,...]`, re-decompose their UNION into ONE new scaffold and
247:`references/consolidate-dry-run-sample.md`.
273:6. **Provenance per sub-goal.** Every consolidated sub-goal records `from: <mega-A>/SG-03 +
285:**When NOT to consolidate:** any old mega **>=80% done** (just finish it, import nothing);
316:de-escalation, the `lib/lane-classify.sh deescalate` verb mirrored explicitly at Step 5);
318:`plan-for-mega-goal` SKILL.md (the authoring mirror source, incl. its tiny-item rule and
319:`lib/lane-classify.sh deescalate` verb mirrored explicitly at Step 5);
```

## Never-diverge checklist (skill <-> mega.md, beat by beat)

| Beat | Skill-side location | `mega.md` location | Status |
|---|---|---|---|
| Decompose | `references/GUIDE.md` "How to use it" step 3 | Step 1 | SYNCED (pre-existing) |
| Front-load every clarification ONCE | `references/GUIDE.md` step 3 | Step 2 | SYNCED (pre-existing) |
| Merge config | `references/GUIDE.md` "Merge policy & autonomy" | Step 3 | SYNCED (pre-existing) |
| Scaffold fields (`Model:`/`Design:`/`Done-mode:`/`## Touches`) | `references/subgoal-template.md` | Step 4 | SYNCED (#164) |
| Run mode | `references/invocation-template.md` | Step 5 | SYNCED (#164) |
| Close the run visibly | `references/GUIDE.md` step 9 + `notes-template.md` | Step 5 | SYNCED (#164) |
| Tiny-item batching rule | `references/GUIDE.md` step 3 | Step 1 | SYNCED (this PR) |
| Consolidate mode (remega) | `references/GUIDE.md` "Consolidate mode (remega)" | `## Consolidate mode` | SYNCED (this PR) |
| Ship-time lane de-escalation | SPEC-141 + `commands/ship.md` Step 8 (kit-originated, no skill counterpart) | Step 5, added `deescalate` call | SYNCED (this PR) |
| OPERATE.md RUN CONTRACT pointer | `references/OPERATE.md` | (none) | DELIBERATELY NOT MIRRORED, parked (ID-246), per #164 |

Full checklist + Design rationale: `docs/specs/SPEC-142-mega-mirror-sync.md`.

## Gates

Recorded via `lib/gate-ledger.sh` on rid `mega-mirror-sync`: grill skipped
(operator-wave), think skipped (design obvious), spec ran (SPEC-142),
design-record skipped (obvious), test-plan skipped (docs-only, verification
is the grep table), build ran, review skipped (home-turf, solo docs lane),
docs ran, ship ran.

## Test plan

- [x] `rg -n 'tiny|consolidat|deescalate|LANE_DEESCALATE' commands/mega.md` shows all three mirror rows (above)
- [x] `env HOME="$(mktemp -d)" bash tests/test-docs-wiring.sh` -- 22/22 passed (unaffected, no lib touched)
- [x] Never-diverge checklist committed in `docs/specs/SPEC-142-mega-mirror-sync.md`
- [x] No `lib/` or `hooks/` file changed; docs-only diff plus one new (unreachable-until-copy-pasted) `bash` line reusing the existing SPEC-141 verb

🤖 Generated with [Claude Code](https://claude.com/claude-code)
