### PR TITLE
feat(plugin-check): port cc-plugin-check from ops-toolkit

### DIFF
--- a/docs/proof/kit-foldin-plugin-check.md
+++ b/docs/proof/kit-foldin-plugin-check.md
@@ -1,0 +1,71 @@
+# Proof of done: kit-foldin SG-05, plugin-check
+
+**Acceptance criteria** (from `ops-toolkit/_meta/megagoals/kit-foldin/goals/05-plugin-check.md`):
+
+1. `ops-toolkit/tools/cc-plugin-check/` moved to `dwarves-kit/tools/plugin-check/` (drop `cc-`).
+2. Any hardcoded plugin-dir path becomes an arg/env default, opt-in (no ops-toolkit-layout assumption).
+3. A fixture plugin dir under `tests/fixtures/` with a fresh variant and a stale variant.
+4. Run-table: fresh fixture -> verdict `current`; stale fixture -> verdict `OUTDATED` (the named NC).
+5. Done gate: `grep -rn 'workspace/tieubao' tools/plugin-check/` empty.
+
+## Implementation
+
+Straight port, no new logic. `bin/cc-plugin-check` -> `bin/plugin-check`; every in-script
+self-reference (`die()` prefix, usage banner, table header, `--help` text) renamed
+`cc-plugin-check` -> `plugin-check`. Verdict logic, comparison rules, table format, and CLI
+surface (`status`, `update [name] [--apply]`) are byte-identical to the source tool.
+
+The plugin-state directory was already opt-in before the move: `PLUGINS_DIR="${CC_PLUGINS_DIR:-$HOME/.claude/plugins}"`
+(`bin/plugin-check:24`) defaults to the standard per-user Claude Code plugin directory, not
+an ops-toolkit path, so there was no hardcoded ops-toolkit path in the executable to
+replace. The two doc-only mentions of `~/workspace/tieubao/dwarves-kit` (in the ported
+`docs/specs/SPEC-105-cc-plugin-check.md` and `docs/implementation-notes/cc-plugin-check.md`,
+describing Han's own `directory`-marketplace dev checkout as a worked example) were
+generalized to "the local dwarves-kit checkout" so the grep-clean gate holds across the
+whole moved subtree, docs included.
+
+## Confirmation run-table
+
+| # | Command | Fixture | Expected verdict | Result |
+|---|---|---|---|---|
+| 1 | `bin/plugin-check status` (ponytail row) | `tests/fixtures/*` , ponytail's installed sha rewritten in-test to match its marketplace clone HEAD (a real git repo, not mocked) | `current` | PASS , `tests/smoke.sh` [3]: "ponytail current (sha proven)" |
+| 2 | `bin/plugin-check status` (superpowers row) | `tests/fixtures/plugin-catalog-cache.json` pins `superpowers`'s catalog `source_sha` to a value that differs from the fixture's `installed_plugins.json` `gitCommitSha` | `OUTDATED` (the named NC: a stale plugin is flagged, not silently passed as current) | PASS , `tests/smoke.sh` [4] (AC3 negative control): "OUTDATED row present for pinned-old superpowers" |
+
+Both rows come from the same fixture set and the same `status` invocation (one `claude`
+roster + one catalog + one set of marketplace clones), so the fresh and stale verdicts are
+proven side-by-side in a single run, not two separately-staged fixtures.
+
+Full suite (27 assertions covering every verdict path: current/OUTDATED/unknown, offline
+degrade, `--no-refresh`, dry-run vs `--apply`, injection-defense, absent-CLI, torn JSON):
+
+```
+$ cd tools/plugin-check && bash tests/smoke.sh
+[setup] ponytail HEAD=3ae2704c1  workdir=/var/folders/.../plugin-check-smoke.XXXXXX
+[1] status: all 6 fixture plugins each appear with a STATUS (AC1)
+  ok: 6 plugin rows present
+...
+[3] status: ponytail (single-plugin mp, clone HEAD == installed sha) shows current (AC2)
+  ok: ponytail current (sha proven)
+[4] status (AC3 negative control): superpowers pinned-old in fixture -> OUTDATED
+  ok: OUTDATED row present for pinned-old superpowers
+...
+[27] update <outdated> --apply on an already-latest plugin -> 'already latest' no-op, NOT 'applied', exit 0
+  ok: --apply already-latest reported as no-op (not 'applied'), exit 0
+
+smoke: all 27 passed
+```
+
+## Done-gate check
+
+```
+$ grep -rn 'workspace/tieubao' tools/plugin-check/
+(no output, exit 1)
+```
+
+## Reproduce
+
+```bash
+cd dwarves-kit/tools/plugin-check
+bash tests/smoke.sh          # hermetic, 27/27
+bin/plugin-check status      # live, over your real installed plugins ($CC_PLUGINS_DIR)
+```

--- a/docs/verification/kit-foldin-05-plugin-check.md
+++ b/docs/verification/kit-foldin-05-plugin-check.md
@@ -1,0 +1,66 @@
+# Verification: kit-foldin SG-05, plugin-check
+
+Proof of done for porting `ops-toolkit/tools/cc-plugin-check/` to
+`dwarves-kit/tools/plugin-check/`. Work-type: spec-feature / behavioral (a CLI tool). The
+canonical mega-goal proof narrative lives at `docs/proof/kit-foldin-plugin-check.md`; this
+file is the kit ship-gate artifact (green run + negative control + reproduce).
+
+## 1. Green, captured
+
+The real primary flow is the freshness verdict over a plugin state dir, exercised by the
+tool's own hermetic suite (stubbed `claude`, real micro-git repos backing the sha compare;
+27 assertions covering every verdict path). The fresh/stale run-table (the named NC for
+this sub-goal) is assertions [3] (fresh -> `current`) and [4] (stale -> `OUTDATED`).
+
+```
+Command: cd tools/plugin-check && bash tests/smoke.sh
+Exit: 0
+Verdict: PASS
+
+  [3] status: ponytail (single-plugin mp, clone HEAD == installed sha) shows current (AC2)
+    ok: ponytail current (sha proven)
+  [4] status (AC3 negative control): superpowers pinned-old in fixture -> OUTDATED
+    ok: OUTDATED row present for pinned-old superpowers
+  ...
+  smoke: all 27 passed
+```
+
+## 2. Negative control (revert -> RED -> restore)
+
+To prove the green is not trivially green, staleness detection was disabled in
+`bin/plugin-check` (the `OUTDATED` verdict branch was replaced with `current`), the suite
+re-run, then the change reverted.
+
+```
+Command (broken): replace `echo -e "OUTDATED\tsha differs from upstream"` with `echo -e "current\t"` in verdict(), then bash tests/smoke.sh
+Exit: 1
+Verdict: RED (expected)
+
+  [4] status (AC3 negative control): superpowers pinned-old in fixture -> OUTDATED
+    FAIL: AC3 OUTDATED missing
+  smoke: 23 passed, 4 FAILED
+```
+
+The stale-fixture assertion [4] flips to FAIL the moment the verdict logic stops
+distinguishing stale from fresh, so the green run genuinely exercises staleness detection.
+
+```
+Command (restored): git checkout -- tools/plugin-check/bin/plugin-check && bash tests/smoke.sh
+Exit: 0
+Verdict: PASS (smoke: all 27 passed); working tree identical to HEAD (git status clean)
+```
+
+## 3. Reproduce
+
+```bash
+cd dwarves-kit/tools/plugin-check
+bash tests/smoke.sh          # 27/27, includes the fresh [3] + stale [4] run-table
+```
+
+## Done-gate: no hardcoded ops path
+
+```
+Command: grep -rn 'workspace/tieubao' tools/plugin-check/
+Exit: 1 (no matches)
+Verdict: PASS
+```

