### PR TITLE
Layered install: spine + opt-in modules via kit.toml manifest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Run meta integrity tests
         run: bash tests/test-meta.sh
+
+      - name: Run layered-install module tests (ID-277 SG-04)
+        run: bash tests/test-install-modules.sh
       - name: Golden run (e2e)
         run: bash tests/test-e2e.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ HANDOFF*.md
 # Python bytecode caches (e.g. lib/handoff/__pycache__) , regenerated, never tracked.
 __pycache__/
 *.pyc
+
+# install.sh's per-consumer module manifest (ID-277 SG-04). Only meaningful at an
+# INSTALLED destination; an in-place install (KIT_DIR == ~/.claude/dwarves-kit) writes
+# it at the repo root, so it must never be committed from a maintainer's own machine.
+/kit.toml

--- a/docs/proof/kitmod-install-wire.md
+++ b/docs/proof/kitmod-install-wire.md
@@ -1,0 +1,136 @@
+# Proof of done: kit-modularity sub-goal 04 (install-wire)
+
+Layers `install.sh`: the SDD spine wires unconditionally; every other hook belongs to an
+opt-in module, wired only via `install.sh --with <a,b,c>` and recorded in a `kit.toml
+[modules]` manifest. A re-run is additive (never un-wires a hook a prior run, or an old
+all-hooks install, already wired); `--prune --with <modules>` is the explicit trim path. A
+reserved `team_mode` slot exists and is not installable. Executes Decision B (+ the
+`team_mode` reservation of Decision C) from `ops-toolkit/_meta/megagoals/kit-modularity/
+research/2026-07-05-kit-modularity-design.md`.
+
+## Acceptance criteria
+
+1. A spine-only temp-HOME install (`bash install.sh`, no flags) wires ONLY the 6 spine
+   hooks; grepping the installed `settings.json` shows zero optional-module hooks.
+2. `install.sh --with board,stats` wires exactly those modules' hooks (spine + board's
+   `backlog-stage.sh`; `stats` is hookless) and records `board = true`, `stats = true` in
+   `kit.toml [modules]`; a bare re-run (no `--with`) reproduces the identical wired set
+   from the manifest.
+3. An un-opted-in module's hook (cosmetic/session/advisor) never reaches `settings.json`.
+4. `kit.toml [modules]` always carries `team_mode = false`; `--with team_mode` is a clean,
+   non-zero-exit error (reserved, not installable; Decision C).
+5. An unknown module name (`--with bogus`) is a clean, non-zero-exit error naming the
+   unknown module, not a silent no-op.
+6. Existing-consumer migration is additive: re-running `install.sh` on a consumer with an
+   OLD all-hooks install (no `kit.toml` yet) drops nothing; `--prune --with <modules>` is
+   the only path that trims a previously-wired hook.
+7. Post-install smoke: every hook that IS wired runs cleanly (exit 0) on a no-op event.
+8. Standing anti-drift lint: no file under `hooks/` reads `kit.toml` at runtime (the
+   manifest is a shell-install record, never a runtime feature-registry).
+9. Coverage-delta: every module named in the manifest maps to a real installable unit
+   (an existing hook file, or a documented hookless command/skill/lib subsystem).
+10. Full kit test suite stays green before and after (no regression from the layering).
+
+## The spine/optional split (reconciled against the real tree)
+
+Read `install.sh`, `hooks/hooks.json`, `settings.json`, and every `hooks/*.sh` header
+comment before classifying (not the design note's provisional names). Result:
+
+**Spine (always wired, never gated):** `safety-gate.sh`, `ship-gate.sh`,
+`spec-drift-guard.sh`, `secrets-guard.sh`, `commit-format.sh`, `anti-rationalization.sh`.
+Essential per Decision B (`spec`/`execute`/`review`/`ship` + `gate-ledger`/`ship-gate` +
+`lane-classify`/`proof-gate` + core verifiers); the four PreToolUse gates plus the Stop-hook
+that catches false-completion rationalizing are the kit's non-negotiable floor. `lib/`
+essentials (`lane-classify.sh`, `proof-ledger.sh`, `gate-ledger.sh`, the verifier agents)
+are not hooks and are unaffected by module gating; they are always deployed.
+
+**Optional modules (opt-in via `--with`), hook-bearing:**
+
+| Module | Hook(s) gated | Rationale |
+|---|---|---|
+| `board` | `backlog-stage.sh` | Files backlog items; board-adjacent (kit-foldin `cc-backlog` port). |
+| `session` | `context-readiness.sh`, `output-offload.sh`, `pre-compact-backup.sh`, `post-compact-reinject.sh`, `session-state-save.sh`, `harvest.sh`, `citation-guard.sh` | Session lifecycle/continuity + kit-foldin absorptions (`cc-harvest`, `cc-citation-guard`) grouped by their PreCompact/SessionStart/Stop/SubagentStop firing points. |
+| `advisor` | `context-hints.sh` | Skill-trigger over-suggestion (kit-foldin `cc-context-hooks` port); matches Decision B's "advisor over-suggest". |
+| `cosmetic` | `auto-format.sh`, `notification.sh`, `slop-cleaner.sh`, `statusline.sh` (+ the `statusLine` config key), `codebase-index.sh`, `permission-auto-approve.sh` | Named cosmetic in Decision B (`slop-cleaner`/`statusline`/`notification`/`auto-format`/`codebase-index`); `permission-auto-approve` added to this bucket as a judgment call (a convenience hook not explicitly named either way in the design note). |
+
+**Optional modules, hookless (no `settings.json` entry to gate; still valid `--with` names,
+recorded in the manifest for discovery/consistency):** `queue` (`lib/queue/`,
+`dispatch`/`orchestrate`), `stats` (`lib/stats/`, the read-plane projection command),
+`quiz_gate` (`commands/quiz-gate.md`), `weekend_batch` (the weekend-debt-paydown flow),
+`bridge` (the board-writeback `bridge=on` per-project flag `lib/board/board.sh` already
+generalizes).
+
+**Reserved, not installable:** `team_mode`, always `false` in the manifest;
+`--with team_mode` errors cleanly (Decision C: attestation-not-sync design exists, tripwire
+to unpark has not fired).
+
+## Non-obvious judgment calls (flagged for DECISIONS.md)
+
+- `session` bundles two DIFFERENT things under one name: the continuity/harvest HOOKS
+  (`context-readiness`, `output-offload`, `pre-compact-backup`, `post-compact-reinject`,
+  `session-state-save`, `harvest`, `citation-guard`) vs. the `lib/session/` SUBSYSTEM
+  (`session-observe`/`session-recall`/`session-intel`, the folded former `cc-observe`/
+  `recall`/`intel` commands from SG-01). The lib subsystem has no hook to gate (it's a
+  pull command), so it stays always-installed regardless of the `session` module toggle;
+  only the hook set is gated. This is a defensible but non-obvious split worth naming.
+- `permission-auto-approve.sh` and `citation-guard.sh` are not explicitly named in the
+  design note's cosmetic/session lists; placed by inferred intent (permission-auto-approve
+  -> `cosmetic`/convenience; citation-guard -> `session`, grouped with the other kit-foldin
+  Stop/PreCompact absorptions) rather than a stated decision.
+- `commit-format.sh` and `anti-rationalization.sh` are classified SPINE despite not being
+  explicitly named essential in Decision B's list (which named `spec`/`execute`/`review`/
+  `ship` + gates + verifiers, not individual hook files). Reasoning: commit-format enforces
+  the `ship` discipline (conventional-commit hygiene at the push boundary) and
+  anti-rationalization enforces the `review`/honesty discipline (catching false-completion
+  claims), both are floor-level SDD behaviors, not conveniences, so they ride with the
+  four PreToolUse gates rather than becoming opt-in.
+
+## Confirmation run-table
+
+| # | Check | Command | Result |
+|---|---|---|---|
+| 1 | Spine-only wires only 6 spine hooks | `HOME=$(mktemp -d) bash install.sh` then grep installed `settings.json` | PASS, exactly `anti-rationalization,commit-format,safety-gate,secrets-guard,ship-gate,spec-drift-guard.sh`, zero extra |
+| 2 | `--with board,stats` wires exactly those + manifest | `HOME=... bash install.sh --with board,stats` | PASS, spine + `backlog-stage.sh`; `kit.toml` records `board=true stats=true`, rest `false` |
+| 2b | Re-run reproduces | `HOME=... bash install.sh` (no flags, same HOME) | PASS, identical wired set to run above |
+| 3 | Un-opted-hook-absent | grep installed `settings.json` for the 14 cosmetic/session/advisor hook basenames | PASS, 0 matches |
+| 4 | `team_mode` reserved | `bash install.sh --with team_mode` | PASS, exit 1, "reserved" in stderr, no settings.json written |
+| 5 | Unknown module | `bash install.sh --with bogus-module` | PASS, exit 1, names `bogus-module`, no settings.json written |
+| 6 | Additive migration | seed settings.json = full kit settings.json (simulated old all-hooks install), then `bash install.sh` (no flags) | PASS, all 20 previously-wired hooks still present, 0 dropped |
+| 6b | `--prune` explicit trim | same seed, then `bash install.sh --prune --with board` | PASS, trims to spine + board only |
+| 7 | Post-install smoke | install `--with` all 9 modules; `echo '{}' \| bash <hook>` for all 21 wired hooks, from a throwaway git repo | PASS, 21/21 exit 0 |
+| 8 | Anti-drift lint | `grep -rl kit.toml hooks/` | PASS, empty |
+| 9 | Coverage-delta | every module maps to a real hook file or documented lib/command unit | PASS, 0 missing |
+| 10 | Full suite before/after | `tests/test-hooks.sh` (452/452), `tests/test-meta.sh` (679/679), `tests/test-install-contract.sh` (3/3), `tests/test-install-compat.sh` (7/7), `tests/test-kit-foldin-hooks.sh` (49/49, updated for `--with`), `tests/test-adopt.sh` (12/12), `tests/test-e2e.sh` (20/20) | PASS, all green; test files unchanged except `test-kit-foldin-hooks.sh`'s install call, which now passes `--with board,session,advisor` since those hooks moved from always-wired to opt-in |
+
+New test file: `tests/test-install-modules.sh` (21 assertions covering checks 1-9 above),
+wired into CI (`.github/workflows/test.yml`).
+
+## Run detail
+
+```
+$ HOME=$(mktemp -d) bash install.sh
+...
+[ok] Wrote module manifest: .../dwarves-kit/kit.toml
+[ok] Enabled modules: <spine-only>
+$ jq -r '[.hooks[]?[]?.hooks[]?.command]|.[]' $HOME/.claude/settings.json | grep -oE 'hooks/[a-z-]+\.sh' | sort -u
+hooks/anti-rationalization.sh
+hooks/commit-format.sh
+hooks/safety-gate.sh
+hooks/secrets-guard.sh
+hooks/ship-gate.sh
+hooks/spec-drift-guard.sh
+
+$ bash tests/test-install-modules.sh
+...
+== 21 passed, 0 failed ==
+```
+
+## Reproduce
+
+```
+cd dwarves-kit
+bash tests/test-install-modules.sh
+bash tests/test-hooks.sh && bash tests/test-meta.sh
+bash tests/test-install-contract.sh && bash tests/test-install-compat.sh
+bash tests/test-kit-foldin-hooks.sh && bash tests/test-adopt.sh && bash tests/test-e2e.sh
+```

