### PR TITLE
fix(docs): drop tenant paths from kit MANUAL + README

### DIFF
--- a/tools/session-observe/README.md
+++ b/tools/session-observe/README.md
@@ -39,7 +39,7 @@ It feeds a windowed, capped sample of recent user prompts to Claude Haiku (`clau
 Scope to one project (note the **equals form**, slugs start with `-`):
 
 ```bash
-cc-observe hooks --project=-Users-tieubao-workspace-tieubao-ops-toolkit --days 7
+cc-observe hooks --project=<project-slug> --days 7
 ```
 
 ## What it reads

--- a/tools/skill-curator/MANUAL.md
+++ b/tools/skill-curator/MANUAL.md
@@ -101,7 +101,7 @@ wins** over the file. Tests use the env path; you will normally edit the file.
 | `CC_SI_STATE_DIR` | `~/.claude/skill-curator` | ledger + lock + config + reports |
 | `CC_SI_PROPOSALS_DIR` | `~/.claude/skill-proposals` | the staging gate |
 | `CC_SI_SKILLS_DIR` | `~/.claude/skills` | the live library + `_archive/` |
-| `CC_SI_MEMORY_LEDGER` | ops-toolkit `_meta/learned-ledger.md` | cc-harvest ledger the surface line counts |
+| `CC_SI_MEMORY_LEDGER` | (unset; required) | the harvest ledger the surface line counts |
 | `CC_SI_SETTINGS` | `~/.claude/settings.json` | install/uninstall target (point elsewhere for a dry run) |
 | `CC_SI_REVIEWER_CMD` / `CC_SI_CURATOR_CMD` | (unset) | test seam: replace the `claude -p` call with a mock |
 


### PR DESCRIPTION
Two kit doc files still carried ops-toolkit tenant paths after the kit-foldin fold-in (caught by the convergence advisor pass; the dash-slug form evaded the sub-goal `workspace/tieubao` greps):

- `tools/skill-curator/MANUAL.md` documented `CC_SI_MEMORY_LEDGER`'s default as the ops-toolkit `_meta/learned-ledger.md` path, but SG-04 flipped it to required-explicit (unset → clean error). Cell now reads `(unset; required)`.
- `tools/session-observe/README.md` usage example hardcoded a personal project slug → `<project-slug>`.

Keeps the no-tenant-path-in-kit invariant. Doc-only; no code paths touched.