--- a/tools/plugin-check/README.md
+++ b/tools/plugin-check/README.md
@@ -1,0 +1,147 @@
+# plugin-check
+
+Which adopted Claude Code plugins are outdated, in one glance. A read-only freshness lens
+over every CC plugin you have installed, across all marketplace shapes: single-plugin
+marketplaces, the local `directory` marketplace (e.g. a `kit@<marketplace>` dev checkout),
+and a big multi-plugin marketplace such as `claude-plugins-official`. It prints the exact
+command to bump each stale one.
+
+**Migrated into dwarves-kit (kit-foldin SG-05, 2026-07-05).** This tool moved here verbatim
+from `ops-toolkit/tools/cc-plugin-check/` (dropped the `cc-` prefix per the kit naming
+rule: kit artifacts are named by function, not by host agent). No functional change: same
+verdict logic, same CLI surface, same 27-assertion test suite, unmodified. Full design:
+`docs/specs/SPEC-105-cc-plugin-check.md`. Why the data sources differ from the spec's
+originally-named JSON shape: `docs/implementation-notes/cc-plugin-check.md`.
+
+## The one contract: a false "current" is unacceptable
+
+It prints `current` for a plugin ONLY when it can prove it: the installed commit sha equals
+the upstream commit sha, off a freshly refreshed catalog. Every doubt degrades to `unknown,
+go look`, never a false all-clear:
+
+- offline / catalog refresh failed -> the row that would be "current" off a stale catalog is
+  marked `unknown` ("catalog stale"), because a stale upstream sha cannot prove freshness.
+- a plugin with no installed sha, or a version-less plugin with no sha to compare -> `unknown`.
+- a local `directory` marketplace -> `unknown` + `local (dev tree, may be ahead)`; its
+  working copy is routinely ahead of the installed snapshot, so no hard verdict is honest.
+
+`OUTDATED` means the shas genuinely differ. `current` means proven equal. `unknown` means go look.
+
+## Install
+
+```bash
+ln -s "$(pwd)/tools/plugin-check/bin/plugin-check" ~/.local/bin/plugin-check   # ~/.local/bin is on PATH
+```
+
+Needs `claude` (the CLI it delegates to) and `jq`.
+
+## Use
+
+```bash
+plugin-check                 # = status (refreshes the catalog first, then the table)
+plugin-check status          # same
+plugin-check status --no-refresh   # skip the network refresh; an honest offline read
+plugin-check update <name>   # print the exact bump command(s) for <name>; runs NOTHING
+plugin-check update          # print bump commands for every OUTDATED plugin; runs NOTHING
+plugin-check update <name> --apply   # OPERATOR ONLY: actually run the bump (see below)
+```
+
+`status` table:
+
+```
+# plugin-check  (catalog refreshed)
+  PLUGIN             INSTALLED  UPSTREAM   STATUS    MARKETPLACE
+  -----------------  ---------  ---------  --------  -----------------------------------------------------
+  ponytail           4.7.0      0403c4dd5  current   ponytail
+  superpowers        6.0.3      896224c4b  OUTDATED  claude-plugins-official  (sha differs from upstream)
+  kit                1.6.0      5c918d15b  unknown   dwarves-marketplace  (local (dev tree, may be ahead))
+  swift-lsp          1.0.0      aecd4c852  unknown   claude-plugins-official  (no installed sha)
+  ...
+  current=1  OUTDATED=8  unknown=3
+  bump a stale one:  plugin-check update <plugin>        (dry-run; add --apply to run)
+```
+
+`INSTALLED` / `UPSTREAM` show the version when it is a real one, else a short commit sha
+(the comparison is sha-primary; the version is display-only and absent for some plugins).
+
+## `update`: dry-run by default
+
+`update` prints the exact commands and runs nothing:
+
+```
+$ plugin-check update superpowers
+# dry-run (nothing was run). To apply: re-run with --apply.
+  # superpowers  (marketplace: claude-plugins-official)
+  claude plugin marketplace update -- claude-plugins-official
+  claude plugin update -- superpowers@claude-plugins-official
+
+# Restart Claude Code after applying for the new plugin version to load.
+```
+
+The plugin id passed to the real CLI is the full `<plugin>@<marketplace>` form (a bare name
+is "Plugin not found" on the official `plugin update` verb), guarded with `--` and
+shell-quoted so a hostile plugin/marketplace name is never paste-unsafe.
+
+### `--apply` is operator-only
+
+`update --apply` actually runs the bumps via the official `claude plugin` CLI, per plugin,
+echoing each command before it runs, continuing past a failure, and exiting non-zero if any
+failed. An already-current plugin is a no-op (`skip: already current`). After any success it
+prints the restart reminder once.
+
+This is **operator-only**. An autonomous agent loop must never run `--apply` against a real
+plugin (it could pull a breaking upstream change mid-session). The hermetic test suite stubs
+`claude` and verifies `--apply` only through the already-current no-op and the dry-run print;
+it never shells the real updater (a canary file asserts this).
+
+## How it resolves (no `gh`, delegated to the CLI)
+
+Resolution is delegated to the official `claude plugin` CLI and the state files it owns. There
+is no hand-rolled GitHub path resolution and no `gh` dependency.
+
+| What | Source |
+|---|---|
+| installed roster + display version + scope | `claude plugin list --json` (the authoritative "what is installed") |
+| installed commit sha | `$CC_PLUGINS_DIR/installed_plugins.json` -> `.plugins[id][0].gitCommitSha` |
+| upstream sha (claude-plugins-official) | `$CC_PLUGINS_DIR/plugin-catalog-cache.json` -> `.catalog.plugins[id].source_sha` (the CLI writes this; `marketplace update` refreshes it) |
+| upstream sha (other marketplaces) | the marketplace clone HEAD: `git -C <known_marketplaces installLocation> rev-parse HEAD` (the CLI's own clone; for a `directory` source, the live dev tree) |
+
+`status` refreshes the catalog first via `claude plugin marketplace update` (skippable with
+`--no-refresh`); that refresh is what makes the upstream sha trustworthy. The comparison is
+**sha-primary**: equal = `current`, differ = `OUTDATED`, missing-or-stale = `unknown`. A
+sentinel installed version (`unknown` / `0.0.0` / empty) never gets string-compared; the sha
+path governs it.
+
+### Config: `CC_PLUGINS_DIR` (opt-in, defaults to the standard CC plugin dir)
+
+The tool reads Claude Code's own plugin state from `$CC_PLUGINS_DIR`, which defaults to
+`$HOME/.claude/plugins` (the standard per-user Claude Code plugin directory). There is no
+kit- or consumer-specific path assumption: set `CC_PLUGINS_DIR` only to point the tool at a
+non-default location (e.g. a test fixture, per `tests/smoke.sh`).
+
+> Note: SPEC-105 named `claude plugin list --available --json` `source.sha` as the upstream
+> signal. On the CLI version it was built against (2.1.183), `--available` lists only
+> *not-installed* plugins and carries no installed-plugin sha, so the tool reads the CLI's
+> catalog-cache + clone state instead. This is still CLI-delegation (the catalog is the
+> CLI's, refreshed by the CLI), and it is isolated to one `read_state()` function, so a
+> future CLI that exposes upstream sha via `--available` is a one-place swap. Detail in the
+> implementation notes.
+
+## Limits
+
+- `scope: user` plugins only (the common case); other scopes are not read in v1.
+- Inside a multi-plugin monorepo marketplace, a moved marketplace HEAD can over-report a
+  subdir plugin as possibly-stale. v1 accepts honest over-reporting toward "go look", never a
+  false `current`.
+- No `status --json`, no launchd/cron timer, no surfacing hook in v1 (on-demand only, or
+  wire your own scheduler; the tool never schedules itself).
+- Read-only on installed state by contract: the only state mutation is `update --apply`
+  shelling the official CLI; `status`'s only side effect is the official catalog refresh.
+
+## Verify
+
+```bash
+cd tools/plugin-check
+bash tests/smoke.sh             # hermetic: stubbed `claude`, never shells the real updater
+bin/plugin-check status         # live, over your real installed plugins
+```

--- a/tools/plugin-check/bin/plugin-check
+++ b/tools/plugin-check/bin/plugin-check
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+# plugin-check: which adopted Claude Code plugins are outdated, in one glance.
+#
+# The CC-plugin analogue of the mini-agent-update skill. Read-only on installed
+# state. Compares each installed plugin's commit sha against its upstream sha and
+# prints the exact bump command for every stale one. Prints "current" ONLY when it
+# can prove it (installed sha == upstream sha); every doubt degrades to "unknown,
+# go look", never a false all-clear. A false "current" is the one unacceptable output.
+#
+#   plugin-check                 # = status
+#   plugin-check status [--no-refresh]
+#   plugin-check update [name]            # dry-run: print the bump commands
+#   plugin-check update [name] --apply    # OPERATOR ONLY: run the bumps
+#
+# Resolution is delegated to the official `claude plugin` CLI and the state files it
+# owns. NO `gh`, no hand-rolled GitHub path resolution. See README "How it resolves"
+# and docs/implementation-notes for why the data sources differ from SPEC-105's named
+# JSON shape (the CLI version on this host does not expose upstream sha via
+# `list --available --json`; the catalog-cache file it writes does).
+#
+# Hard deps: `claude` (the CLI it delegates to) and `jq`.
+set -euo pipefail
+
+PLUGINS_DIR="${CC_PLUGINS_DIR:-$HOME/.claude/plugins}"
+INSTALLED_JSON="$PLUGINS_DIR/installed_plugins.json"
+CATALOG_JSON="$PLUGINS_DIR/plugin-catalog-cache.json"
+MARKETPLACES_JSON="$PLUGINS_DIR/known_marketplaces.json"
+# Test seam: tests set CLAUDE_BIN to a stub so the suite never shells the real CLI.
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+
+die() { echo "plugin-check: $*" >&2; exit 1; }
+
+# ---- dependency + CLI probes ------------------------------------------------
+
+need_jq() {
+  command -v jq >/dev/null 2>&1 || die "jq is required but not found on PATH. Install jq (e.g. brew install jq)."
+}
+
+# Probe the CLI once. The tool fully depends on it; if it (or the plugin verb) is
+# gone, print the intended commands and exit non-zero, never a partial shell error.
+probe_claude() {
+  if ! command -v "$CLAUDE_BIN" >/dev/null 2>&1; then
+    echo "plugin-check: the 'claude' CLI was not found on PATH; this tool delegates to it." >&2
+    echo "  Intended freshness flow (run once 'claude' is available):" >&2
+    echo "    claude plugin marketplace update      # refresh the catalog" >&2
+    echo "    claude plugin list --json             # the installed roster" >&2
+    return 1
+  fi
+  if ! "$CLAUDE_BIN" plugin --help >/dev/null 2>&1; then
+    echo "plugin-check: 'claude plugin' verb is unrecognized (CLI too old or changed)." >&2
+    echo "  Update Claude Code, then re-run. Intended flow: claude plugin marketplace update; claude plugin list --json" >&2
+    return 1
+  fi
+  return 0
+}
+
+# ---- the ONE parser boundary: read_state() ----------------------------------
+# Emits one normalized TSV record per installed (scope=user) plugin:
+#   plugin <TAB> marketplace <TAB> installed_version <TAB> installed_sha <TAB>
+#   upstream_sha <TAB> source_type <TAB> resolved_via
+# Everything downstream consumes this; a CLI/state-file schema change is a one-place fix.
+# A field that cannot be resolved is the literal "-" (never empty, never guessed).
+#
+# Data sources (all CLI-owned; refreshed by `claude plugin marketplace update`):
+#   roster + display version + scope : `claude plugin list --json`
+#   installed_sha                    : installed_plugins.json .plugins[id][0].gitCommitSha
+#   upstream_sha (official)          : plugin-catalog-cache.json .catalog.plugins[id].source_sha (else .sha)
+#   upstream_sha (other marketplaces): git -C <known_marketplaces installLocation> rev-parse HEAD
+read_state() {
+  local roster
+  # The roster comes from the CLI (authoritative "what is installed"). A torn read
+  # (CC mid-write) makes this invalid JSON; the caller handles a non-zero return.
+  roster="$("$CLAUDE_BIN" plugin list --json 2>/dev/null)" || return 2
+  echo "$roster" | jq -e 'type=="array"' >/dev/null 2>&1 || return 2
+
+  # Pre-read the two state files into jq-safe blobs (absent file -> empty object).
+  local installed_blob catalog_blob mkts_blob
+  installed_blob="$( [ -f "$INSTALLED_JSON" ] && cat "$INSTALLED_JSON" 2>/dev/null || echo '{}' )"
+  echo "$installed_blob" | jq -e . >/dev/null 2>&1 || installed_blob='{}'
+  catalog_blob="$( [ -f "$CATALOG_JSON" ] && cat "$CATALOG_JSON" 2>/dev/null || echo '{}' )"
+  echo "$catalog_blob" | jq -e . >/dev/null 2>&1 || catalog_blob='{}'
+  mkts_blob="$( [ -f "$MARKETPLACES_JSON" ] && cat "$MARKETPLACES_JSON" 2>/dev/null || echo '{}' )"
+  echo "$mkts_blob" | jq -e . >/dev/null 2>&1 || mkts_blob='{}'
+
+  # First jq pass: emit per-plugin id/marketplace/version/installed_sha/upstream_sha
+  # (catalog) /source_type, and for rows still missing an upstream sha, the marketplace
+  # installLocation so the shell can ask git for the clone HEAD.
+  local rows
+  rows="$(
+    echo "$roster" | jq -r \
+      --argjson inst "$installed_blob" \
+      --argjson cat "$catalog_blob" \
+      --argjson mkts "$mkts_blob" '
+      ($inst.plugins // {}) as $ip
+      | ($cat.catalog.plugins // {}) as $cp
+      | .[]
+      | select((.scope // "user") == "user")
+      | .id as $id
+      | ($id | split("@")) as $parts
+      | ($parts[0]) as $name
+      | ($parts[1] // "?") as $mp
+      | ($ip[$id][0].gitCommitSha // "-") as $isha
+      | ($ip[$id][0].version // .version // "-") as $iver
+      | ($cp[$id]) as $ce
+      | (if ($ce|type)=="object" then ($ce.source_sha // $ce.sha // "-") else "-" end) as $usha
+      | ($mkts[$mp].source.source // "?") as $mptype
+      | (if ($ce|type)=="object"
+           then (($ce.marketplace_entry.source) as $ms
+                 | if ($ms|type)=="object" then ($ms.source // "catalog")
+                   elif ($ms|type)=="string" then "subdir-string"
+                   else "catalog" end)
+           else $mptype end) as $stype
+      | ($mkts[$mp].installLocation // "-") as $loc
+      | [$name, $mp, $iver, $isha, $usha, $stype, $loc] | @tsv
+    '
+  )" || return 2
+
+  # Second pass (shell): for rows whose upstream sha is still "-", resolve it from the
+  # marketplace clone HEAD (the CLI's own clone; for a `directory` source that is the
+  # live dev tree). This is the only non-CLI-JSON read, and it touches only the CLI's
+  # own clone path, never a third-party slug.
+  local name mp iver isha usha stype loc
+  while IFS=$'\t' read -r name mp iver isha usha stype loc; do
+    [ -z "${name:-}" ] && continue
+    if [ "$usha" = "-" ] && [ "$loc" != "-" ] && [ -d "$loc/.git" ]; then
+      local head
+      head="$(git -C "$loc" rev-parse HEAD 2>/dev/null || true)"
+      [ -n "$head" ] && usha="$head"
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$name" "$mp" "$iver" "$isha" "$usha" "$stype"
+  done <<< "$rows"
+}
+
+# ---- verdict logic ----------------------------------------------------------
+# Comparison: sha-primary. A sentinel installed version (unknown/empty/0.0.0/-) never
+# string-compares; it forces the sha path. A `directory` source never gets a hard
+# verdict (its dev tree is routinely ahead of the installed snapshot).
+# Echoes: STATUS<TAB>note   where STATUS in {current,OUTDATED,unknown}.
+
+# A version string we must NOT trust for a version-equality compare. These are the CLI's
+# placeholders for "no real version", so string-diffing them would manufacture a verdict.
+is_sentinel_version() {
+  case "$1" in
+    unknown|0.0.0|""|-) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# A value we will trust as a git commit sha for an equality compare. Anything not shaped like
+# a hex object id (7-40 hex chars) is refused, so a non-hex sentinel (the literal "null", "-",
+# empty, a placeholder) can NEVER manufacture a `current`. Defense-in-depth behind read_state's
+# "-" rule: a false "current" is the one unacceptable output, so we exclude it structurally,
+# not just by trusting the upstream to never write a non-hex sha.
+is_real_sha() {
+  [[ "$1" =~ ^[0-9a-f]{7,40}$ ]]
+}
+
+verdict() {
+  local iver="$1" isha="$2" usha="$3" stype="$4" catalog_stale="$5"
+  # directory source: dev-tree hint only, never a hard verdict.
+  if [ "$stype" = "directory" ]; then
+    echo -e "unknown\tlocal (dev tree, may be ahead)"
+    return
+  fi
+  # Both shas shaped like real git object ids -> the universal, provable signal. The hex-shape
+  # guard (is_real_sha, not merely != "-") means no non-hex sentinel can ever reach `current`.
+  if is_real_sha "$isha" && is_real_sha "$usha"; then
+    if [ "$isha" = "$usha" ]; then
+      # Provably current. But if the catalog could not be refreshed we cannot prove
+      # the upstream sha is fresh, so we must not assert current off a stale catalog.
+      if [ "$catalog_stale" = "1" ]; then
+        echo -e "unknown\tcatalog stale; sha matches stale upstream"
+      else
+        echo -e "current\t"
+      fi
+    else
+      echo -e "OUTDATED\tsha differs from upstream"
+    fi
+    return
+  fi
+  # No sha on one side. We do NOT manufacture a verdict from version strings here:
+  # versions are display-only (spec: sha is primary, version secondary-for-display), and
+  # the only honest fallback signals available are shas. Never string-compare a sentinel.
+  if ! is_sentinel_version "$iver" && [ "$usha" = "-" ]; then
+    echo -e "unknown\tno upstream sha to compare"
+    return
+  fi
+  echo -e "unknown\tno installed sha"
+}
+
+# ---- catalog refresh --------------------------------------------------------
+# Returns 0 if the catalog was refreshed, 1 if refresh failed/skipped (caller then
+# marks rows "catalog stale" and downgrades not-provably-current rows to unknown).
+refresh_catalog() {
+  "$CLAUDE_BIN" plugin marketplace update >/dev/null 2>&1
+}
+
+# ---- status -----------------------------------------------------------------
+cmd_status() {
+  local no_refresh=0
+  for a in "$@"; do
+    case "$a" in
+      --no-refresh) no_refresh=1 ;;
+      *) die "status: unknown argument '$a' (only --no-refresh)" ;;
+    esac
+  done
+
+  need_jq
+  probe_claude || exit 1
+
+  if [ ! -d "$PLUGINS_DIR" ]; then
+    echo "no plugins installed (no $PLUGINS_DIR)"
+    exit 0
+  fi
+
+  local catalog_stale=0
+  if [ "$no_refresh" = "1" ]; then
+    catalog_stale=1
+  else
+    if ! refresh_catalog; then
+      catalog_stale=1
+    fi
+  fi
+
+  local state rc=0
+  state="$(read_state)" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "CC plugin state unreadable; re-run in a moment."
+    exit 0
+  fi
+  if [ -z "$state" ]; then
+    echo "no plugins installed"
+    exit 0
+  fi
+
+  # Build rows: PLUGIN INSTALLED UPSTREAM STATUS MARKETPLACE
+  # INSTALLED/UPSTREAM show the version when known, else a short sha.
+  local out
+  out=""
+  local name mp iver isha usha stype
+  local n_current=0 n_outdated=0 n_unknown=0
+  while IFS=$'\t' read -r name mp iver isha usha stype; do
+    [ -z "${name:-}" ] && continue
+    local v
+    v="$(verdict "$iver" "$isha" "$usha" "$stype" "$catalog_stale")"
+    local status note
+    status="${v%%$'\t'*}"
+    note="${v#*$'\t'}"
+    case "$status" in
+      current)  n_current=$((n_current+1)) ;;
+      OUTDATED) n_outdated=$((n_outdated+1)) ;;
+      *)        n_unknown=$((n_unknown+1)) ;;
+    esac
+    local inst_disp up_disp
+    if is_sentinel_version "$iver"; then inst_disp="$(short_sha "$isha")"; else inst_disp="$iver"; fi
+    up_disp="$(short_sha "$usha")"
+    # A stale-catalog row carries the note so the operator knows why it is unknown.
+    local mp_disp="$mp"
+    if [ -n "$note" ]; then mp_disp="$mp  ($note)"; fi
+    out+="$name"$'\t'"$inst_disp"$'\t'"$up_disp"$'\t'"$status"$'\t'"$mp_disp"$'\n'
+  done <<< "$state"
+
+  local header=""
+  if [ "$catalog_stale" = "1" ]; then
+    if [ "$no_refresh" = "1" ]; then
+      header="# plugin-check  (catalog NOT refreshed: --no-refresh; not-provably-current rows = unknown)"
+    else
+      header="# plugin-check  (catalog refresh FAILED, likely offline; rows labelled stale, downgraded to unknown)"
+    fi
+  else
+    header="# plugin-check  (catalog refreshed)"
+  fi
+  echo "$header"
+  print_table "$out"
+  echo
+  echo "  current=$n_current  OUTDATED=$n_outdated  unknown=$n_unknown"
+  if [ "$n_outdated" -gt 0 ]; then
+    echo "  bump a stale one:  plugin-check update <plugin>        (dry-run; add --apply to run)"
+  fi
+  exit 0
+}
+
+short_sha() {
+  local s="$1"
+  if [ "$s" = "-" ] || [ -z "$s" ]; then echo "-"; else echo "${s:0:9}"; fi
+}
+
+# Fixed-width table: first column left-aligned, rest left-aligned (values are short
+# tokens / words, not numbers). Input is TSV rows on stdin-arg.
+print_table() {
+  local data="$1"
+  printf '%s' "$data" | awk -F'\t' '
+    BEGIN { split("PLUGIN\tINSTALLED\tUPSTREAM\tSTATUS\tMARKETPLACE", H, "\t"); for (i=1;i<=5;i++){ w[i]=length(H[i]) } }
+    { for (i=1;i<=5;i++){ if (length($i)>w[i]) w[i]=length($i) }; for (i=1;i<=5;i++) rows[NR""SUBSEP i]=$i; nr=NR }
+    END {
+      line=""
+      for (i=1;i<=5;i++){ line=line sprintf("  %-*s", w[i], H[i]) }
+      print line
+      sep=""
+      for (i=1;i<=5;i++){ d=""; for (k=0;k<w[i];k++) d=d"-"; sep=sep sprintf("  %-*s", w[i], d) }
+      print sep
+      for (r=1;r<=nr;r++){ line=""; for (i=1;i<=5;i++){ line=line sprintf("  %-*s", w[i], rows[r""SUBSEP i]) } print line }
+    }
+  '
+}
+
+# ---- update -----------------------------------------------------------------
+cmd_update() {
+  local apply=0 name=""
+  for a in "$@"; do
+    case "$a" in
+      --apply) apply=1 ;;
+      --*) die "update: unknown flag '$a' (only --apply)" ;;
+      *) if [ -n "$name" ]; then die "update: only one plugin name accepted (got '$name' and '$a')"; fi; name="$a" ;;
+    esac
+  done
+
+  need_jq
+  probe_claude || exit 1
+  [ -d "$PLUGINS_DIR" ] || { echo "no plugins installed (no $PLUGINS_DIR)"; exit 0; }
+
+  # update reads current state WITHOUT mutating it (no catalog refresh here; the operator
+  # who runs --apply will have just looked at `status`). Treat catalog as possibly-stale.
+  local state rc=0
+  state="$(read_state)" || rc=$?
+  if [ "$rc" -ne 0 ]; then echo "CC plugin state unreadable; re-run in a moment."; exit 0; fi
+  [ -n "$state" ] || { echo "no plugins installed"; exit 0; }
+
+  # Collect the targets: a single named plugin (must be installed), else every OUTDATED.
+  # Each target is "name<TAB>marketplace". We do NOT include directory-source or unknown
+  # rows in the "all outdated" set (no hard OUTDATED verdict for those).
+  local targets="" found_name=0 named_refused="" named_refused_mp=""
+  local n mp iver isha usha stype
+  while IFS=$'\t' read -r n mp iver isha usha stype; do
+    [ -z "${n:-}" ] && continue
+    if [ -n "$name" ]; then
+      [ "$n" = "$name" ] || continue
+      found_name=1
+      # Gate the NAMED row on its verdict: refuse to act on a row the tool itself cannot call
+      # OUTDATED (a directory dev-tree, or an unknown/no-sha row). Bumping something we labelled
+      # "unknown" would contradict the honest-unknown contract. A `current` row passes through
+      # (the --apply loop no-ops it); only unknown / dev-tree is refused. The operator can still
+      # run the official `claude plugin update <id>` by hand if they are sure.
+      local nv nst
+      nv="$(verdict "$iver" "$isha" "$usha" "$stype" 0)"
+      nst="${nv%%$'\t'*}"
+      if [ "$nst" != "OUTDATED" ] && [ "$nst" != "current" ]; then
+        named_refused="$nst"; named_refused_mp="$mp"
+      else
+        targets+="$n"$'\t'"$mp"$'\t'"$iver"$'\t'"$isha"$'\t'"$usha"$'\t'"$stype"$'\n'
+      fi
+    else
+      local v st
+      v="$(verdict "$iver" "$isha" "$usha" "$stype" 0)"
+      st="${v%%$'\t'*}"
+      if [ "$st" = "OUTDATED" ]; then
+        targets+="$n"$'\t'"$mp"$'\t'"$iver"$'\t'"$isha"$'\t'"$usha"$'\t'"$stype"$'\n'
+      fi
+    fi
+  done <<< "$state"
+
+  if [ -n "$name" ] && [ "$found_name" = "0" ]; then
+    die "update: plugin '$name' is not installed (run plugin-check status to see installed plugins)"
+  fi
+  # A named row the tool refused to verdict (unknown / directory dev-tree): do not pretend it is
+  # "nothing to do" and do not silently act on it. Refuse explicitly, exit non-zero.
+  if [ -n "$name" ] && [ -n "$named_refused" ] && [ -z "$targets" ]; then
+    echo "refusing to --apply '$name': status is '$named_refused' (no provable OUTDATED verdict)." >&2
+    echo "  If you are sure, run the official CLI directly:  claude plugin update -- $(printf '%q' "$name@$named_refused_mp")" >&2
+    exit 1
+  fi
+  if [ -z "$targets" ]; then
+    if [ -n "$name" ]; then echo "nothing to do: '$name' has no resolvable update."; else echo "nothing to do: no OUTDATED plugins."; fi
+    exit 0
+  fi
+
+  if [ "$apply" = "0" ]; then
+    # Dry-run: print the exact bump commands. Runs nothing.
+    echo "# dry-run (nothing was run). To apply: re-run with --apply."
+    while IFS=$'\t' read -r n mp iver isha usha stype; do
+      [ -z "${n:-}" ] && continue
+      emit_bump_commands "$n" "$mp"
+    done <<< "$targets"
+    echo
+    echo "# Restart Claude Code after applying for the new plugin version to load."
+    exit 0
+  fi
+
+  # --apply: OPERATOR ONLY. Per-plugin, echo each command before running, continue past
+  # a failure, exit non-zero if any failed, print the restart reminder once after success.
+  local any_fail=0 any_ok=0
+  local applied="" failed="" skipped=""
+  while IFS=$'\t' read -r n mp iver isha usha stype; do
+    [ -z "${n:-}" ] && continue
+    # idempotent no-op: a plugin already current (sha match, real shas) is skipped.
+    if [ "$isha" != "-" ] && [ "$usha" != "-" ] && [ "$isha" = "$usha" ]; then
+      echo "skip: $n already current ($(short_sha "$isha"))"
+      skipped+="$n "
+      continue
+    fi
+    echo "==> $n@$mp"
+    # AC10: names pass as quoted argv with a `--` guard; never interpolated into a string,
+    # never eval'd. The `--` stops any name that looks like a flag from being parsed as one.
+    echo "    \$ $CLAUDE_BIN plugin marketplace update -- $mp"
+    if "$CLAUDE_BIN" plugin marketplace update -- "$mp" >/dev/null 2>&1; then :; else
+      echo "    marketplace update failed for $mp (continuing)"
+    fi
+    # The real CLI's update verb needs the FULL pluginId <plugin>@<marketplace>; a bare name is
+    # "Plugin not found" (learned by running it live, see implementation-notes). `--` guard kept.
+    echo "    \$ $CLAUDE_BIN plugin update -- $n@$mp"
+    local up_out up_rc=0
+    up_out="$("$CLAUDE_BIN" plugin update -- "$n@$mp" 2>&1)" || up_rc=$?
+    if [ "$up_rc" -ne 0 ]; then
+      echo "    FAILED: $n"
+      failed+="$n "; any_fail=1
+    elif printf '%s' "$up_out" | grep -qiE 'already (at the latest|up to date)'; then
+      # Version-current despite a differing sha (the accepted over-report): the CLI did nothing.
+      echo "    already latest: $n (no change)"
+      skipped+="$n "
+    else
+      echo "    applied: $n"
+      applied+="$n "; any_ok=1
+    fi
+  done <<< "$targets"
+
+  echo
+  echo "# summary"
+  [ -n "$applied" ] && echo "  applied:  $applied"
+  [ -n "$skipped" ] && echo "  skipped:  $skipped (already current)"
+  [ -n "$failed" ]  && echo "  failed:   $failed"
+  if [ "$any_ok" = "1" ]; then
+    echo "# Restart Claude Code for the updated plugin(s) to load."
+  fi
+  [ "$any_fail" = "1" ] && exit 1
+  exit 0
+}
+
+# Print the bump commands for one plugin. The `plugin update` verb needs the FULL pluginId
+# <plugin>@<marketplace> (a bare name is "Plugin not found" on the real CLI); see implementation-notes.
+emit_bump_commands() {
+  local n="$1" mp="$2"
+  # These lines are meant to be COPY-PASTED, so they must be paste-safe even when a (hostile)
+  # marketplace/plugin name carries shell metacharacters or a leading dash: shell-quote the id
+  # (printf %q) AND keep the `--` end-of-options guard, mirroring the --apply exec path. For an
+  # ordinary id printf %q is a no-op, so the common output stays clean ("... update -- ponytail@ponytail").
+  local qid qmp
+  qid="$(printf '%q' "$n@$mp")"
+  qmp="$(printf '%q' "$mp")"
+  echo "  # $n  (marketplace: $mp)"
+  echo "  claude plugin marketplace update -- $qmp"
+  echo "  claude plugin update -- $qid"
+}
+
+# ---- dispatch ---------------------------------------------------------------
+main() {
+  local cmd="${1:-status}"
+  case "$cmd" in
+    status) shift || true; cmd_status "$@" ;;
+    update) shift; cmd_update "$@" ;;
+    -h|--help|help)
+      cat <<'EOF'
+plugin-check , which adopted Claude Code plugins are outdated, in one glance.
+
+  plugin-check                       same as: status
+  plugin-check status [--no-refresh] freshness table (refreshes the catalog first)
+  plugin-check update [name]         print the exact bump command(s); runs nothing
+  plugin-check update [name] --apply OPERATOR ONLY: run the bumps via the official CLI
+
+STATUS column: current (installed sha == upstream sha, proven), OUTDATED (sha differs),
+unknown (offline / no sha / version-less / directory-source dev tree). It prints "current"
+only when it can prove it; every doubt is "unknown, go look", never a false all-clear.
+
+Resolution is delegated to the official `claude plugin` CLI + the state files it owns
+(no gh, no hand-rolled GitHub path math). See README "How it resolves".
+EOF
+      ;;
+    *) die "unknown command '$cmd' (use: status | update | --help)" ;;
+  esac
+}
+
+main "$@"

--- a/tools/plugin-check/docs/implementation-notes/cc-plugin-check.md
+++ b/tools/plugin-check/docs/implementation-notes/cc-plugin-check.md
@@ -1,0 +1,140 @@
+# Implementation notes: cc-plugin-check
+
+**Migrated into dwarves-kit (kit-foldin SG-05, 2026-07-05).** This tool moved here verbatim
+from `ops-toolkit/tools/cc-plugin-check/`, renamed `plugin-check` (kit naming rule: drop
+the host-agent prefix on entry). No functional or test change; kept below for continuity,
+predating the move.
+
+Delta-from-spec log. The spec (`docs/specs/SPEC-105-cc-plugin-check.md`) holds the design;
+this file holds ONLY what the spec did not pin down, what I changed against it, and host
+quirks discovered while building. Not a restatement of the spec.
+
+## 2026-06-20 11:50 The spec's `--available --json` join mechanism does not exist in CLI 2.1.183
+
+- Context: spec §Architecture mandates `read_state()` join installed `gitCommitSha`
+  (from `claude plugin list --json`) against available `source.sha`
+  (from `claude plugin list --available --json`). I probed the live CLI (v2.1.183)
+  before writing any code.
+- Discovery (the load-bearing host quirk):
+  1. `claude plugin list --json` carries NO `gitCommitSha`. Its per-plugin keys are
+     `id, version, scope, enabled, installPath, installedAt, lastUpdated[, mcpServers]`.
+     The installed sha lives instead in `~/.claude/plugins/installed_plugins.json` at
+     `.plugins["<id>"][0].gitCommitSha`.
+  2. `claude plugin list --available --json` returns `{available:[...], installed:[...]}`.
+     `.available` is the catalog of NOT-installed plugins and contains ONLY
+     `claude-plugins-official` entries (227). My 12 installed plugins are EXCLUDED from
+     `.available` (it lists what you *could* install, the opposite of what the spec
+     assumed), so the installed->available sha join the spec describes returns zero rows.
+  3. The real upstream truth the CLI keeps is `~/.claude/plugins/plugin-catalog-cache.json`
+     at `.catalog.plugins["<id>"]`, an object keyed by pluginId. Per entry the upstream
+     sha is `.source_sha` (ALWAYS present for official plugins); `.sha` is populated only
+     for url / git-subdir sources (external repos, e.g. superpowers) and is `null` for
+     subdir-string sources (`./plugins/x`, the plugins that live inside the official
+     monorepo). So the universal upstream-sha field is **`source_sha`** (fall back to
+     `sha`). The catalog cache holds `claude-plugins-official` only.
+  4. The single-plugin marketplaces (ponytail, ouroboros, zedra, claude-code-warp) and the
+     local `directory` marketplace (kit@dwarves-marketplace) are NOT in the catalog cache.
+     Their upstream sha is the marketplace clone HEAD:
+     `git -C <known_marketplaces.json[mp].installLocation> rev-parse HEAD`. For the
+     `directory` source that installLocation is the live dev working tree
+     (the local dwarves-kit checkout).
+- Decision / Change: keep the spec's INTENT (delegate to the CLI, sha-primary compare,
+  one `read_state()` boundary, refresh via `claude plugin marketplace update`, honest
+  unknown) but change the DATA SOURCES `read_state()` reads, because the spec's named
+  JSON shape does not exist in this CLI version:
+  - installed sha + version <- `installed_plugins.json` (the CLI's own state file).
+  - upstream sha <- `plugin-catalog-cache.json` `.catalog.plugins[id].source_sha`
+    (official) ELSE the marketplace clone HEAD (non-official, from
+    `known_marketplaces.json`).
+  - `claude plugin marketplace update` still drives the catalog refresh at `status` start;
+    it is what rewrites `plugin-catalog-cache.json`, so refreshing via the CLI then reading
+    the file it wrote is still "delegate resolution to the CLI", just async through its
+    state file rather than a synchronous `--available` call.
+  - `claude plugin list --json` is still called once, as the authoritative roster of which
+    plugins are installed + their display version + scope filter (`scope == user`), per
+    the spec's "list --json is the installed roster" intent.
+- Why: a false "current" is the spec's one unacceptable output (§Solution). The
+  `--available` join the spec names would silently return no matching rows -> every plugin
+  would fall through to a non-sha path. Using the CLI's real upstream state file is the
+  only way to get a *provable* installed-sha == upstream-sha equality, which is the whole
+  honest-current contract.
+- Alternatives considered:
+  - `gh api` upstream fetch: explicitly rejected by the spec (approach 2; injection + 404
+    on multi-plugin marketplaces). Not revived.
+  - Parse `--available --json` `.installed[]`: it carries the same shape as `list --json`
+    (no sha, no source), so it adds nothing.
+  - `claude plugin details <name>`: shows installed version + component inventory, no
+    upstream sha. Useless for freshness.
+- Impact: `read_state()` reads three CLI-owned JSON files + (for non-official mp) one
+  `git rev-parse` per marketplace. Still no `gh`, still no hand-rolled GitHub path math
+  (the clone is the CLI's, the catalog is the CLI's). A future CLI that DOES expose
+  upstream sha via `--available` would be a one-place swap inside `read_state()`.
+  Documented in README + MANUAL as the resolution path.
+
+## 2026-06-20 Live resolution result for the real 12 (recorded for proof-of-done)
+
+current (sha match): ouroboros, ponytail, warp, zedra.
+OUTDATED (sha differs): code-simplifier, frontend-design, kit, playwright,
+  security-guidance, superpowers.
+unknown (no installed gitCommitSha in installed_plugins.json): swift-lsp, telegram.
+kit@dwarves-marketplace is `directory` source -> labelled `local (dev tree, may be ahead)`,
+  no hard verdict asserted (its dev-tree HEAD is routinely ahead of the installed snapshot),
+  per spec Edge Cases. It is reported under STATUS=unknown with the dev-tree note, never a
+  hard current/OUTDATED.
+
+## 2026-06-20 Review-round fixes (3-lens /review-team on the PR; no criticals, warnings folded)
+
+Lead-applied after the build, on this branch. Each is a delta from the as-built code; the spec
+got a v3 Amendment for the data-source supersede (already logged above) + these:
+
+- **Hex-sha guard in `verdict()`** (`is_real_sha`, `^[0-9a-f]{7,40}$`). The `current` arm now
+  requires both shas to be hex-shaped, not merely `!= "-"`. This makes a false `current`
+  *structurally* impossible even if a future CLI wrote a non-hex sentinel (e.g. the literal
+  string `"null"`) into the sha field. Defense-in-depth behind read_state's `-` rule; the one
+  unacceptable output (false `current`) is now excluded by shape, not by trusting the input.
+- **Paste-safe dry-run** (`emit_bump_commands`). The printed bump commands now `printf %q` the
+  name and carry the `--` end-of-options guard, mirroring the `--apply` exec path. Reason: the
+  dry-run output exists to be copy-pasted, and a hostile plugin/marketplace name (the `evil`
+  fixture) previously printed a runnable injection. `--` is valid for the commander.js-style
+  `claude plugin update [options] <plugin>` (verified `--help`).
+- **Named `update <name> --apply` verdict gate.** A named `--apply` now refuses an
+  `unknown`/`directory`-dev-tree row (it cannot be verdicted OUTDATED) with a non-zero exit and
+  a "run the official CLI yourself" hint, instead of attempting a bump on something the tool
+  labelled `unknown`. The bulk `--apply` already excluded those; this closes the named-path
+  asymmetry both review lenses flagged. (Operator-driven; the AC9 autonomy gate, loop never runs
+  `--apply`, was already intact.)
+- **Tests (+4, smoke now 26).** Added: AC6 `--apply` applied-summary + exit 0 ([23]); AC6
+  partial-failure failed-summary + non-zero exit ([24]); the named-apply refusal + no-canary
+  ([25]); dry-run paste-safety on the `evil` row ([26]). Stub gained a `STUB_ALLOW_UPDATE` mode
+  so the apply/summary path can run without firing the autonomy canary (still the stub, never the
+  real CLI). AC3 control de-dead-claused (the old `(A && B) || A` collapsed to `A`).
+- **MANUAL freshness caveat.** Documented that a single-plugin-marketplace `current` is only as
+  fresh as what `marketplace update` pulled into the clone (it is the CLI's fetch, not ours).
+
+## 2026-06-20 Real-CLI dogfood: bump-form was WRONG; tests stubbed the contract away
+
+First live `update --apply` (operator ran it on the real 8 OUTDATED) failed ALL 8. Root cause
+found by running the real CLI directly (the suite only ever stubbed it, so it shipped):
+
+- **Bump-command form bug (the merged tool was broken).** The tool emitted/ran
+  `claude plugin update -- <bare-name>`. The real CLI rejects a bare name: `Plugin "ouroboros"
+  not found`. The correct form is the full pluginId `claude plugin update -- <plugin>@<marketplace>`
+  (verified live: `ouroboros@ouroboros` updated 0.29.1 -> 0.42.4). The `--` guard itself is fine
+  (`claude plugin update -- ouroboros@ouroboros` works); only the bare-vs-full-id was wrong. The
+  spec's AC5 + the build + the solution-design review lens all asserted "bare name, NOT @mp" by
+  reading `claude plugin update --help` (`<plugin>`), never running it. Fix: emit/run the full id.
+- **Why no test caught it (the lesson).** `tests/fixtures/stub-claude` accepted ANY name shape,
+  so the stub validated an imagined contract, not the real CLI's. Fix: the stub now mimics the
+  real CLI , a bare name (no `@`) returns "Plugin not found" + non-zero, so a regression to the
+  bare form fails the suite. This is the durable guard.
+- **`--apply` honesty.** The real CLI exits 0 with "already at the latest version" for a plugin
+  that is version-current even when its sha differs (the accepted over-report). Without parsing
+  that, `--apply` would report "applied" for an unchanged plugin. Fix: capture the CLI output and
+  classify `already (at the latest|up to date)` as a no-op ("already latest"), distinct from a
+  real "applied". Stub gained `STUB_ALREADY_LATEST` to test this.
+- **version-primary was investigated and REJECTED (no data).** The over-report (sha differs but
+  version unchanged) cannot be fixed by comparing versions: the CLI's state exposes no upstream
+  VERSION (`list --available --json` has `version: null`; only `source.ref` carries a tag, and
+  single-plugin marketplaces have no catalog entry at all). So sha-primary stays; the over-report
+  is documented as "sha moved, run `update` and the CLI is the version authority", and `--apply`'s
+  new already-latest handling makes it harmless in practice.

--- a/tools/plugin-check/docs/specs/SPEC-105-cc-plugin-check.md
+++ b/tools/plugin-check/docs/specs/SPEC-105-cc-plugin-check.md
@@ -11,7 +11,7 @@ on-disk marketplace clone is stale until manually refreshed.
 
 Han runs 6 marketplaces hosting **12 installed plugins**: single-plugin marketplaces
 (`ponytail`, `ouroboros`, `zedra`, `claude-code-warp`), a local `directory` marketplace
-(`kit@dwarves-marketplace`, source path the local dwarves-kit checkout), and the big
+(`kit@dwarves-marketplace`, whose source path is the local dwarves-kit checkout), and the big
 multi-plugin `claude-plugins-official` (234 plugins; hosts 8 of Han's: playwright,
 frontend-design, superpowers, swift-lsp, security-guidance, code-simplifier, telegram,
 agent-sdk-dev). Keeping them current means noticing staleness yourself and hand-running

--- a/tools/plugin-check/docs/specs/SPEC-105-cc-plugin-check.md
+++ b/tools/plugin-check/docs/specs/SPEC-105-cc-plugin-check.md
@@ -1,0 +1,313 @@
+# Spec: cc-plugin-check (adopted Claude Code plugin freshness + bump helper)
+Generated: 2026-06-20
+Status: VALIDATED (revised v2 after 5-lens /spec-validate; see Amendments)
+
+## Problem
+
+Claude Code installs external plugins from marketplaces but offers no "what have I
+adopted, and which are outdated" surface. It tracks installed plugins and their
+marketplaces, but never compares installed against upstream and never notifies. The
+on-disk marketplace clone is stale until manually refreshed.
+
+Han runs 6 marketplaces hosting **12 installed plugins**: single-plugin marketplaces
+(`ponytail`, `ouroboros`, `zedra`, `claude-code-warp`), a local `directory` marketplace
+(`kit@dwarves-marketplace`, source path the local dwarves-kit checkout), and the big
+multi-plugin `claude-plugins-official` (234 plugins; hosts 8 of Han's: playwright,
+frontend-design, superpowers, swift-lsp, security-guidance, code-simplifier, telegram,
+agent-sdk-dev). Keeping them current means noticing staleness yourself and hand-running
+`claude plugin marketplace update` + `claude plugin update <plugin>` per plugin.
+
+cc-plugin-check is the read-only freshness lens: it answers "which adopted CC plugins are
+outdated" and emits the exact bump commands. It is the Claude-Code-plugin analogue of the
+`mini-agent-update` **skill** (which does the same for the Mini's deployed agents).
+
+## Solution
+
+### Approaches considered
+
+1. **Delegate all resolution to the official `claude plugin` CLI (chosen).** Read installed
+   state via `claude plugin list --json` and upstream state via `claude plugin list
+   --available --json` (which the CLI resolves across every source type and which exposes a
+   per-plugin upstream `ref` + `sha`). Compare installed vs available primarily by **commit
+   sha** (the one universal signal), secondarily by version string (for display). Refresh the
+   catalog first via `claude plugin marketplace update`. `update` shells the official
+   `claude plugin` verbs. No `gh`, no hand-rolled path resolution.
+2. **Hand-fetch upstream `plugin.json` via `gh api` (rejected).** This was the v1 design. It
+   is broken and unsafe: multi-plugin marketplaces (claude-plugins-official) have no
+   repo-root `plugin.json`, so a root fetch 404s for 8 of 12 plugins; each plugin's real path
+   lives in `marketplace.json`'s per-plugin `source` (which can be `git-subdir` / `url` /
+   subdir-string), and resolving that by hand is exactly the work the official CLI already
+   does. It also interpolates third-party repo slugs into a shell `gh` call (injection), and
+   adds `gh` as a dependency. Rejected in favor of approach 1.
+3. **Curated `cc-plugins.toml` registry (rejected for v1).** A hand-maintained adoption list.
+   Duplicates state the CLI already owns; the "what I adopted + why" record lives in
+   BACKLOG/LAB_LOG. Re-introducible later if non-marketplace plugins need tracking.
+4. **Do nothing; run `claude plugin update` periodically (rejected).** No `--all` verb, no
+   freshness visibility; you bump blind.
+
+### Chosen approach + why
+
+Delegate resolution to the official CLI (approach 1). The CLI is the authoritative resolver
+for every marketplace shape (single-plugin, multi-plugin monorepo, `git-subdir`, `url`,
+local `directory`), so the tool never guesses paths and never touches a third-party repo
+slug. The **commit sha is the universal freshness signal**: `claude plugin list --json`
+carries the installed `gitCommitSha`, `claude plugin list --available --json` carries the
+upstream `source.sha`; equal = current, differ = outdated, works even when no semver exists.
+This mirrors `cc-observe` (reads CC's own surfaces read-only) and is ponytail-correct: use
+the platform feature instead of reimplementing it. `gh` is not a dependency.
+
+### Extensibility & boundaries
+
+- **The CLI is the resolution oracle.** Any new source type CC adds is resolved by the CLI,
+  not by this tool; the tool only consumes `list --json` / `list --available --json`.
+- **Read-only on INSTALLED state.** The tool never writes installed-plugin state or cache.
+  `status` does run the official `claude plugin marketplace update` (a benign, idempotent
+  **catalog** refresh, not an install-state change); `--no-refresh` skips it for a pure
+  offline read. Installed-plugin mutation happens ONLY via `update --apply` shelling the
+  official CLI.
+- **Honest unknown is mandatory.** Offline / catalog-not-refreshed / missing sha both sides /
+  version-less with no sha → STATUS=unknown, never a false "current". A false "current" is
+  the one unacceptable output.
+
+### Architecture
+
+> **SUPERSEDED in part (v3, 2026-06-20, see Amendments).** The `claude plugin list
+> --available --json` join described below returns NOT-installed plugins on the shipped CLI
+> (v2.1.183) and exposes no installed-plugin sha, so it resolves zero rows. The shipped data
+> sources keep this section's INTENT (CLI-delegation, sha-primary, one `read_state()` boundary,
+> refresh-via-`marketplace update`, honest-unknown) but read: installed sha from
+> `installed_plugins.json`; upstream sha from `plugin-catalog-cache.json .catalog.plugins[id].source_sha`
+> (the file `marketplace update` writes) else the marketplace clone HEAD. See Amendments v3 and
+> `docs/implementation-notes/cc-plugin-check.md`. The prose below is retained for design history.
+
+A bash CLI `bin/cc-plugin-check` (no `.sh` extension, `#!/usr/bin/env bash`, `set -euo
+pipefail`, `chmod +x`), jq for parsing the CLI's JSON. **No `gh`.** Subcommands:
+
+- `status` (default): refresh catalog (unless `--no-refresh`), read installed + available,
+  join, render the freshness table.
+- `update [name] [--apply]`: emit (default) or run (`--apply`) the bump commands.
+
+**One `read_state()` boundary** is the only parser of the CLI's JSON shape; everything
+downstream consumes a normalized record `{plugin, marketplace, installed_version,
+installed_sha, available_ref, available_sha, source_type}`. A CLI schema change is then a
+one-place fix. Comparison: if `installed_sha` and `available_sha` both present, equal=current
+/ differ=OUTDATED; else if both have a real version, compare versions; else STATUS=unknown.
+A sentinel installed version (`unknown`, empty, `0.0.0`) forces the sha path, never a
+string-compare against the sentinel.
+
+## Technical Design
+
+### Interfaces (I/O contract)
+
+- `cc-plugin-check` | `cc-plugin-check status [--no-refresh]`: table with columns
+  `PLUGIN | INSTALLED | UPSTREAM | STATUS | MARKETPLACE`, STATUS in {current, OUTDATED,
+  unknown}. INSTALLED/UPSTREAM show the version when known, else a short sha. Exit 0 always.
+  When the catalog refresh failed or was skipped and a row cannot be proven current, that
+  row's STATUS is `unknown` (labelled "catalog stale"), never `current`.
+- `cc-plugin-check update [name]`: for each outdated plugin (or just `name`), print the exact
+  `claude plugin marketplace update <marketplace>` + `claude plugin update <plugin>@<marketplace>`
+  (the FULL pluginId; a bare name is "Plugin not found" on the real CLI, see Amendments v4) + the
+  "restart Claude Code to apply" note. Default is dry-run (print only, runs nothing).
+- `cc-plugin-check update --apply [name]`: run those commands per outdated plugin via the
+  official CLI. Iterates per-plugin; echoes each command immediately before running it;
+  reports `applied | failed(<reason>) | skipped(already current)` per plugin; one plugin's
+  failure does not abort the rest; exits non-zero if any failed; prints the restart reminder
+  once after any success. A plugin already current is a no-op.
+
+### Data model (runtime state, NOT in repo)
+
+No repo-side state, no `cc-plugins.toml`. The tool's inputs are the JSON outputs of
+`claude plugin list --json` and `claude plugin list --available --json` (the CLI owns reading
+`~/.claude/plugins/*`). Freshness is computed live each run; no cache.
+
+### Infrastructure changes
+
+None: on-demand CLI, no daemon, no `gh`. Hard dependencies: `claude` (the CLI it delegates
+to) and `jq`. v1 ships NO launchd timer and NO surfacing hook (minimum-infra; both deferred).
+
+## Task Breakdown (single goal, logical steps)
+
+1. Scaffold `tools/cc-plugin-check/` per ops-tool-shape, mirroring `cc-observe`
+   (`bin/`, `docs/`, `tests/`, `tool.toml`, `README.md`, `.gitignore`).
+2. `status` read + compare: `read_state()` over the two CLI JSON outputs, sha-primary /
+   version-secondary verdict, refresh + `--no-refresh`, table render; exit 0.
+3. `update` dry-run + `--apply` (per-plugin, echo-before-run, partial-failure summary,
+   idempotent no-op when current).
+4a. Test + proof harness: hermetic `tests/smoke.sh` over fixture CLI-JSON (stubbed `claude
+    plugin`, never the real binary) covering current / OUTDATED / unknown / sentinel-version /
+    injection-defense; capture a real `status` run into `docs/proof-of-done.md`.
+4b. Close-out: README + MANUAL + `docs/proof-of-done.md` finalized + MANIFEST row + LAB_LOG,
+    then `/review` + `/review-team`, fix findings on-branch.
+
+## After state
+
+`cc-plugin-check` lists all 12 adopted plugins with installed-vs-upstream freshness (sha- or
+version-based); outdated rows carry the exact bump command; `update --apply` performs the
+bump via the official CLI. It sits in `tools/` as the CC-plugin analogue of the
+`mini-agent-update` skill.
+
+## Acceptance Criteria (global)
+
+- **AC1** `cc-plugin-check` prints one row per installed plugin (all 12), each with a
+  MARKETPLACE and a STATUS, exit 0. Plugins from the multi-plugin `claude-plugins-official`
+  marketplace appear (not just single-plugin marketplaces).
+- **AC2** A `claude-plugins-official`-hosted plugin (e.g. superpowers) AND ponytail both
+  resolve to a real STATUS (current/OUTDATED), proving multi-plugin + single-plugin paths
+  both work; ponytail shows `current` when installed sha == available sha.
+- **AC3** A fixture whose installed sha/version is forced older than available shows
+  `OUTDATED` with the delta (negative control).
+- **AC4** Catalog-refresh failure (offline) or `--no-refresh` yields STATUS=unknown for any
+  row not provably current, never a false "current"; exit still 0.
+- **AC5** `update <outdated>` prints `claude plugin marketplace update <mp>` then
+  `claude plugin update <plugin>@<marketplace>` (the FULL pluginId; bare name is rejected by the
+  real CLI, see Amendments v4) + restart note, and runs nothing without `--apply`.
+- **AC6** `update --apply` on an already-current plugin is a no-op ("already current"); on a
+  set with one failing plugin, the others still apply and the summary names the failure; a
+  version-current-but-sha-differing plugin (the CLI says "already at the latest version") is
+  reported "already latest (no change)", not a false "applied".
+- **AC7** Read-only-on-installed-state holds: no code path writes installed-plugin state or
+  cache; the only install mutation is `update --apply` shelling the official CLI; `status`'s
+  only side effect is the official catalog refresh (skippable via `--no-refresh`).
+- **AC8** A version-less / sentinel plugin (installed `version: "unknown"`, e.g. playwright)
+  is compared by sha or marked unknown, and NEVER reported a false `current`/`OUTDATED` from
+  string-diffing the sentinel.
+- **AC9 (autonomy gate)** `update --apply` is operator-only. The autonomous `/goal` loop MUST
+  NOT invoke `--apply` against any plugin; it verifies `--apply` solely via the
+  already-current no-op (AC6) and the dry-run print (AC5). `tests/smoke.sh` stubs `claude
+  plugin` and asserts the suite never shells the real updater.
+- **AC10 (input defense)** Plugin/marketplace names are passed as quoted argv with a `--`
+  guard so a name cannot become a flag, and a fixture name containing shell metacharacters or
+  a leading `-` runs no injected side effect (canary-file-not-created assertion).
+- **AC11** `docs/proof-of-done.md` is committed with a captured real `status` run-table over
+  the 12 plugins plus the AC3/AC4/AC8 negative controls, and contains no token, no `op://`,
+  and no surprising absolute paths.
+
+## Verification
+
+`tests/smoke.sh` is hermetic: it feeds fixture JSON in the shape of `claude plugin list
+--json` / `--available --json` via a **stubbed `claude` on PATH** (the suite must never call
+the real `claude plugin ... update`), asserting: one row per fixture plugin (AC1/AC2); an
+OUTDATED row for the pinned-old fixture (AC3); an unknown row when refresh is forced to fail
+(AC4); a sentinel-version row never false-current (AC8); `update` without `--apply` mutates
+nothing (AC5/AC7); the injection canary is not created (AC10). A live `status` run over the
+real 12 plugins is captured into `docs/proof-of-done.md` (AC11). Kit-adopted repo: the work
+runs its `lane-classify` lane and the ship-gate is the final `Done` check.
+
+## Edge Cases
+
+- Multi-plugin marketplace (claude-plugins-official): resolved by `list --available --json`;
+  no per-plugin path math in this tool.
+- `url` / `git-subdir` sources (superpowers): the available entry carries `source.sha`;
+  compare against installed `gitCommitSha`.
+- Subdir-string source (`"./plugins/x"`) with no per-entry sha: fall back to the marketplace
+  clone HEAD (`git -C ~/.claude/plugins/marketplaces/<mp> rev-parse HEAD`) vs installed sha;
+  if unavailable, unknown.
+- Local `directory` source (kit@dwarves-marketplace): the available version reflects the live
+  dev working copy, which is routinely ahead of the installed snapshot. Label such rows
+  `local (dev tree, may be ahead)` and never assert a hard `current`/`OUTDATED`; this is a
+  freshness hint, not a verdict.
+- Plugin installed at multiple scopes: v1 reads `scope: user` only (documented narrowing).
+- Version strings non-semver / `v`-prefixed: prefer the sha signal; use version only for display.
+
+## Failure modes
+
+- `claude` CLI absent or a verb/flag unrecognized (the tool fully depends on it): probe
+  `claude plugin --help` once; on failure print the intended commands + a clear message and
+  exit non-zero, never a partial/opaque shell error.
+- Catalog refresh fails (offline / DNS / network): fall back to the existing clone, label
+  rows "catalog stale", and downgrade any not-provably-current row to unknown (AC4). Never
+  false-current off a stale catalog.
+- `jq` missing: hard error, one clear line.
+- `update --apply` partial failure: per-plugin `applied|failed|skipped`, continue past a
+  failure, exit non-zero if any failed (AC6).
+- Torn read (CC mid-write): the CLI returns invalid JSON; wrap the parse and emit one clear
+  line ("CC plugin state unreadable; re-run in a moment"), exit 0, not a jq trace.
+- `~/.claude/plugins/` absent: "no plugins installed", exit 0.
+
+## Out of Scope
+
+- The `gh`-live-fetch resolution (approach 2; rejected).
+- A curated `cc-plugins.toml` registry (approach 3; deferred).
+- A `status --json` machine-output flag (no consumer in v1; YAGNI).
+- Any surfacing wiring (vps-mon honest-link / SessionStart line / launchd timer): v1 is
+  pure on-demand; surfacing is a follow-up decision, not the loop's to make.
+- Per-plugin commit-diff precision inside a monorepo marketplace (a moved marketplace HEAD
+  may over-report a subdir plugin as possibly-stale; v1 accepts honest over-reporting toward
+  "go look", never false-current).
+- Rollback / pinning (the official CLI owns version management).
+
+## Touches
+
+- New: `tools/cc-plugin-check/**` (bin, docs, tests, tool.toml, README).
+- `MANIFEST.md` (new tool row).
+- `_meta/LAB_LOG.md` (close-out entry on the feature branch).
+
+## Decision Log
+
+- **CLI-delegation over gh-fetch (approach 1 vs 2).** The official `claude plugin list
+  --json` / `--available --json` resolves every source type and exposes installed + upstream
+  sha; hand-fetching via `gh` 404s on multi-plugin marketplaces, opens a shell-injection
+  surface, and adds a dependency. Verified against live state during /spec-validate.
+- **Commit sha is the primary freshness signal.** Versions are absent for ~3 plugins and
+  null in 94% of `claude-plugins-official` entries; sha is universal. Version is display-only.
+- **`update --apply` is operator-only (autonomy gate).** The `/goal` loop must never bump a
+  real plugin; it verifies only the no-op + dry-run paths. (AC9.)
+- **Input passed as quoted argv with `--`.** Defense-in-depth even though names now come from
+  the trusted CLI, not third-party slugs. (AC10.)
+- **Read-only on installed state; catalog refresh is benign.** `status` may refresh the
+  catalog (official, idempotent) but never changes what is installed; `--no-refresh` offers a
+  pure read.
+- **Honest unknown over false current.** Every failure/ambiguous path degrades to unknown.
+- **No daemon, no surfacing, no `--json`, no registry in v1.** Minimum-infra + YAGNI.
+
+## Amendments
+
+- **v2 (2026-06-20), after 5-lens /spec-validate.** Critical fixes: (1) replaced the broken
+  `gh`-root-fetch resolution with official-CLI delegation, fixing the 8-of-12 multi-plugin
+  miss and removing the gh-injection surface [assumption + solution-design + failure-mode +
+  security lenses]; (2) sha-primary comparison + sentinel-version handling, fixing false
+  current/OUTDATED on version-less plugins [assumption + solution-design + failure-mode]; (3)
+  corrected bump command form to bare `<plugin>` [solution-design]; (4) added the autonomy
+  gate AC9 so the loop cannot run `--apply` [scope]; (5) added input-defense AC10
+  [security]. Warnings folded: single `read_state()` boundary; directory-source dev-tree
+  staleness label; `--apply` partial-failure semantics; `claude`-absent failure mode;
+  torn-read guard; secrets check on the committed proof; step 5 split into 4a/4b; dropped
+  `--json` and surfacing to Out of Scope; corrected marketplace names. PASS (kept): read-only
+  + shell-out boundary, honest-unknown invariant, minimum-infra framing, dry-run-by-default.
+
+- **v3 (2026-06-20), during build + post-build review round.** (a) **Data-source correction
+  (the §Architecture supersede above):** the v2 `claude plugin list --available --json`
+  `source.sha` join does not exist on the shipped CLI (v2.1.183) , `--available` lists
+  NOT-installed plugins. Shipped resolution keeps the v2 intent but reads installed sha from
+  `installed_plugins.json` and upstream sha from `plugin-catalog-cache.json
+  .catalog.plugins[id].source_sha` (the file `marketplace update` writes) else the marketplace
+  clone HEAD; detail in `docs/implementation-notes/cc-plugin-check.md`. (b) **Review-round
+  hardening (3 lenses, no criticals; warnings folded):** a hex-sha guard so a non-hex sentinel
+  can never reach `current` (defense-in-depth behind the honest-unknown contract); the dry-run
+  bump commands are now paste-safe (`printf %q` + `--` guard, mirroring `--apply`); a named
+  `update <name> --apply` now refuses an `unknown`/dev-tree row instead of attempting a bump it
+  cannot verdict; tests added for the `--apply` applied/failed summary (AC6), the named-apply
+  refusal, the dry-run paste-safety, and the AC3 control was de-dead-claused (smoke now 26).
+  (c) **MANUAL note:** single-plugin-marketplace freshness is only as fresh as what
+  `marketplace update` pulls into the clone.
+
+- **v4 (2026-06-20), after the first real `update --apply` (operator-run, exposed a shipped bug).**
+  The stubbed suite hid a wrong command form; running the real CLI broke all 8 bumps. Fixes:
+  (1) **bump-form correction (the bug):** the update verb needs the FULL `<plugin>@<marketplace>`
+  pluginId, NOT the bare name v2/v3 asserted (read from `--help`, never run). `claude plugin
+  update -- <bare>` returns "Plugin not found"; `-- <plugin>@<marketplace>` works (the `--`
+  injection guard is fine). Corrected in `emit_bump_commands`, the `--apply` exec, and the
+  named-refusal hint, and in AC5/Interfaces above. (2) **`--apply` honesty:** the CLI exits 0 with
+  "already at the latest version" for a version-current plugin whose sha differs (the accepted
+  over-report); the tool now classifies that as "already latest (no change)", not "applied" (AC6).
+  (3) **the lesson-fix:** `tests/fixtures/stub-claude` now mimics the real CLI contract , a bare
+  name (no `@`) returns "Plugin not found" + non-zero , so a regression to the bare form fails the
+  suite. New tests: AC5 full-id assertion, `STUB_ALREADY_LATEST` no-op classification (smoke now
+  27). (4) **version-primary stays REJECTED:** investigated again; the CLI exposes no upstream
+  VERSION (`list --available --json` `version: null`; only `source.ref` carries a tag; single-plugin
+  marketplaces have no catalog entry), so sha-primary remains and the over-report is documented,
+  with `--apply`'s already-latest handling making it harmless in practice.
+
+## Open questions
+
+(none material; surfacing choice is explicitly deferred to a follow-up, not v1.)

--- a/tools/plugin-check/tests/fixtures/installed_plugins.json
+++ b/tools/plugin-check/tests/fixtures/installed_plugins.json
@@ -1,0 +1,64 @@
+{
+  "version": 2,
+  "plugins": {
+    "ponytail@ponytail": [
+      {
+        "scope": "user",
+        "installPath": "/fixture/cache/ponytail/ponytail/4.7.0",
+        "version": "4.7.0",
+        "installedAt": "2026-06-20T03:58:29.566Z",
+        "lastUpdated": "2026-06-20T03:58:29.566Z",
+        "gitCommitSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ],
+    "superpowers@claude-plugins-official": [
+      {
+        "scope": "user",
+        "installPath": "/fixture/cache/claude-plugins-official/superpowers/6.0.3",
+        "version": "6.0.3",
+        "installedAt": "2026-04-20T09:09:03.875Z",
+        "lastUpdated": "2026-06-19T00:58:29.877Z",
+        "gitCommitSha": "1111111111111111111111111111111111111111"
+      }
+    ],
+    "playwright@claude-plugins-official": [
+      {
+        "scope": "user",
+        "installPath": "/fixture/cache/claude-plugins-official/playwright/unknown",
+        "version": "unknown",
+        "installedAt": "2026-04-20T09:08:44.303Z",
+        "lastUpdated": "2026-06-20T04:37:47.162Z",
+        "gitCommitSha": "5555555555555555555555555555555555555555"
+      }
+    ],
+    "swift-lsp@claude-plugins-official": [
+      {
+        "scope": "user",
+        "installPath": "/fixture/cache/claude-plugins-official/swift-lsp/1.0.0",
+        "version": "1.0.0",
+        "installedAt": "2026-05-15T17:12:07.998Z",
+        "lastUpdated": "2026-05-15T17:12:07.998Z"
+      }
+    ],
+    "kit@dwarves-marketplace": [
+      {
+        "scope": "user",
+        "installPath": "/fixture/cache/dwarves-marketplace/kit/1.6.0",
+        "version": "1.6.0",
+        "installedAt": "2026-06-01T12:00:35.241Z",
+        "lastUpdated": "2026-06-01T12:00:35.241Z",
+        "gitCommitSha": "3333333333333333333333333333333333333333"
+      }
+    ],
+    "evil; touch /tmp/SHOULD_NOT_EXIST $(touch /tmp/SHOULD_NOT_EXIST) `touch /tmp/SHOULD_NOT_EXIST`@claude-plugins-official": [
+      {
+        "scope": "user",
+        "installPath": "/fixture/cache/claude-plugins-official/evil/0.0.1",
+        "version": "0.0.1",
+        "installedAt": "2026-06-20T00:00:00.000Z",
+        "lastUpdated": "2026-06-20T00:00:00.000Z",
+        "gitCommitSha": "9999999999999999999999999999999999999999"
+      }
+    ]
+  }
+}

--- a/tools/plugin-check/tests/fixtures/known_marketplaces.template.json
+++ b/tools/plugin-check/tests/fixtures/known_marketplaces.template.json
@@ -1,0 +1,17 @@
+{
+  "claude-plugins-official": {
+    "source": { "source": "github", "repo": "anthropics/claude-plugins-official" },
+    "installLocation": "@OFFICIAL_CLONE@",
+    "lastUpdated": "2026-06-20T04:37:47.103Z"
+  },
+  "ponytail": {
+    "source": { "source": "github", "repo": "DietrichGebert/ponytail" },
+    "installLocation": "@PONYTAIL_CLONE@",
+    "lastUpdated": "2026-06-20T03:58:26.832Z"
+  },
+  "dwarves-marketplace": {
+    "source": { "source": "directory", "path": "@KIT_DIR@" },
+    "installLocation": "@KIT_DIR@",
+    "lastUpdated": "2026-05-22T08:11:47.014Z"
+  }
+}

--- a/tools/plugin-check/tests/fixtures/plugin-catalog-cache.json
+++ b/tools/plugin-check/tests/fixtures/plugin-catalog-cache.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "fetchedAt": "2026-06-20T11:00:00.000Z",
+  "catalog": {
+    "generated_at": "2026-06-20T11:00:00.000Z",
+    "marketplace_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "plugins": {
+      "superpowers@claude-plugins-official": {
+        "version": "6.1.0",
+        "sha": "2222222222222222222222222222222222222222",
+        "source_sha": "2222222222222222222222222222222222222222",
+        "source": "superpowers@claude-plugins-official",
+        "marketplace_entry": {
+          "name": "superpowers",
+          "source": {
+            "source": "url",
+            "url": "https://github.com/obra/superpowers.git",
+            "sha": "2222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "playwright@claude-plugins-official": {
+        "version": "1.0.0",
+        "sha": null,
+        "source_sha": "5555555555555555555555555555555555555555",
+        "source": "playwright@claude-plugins-official",
+        "marketplace_entry": {
+          "name": "playwright",
+          "source": "./plugins/playwright"
+        }
+      },
+      "swift-lsp@claude-plugins-official": {
+        "version": "1.0.0",
+        "sha": null,
+        "source_sha": "7777777777777777777777777777777777777777",
+        "source": "swift-lsp@claude-plugins-official",
+        "marketplace_entry": {
+          "name": "swift-lsp",
+          "source": "./plugins/swift-lsp"
+        }
+      },
+      "evil; touch /tmp/SHOULD_NOT_EXIST $(touch /tmp/SHOULD_NOT_EXIST) `touch /tmp/SHOULD_NOT_EXIST`@claude-plugins-official": {
+        "version": "0.0.2",
+        "sha": null,
+        "source_sha": "8888888888888888888888888888888888888888",
+        "source": "evil@claude-plugins-official",
+        "marketplace_entry": {
+          "name": "evil",
+          "source": "./plugins/evil"
+        }
+      }
+    }
+  }
+}

--- a/tools/plugin-check/tests/fixtures/roster.json
+++ b/tools/plugin-check/tests/fixtures/roster.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ponytail@ponytail",
+    "version": "4.7.0",
+    "scope": "user",
+    "enabled": true,
+    "installPath": "/fixture/cache/ponytail/ponytail/4.7.0",
+    "installedAt": "2026-06-20T03:58:29.566Z",
+    "lastUpdated": "2026-06-20T03:58:29.566Z"
+  },
+  {
+    "id": "superpowers@claude-plugins-official",
+    "version": "6.0.3",
+    "scope": "user",
+    "enabled": true,
+    "installPath": "/fixture/cache/claude-plugins-official/superpowers/6.0.3",
+    "installedAt": "2026-04-20T09:09:03.875Z",
+    "lastUpdated": "2026-06-19T00:58:29.877Z"
+  },
+  {
+    "id": "playwright@claude-plugins-official",
+    "version": "unknown",
+    "scope": "user",
+    "enabled": true,
+    "installPath": "/fixture/cache/claude-plugins-official/playwright/unknown",
+    "installedAt": "2026-04-20T09:08:44.303Z",
+    "lastUpdated": "2026-06-20T04:37:47.162Z"
+  },
+  {
+    "id": "swift-lsp@claude-plugins-official",
+    "version": "1.0.0",
+    "scope": "user",
+    "enabled": true,
+    "installPath": "/fixture/cache/claude-plugins-official/swift-lsp/1.0.0",
+    "installedAt": "2026-05-15T17:12:07.998Z",
+    "lastUpdated": "2026-05-15T17:12:07.998Z"
+  },
+  {
+    "id": "kit@dwarves-marketplace",
+    "version": "1.6.0",
+    "scope": "user",
+    "enabled": true,
+    "installPath": "/fixture/cache/dwarves-marketplace/kit/1.6.0",
+    "installedAt": "2026-06-01T12:00:35.241Z",
+    "lastUpdated": "2026-06-01T12:00:35.241Z"
+  },
+  {
+    "id": "evil; touch /tmp/SHOULD_NOT_EXIST $(touch /tmp/SHOULD_NOT_EXIST) `touch /tmp/SHOULD_NOT_EXIST`@claude-plugins-official",
+    "version": "0.0.1",
+    "scope": "user",
+    "enabled": true,
+    "installPath": "/fixture/cache/claude-plugins-official/evil/0.0.1",
+    "installedAt": "2026-06-20T00:00:00.000Z",
+    "lastUpdated": "2026-06-20T00:00:00.000Z"
+  }
+]

--- a/tools/plugin-check/tests/fixtures/stub-claude
+++ b/tools/plugin-check/tests/fixtures/stub-claude
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Hermetic stub for the `claude` CLI used by tests/smoke.sh.
+#
+# It answers ONLY the read-only / benign verbs cc-plugin-check legitimately calls:
+#   plugin --help                  -> exit 0 (the probe)
+#   plugin list --json             -> emit $STUB_ROSTER (the installed roster)
+#   plugin marketplace update [..] -> exit 0, UNLESS $STUB_REFRESH_FAIL=1 (AC4 offline sim)
+#
+# ANY OTHER verb , crucially `plugin update <x>` (the REAL updater) , is treated as an
+# UNEXPECTED verb: the stub touches $STUB_CANARY and exits non-zero. The suite asserts the
+# canary never appears, proving cc-plugin-check never shelled the real plugin updater
+# (AC9 autonomy gate, AC10 injection defense). It never reaches the network.
+set -euo pipefail
+
+canary() { : > "${STUB_CANARY:-/tmp/cc-plugin-check-stub-canary}"; }
+
+# Drop a leading "plugin"/"plugins" if present so we can match subverbs uniformly.
+if [ "${1:-}" = "plugin" ] || [ "${1:-}" = "plugins" ]; then
+  shift
+fi
+
+case "${1:-}" in
+  --help|-h|help)
+    echo "stub claude plugin help"
+    exit 0
+    ;;
+  list)
+    # Only the read-only JSON list is supported.
+    shift || true
+    want_json=0
+    for a in "$@"; do [ "$a" = "--json" ] && want_json=1; done
+    if [ "$want_json" = "1" ]; then
+      if [ -n "${STUB_ROSTER:-}" ] && [ -f "${STUB_ROSTER}" ]; then
+        cat "${STUB_ROSTER}"
+        exit 0
+      fi
+      echo "[]"
+      exit 0
+    fi
+    # A non-json list is not something the tool calls; treat as unexpected.
+    canary
+    echo "stub: unexpected 'plugin list' without --json" >&2
+    exit 3
+    ;;
+  marketplace)
+    shift || true
+    if [ "${1:-}" = "update" ]; then
+      if [ "${STUB_REFRESH_FAIL:-0}" = "1" ]; then
+        echo "stub: simulated marketplace update failure (offline)" >&2
+        exit 7
+      fi
+      exit 0
+    fi
+    canary
+    echo "stub: unexpected 'plugin marketplace ${1:-}'" >&2
+    exit 3
+    ;;
+  update)
+    # `update` is the real mutating verb. BY DEFAULT reaching it means the tool shelled the real
+    # updater -> canary so the test fails loudly (AC9 autonomy gate). In STUB_ALLOW_UPDATE mode the
+    # stub instead ACTS as a controllable updater so the apply/summary path (AC6) can be exercised:
+    # exit 0, or exit 1 when the target matches STUB_FAIL_PLUGIN. It is still the stub, never the
+    # real CLI; the autonomy story for the default suite ([13][17][18]) is unchanged.
+    if [ "${STUB_ALLOW_UPDATE:-0}" = "1" ]; then
+      shift || true
+      target=""
+      for a in "$@"; do [ "$a" = "--" ] && continue; target="$a"; done
+      # MIMIC THE REAL CLI's name contract: the update verb needs the full <plugin>@<marketplace>
+      # pluginId; a BARE name (no '@') is rejected as "Plugin not found". This is the regression
+      # guard for the bump-form bug (the old stub accepted any shape, so the bug shipped).
+      case "$target" in
+        *@*) : ;;
+        *) echo "Checking for updates for plugin \"$target\" at user scope…"; echo "✘ Failed to update plugin \"$target\": Plugin \"$target\" not found" >&2; exit 1 ;;
+      esac
+      target_name="${target%@*}"   # match STUB_* knobs on the name part, not the full id
+      if [ -n "${STUB_FAIL_PLUGIN:-}" ] && [ "$target_name" = "${STUB_FAIL_PLUGIN}" ]; then
+        echo "stub: simulated update FAILURE for $target" >&2
+        exit 1
+      fi
+      if [ -n "${STUB_ALREADY_LATEST:-}" ] && [ "$target_name" = "${STUB_ALREADY_LATEST}" ]; then
+        echo "✔ $target_name is already at the latest version."
+        exit 0
+      fi
+      echo "✔ Plugin \"$target_name\" updated. Restart to apply changes."
+      exit 0
+    fi
+    canary
+    echo "stub: FORBIDDEN verb reached: plugin update $*" >&2
+    exit 42
+    ;;
+  install|uninstall|remove|enable|disable|tag|prune|autoremove|init|new|validate|details)
+    # The other mutating verbs cc-plugin-check must never shell.
+    canary
+    echo "stub: FORBIDDEN verb reached: plugin ${1:-} $*" >&2
+    exit 42
+    ;;
+  *)
+    canary
+    echo "stub: unexpected verb: ${1:-} $*" >&2
+    exit 3
+    ;;
+esac