--- a/docs/verification/kitmod-install-wire.md
+++ b/docs/verification/kitmod-install-wire.md
@@ -1,0 +1,32 @@
+# Verification: kitmod-install-wire (kit-modularity SG-04, ID-277)
+
+Flat back-compat pointer for the ship-gate (`docs/verification/.+\.md`). Canonical proof:
+`docs/proof/kitmod-install-wire.md`.
+
+## Summary
+
+`install.sh` is layered: the SDD spine (`safety-gate`, `ship-gate`, `spec-drift-guard`,
+`secrets-guard`, `commit-format`, `anti-rationalization`) wires unconditionally; every
+other hook belongs to an opt-in module (`board`, `session`, `advisor`, `cosmetic`, plus the
+hookless `queue`/`stats`/`quiz_gate`/`weekend_batch`/`bridge`), wired only via
+`--with <a,b,c>` and recorded in a `kit.toml [modules]` manifest. A re-run is additive
+(never un-wires a previously-wired hook); `--prune --with <modules>` is the explicit trim.
+A reserved `team_mode = false` slot exists and is not installable.
+
+## Verification run
+
+```
+$ bash tests/test-install-modules.sh
+== 21 passed, 0 failed ==
+
+$ bash tests/test-hooks.sh   # 452/452
+$ bash tests/test-meta.sh    # 679/679
+$ bash tests/test-install-contract.sh   # 3/3
+$ bash tests/test-install-compat.sh     # 7/7
+$ bash tests/test-kit-foldin-hooks.sh   # 49/49 (updated for --with)
+$ bash tests/test-adopt.sh              # 12/12
+$ bash tests/test-e2e.sh                # 20/20
+```
+
+All green. Anti-drift lint (`grep -rl kit.toml hooks/`) confirmed empty: no hook reads the
+manifest at runtime.

