### PR TITLE
feat(review): inject stale-ADR inversion rule into review surfaces

### DIFF
--- a/agents/advisor.md
+++ b/agents/advisor.md
@@ -34,6 +34,7 @@ reviewers each missed BECAUSE they were narrow:
   sub-goals each half-built, a seam between two independently-reviewed pieces.
 - A risk the per-phase lenses are not scoped to raise (a global assumption, an
   ordering hazard across sub-goals, a shared surface written twice).
+- **Stale-ADR inversion.** Behavior that matches what a spec/ADR/intent doc claims is BY DESIGN, not a finding, even if it looks surprising at first glance. Code that has DRIFTED from what a spec/ADR/intent doc claims IS itself a finding: report the drift naming the doc's line and the code's line. A doc can never blanket-mute observed behavior. Emit a drift finding with a `stale-adr:` finding-key prefix (e.g. `stale-adr: <doc>:<line> claims X, <code>:<line> does Y`) so it reads as this lens type, distinct from other findings.
 
 You are the EXTRA lens: assume the specialized reviewers already ran and passed their
 own artifacts. Do not re-do their job (do not re-lint one spec, do not re-review one

--- a/commands/review-team.md
+++ b/commands/review-team.md
@@ -78,6 +78,8 @@ Use the security-reviewer agent (the dedicated deep-security reviewer; more thor
 Review this code diff through the ARCHITECTURE lens only.
 Use the code-reviewer agent with lens: architecture.
 
+**Stale-ADR inversion.** Behavior that matches what a spec/ADR/intent doc claims is BY DESIGN, not a finding, even if it looks surprising at first glance. Code that has DRIFTED from what a spec/ADR/intent doc claims IS itself a finding: report the drift naming the doc's line and the code's line. A doc can never blanket-mute observed behavior. Emit a drift finding with a `stale-adr:` finding-key prefix (e.g. `stale-adr: <doc>:<line> claims X, <code>:<line> does Y`) so it reads as this lens type, distinct from other findings.
+
 Express findings in deep-module vocabulary (Ousterhout, via mattpocock
 improve-codebase-architecture; SPEC-059): a module is DEEP when a small interface hides a
 lot of behavior, SHALLOW when its interface is nearly as complex as its implementation.

--- a/commands/review.md
+++ b/commands/review.md
@@ -23,6 +23,7 @@ For EVERY changed file, evaluate:
 
 **Architecture (weight: high)**
 - Does this match the spec in `docs/specs/SPEC-NNN-<slug>.md`?
+- **Stale-ADR inversion.** Behavior that matches what a spec/ADR/intent doc claims is BY DESIGN, not a finding, even if it looks surprising at first glance. Code that has DRIFTED from what a spec/ADR/intent doc claims IS itself a finding: report the drift naming the doc's line and the code's line. A doc can never blanket-mute observed behavior. Emit a drift finding with a `stale-adr:` finding-key prefix (e.g. `stale-adr: <doc>:<line> claims X, <code>:<line> does Y`) so it reads as this lens type, distinct from other findings.
 - Does it follow existing patterns in the codebase?
 - Are there new abstractions that aren't justified?
 - Is there dead code or unreachable branches?

--- a/docs/implementation-notes/spec-143-stale-adr-inversion.md
+++ b/docs/implementation-notes/spec-143-stale-adr-inversion.md
@@ -1,0 +1,22 @@
+# Implementation notes: SPEC-143 stale-adr-inversion
+
+No deviations; matches the sub-goal contract
+(`ops-toolkit/_meta/megagoals/gate-review-absorptions/goals/01-stale-adr-inversion.md`)
+verbatim on scope and the 3 surfaces.
+
+One placement decision the contract left to the worker's judgment, recorded here since
+it is not already pinned upstream:
+
+- **Where inside `commands/review-team.md` to inject the rule.** The contract names the
+  file as a surface but not which of its several dispatch-prompt blocks (security,
+  architecture, test-coverage, advisor Step 2b) should carry the rule. Picked the
+  Architecture-lens dispatch prompt (Reviewer 2), because (a) it is the one block that
+  already partially implies reading intent docs via its "Architecture context" input and
+  the deep-module vocabulary's structural framing, and (b) the `advisor` agent dispatched
+  from Step 2b loads `agents/advisor.md` as its own system prompt when invoked by name
+  through the Task tool, so it already inherits the rule from surface 1 and does not need
+  a second copy inside `review-team.md`'s short Step 2b prompt text -- adding it there
+  too would be the duplicate-injection the contract's Quality bar rules out ("one rule,
+  stated once per surface"). Security and test-coverage lenses were left untouched: the
+  rule is about spec/ADR-vs-code drift, which is architecture's territory, not
+  security's or test-coverage's.

--- a/docs/specs/SPEC-143-stale-adr-inversion.md
+++ b/docs/specs/SPEC-143-stale-adr-inversion.md
@@ -1,0 +1,76 @@
+# Spec: Stale-ADR inversion in the generic review surfaces
+
+Generated: 2026-07-04
+Status: VALIDATED
+Lane: normal (advisory wording only, no new agent/gate/severity machinery, three
+files touched; classified `normal` by `lib/lane-classify.sh`).
+
+## Problem
+
+Every surface that tells a reviewer to read a spec/ADR/intent doc has a one-sided
+failure mode: a doc can be used to blanket-mute a finding ("the spec says X, so this
+is fine") without ever checking whether the code still matches what the doc claims.
+shadcn/improve's playbook names the fix directly: "a stale ADR is itself a finding...
+don't use the doc to suppress it" (`research/2026-07-04-pxpipe-plannotator-improve-absorption.md`
+§3, A4, in `ops-toolkit`). None of the kit's three generic review surfaces
+(`agents/advisor.md`, `commands/review.md`, `commands/review-team.md`) state the
+two-sided rule today.
+
+## Solution
+
+Inject one identical rule block, verbatim (copy-paste, no paraphrase drift), into
+each of the 3 surfaces, at the point each surface already reads intent docs:
+
+1. `agents/advisor.md` -- new bullet in the critique-mode (P5) "look for" list.
+2. `commands/review.md` -- new bullet inside the Architecture checklist, right after
+   the existing "Does this match the spec ...?" line it completes.
+3. `commands/review-team.md` -- injected INTO the Architecture-lens dispatch prompt's
+   fenced text block (Reviewer 2), because a dispatched reviewer does not inherit the
+   parent session's rules; the rule must ride inside the literal prompt text.
+
+Rule text (identical in all 3, `file:line` at time of writing):
+
+> **Stale-ADR inversion.** Behavior that matches what a spec/ADR/intent doc claims is
+> BY DESIGN, not a finding, even if it looks surprising at first glance. Code that has
+> DRIFTED from what a spec/ADR/intent doc claims IS itself a finding: report the drift
+> naming the doc's line and the code's line. A doc can never blanket-mute observed
+> behavior. Emit a drift finding with a `stale-adr:` finding-key prefix (e.g.
+> `stale-adr: <doc>:<line> claims X, <code>:<line> does Y`) so it reads as this lens
+> type, distinct from other findings.
+
+The `stale-adr:` finding-key prefix is the naming convention advisor P6 needs: a
+later grep-based pre-flag check and a later observatory adapter (both downstream
+sub-goals of the `gate-review-absorptions` mega-goal) can select this lens type by
+prefix without any new schema.
+
+**Not changed:** no new agent, no new gate, no new severity tier, no change to what a
+reviewer MUST do beyond this one advisory lens. The specialized domain reviewers
+(security/api/frontend/infra/performance) are out of scope; they inherit any parent
+rule only via `review-team.md`'s dispatch template, which this spec does not touch
+for them.
+
+## Design
+
+`obvious: not design-bearing`. No new component, no schema, no external integration,
+no irreversible choice, and exactly one viable approach (state the same rule text at
+the 3 points reviewers already read intent docs). The before/after is fully captured
+by the rule-text block above, so a diagram would restate it without adding
+information.
+
+## Acceptance criteria
+
+1. The identical rule text (byte-for-byte) appears in `agents/advisor.md`,
+   `commands/review.md`, and `commands/review-team.md`.
+2. A seeded code-vs-ADR contradiction, run through the rule, is reported as a
+   `stale-adr:`-prefixed finding naming both the doc line and the code line.
+3. A seeded by-design match (code that matches its doc) is NOT flagged when run
+   through the same rule.
+4. No new agent, gate, or severity machinery was added.
+
+## Verification
+
+Fixture capture (real primary flow, simulated dispatch per the sub-goal contract):
+`docs/verification/spec-143-stale-adr-inversion.md`. Includes a positive control
+(the drift case, RED without the rule / flagged with it) and a negative control (the
+by-design case, silent either way it should stay silent -- proving the rule does not
+over-fire).

--- a/docs/verification/spec-143-stale-adr-inversion.md
+++ b/docs/verification/spec-143-stale-adr-inversion.md
@@ -1,0 +1,113 @@
+# Verification: SPEC-143 stale-adr-inversion
+
+Real dispatch, not a hand-simulated transcript: each run below is a genuine
+`kit:code-reviewer` (architecture lens) subagent invocation via the Task tool, reading
+real files on disk. The fixture and both prompts are reproducible from this file.
+
+## Fixture
+
+```
+$FIXTURE/
+├── cache.go                              # matches its ADR (by-design case)
+├── retry.go                              # drifted from its ADR (drift case)
+└── docs/decisions/
+    ├── ADR-0099-cache-ttl.md             # "MUST expire entries after 300 seconds"
+    └── ADR-0100-retry-budget.md          # "MUST retry at most 3 times"
+```
+
+`cache.go`:
+```go
+package cache
+
+import "time"
+
+// TTL controls how long a cached response is served before refetch.
+// Per ADR-0099, this must be 300 seconds.
+const TTL = 300 * time.Second
+
+func IsExpired(cachedAt time.Time) bool {
+	return time.Since(cachedAt) > TTL
+}
+```
+`TTL = 300 * time.Second` matches ADR-0099 line 7 ("MUST expire entries after 300
+seconds") exactly -- the seeded BY-DESIGN case.
+
+`retry.go`:
+```go
+package retry
+
+// MaxAttempts bounds outbound retries before giving up.
+const MaxAttempts = 5
+
+func ShouldRetry(attempt int) bool {
+	return attempt < MaxAttempts
+}
+```
+`MaxAttempts = 5` contradicts ADR-0100 line 7 ("MUST retry at most 3 times") -- the
+seeded DRIFT case. No comment in the code discloses the drift (an earlier fixture draft
+had a self-labeled "DRIFT" comment; removed so neither run gets a free hint).
+
+## Run 1: WITH the stale-ADR rule (the rule text now injected into `commands/review-team.md`'s Architecture-lens dispatch prompt, byte-identical to `agents/advisor.md`:37 and `commands/review.md`:26)
+
+Dispatched via `Agent(subagent_type: "kit:code-reviewer")` with the exact Architecture
+lens prompt from `commands/review-team.md` (post-SPEC-143), pointed at the fixture.
+
+Result (verbatim from the agent):
+```
+1. PASS (by-design): cache.go -- TTL = 300 * time.Second matches
+   ADR-0099-cache-ttl.md:7 ("MUST expire entries after 300 seconds"). No finding.
+
+2. stale-adr: docs/decisions/ADR-0100-retry-budget.md:7 claims "retry at most 3
+   times", retry.go:4 does `MaxAttempts = 5`
+   File: retry.go:4
+   What: The retry budget has drifted from 3 (ADR-0100) to 5 attempts, widening
+   worst-case latency under a flapping dependency beyond what the ADR bounds.
+   Fix: Either update MaxAttempts to 3 to match ADR-0100, or if 5 is now the
+   intended value, revise ADR-0100 to reflect the new decision.
+```
+
+**Outcome: the drift case is REPORTED as a `stale-adr:`-prefixed finding naming the
+doc line (`ADR-0100-retry-budget.md:7`) and the code line (`retry.go:4`); the by-design
+case is explicitly PASS/no-finding.** Exactly the two-sided behavior the rule specifies.
+
+## Run 2: WITHOUT the rule (negative control -- baseline Architecture-lens prompt, no stale-ADR text)
+
+Same fixture, same agent type, same two ADRs handed as "Architecture context", but the
+dispatch prompt omits the stale-ADR inversion paragraph (i.e. `commands/review-team.md`
+as it existed before this SPEC).
+
+Result (verbatim from the agent):
+```
+Both files are minimal, deep modules for their size... No dead code, no unreachable
+branches, no new abstractions, no coupling...
+
+## Issues found
+None.
+
+Note: I did not cross-check the numeric constants (TTL = 300s, MaxAttempts = 5)
+against the ADR text as a distinct step, per the instructions for this run. I did
+notice the cache.go comment cites ADR-0099 inline, but did not open the ADR files to
+verify the value matches.
+```
+
+**Outcome: with the rule absent, the reviewer does not open the ADRs at all and reports
+zero findings -- the same drifted `retry.go` that Run 1 catches is invisible.** This is
+the negative control: revert the rule (drop the injected paragraph) and the true
+positive goes RED (unreported). Restoring the rule (Run 1) turns it back GREEN.
+
+## Reproduce
+
+```bash
+# 1. Recreate the fixture files above under $FIXTURE (any temp dir).
+# 2. Dispatch kit:code-reviewer with the Architecture-lens prompt text from
+#    commands/review-team.md (with the rule) -> expect the stale-adr: finding.
+# 3. Dispatch the same agent with the rule paragraph removed -> expect silence.
+```
+
+## Verdict
+
+PASS. The rule as injected produces the two-sided behavior required by SPEC-143's
+acceptance criteria 2 and 3: a seeded code-vs-ADR contradiction is reported with a
+`stale-adr:`-prefixed finding-key naming both lines; a seeded by-design match is not
+flagged. The negative control (rule removed) shows the drift going undetected,
+confirming the rule -- not incidental reviewer thoroughness -- is what closes the gap.


### PR DESCRIPTION
Stale-ADR inversion in the generic review surfaces: intent docs suppress by-design findings, observed code-vs-doc drift is itself a finding, docs never blanket-mute. Verbatim injection into review-team dispatch prompts (dispatched lenses don't inherit). Covers ID-264 (kit half).

## Test plan

- [x] Identical rule text (byte-for-byte) in `agents/advisor.md:37`, `commands/review.md:26`, `commands/review-team.md:81`
- [x] Fixture dispatch: seeded ADR-vs-code drift reported as a `stale-adr:`-prefixed finding naming doc line + code line
- [x] Fixture dispatch: seeded by-design match not flagged
- [x] Negative control: same fixture with the rule removed from the dispatch prompt never opens the ADRs and reports nothing

See `docs/verification/spec-143-stale-adr-inversion.md` for the full run capture.