--- a/tools/plugin-check/tests/smoke.sh
+++ b/tools/plugin-check/tests/smoke.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# plugin-check smoke test. FULLY HERMETIC: a stub `claude` (tests/fixtures/stub-claude)
+# stands in for the real CLI and returns fixture JSON; the suite NEVER shells the real
+# `claude plugin ... update`. The stub touches a canary file on any forbidden/unexpected
+# verb (above all `plugin update`), and the suite asserts the canary never appears (AC9/AC10).
+#
+# State files (installed_plugins.json / plugin-catalog-cache.json / known_marketplaces.json)
+# are assembled into an ephemeral $CC_PLUGINS_DIR per run; a real micro-git-repo backs the
+# ponytail "current" case and the kit directory-source case so the sha compare is real, not
+# mocked.
+#
+# Run: bash tests/smoke.sh   Pass: "smoke: all N passed", exit 0. Fail: prints which, exit 1.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${DIR}/bin/plugin-check"
+FX="${DIR}/tests/fixtures"
+STUB="${FX}/stub-claude"
+
+pass=0; fail=0
+ok() { echo "  ok: $*"; pass=$((pass+1)); }
+no() { echo "  FAIL: $*" >&2; fail=$((fail+1)); }
+
+# --- build an ephemeral plugins dir + stub PATH ------------------------------
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/plugin-check-smoke.XXXXXX")"
+CANARY="${WORK}/CANARY-real-updater-was-shelled"
+STUBBIN="${WORK}/bin"; mkdir -p "$STUBBIN"
+# Put the stub on PATH AS `claude` too (defense: the tool defaults CLAUDE_BIN=claude).
+cp "$STUB" "$STUBBIN/claude"; chmod +x "$STUBBIN/claude"
+
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# ponytail upstream = a real micro git repo whose HEAD sha we pin into installed_plugins.
+PONYTAIL_CLONE="${WORK}/marketplaces/ponytail"
+mkdir -p "$PONYTAIL_CLONE"
+git -C "$PONYTAIL_CLONE" init -q
+git -C "$PONYTAIL_CLONE" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "ponytail head"
+PONYTAIL_HEAD="$(git -C "$PONYTAIL_CLONE" rev-parse HEAD)"
+
+# kit = a directory-source marketplace (a real git working tree, deliberately "ahead").
+KIT_DIR="${WORK}/dwarves-kit"
+mkdir -p "$KIT_DIR"
+git -C "$KIT_DIR" init -q
+git -C "$KIT_DIR" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "kit head"
+
+OFFICIAL_CLONE="${WORK}/marketplaces/claude-plugins-official"  # not-git on purpose (real one is not git)
+mkdir -p "$OFFICIAL_CLONE"
+
+CCDIR="${WORK}/plugins"; mkdir -p "$CCDIR"
+
+# installed_plugins: copy the fixture, but rewrite ponytail's installed sha to the real
+# PONYTAIL_HEAD so the clone-HEAD compare yields a provable "current".
+jq --arg head "$PONYTAIL_HEAD" '
+  .plugins["ponytail@ponytail"][0].gitCommitSha = $head
+' "${FX}/installed_plugins.json" > "${CCDIR}/installed_plugins.json"
+
+cp "${FX}/plugin-catalog-cache.json" "${CCDIR}/plugin-catalog-cache.json"
+
+# known_marketplaces: fill the @PLACEHOLDERS@ with the ephemeral clone paths.
+sed -e "s|@OFFICIAL_CLONE@|${OFFICIAL_CLONE}|g" \
+    -e "s|@PONYTAIL_CLONE@|${PONYTAIL_CLONE}|g" \
+    -e "s|@KIT_DIR@|${KIT_DIR}|g" \
+    "${FX}/known_marketplaces.template.json" > "${CCDIR}/known_marketplaces.json"
+
+# The environment every plugin-check invocation runs under.
+run() {
+  CC_PLUGINS_DIR="$CCDIR" \
+  CLAUDE_BIN="${STUBBIN}/claude" \
+  STUB_ROSTER="${FX}/roster.json" \
+  STUB_CANARY="$CANARY" \
+  PATH="${STUBBIN}:${PATH}" \
+  "$BIN" "$@"
+}
+
+echo "[setup] ponytail HEAD=${PONYTAIL_HEAD:0:9}  workdir=$WORK"
+
+# === status (refresh path: stub marketplace update succeeds) =================
+STATUS_OUT="$(run status 2>&1)" || true
+
+echo "[1] status: all 6 fixture plugins each appear with a STATUS (AC1)"
+n_rows=$(grep -Ec '(current|OUTDATED|unknown)[[:space:]]' <<<"$STATUS_OUT" || true)
+if grep -q 'ponytail' <<<"$STATUS_OUT" && grep -q 'superpowers' <<<"$STATUS_OUT" \
+   && grep -q 'playwright' <<<"$STATUS_OUT" && grep -q 'swift-lsp' <<<"$STATUS_OUT" \
+   && grep -q 'kit' <<<"$STATUS_OUT" && grep -q 'evil' <<<"$STATUS_OUT" \
+   && [ "${n_rows:-0}" -ge 6 ]; then ok "6 plugin rows present"; else no "status missing rows ($n_rows):
+$STATUS_OUT"; fi
+
+echo "[2] status: a claude-plugins-official plugin resolves to a real STATUS (multi-plugin path, AC1/AC2)"
+if grep -Eq 'superpowers[[:space:]]+6.0.3[[:space:]]+[0-9a-f]+[[:space:]]+OUTDATED[[:space:]]+claude-plugins-official' <<<"$STATUS_OUT"; then
+  ok "superpowers (official) resolved -> OUTDATED"; else no "official multi-plugin row wrong:
+$STATUS_OUT"; fi
+
+echo "[3] status: ponytail (single-plugin mp, clone HEAD == installed sha) shows current (AC2)"
+if grep -Eq 'ponytail[[:space:]].*[[:space:]]current[[:space:]]+ponytail' <<<"$STATUS_OUT"; then
+  ok "ponytail current (sha proven)"; else no "ponytail not current:
+$STATUS_OUT"; fi
+
+echo "[4] status (AC3 negative control): superpowers pinned-old in fixture -> OUTDATED"
+# (Single clean assertion. This control genuinely fails if the row regresses to current/unknown.)
+if grep -Eq 'superpowers[[:space:]].*OUTDATED' <<<"$STATUS_OUT"; then
+  ok "OUTDATED row present for pinned-old superpowers"; else no "AC3 OUTDATED missing:
+$STATUS_OUT"; fi
+
+echo "[5] status (AC8): sentinel-version playwright NEVER false-current from string-diff; sha governs"
+# playwright installed version is the sentinel 'unknown'; upstream source_sha == installed sha,
+# so it is legitimately current VIA SHA (not via comparing the string 'unknown' to '1.0.0').
+if grep -Eq 'playwright[[:space:]].*[[:space:]]current[[:space:]]' <<<"$STATUS_OUT" \
+   && ! grep -Eq 'playwright[[:space:]]+unknown[[:space:]]+1.0.0' <<<"$STATUS_OUT"; then
+  ok "playwright current via sha; sentinel version not string-compared"; else no "AC8 playwright wrong:
+$STATUS_OUT"; fi
+
+echo "[6] status (AC8 variant): swift-lsp has NO installed sha -> unknown, never false current"
+if grep -Eq 'swift-lsp[[:space:]].*[[:space:]]unknown[[:space:]]' <<<"$STATUS_OUT" \
+   && grep -q 'no installed sha' <<<"$STATUS_OUT"; then
+  ok "swift-lsp unknown (no installed sha)"; else no "swift-lsp should be unknown:
+$STATUS_OUT"; fi
+
+echo "[7] status: kit directory-source labelled dev-tree, no hard verdict (edge case)"
+if grep -Eq 'kit[[:space:]].*[[:space:]]unknown[[:space:]]' <<<"$STATUS_OUT" \
+   && grep -q 'dev tree, may be ahead' <<<"$STATUS_OUT"; then
+  ok "kit unknown + 'local (dev tree, may be ahead)'"; else no "kit dir-source label wrong:
+$STATUS_OUT"; fi
+
+echo "[8] status: exit 0 even though some rows are unknown/outdated"
+run status >/dev/null 2>&1 && rc=0 || rc=$?
+if [ "$rc" -eq 0 ]; then ok "status exit 0"; else no "status exit=$rc"; fi
+
+# === AC4: catalog-refresh failure (offline) -> unknown, never false-current ==
+echo "[9] status (AC4): refresh FAILS (offline sim) -> not-provably-current rows degrade to unknown"
+OFFLINE_OUT="$(CC_PLUGINS_DIR="$CCDIR" CLAUDE_BIN="${STUBBIN}/claude" STUB_ROSTER="${FX}/roster.json" \
+  STUB_CANARY="$CANARY" STUB_REFRESH_FAIL=1 PATH="${STUBBIN}:${PATH}" "$BIN" status 2>&1)" || true
+# ponytail matched the (now-unrefreshable) clone, so it must NOT be asserted current; it degrades.
+if grep -q 'catalog refresh FAILED' <<<"$OFFLINE_OUT" \
+   && grep -Eq 'ponytail[[:space:]].*[[:space:]]unknown[[:space:]]' <<<"$OFFLINE_OUT" \
+   && grep -q 'catalog stale' <<<"$OFFLINE_OUT"; then
+  ok "offline: ponytail downgraded to unknown (no false current)"; else no "AC4 offline wrong:
+$OFFLINE_OUT"; fi
+
+echo "[10] status --no-refresh: catalog treated stale -> ponytail unknown, exit 0 (AC4)"
+NR_OUT="$(run status --no-refresh 2>&1)" || true
+if grep -q 'catalog NOT refreshed' <<<"$NR_OUT" \
+   && grep -Eq 'ponytail[[:space:]].*[[:space:]]unknown[[:space:]]' <<<"$NR_OUT"; then
+  ok "--no-refresh degrades ponytail to unknown"; else no "AC4 --no-refresh wrong:
+$NR_OUT"; fi
+
+echo "[11] status --no-refresh: still NEVER prints 'current' for a sha-matched row off a stale catalog"
+if ! grep -Eq '[[:space:]]current[[:space:]]' <<<"$NR_OUT"; then
+  ok "no false 'current' on stale catalog"; else no "false current on stale catalog:
+$NR_OUT"; fi
+
+# === update dry-run (AC5/AC7): prints commands, runs NOTHING =================
+echo "[12] update <plugin> dry-run prints 'marketplace update -- <mp>' then 'update -- <plugin>@<mp>' (full pluginId, -- guard) + restart note (AC5)"
+UP_OUT="$(run update superpowers 2>&1)" || true
+if grep -q 'claude plugin marketplace update -- claude-plugins-official' <<<"$UP_OUT" \
+   && grep -Eq 'claude plugin update -- superpowers@claude-plugins-official$' <<<"$UP_OUT" \
+   && grep -qi 'restart' <<<"$UP_OUT"; then
+  ok "dry-run bump commands correct (full pluginId <plugin>@<mp>, -- guard, restart note)"; else no "AC5 dry-run wrong:
+$UP_OUT"; fi
+
+echo "[13] update dry-run mutated NOTHING: canary absent (AC5/AC7/AC9)"
+if [ ! -e "$CANARY" ]; then ok "no canary after dry-run (real updater never shelled)"; else no "CANARY created by dry-run!"; fi
+
+echo "[14] update dry-run state files unchanged on disk (AC7 read-only on installed state)"
+before="$(shasum "${CCDIR}/installed_plugins.json" | awk '{print $1}')"
+run update >/dev/null 2>&1 || true
+after="$(shasum "${CCDIR}/installed_plugins.json" | awk '{print $1}')"
+if [ "$before" = "$after" ]; then ok "installed_plugins.json untouched by update dry-run"; else no "update dry-run mutated state file"; fi
+
+# === AC10: injection-defense ================================================
+echo "[15] AC10: injection plugin name created NO side-effect file (/tmp/SHOULD_NOT_EXIST)"
+rm -f /tmp/SHOULD_NOT_EXIST
+run status >/dev/null 2>&1 || true
+run update >/dev/null 2>&1 || true
+# also exercise the dry-run that targets the evil row explicitly via the "all outdated" set
+if [ ! -e /tmp/SHOULD_NOT_EXIST ]; then ok "injection name ran no side effect"; else no "INJECTION FIRED: /tmp/SHOULD_NOT_EXIST exists"; rm -f /tmp/SHOULD_NOT_EXIST; fi
+
+echo "[16] AC10: injection name appears as a literal plugin row (handled as data, not flag/code)"
+if grep -q 'evil' <<<"$STATUS_OUT"; then ok "injection name shown as inert data row"; else no "injection row missing:
+$STATUS_OUT"; fi
+
+echo "[17] AC9: across ALL the above runs, the forbidden 'plugin update' verb was never reached (no canary)"
+if [ ! -e "$CANARY" ]; then ok "canary absent across full suite (autonomy gate held)"; else no "canary present: real updater WAS shelled"; fi
+
+# === AC6/AC9: --apply on an already-current plugin is a no-op (no real updater shelled) ==
+# This is the ONLY --apply path the suite exercises (the autonomy gate, AC9): ponytail is
+# provably current (clone HEAD == installed sha), so --apply must short-circuit to "skip:
+# already current" BEFORE shelling `plugin update`. If it shelled the updater, the stub
+# would canary. We refresh-success here (default stub) so ponytail is genuinely current.
+echo "[18] update ponytail --apply on a CURRENT plugin -> no-op 'already current', no canary (AC6/AC9)"
+rm -f "$CANARY"
+APPLY_OUT="$(run update ponytail --apply 2>&1)" && arc=0 || arc=$?
+if grep -qi 'already current' <<<"$APPLY_OUT" && [ ! -e "$CANARY" ] && [ "$arc" -eq 0 ]; then
+  ok "--apply no-op on current plugin (real updater never shelled)"; else no "AC6/AC9 no-op wrong (rc=$arc, canary=$([ -e "$CANARY" ] && echo YES || echo no)):
+$APPLY_OUT"; fi
+
+# === failure modes ==========================================================
+echo "[19] no plugins dir -> 'no plugins installed', exit 0"
+EMPTY="${WORK}/empty-home"; mkdir -p "$EMPTY"
+OUT="$(CC_PLUGINS_DIR="${EMPTY}/nope" CLAUDE_BIN="${STUBBIN}/claude" STUB_ROSTER="${FX}/roster.json" STUB_CANARY="$CANARY" PATH="${STUBBIN}:${PATH}" "$BIN" status 2>&1)" && rc=0 || rc=$?
+if grep -q 'no plugins installed' <<<"$OUT" && [ "$rc" -eq 0 ]; then ok "absent plugins dir handled, exit 0"; else no "absent dir wrong (rc=$rc): $OUT"; fi
+
+echo "[20] torn/invalid roster JSON -> 'state unreadable', exit 0 (not a jq trace)"
+BADROSTER="${WORK}/bad-roster.json"; printf '%s' '[{"id":"x@y","ver' > "$BADROSTER"
+OUT="$(CC_PLUGINS_DIR="$CCDIR" CLAUDE_BIN="${STUBBIN}/claude" STUB_ROSTER="$BADROSTER" STUB_CANARY="$CANARY" PATH="${STUBBIN}:${PATH}" "$BIN" status 2>&1)" && rc=0 || rc=$?
+if grep -q 'state unreadable' <<<"$OUT" && [ "$rc" -eq 0 ] && ! grep -qi 'jq: error' <<<"$OUT"; then
+  ok "torn JSON -> clean message, exit 0"; else no "torn-read wrong (rc=$rc): $OUT"; fi
+
+echo "[21] update <not-installed> -> clear error, exit non-zero"
+OUT="$(run update definitely-not-installed 2>&1)" && rc=0 || rc=$?
+if grep -q 'not installed' <<<"$OUT" && [ "$rc" -ne 0 ]; then ok "unknown plugin rejected (exit $rc)"; else no "unknown-plugin path wrong (rc=$rc): $OUT"; fi
+
+echo "[22] claude CLI absent -> prints intended commands, exit non-zero (never opaque shell error)"
+OUT="$(CC_PLUGINS_DIR="$CCDIR" CLAUDE_BIN="/nonexistent/claude-binary" PATH="/usr/bin:/bin" "$BIN" status 2>&1)" && rc=0 || rc=$?
+if grep -qi "claude.*not found" <<<"$OUT" && grep -q 'claude plugin marketplace update' <<<"$OUT" && [ "$rc" -ne 0 ]; then
+  ok "absent CLI -> intended commands + non-zero exit"; else no "absent-CLI path wrong (rc=$rc): $OUT"; fi
+
+# === AC6: --apply applies + summarizes (stub acts as a controllable updater) ==
+# These set STUB_ALLOW_UPDATE so the stub EMULATES the updater (exit 0, or 1 on STUB_FAIL_PLUGIN)
+# instead of canarying. It is still the stub, never the real CLI; the autonomy gate (AC9) stays
+# proven by the DEFAULT-stub runs above ([13][17][18], canary absent). superpowers is OUTDATED.
+echo "[23] update <outdated> --apply success -> 'applied' summary, exit 0, restart reminder (AC6)"
+A_OK="$(CC_PLUGINS_DIR="$CCDIR" CLAUDE_BIN="${STUBBIN}/claude" STUB_ROSTER="${FX}/roster.json" \
+  STUB_CANARY="$CANARY" STUB_ALLOW_UPDATE=1 PATH="${STUBBIN}:${PATH}" \
+  "$BIN" update superpowers --apply 2>&1)" && a_ok_rc=0 || a_ok_rc=$?
+if grep -Eq 'applied:.*superpowers' <<<"$A_OK" && grep -qi 'restart' <<<"$A_OK" && [ "$a_ok_rc" -eq 0 ]; then
+  ok "--apply success: applied summary + exit 0"; else no "AC6 applied-path wrong (rc=$a_ok_rc):
+$A_OK"; fi
+
+echo "[24] update <outdated> --apply failure -> 'failed' summary, exit non-zero (AC6 partial-failure)"
+A_BAD="$(CC_PLUGINS_DIR="$CCDIR" CLAUDE_BIN="${STUBBIN}/claude" STUB_ROSTER="${FX}/roster.json" \
+  STUB_CANARY="$CANARY" STUB_ALLOW_UPDATE=1 STUB_FAIL_PLUGIN=superpowers PATH="${STUBBIN}:${PATH}" \
+  "$BIN" update superpowers --apply 2>&1)" && a_bad_rc=0 || a_bad_rc=$?
+if grep -Eq 'failed:.*superpowers' <<<"$A_BAD" && [ "$a_bad_rc" -ne 0 ]; then
+  ok "--apply failure: failed summary + exit non-zero"; else no "AC6 failed-path wrong (rc=$a_bad_rc):
+$A_BAD"; fi
+
+echo "[25] named update <unknown/dir> --apply is REFUSED, real updater never shelled (verdict gate)"
+rm -f "$CANARY"
+G_OUT="$(run update kit --apply 2>&1)" && g_rc=0 || g_rc=$?
+if grep -qi 'refusing to --apply' <<<"$G_OUT" && [ ! -e "$CANARY" ] && [ "$g_rc" -ne 0 ]; then
+  ok "named --apply on a dev-tree/unknown row refused, no canary, exit $g_rc"; else no "named-apply gate wrong (rc=$g_rc, canary=$([ -e "$CANARY" ] && echo YES || echo no)):
+$G_OUT"; fi
+
+echo "[26] AC10: dry-run bump command for the hostile 'evil' row is paste-safe (-- guard + shell-quoted)"
+EVIL_DRY="$(run update 2>&1)" || true   # 'all outdated' dry-run; evil is OUTDATED so its cmd is emitted
+EVIL_CMD_LINES="$(grep -E '^[[:space:]]*claude plugin (update|marketplace update) ' <<<"$EVIL_DRY" || true)"
+# the emitted command lines must carry the -- guard and must NOT contain the raw injection payload.
+# shellcheck disable=SC2016  # the single-quoted '$(touch' is an intentional literal for grep -F
+if grep -qF 'plugin update -- ' <<<"$EVIL_CMD_LINES" \
+   && ! grep -qF '; touch /tmp/SHOULD_NOT_EXIST' <<<"$EVIL_CMD_LINES" \
+   && ! grep -qF '$(touch' <<<"$EVIL_CMD_LINES"; then
+  ok "dry-run bump commands paste-safe (-- guard present, metachars quoted)"; else no "AC10 paste-safety wrong:
+$EVIL_CMD_LINES"; fi
+
+echo "[27] update <outdated> --apply on an already-latest plugin -> 'already latest' no-op, NOT 'applied', exit 0"
+# the CLI exits 0 with 'already at the latest version' for a version-current plugin whose sha
+# differs (the accepted over-report); the tool must classify that as a no-op, not a real apply.
+AL_OUT="$(CC_PLUGINS_DIR="$CCDIR" CLAUDE_BIN="${STUBBIN}/claude" STUB_ROSTER="${FX}/roster.json" \
+  STUB_CANARY="$CANARY" STUB_ALLOW_UPDATE=1 STUB_ALREADY_LATEST=superpowers PATH="${STUBBIN}:${PATH}" \
+  "$BIN" update superpowers --apply 2>&1)" && al_rc=0 || al_rc=$?
+if grep -qi 'already latest' <<<"$AL_OUT" && ! grep -Eq 'applied:.*superpowers' <<<"$AL_OUT" && [ "$al_rc" -eq 0 ]; then
+  ok "--apply already-latest reported as no-op (not 'applied'), exit 0"; else no "already-latest classification wrong (rc=$al_rc):
+$AL_OUT"; fi
+
+echo
+if [[ $fail -gt 0 ]]; then echo "smoke: $pass passed, $fail FAILED" >&2; exit 1; fi
+echo "smoke: all $pass passed"