--- a/docs/verification/kitmod-install-wire.md
+++ b/docs/verification/kitmod-install-wire.md
@@ -13,20 +13,55 @@ hookless `queue`/`stats`/`quiz_gate`/`weekend_batch`/`bridge`), wired only via
 (never un-wires a previously-wired hook); `--prune --with <modules>` is the explicit trim.
 A reserved `team_mode = false` slot exists and is not installable.
 
-## Verification run
+## Green run
+
+Command: `bash tests/test-install-modules.sh`
+Exit: 0
+Output: `== 21 passed, 0 failed ==`
+Verdict: PASS
+
+Command: `bash tests/test-hooks.sh`
+Exit: 0
+Output: `Passed: 452 / 452`
+Verdict: PASS
+
+Command: `bash tests/test-meta.sh`
+Exit: 0
+Output: `Passed: 679 / 679`
+Verdict: PASS
+
+Command: `bash tests/test-install-contract.sh` / `test-install-compat.sh` / `test-kit-foldin-hooks.sh` (updated for `--with`) / `test-adopt.sh` / `test-e2e.sh`
+Exit: 0 / 0 / 0 / 0 / 0
+Output: `3/3` / `7/7` / `49/49` / `12/12` / `20/20`
+Verdict: PASS
+
+Command: `grep -rl kit.toml hooks/` (standing anti-drift lint: no hook reads the manifest at runtime)
+Exit: 1 (grep found nothing)
+Output: (empty)
+Verdict: PASS
+
+## NEGATIVE CONTROL
+
+Reverted `install.sh` to its pre-SG-04 (parent commit) content, re-ran, restored:
 
 ```
+$ command cp -f /tmp/install.sh.pre install.sh   # revert to the all-hooks installer
+$ HOME=$(mktemp -d) bash install.sh
+$ jq -r '[.hooks[]?[]?.hooks[]?.command]|.[]' $HOME/.claude/settings.json \
+    | grep -oE 'hooks/[A-Za-z0-9._-]+\.sh' | sort -u | wc -l
+20                                                # RED: all 20 hooks wired, no layering
+
 $ bash tests/test-install-modules.sh
-== 21 passed, 0 failed ==
+...
+== 6 passed, 15 failed ==                         # RED: 15/21 NCs fail without the layering
 
-$ bash tests/test-hooks.sh   # 452/452
-$ bash tests/test-meta.sh    # 679/679
-$ bash tests/test-install-contract.sh   # 3/3
-$ bash tests/test-install-compat.sh     # 7/7
-$ bash tests/test-kit-foldin-hooks.sh   # 49/49 (updated for --with)
-$ bash tests/test-adopt.sh              # 12/12
-$ bash tests/test-e2e.sh                # 20/20
+$ command cp -f /tmp/install.sh.new install.sh    # restore
+$ git diff --stat install.sh
+(empty)                                           # byte-identical to the committed version
+$ bash tests/test-install-modules.sh
+...
+== 21 passed, 0 failed ==                         # GREEN again
 ```
 
-All green. Anti-drift lint (`grep -rl kit.toml hooks/`) confirmed empty: no hook reads the
-manifest at runtime.
+Verdict: PASS (negative control confirms the layering is load-bearing, not a no-op: without
+it, every optional hook wires unconditionally and 15 of the 21 new NCs fail).

--- a/install.sh
+++ b/install.sh
@@ -606,7 +606,15 @@ esac
 echo ""
 echo "=== Verification ==="
 echo "Modules: spine (always on) + ${KIT_ENABLED_MODULES:-<none opted in>}"
-echo "  Not enabled: $(for m in $KIT_KNOWN_MODULES; do case " $KIT_ENABLED_MODULES " in *" $m "*) ;; *) printf '%s ' "$m" ;; esac; done) team_mode(reserved)"
+KIT_NOT_ENABLED=""
+for _mod in $KIT_KNOWN_MODULES; do
+  case " $KIT_ENABLED_MODULES " in
+    *" $_mod "*) : ;;
+    *) KIT_NOT_ENABLED="$KIT_NOT_ENABLED $_mod" ;;
+  esac
+done
+unset _mod
+echo "  Not enabled:${KIT_NOT_ENABLED} team_mode(reserved)"
 echo "  --with <modules> to opt in, --prune --with <modules> to trim, kit.toml: $KIT_TOML"
 echo "Hooks wired into settings.json:"
 printf '%s\n' $KIT_ENABLED_HOOK_NAMES | sort -u | while read -r h; do [ -n "$h" ] && echo "  [hook] $h"; done

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,12 @@
 #
 # v1.1: Fixed jq merge (concat arrays, don't deduplicate by matcher).
 # Added --uninstall flag. Backs up settings.json before modifying.
+#
+# v1.2 (ID-277 SG-04): layered install. The spine (safety-gate, ship-gate,
+# spec-drift-guard, secrets-guard, commit-format, anti-rationalization) is always
+# wired; everything else is an opt-in module via `--with <a,b,c>`, recorded in a
+# `kit.toml [modules]` manifest. A re-run is additive (never un-wires a previously
+# wired hook); `--prune --with <modules>` is the explicit trim path.
 
 set -euo pipefail
 
@@ -126,6 +132,12 @@ if [ "${1:-}" = "--uninstall" ]; then
     fi
   fi
 
