### PR TITLE
docs(mega): mirror intake triage ladder into commands/mega.md

### DIFF
--- a/commands/mega.md
+++ b/commands/mega.md
@@ -29,6 +29,22 @@ bounded loop, one PR per sub-goal (SPEC-034). A real dependency GRAPH (fan-in,
 fan-out, waves, topological order) is neither; that is the GSD v2 handoff tripwire,
 not a reason to grow a scheduler here.
 
+The intake ladder below (mirrors the skill's ladder verbatim, SPEC-142) is the FIRST
+check, before Prerequisites: it decides whether this command is even the right one to
+invoke for the task at hand.
+
+<!-- BEGIN triage-ladder -->
+## Intake triage ladder (check first, before drafting anything)
+
+Before drafting a goal, a scaffold, or a plan, classify the task against three rungs. This is a MUST-check routing step, not advice: a task that fits a lower rung never gets a higher rung's ceremony.
+
+1. **DIRECT kit lane, in-session.** One file, one behavior, one obvious proof. `lane-classify` calls it tiny or small: one worker drafts the change, verifies it, opens one PR. No scaffold, no conductor; the gate-ledger still records. Worked example: fixing a broken link in one README section, one file changed, verified by rendering the link.
+2. **Single `/goal`.** One objective, multiple steps, one stopping condition. Worked example: "users can sort the trade log by realized PnL", a multi-step feature with one verification command, handed to `/goal` via `plan-for-goal`.
+3. **Mega-goal.** Multiple objectives, multiple repos, or multiple gates converging on one destination. Worked example: the runner-fastpath mega-goal itself, eight sub-goals across three repos (dotfiles, dwarves-kit, ops-toolkit) each running its own `/goal` with its own PR, converging on one overnight runner.
+
+Escape hatch: the user explicitly asking for a mega-goal overrides the ladder; never downgrade a request the user has already sized.
+<!-- END triage-ladder -->
+
 ## Prerequisites
 
 1. The conversation names **3-8 genuinely dependent sub-goals** sharing one

--- a/docs/specs/SPEC-142-mega-mirror-sync.md
+++ b/docs/specs/SPEC-142-mega-mirror-sync.md
@@ -157,6 +157,7 @@ Every beat either side carries, so the NEXT skill change has a diff target.
 | Tiny-item batching rule | `references/GUIDE.md` "How to use it" step 3, "Tiny items never become their own sub-goal" | Step 1 (this spec) | SYNCED (this PR) |
 | Consolidate mode (remega) | `references/GUIDE.md` "Consolidate mode (remega)" + `SKILL.md` `argument-hint` | `## Consolidate mode` (this spec) | SYNCED (this PR) |
 | Ship-time lane de-escalation | this kit's own `SPEC-141-lane-de-escalation.md` + `commands/ship.md` Step 8 bullet 4 (no skill-side counterpart -- kit-originated knob) | Step 5, added `deescalate` call (this spec) | SYNCED (this PR, kit-to-kit mirror for conductor visibility) |
+| Intake triage ladder (3-rung: direct kit lane / single `/goal` / mega-goal) | `goal-craft`/`plan-for-goal` `SKILL.md` `<!-- BEGIN/END triage-ladder -->` fence (shasum `a42939f37e91e61eadfa0a7e4de7034a3309a22c`) | before `## Prerequisites`, same fence markers, byte-identical (runner-fastpath sub-goal 02) | NEVER-DIVERGE -- byte-identical inside the markers; a drift here is a bug, re-copy the fence verbatim on any skill-side edit |
 | OPERATE.md RUN CONTRACT pointer | `references/OPERATE.md` | (none) | DELIBERATELY NOT MIRRORED -- private ops-toolkit path, parked on portability re-apply (ID-246), per #164 |
 
 ## Out of scope


### PR DESCRIPTION
## Outcome

`/kit:mega` (`commands/mega.md`) now carries the SAME marker-fenced intake triage ladder that landed in the `goal-craft`/`plan-for-goal` skills (dotfiles PR #202): before drafting a goal, scaffold, or plan, classify the task DIRECT kit lane / single `/goal` / mega-goal, each rung with one worked example. Inserted before `## Prerequisites` so it is the first check, ahead of the existing 3-8-sub-goal sizing rule. `docs/specs/SPEC-142-mega-mirror-sync.md`'s never-diverge table gains a row for this pair so a future skill-side edit to the ladder fails the sync check here.

## Verification

```
$ a=$(awk '/BEGIN triage-ladder/,/END triage-ladder/' commands/mega.md | shasum)
$ echo "$a"
a42939f37e91e61eadfa0a7e4de7034a3309a22c  -
```

Matches the shasum SG-01 recorded in runner-fastpath `DECISIONS.md`: `a42939f37e91e61eadfa0a7e4de7034a3309a22c`. Byte-identical inside the `<!-- BEGIN/END triage-ladder -->` markers.

```
$ rg -n "triage-ladder" docs/ commands/mega.md
commands/mega.md:36:<!-- BEGIN triage-ladder -->
commands/mega.md:46:<!-- END triage-ladder -->
docs/specs/SPEC-142-mega-mirror-sync.md:160:| Intake triage ladder (3-rung: direct kit lane / single `/goal` / mega-goal) | `goal-craft`/`plan-for-goal` `SKILL.md` `<!-- BEGIN/END triage-ladder -->` fence (shasum `a42939f37e91e61eadfa0a7e4de7034a3309a22c`) | before `## Prerequisites`, same fence markers, byte-identical (runner-fastpath sub-goal 02) | NEVER-DIVERGE -- byte-identical inside the markers; a drift here is a bug, re-copy the fence verbatim on any skill-side edit |
```

## Mechanics

- dwarves-kit IS kit-adopted: lane-classified `normal` (`lib/lane-classify.sh classify`), gate-ledger phases recorded under rid `mega-mirror-triage` (grill/think/spec/design-record/test-plan skipped with reasons, build/review/docs/ship ran), `lib/gate-ledger.sh check normal <rid>` passes clean.
- The mirror is a projection, never a rewrite: only the fenced block + one never-diverge table row changed.

## Link

ops-toolkit `_meta/megagoals/runner-fastpath/ROADMAP.md`. Stacked note not needed (base master).