--- a/tools/plugin-check/tool.toml
+++ b/tools/plugin-check/tool.toml
@@ -1,5 +1,5 @@
 name        = "plugin-check"
-description = "Which adopted Claude Code plugins are outdated, in one glance. Read-only freshness lens over every adopted CC plugin (single-plugin marketplaces, the local directory marketplace, and the big claude-plugins-official); compares installed commit sha against upstream and prints the exact bump command for each stale one. Resolution is delegated to the official `claude plugin` CLI + the state files it owns (no gh)."
+summary     = "Which adopted Claude Code plugins are outdated, in one glance. Read-only freshness lens over every adopted CC plugin (single-plugin marketplaces, the local directory marketplace, and the big claude-plugins-official); compares installed commit sha against upstream and prints the exact bump command for each stale one. Resolution is delegated to the official `claude plugin` CLI + the state files it owns (no gh)."
 language    = "bash"
 status      = "active"
 entry       = "bin/plugin-check"

--- a/tools/plugin-check/tool.toml
+++ b/tools/plugin-check/tool.toml
@@ -1,0 +1,26 @@
+name        = "plugin-check"
+description = "Which adopted Claude Code plugins are outdated, in one glance. Read-only freshness lens over every adopted CC plugin (single-plugin marketplaces, the local directory marketplace, and the big claude-plugins-official); compares installed commit sha against upstream and prints the exact bump command for each stale one. Resolution is delegated to the official `claude plugin` CLI + the state files it owns (no gh)."
+language    = "bash"
+status      = "active"
+entry       = "bin/plugin-check"
+created     = 2026-06-20
+
+# Migrated into dwarves-kit (kit-foldin SG-05, 2026-07-05): this tool moved here verbatim
+# from ops-toolkit/tools/cc-plugin-check/ (kit-foldin design note, per-tool disposition
+# table). Renamed cc-plugin-check -> plugin-check per the kit naming rule (drop the
+# host-agent prefix on entry; the object here is CC's own plugin state, not a session).
+# No functional change: same verdict logic, same CLI surface, same test suite (27/27
+# pass unmodified in the new location). The ops-toolkit copy retires in the paired
+# batched retire sweep (SG-07).
+#
+# No plugin-check-specific tenant config exists to make opt-in: CC_PLUGINS_DIR already
+# defaulted to $HOME/.claude/plugins (the standard per-user Claude Code plugin dir, not an
+# ops-toolkit path), so there was no hardcoded ops-toolkit path to replace.
+consumers   = []
+
+systems     = ["claude-code"]
+
+# Read-only over CC's own plugin state; no credentials of any kind.
+secrets     = []
+
+depends_on  = []