+  # Remove the module manifest (ID-277 SG-04); it is meaningless without an install.
+  if [ -f "$CLAUDE_DIR/dwarves-kit/kit.toml" ]; then
+    rm "$CLAUDE_DIR/dwarves-kit/kit.toml"
+    echo "[ok] Removed module manifest: kit.toml"
+  fi
+
   echo ""
   echo "=== Uninstall complete ==="
   echo "Kit directory ($KIT_DIR) was NOT removed. Delete it manually if desired:"
@@ -139,6 +151,73 @@ fi
 echo "=== dwarves-kit installer ==="
 echo "Kit location: $KIT_DIR"
 echo ""
+
+# --- Layered install: spine + opt-in modules (Decision B, ID-277 SG-04) --
+# The core spine (safety-gate, ship-gate, spec-drift-guard, secrets-guard,
+# commit-format, anti-rationalization) is ALWAYS wired. Everything else is an
+# optional module, wired only when named via `--with <a,b,c>`. A `kit.toml
+# [modules]` manifest RECORDS the enabled set (for `--with`-less re-installs
+# and future discovery) -- it is a shell-install RECORD, never a runtime
+# feature-registry: no hook reads it (see tests/test-no-runtime-manifest-read.sh).
+KIT_KNOWN_MODULES="board session advisor cosmetic queue stats quiz_gate weekend_batch bridge"
+KIT_SPINE_HOOKS="safety-gate.sh ship-gate.sh spec-drift-guard.sh secrets-guard.sh commit-format.sh anti-rationalization.sh"
+
+# module -> its hook script basenames (space-separated; empty = hookless, e.g.
+# queue/stats/quiz_gate/weekend_batch/bridge are commands/skills with no hook to
+# gate -- still valid --with names, recorded in the manifest for discovery).
+kit_module_hooks() {
+  case "$1" in
+    board) echo "backlog-stage.sh" ;;
+    session) echo "context-readiness.sh output-offload.sh pre-compact-backup.sh post-compact-reinject.sh session-state-save.sh harvest.sh citation-guard.sh" ;;
+    advisor) echo "context-hints.sh" ;;
+    cosmetic) echo "auto-format.sh notification.sh slop-cleaner.sh statusline.sh codebase-index.sh permission-auto-approve.sh" ;;
+    *) echo "" ;;
+  esac
+}
+
+KIT_WITH_ARG=""
+KIT_PRUNE=0
+KIT_ARGS=("$@")
+_i=0
+while [ $_i -lt ${#KIT_ARGS[@]} ]; do
+  case "${KIT_ARGS[$_i]}" in
+    --with)
+      _i=$((_i + 1))
+      KIT_WITH_ARG="${KIT_ARGS[$_i]:-}"
+      ;;
+    --with=*)
+      KIT_WITH_ARG="${KIT_ARGS[$_i]#--with=}"
+      ;;
+    --prune)
+      KIT_PRUNE=1
+      ;;
+  esac
+  _i=$((_i + 1))
+done
+unset _i
+
+# Validate + normalize the requested module list (clean error on unknown/reserved).
+KIT_REQUESTED_MODULES=""
+if [ -n "$KIT_WITH_ARG" ]; then
+  IFS=',' read -ra _KIT_REQ <<< "$KIT_WITH_ARG"
+  for _m in "${_KIT_REQ[@]}"; do
+    _m="$(echo "$_m" | xargs)"
+    [ -z "$_m" ] && continue
+    if [ "$_m" = "team_mode" ]; then
+      echo "[error] 'team_mode' is a reserved, not-yet-installable module (parked; see DECISIONS.md Decision C)." >&2
+      exit 1
+    fi
+    case " $KIT_KNOWN_MODULES " in
+      *" $_m "*) KIT_REQUESTED_MODULES="$KIT_REQUESTED_MODULES $_m" ;;
+      *)
+        echo "[error] unknown module: '$_m'. Known modules: $KIT_KNOWN_MODULES" >&2
+        exit 1
+        ;;
+    esac
+  done
+  unset _m
+fi
+KIT_REQUESTED_MODULES="$(echo "$KIT_REQUESTED_MODULES" | xargs)"
 
 # --- Plugin-aware compat mode --------------------------------------------
 # If the kit is already installed as a Claude Code plugin, the plugin provides
@@ -289,10 +368,84 @@ if [ -z "$DEST_REAL" ] || [ "$KIT_REAL" != "$DEST_REAL" ]; then
   echo "[ok] Stamped install: $(tr '\n' ' ' < "$CLAUDE_DIR/dwarves-kit/INSTALL-STAMP")"
 fi
 
+# 1f. Resolve the enabled module set (spine always; optionals additive across
+# re-installs unless --prune). Three inputs feed the union so a re-run NEVER
+# retroactively un-wires a hook a prior run (or a hand-edited settings.json) wired:
+#   (a) kit.toml's prior [modules] (this consumer's own record)
+#   (b) hooks ALREADY present in settings.json that map to a known module (covers
+#       a consumer who ran the OLD all-hooks installer, e.g. ops-toolkit/
+#       console-labs/family-office, before this manifest existed)
+#   (c) this run's --with request
+# --prune drops (a)+(b) and trims to exactly --with (spine-only if --with is empty).
+KIT_TOML="$CLAUDE_DIR/dwarves-kit/kit.toml"
+
+KIT_PRIOR_MODULES=""
+if [ -f "$KIT_TOML" ]; then
+  KIT_PRIOR_MODULES="$( (grep -E '^[a-z_]+ = true$' "$KIT_TOML" 2>/dev/null | grep -v '^team_mode' | sed 's/ =.*//' | tr '\n' ' ') || true)"
+fi
+
+KIT_EXISTING_WIRED_MODULES=""
+if [ -f "$SETTINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
+  KIT_EXISTING_CMDS="$(jq -r '(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | .command // empty' "$SETTINGS_FILE" 2>/dev/null || true)"
+  for _mod in $KIT_KNOWN_MODULES; do
+    for _h in $(kit_module_hooks "$_mod"); do
+      if printf '%s\n' "$KIT_EXISTING_CMDS" | grep -q "dwarves-kit/hooks/${_h}"; then
+        KIT_EXISTING_WIRED_MODULES="$KIT_EXISTING_WIRED_MODULES $_mod"
+        break
+      fi
+    done
+  done
+  unset _mod _h
+fi
+
+if [ "$KIT_PRUNE" -eq 1 ]; then
+  KIT_ENABLED_MODULES="$KIT_REQUESTED_MODULES"
+  echo "[ok] --prune: trimming enabled modules to exactly: ${KIT_ENABLED_MODULES:-<spine-only>}"
+else
+  KIT_ENABLED_MODULES="$(printf '%s %s %s\n' "$KIT_PRIOR_MODULES" "$KIT_EXISTING_WIRED_MODULES" "$KIT_REQUESTED_MODULES" \
+    | tr ' ' '\n' | sed '/^$/d' | sort -u | tr '\n' ' ' | xargs)"
+fi
+
+KIT_ENABLED_HOOK_NAMES="$KIT_SPINE_HOOKS"
+for _mod in $KIT_ENABLED_MODULES; do
+  KIT_ENABLED_HOOK_NAMES="$KIT_ENABLED_HOOK_NAMES $(kit_module_hooks "$_mod")"
+done
+unset _mod
+
+KIT_HOOK_RE=""
+for _h in $KIT_ENABLED_HOOK_NAMES; do
+  _esc="$(printf '%s' "$_h" | sed 's/\./\\./g')"
+  if [ -z "$KIT_HOOK_RE" ]; then KIT_HOOK_RE="$_esc"; else KIT_HOOK_RE="$KIT_HOOK_RE|$_esc"; fi
+done
+unset _h _esc
+
+# The filtered kit settings.json: spine hooks + only the opted-in modules' hooks.
+# An un-installed module's hook is never present here, so it can never reach the
+# consumer's settings.json below.
+# statusLine ships with the `cosmetic` module (its command is statusline.sh); strip
+# it here too, not just in step 7's gate, so a fresh (no-prior-settings.json) install
+# doesn't smuggle it in via the blind first-time copy below.
+KIT_STATUSLINE_ON=0
+case " $KIT_ENABLED_HOOK_NAMES " in *" statusline.sh "*) KIT_STATUSLINE_ON=1 ;; esac
+
+KIT_SETTINGS_FILTERED="$(mktemp)"
+jq --arg re "$KIT_HOOK_RE" --argjson sl "$KIT_STATUSLINE_ON" '
+  .hooks |= (
+    to_entries | map(
+      .value |= (
+        map(
+          .hooks |= map(select(.command | test($re)))
+        ) | map(select(.hooks | length > 0))
+      )
+    ) | from_entries
+  )
+  | if ($sl == 1) then . else del(.statusLine) end
+' "$KIT_DIR/settings.json" > "$KIT_SETTINGS_FILTERED"
+
 # 2. Merge settings.json
 if [ ! -f "$SETTINGS_FILE" ]; then
-  # No existing settings, just copy ours
-  cp "$KIT_DIR/settings.json" "$SETTINGS_FILE"
+  # No existing settings, just copy the filtered (spine + opted-in) set
+  cp "$KIT_SETTINGS_FILTERED" "$SETTINGS_FILE"
   echo "[ok] Created $SETTINGS_FILE"
 else
   if command -v jq >/dev/null 2>&1; then
@@ -316,7 +469,7 @@ else
 
     # Then merge: CONCAT arrays (don't deduplicate by matcher)
     # This preserves the user's existing hooks alongside ours