### PR DESCRIPTION
Move cc-plugin-check to `tools/plugin-check` (drop `cc-`); path becomes opt-in.

Straight port of a 268-LOC generic freshness-check CLI (which adopted Claude Code plugins are outdated, in one glance), no new logic. Renamed `cc-plugin-check` -> `plugin-check` per the kit naming rule (named by function, not host-agent). Verdict logic, comparison rules, table format, CLI surface, and the 27-assertion hermetic test suite are unchanged.

The plugin-state dir was already opt-in before the move: `CC_PLUGINS_DIR` defaults to `$HOME/.claude/plugins` (the standard per-user CC plugin dir, not an ops-toolkit path), so there was no hardcoded ops path in the executable to replace. Two doc-only mentions of the ops-toolkit workspace path were generalized so the whole moved subtree is grep-clean.

## Verify: run-table over fresh + stale fixture plugin dirs

| Command | Fixture | Expected | Result |
|---|---|---|---|
| `bin/plugin-check status` (ponytail row) | installed sha == marketplace clone HEAD (real git repo) | `current` | PASS (smoke [3]) |
| `bin/plugin-check status` (superpowers row) | catalog `source_sha` differs from installed sha | `OUTDATED` (named NC) | PASS (smoke [4]) |

Both verdicts come from the same fixture set and the same `status` invocation. Negative control: disabling the `OUTDATED` verdict branch flips the stale assertion to RED (`smoke: 23 passed, 4 FAILED`); restoring returns 27/27.

Done gate: `grep -rn 'workspace/tieubao' tools/plugin-check/` is empty.

Proof: `docs/proof/kit-foldin-plugin-check.md` + kit-gate `docs/verification/kit-foldin-05-plugin-check.md`.

ops-toolkit's copy retires in the paired batched sweep (SG-07).

ROADMAP: `ops-toolkit/_meta/megagoals/kit-foldin/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