-    MERGED=$(echo "$EXISTING_CLEAN" | jq --slurpfile kit "$KIT_DIR/settings.json" '
+    MERGED=$(echo "$EXISTING_CLEAN" | jq --slurpfile kit "$KIT_SETTINGS_FILTERED" '
       . as $existing |
       $kit[0] as $new |
       ($new.hooks // {}) as $kh |
@@ -345,6 +498,28 @@ else
     echo "       Then re-run this script, or manually merge $KIT_DIR/settings.json"
   fi
 fi
+rm -f "$KIT_SETTINGS_FILTERED"
+
+# 2b. Write the kit.toml [modules] manifest -- a RECORD driving the shell wiring
+# above, never a runtime registry (no hook reads this file; see the standing lint
+# in tests/test-no-runtime-manifest-read.sh).
+{
+  echo "# dwarves-kit module manifest. Generated by install.sh -- do not hand-edit;"
+  echo "# use \`install.sh --with <modules>\` (or \`--prune --with <modules>\` to trim) to change it."
+  echo "# This is a shell-install RECORD, not a runtime feature-registry: no hook reads it."
+  echo ""
+  echo "[modules]"
+  echo "team_mode = false"
+  for _mod in $KIT_KNOWN_MODULES; do
+    case " $KIT_ENABLED_MODULES " in
+      *" $_mod "*) echo "$_mod = true" ;;
+      *) echo "$_mod = false" ;;
+    esac
+  done
+  unset _mod
+} > "$KIT_TOML"
+echo "[ok] Wrote module manifest: $KIT_TOML"
+echo "[ok] Enabled modules: ${KIT_ENABLED_MODULES:-<spine-only>}"
 
 # 3. Symlink commands
 for CMD_FILE in "$KIT_DIR/commands/"*.md; do
@@ -406,24 +581,36 @@ if [ -d "$KIT_DIR/rules" ]; then
   echo "  They must live in project .claude/rules/, not ~/.claude/rules/."
 fi
 
-# 7. Merge statusLine config
-if [ -f "$SETTINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
-  HAS_STATUSLINE=$(jq '.statusLine // null' "$SETTINGS_FILE" 2>/dev/null)
-  if [ "$HAS_STATUSLINE" = "null" ]; then
-    STATUSLINE_CMD=$(jq -r '.statusLine.command' "$KIT_DIR/settings.json" 2>/dev/null)
-    if [ -n "$STATUSLINE_CMD" ] && [ "$STATUSLINE_CMD" != "null" ]; then
-      jq --arg cmd "$STATUSLINE_CMD" '.statusLine = {"command": $cmd}' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
-      echo "[ok] Registered statusLine"
+# 7. Merge statusLine config (part of the `cosmetic` module; gated the same as its hook)
+case " $KIT_ENABLED_HOOK_NAMES " in
+  *" statusline.sh "*)
+    if [ -f "$SETTINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
+      HAS_STATUSLINE=$(jq '.statusLine // null' "$SETTINGS_FILE" 2>/dev/null)
+      if [ "$HAS_STATUSLINE" = "null" ]; then
+        STATUSLINE_CMD=$(jq -r '.statusLine.command' "$KIT_DIR/settings.json" 2>/dev/null)
+        if [ -n "$STATUSLINE_CMD" ] && [ "$STATUSLINE_CMD" != "null" ]; then
+          jq --arg cmd "$STATUSLINE_CMD" '.statusLine = {"command": $cmd}' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
+          echo "[ok] Registered statusLine"
+        fi
+      else
+        echo "[ok] statusLine already configured (not overwriting)"
+      fi
     fi
-  else
-    echo "[ok] statusLine already configured (not overwriting)"
-  fi
-fi
+    ;;
+  *)
+    echo "[skip] statusLine not registered (cosmetic module not enabled; --with cosmetic to opt in)"
+    ;;
+esac
 
 # 6. Verify
 echo ""
 echo "=== Verification ==="
-echo "Hooks directory: $KIT_DIR/hooks/"
+echo "Modules: spine (always on) + ${KIT_ENABLED_MODULES:-<none opted in>}"
+echo "  Not enabled: $(for m in $KIT_KNOWN_MODULES; do case " $KIT_ENABLED_MODULES " in *" $m "*) ;; *) printf '%s ' "$m" ;; esac; done) team_mode(reserved)"
+echo "  --with <modules> to opt in, --prune --with <modules> to trim, kit.toml: $KIT_TOML"
+echo "Hooks wired into settings.json:"
+printf '%s\n' $KIT_ENABLED_HOOK_NAMES | sort -u | while read -r h; do [ -n "$h" ] && echo "  [hook] $h"; done
+echo "Hooks directory (all shipped, not all wired): $KIT_DIR/hooks/"
 ls -1 "$KIT_DIR/hooks/"*.sh 2>/dev/null | while read f; do echo "  [hook] $(basename "$f")"; done
 
 echo "Commands:"
@@ -455,5 +642,10 @@ echo ""
 echo "Tip: Adopt a repo into the kit (injects AGENTS.md + a CLAUDE.md pointer + the proof"
 echo "marker, idempotently, and wires the classifiers so the ship-gate engages):"
 echo "  bash $KIT_DIR/lib/adopt.sh <repo-dir>      # or run /kit:adopt from inside the repo"
+echo ""
+echo "Tip: opt into a module (board, session, advisor, cosmetic, queue, stats, quiz_gate,"
+echo "weekend_batch, bridge): bash $KIT_DIR/install.sh --with board,stats"
+echo "Tip: trim to exactly a set (drops anything previously wired, incl. an old all-hooks"
+echo "install): bash $KIT_DIR/install.sh --prune --with board"
 echo ""
 echo "To uninstall: bash $KIT_DIR/install.sh --uninstall"

--- a/tests/test-install-modules.sh
+++ b/tests/test-install-modules.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# test-install-modules.sh -- ID-277 SG-04 (kit-modularity, install/wire): install.sh is
+# LAYERED. The spine (safety-gate, ship-gate, spec-drift-guard, secrets-guard,
+# commit-format, anti-rationalization) is always wired; every other hook belongs to an
+# opt-in module (`--with <a,b,c>`), recorded in a `kit.toml [modules]` manifest that
+# DRIVES the shell wiring above -- it is never a runtime feature-registry a hook reads
+# (see the standing anti-drift lint at the bottom of this file).
+#
+# Run: bash tests/test-install-modules.sh
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
+assert_true() { if [ "$2" -eq 0 ]; then ok "$1"; else bad "$1"; fi; }
+
+wired_hooks() { # $1 = settings.json path
+  jq -r '[.hooks // {} | to_entries[]? | .value[]? | .hooks[]? | .command] | .[]' "$1" 2>/dev/null \
+    | grep -oE 'hooks/[A-Za-z0-9._-]+\.sh' | sed 's#hooks/##' | sort -u
+}
+
+# ============================================================
+echo "== NC spine-only: a plain temp-HOME install wires ONLY the spine =="
+# ============================================================
+H1="$(mktemp -d)"
+HOME="$H1" bash "$KIT_DIR/install.sh" >/tmp/kitmod-h1.log 2>&1
+WIRED1="$(wired_hooks "$H1/.claude/settings.json")"
+EXPECT_SPINE="anti-rationalization.sh
+commit-format.sh
+safety-gate.sh
+secrets-guard.sh
+ship-gate.sh
+spec-drift-guard.sh"
+assert_true "spine-only install wires exactly the 6 spine hooks" "$([ "$WIRED1" = "$EXPECT_SPINE" ]; echo $?)"
+NON_SPINE="$(printf '%s\n' "$WIRED1" | grep -vFxf <(printf '%s\n' "$EXPECT_SPINE") || true)"
+assert_true "spine-only install: no optional-module hook present (extra: ${NON_SPINE:-none})" "$([ -z "$NON_SPINE" ]; echo $?)"
+assert_true "spine-only install: kit.toml has team_mode = false" "$(grep -qx 'team_mode = false' "$H1/.claude/dwarves-kit/kit.toml"; echo $?)"
+OPT_TRUE="$(grep -E '^[a-z_]+ = true$' "$H1/.claude/dwarves-kit/kit.toml" 2>/dev/null || true)"
+assert_true "spine-only install: no module recorded true in kit.toml" "$([ -z "$OPT_TRUE" ]; echo $?)"
+
+# ============================================================
+echo "== NC --with board,stats: wires exactly those + records in kit.toml; re-run reproduces =="
+# ============================================================
+H2="$(mktemp -d)"
+HOME="$H2" bash "$KIT_DIR/install.sh" --with board,stats >/tmp/kitmod-h2.log 2>&1
+WIRED2="$(wired_hooks "$H2/.claude/settings.json")"
+EXPECT_BOARD="$(printf '%s\nbacklog-stage.sh' "$EXPECT_SPINE" | sort -u)"
+assert_true "--with board,stats wires spine + backlog-stage.sh (board's hook) only" "$([ "$WIRED2" = "$EXPECT_BOARD" ]; echo $?)"
+assert_true "kit.toml records board = true" "$(grep -qx 'board = true' "$H2/.claude/dwarves-kit/kit.toml"; echo $?)"
+assert_true "kit.toml records stats = true (hookless module, still recorded)" "$(grep -qx 'stats = true' "$H2/.claude/dwarves-kit/kit.toml"; echo $?)"
+assert_true "kit.toml records session = false (not requested)" "$(grep -qx 'session = false' "$H2/.claude/dwarves-kit/kit.toml"; echo $?)"
+
+HOME="$H2" bash "$KIT_DIR/install.sh" >/tmp/kitmod-h2-rerun.log 2>&1
+WIRED2B="$(wired_hooks "$H2/.claude/settings.json")"
+assert_true "re-run (no --with) reproduces the same wired set from the manifest" "$([ "$WIRED2" = "$WIRED2B" ]; echo $?)"
+
+# ============================================================
+echo "== NC un-opted-hook-absent: a cosmetic/session/advisor hook never reaches settings.json =="
+# ============================================================
+UNWANTED="auto-format.sh notification.sh slop-cleaner.sh statusline.sh codebase-index.sh permission-auto-approve.sh context-hints.sh harvest.sh session-state-save.sh citation-guard.sh context-readiness.sh output-offload.sh pre-compact-backup.sh post-compact-reinject.sh"
+LEAKED=""
+for h in $UNWANTED; do
+  printf '%s\n' "$WIRED2" | grep -qx "$h" && LEAKED="$LEAKED $h"
+done
+assert_true "no un-opted-in module hook present after --with board,stats (leaked:${LEAKED:-none})" "$([ -z "$LEAKED" ]; echo $?)"
+
+# ============================================================
+echo "== NC team_mode reserved: --with team_mode is a clean error, not installable =="
+# ============================================================
+H3="$(mktemp -d)"
+ERR3="$(HOME="$H3" bash "$KIT_DIR/install.sh" --with team_mode 2>&1)"; RC3=$?
+assert_true "--with team_mode exits nonzero" "$([ "$RC3" -ne 0 ]; echo $?)"
+assert_true "--with team_mode error names the reserved reason" "$(printf '%s' "$ERR3" | grep -qi 'reserved'; echo $?)"
+assert_true "--with team_mode never wrote a settings.json" "$([ ! -f "$H3/.claude/settings.json" ]; echo $?)"
+
+# ============================================================
+echo "== NC unknown module name: clean error, not silent =="
+# ============================================================
+H4="$(mktemp -d)"
+ERR4="$(HOME="$H4" bash "$KIT_DIR/install.sh" --with bogus-module 2>&1)"; RC4=$?
+assert_true "--with bogus-module exits nonzero" "$([ "$RC4" -ne 0 ]; echo $?)"
+assert_true "--with bogus-module error names the unknown module" "$(printf '%s' "$ERR4" | grep -q 'bogus-module'; echo $?)"
+assert_true "--with bogus-module never wrote a settings.json" "$([ ! -f "$H4/.claude/settings.json" ]; echo $?)"
+
+# ============================================================
+echo "== NC existing-consumer migration: re-running install.sh is ADDITIVE, never un-wires =="
+# ============================================================
+# Simulate the pre-SG-04 all-hooks installer: seed settings.json with the FULL
+# (unfiltered) kit settings.json, no kit.toml yet.
+H5="$(mktemp -d)"
+mkdir -p "$H5/.claude"
+cp "$KIT_DIR/settings.json" "$H5/.claude/settings.json"
+BEFORE5="$(wired_hooks "$H5/.claude/settings.json")"
+BEFORE5_N="$(printf '%s\n' "$BEFORE5" | grep -c .)"
+HOME="$H5" bash "$KIT_DIR/install.sh" >/tmp/kitmod-h5.log 2>&1
+AFTER5="$(wired_hooks "$H5/.claude/settings.json")"
+DROPPED="$(comm -23 <(printf '%s\n' "$BEFORE5") <(printf '%s\n' "$AFTER5"))"
+assert_true "additive re-install drops nothing from an old all-hooks install (before=$BEFORE5_N, dropped:${DROPPED:-none})" "$([ -z "$DROPPED" ]; echo $?)"
+
+# ============================================================
+echo "== NC --prune: the explicit, only way to trim a previously-wired hook =="
+# ============================================================
+H6="$(mktemp -d)"
+mkdir -p "$H6/.claude"
+cp "$KIT_DIR/settings.json" "$H6/.claude/settings.json"
+HOME="$H6" bash "$KIT_DIR/install.sh" --prune --with board >/tmp/kitmod-h6.log 2>&1
+WIRED6="$(wired_hooks "$H6/.claude/settings.json")"
+EXPECT_PRUNE="$(printf '%s\nbacklog-stage.sh' "$EXPECT_SPINE" | sort -u)"
+assert_true "--prune --with board trims to exactly spine + board (drops the old all-hooks set)" "$([ "$WIRED6" = "$EXPECT_PRUNE" ]; echo $?)"
+
+# ============================================================
+echo "== POST-INSTALL SMOKE: every wired hook script runs cleanly (exit 0) on a no-op event =="
+# ============================================================
+H7="$(mktemp -d)"
+HOME="$H7" bash "$KIT_DIR/install.sh" --with board,session,advisor,cosmetic,queue,stats,quiz_gate,weekend_batch,bridge >/tmp/kitmod-h7.log 2>&1
+# Invoke each installed hook from a real (throwaway) git repo, not the kit checkout
+# itself, so a hook's project-root-relative reads (e.g. .claude/backups, docs/specs)
+# see a clean, self-consistent tree instead of the kit's own live dev state.
+SMOKE_REPO="$(mktemp -d)"
+git -C "$SMOKE_REPO" init -q
+mkdir -p "$SMOKE_REPO/.claude/backups" "$SMOKE_REPO/docs/specs"
+SMOKE_FAIL=0; SMOKE_N=0
+for h in "$H7/.claude/dwarves-kit/hooks/"*.sh; do
+  SMOKE_N=$((SMOKE_N+1))
+  ( cd "$SMOKE_REPO" && echo '{}' | bash "$h" >/tmp/kitmod-smoke-out 2>&1 )
+  rc=$?
+  if [ "$rc" -ne 0 ]; then SMOKE_FAIL=$((SMOKE_FAIL+1)); echo "    smoke-fail: $(basename "$h") exit=$rc"; fi
+done
+assert_true "post-install smoke: all $SMOKE_N wired hooks exit 0 on a no-op event ($SMOKE_FAIL failed)" "$([ "$SMOKE_FAIL" -eq 0 ]; echo $?)"
+
+# ============================================================
+echo "== STANDING ANTI-DRIFT LINT: no hook reads kit.toml at runtime (record, not registry) =="
+# ============================================================
+LEAK="$(grep -rl 'kit\.toml' "$KIT_DIR/hooks" 2>/dev/null || true)"
+assert_true "no hooks/*.sh reads kit.toml (leaked: ${LEAK:-none})" "$([ -z "$LEAK" ]; echo $?)"
+
+# ============================================================
+echo "== COVERAGE-DELTA: every module in the manifest maps to a real installable unit =="
+# ============================================================
+# Each optional module either has >=1 hook that exists on disk, or is a documented
+# hookless module backed by a real command/skill/lib subsystem.
+declare -a HOOKED_MODULES=(board session advisor cosmetic)
+declare -a HOOKLESS_MODULES=(queue stats quiz_gate weekend_batch bridge)
+COV_FAIL=""
+for m in "${HOOKED_MODULES[@]}"; do
+  case "$m" in
+    board) HOOKS="backlog-stage.sh" ;;
+    session) HOOKS="context-readiness.sh output-offload.sh pre-compact-backup.sh post-compact-reinject.sh session-state-save.sh harvest.sh citation-guard.sh" ;;
+    advisor) HOOKS="context-hints.sh" ;;
+    cosmetic) HOOKS="auto-format.sh notification.sh slop-cleaner.sh statusline.sh codebase-index.sh permission-auto-approve.sh" ;;
+  esac
+  for h in $HOOKS; do
+    [ -f "$KIT_DIR/hooks/$h" ] || COV_FAIL="$COV_FAIL $m:$h"
+  done
+done
+[ -d "$KIT_DIR/lib/queue" ] || COV_FAIL="$COV_FAIL queue:lib/queue"
+[ -d "$KIT_DIR/lib/stats" ] || COV_FAIL="$COV_FAIL stats:lib/stats"
+[ -f "$KIT_DIR/commands/quiz-gate.md" ] || COV_FAIL="$COV_FAIL quiz_gate:commands/quiz-gate.md"
+grep -rq "weekend" "$KIT_DIR/commands" 2>/dev/null || COV_FAIL="$COV_FAIL weekend_batch:commands"
+grep -rq "bridge" "$KIT_DIR/lib/board" 2>/dev/null || COV_FAIL="$COV_FAIL bridge:lib/board"
+assert_true "every manifest module maps to a real installable unit (missing:${COV_FAIL:-none})" "$([ -z "$COV_FAIL" ]; echo $?)"
+
+echo
+echo "== $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]

--- a/tests/test-kit-foldin-hooks.sh
+++ b/tests/test-kit-foldin-hooks.sh
@@ -210,8 +210,12 @@ done
 echo ""
 echo "=== Installer materializes all 4 hooks + companions into a temp HOME ==="
 # ============================================================
+# ID-277 SG-04: these 4 hooks are optional modules now (backlog-stage -> board,
+# citation-guard/harvest -> session, context-hints -> advisor), so the settings.json
+# wiring check below needs an explicit --with; the physical-file materialization
+# (hooks/, lib/, etc.) is unconditional regardless of module selection.
 INSTALL_HOME="$TD/install-home"
-if HOME="$INSTALL_HOME" bash "$KIT_DIR/install.sh" >/dev/null 2>&1; then
+if HOME="$INSTALL_HOME" bash "$KIT_DIR/install.sh" --with board,session,advisor >/dev/null 2>&1; then
   DEST="$INSTALL_HOME/.claude/dwarves-kit/hooks"
   for NAME in backlog-stage citation-guard context-hints harvest; do
     RC=0; [ -f "$DEST/${NAME}.sh" ] || RC=1


### PR DESCRIPTION
## Summary

Layers `install.sh`: core spine unconditional + per-module opt-in wire
(`install.sh --with ...`) recorded in a light `kit.toml [modules]` manifest
(+ reserved `team_mode` slot). Install wires only opted-in hooks, a
spine-only consumer's settings.json stays quiet.

- **Spine (always wired):** safety-gate, ship-gate, spec-drift-guard,
  secrets-guard, commit-format, anti-rationalization.
- **Optional modules:** board, session, advisor, cosmetic (hook-bearing);
  queue, stats, quiz_gate, weekend_batch, bridge (hookless, still valid
  `--with` names recorded for discovery).
- **Reserved:** `team_mode` (parked per Decision C; `--with team_mode`
  errors cleanly).
- **Migration:** re-running `install.sh` is ADDITIVE across an old
  all-hooks install (never un-wires a previously-wired hook);
  `--prune --with <modules>` is the explicit trim path.

## Verify

- Spine-only + `--with` temp-HOME installs; manifest reproduce;
  un-opted-hook-absent NC; team_mode/unknown-module clean errors;
  additive-migration + `--prune` NCs; post-install smoke (21/21 wired
  hooks exit 0); standing anti-drift lint (no hook reads `kit.toml`);
  coverage-delta (every module maps to a real unit).
- New `tests/test-install-modules.sh` (21 assertions), wired into CI.
- Full suite green before/after: `test-hooks.sh` 452/452, `test-meta.sh`
  679/679, `test-install-contract.sh` 3/3, `test-install-compat.sh` 7/7,
  `test-kit-foldin-hooks.sh` 49/49 (updated for `--with`), `test-adopt.sh`
  12/12, `test-e2e.sh` 20/20.

Proof: `docs/proof/kitmod-install-wire.md` (table-first, with the
spine/optional reconciliation against the real tree + flagged judgment
calls). Gate-recognized shape: `docs/verification/kitmod-install-wire.md`
(green run + a real revert->RED->restore negative control).

Stacked on #192.

ROADMAP: `ops-toolkit/_meta/megagoals/kit-modularity/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)