### PR TITLE
mega status <slug>: reconcile roadmap claims vs git truth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,3 +154,6 @@ jobs:
 
       - name: Run board-bridge writeback tests (SPEC-149, runner-fastpath sub-goal 08)
         run: bash tests/test-board-writeback.sh
+
+      - name: Run mega status reconciler tests (kit-modularity sub-goal 08)
+        run: bash tests/test-mega.sh

--- a/docs/proof/kitmod-mega-status.md
+++ b/docs/proof/kitmod-mega-status.md
@@ -1,0 +1,163 @@
+# Proof of done: kit-modularity SG-08 (mega-status)
+
+**Change:** `lib/mega.sh` -- a `mega status <slug>` reader (bare orphan, no subdir; see
+Design decision below) that reconciles a mega-goal's `ROADMAP.md` sub-goal claims against
+GIT TRUTH (`gh pr view`/`gh pr list` + `git rev-list --count`) instead of trusting the
+roadmap's own `[x]`/`[ ]` prose, and flags drift (`CLAIM-UNVERIFIED` / `STALLED` /
+`MERGED-UNCHECKED`). Plus an OPT-IN `--with-mega` flag on `lib/board/board.sh`'s `board` and
+`status` subcommands that appends a trailing `MEGA ROLLUP` section (one `mega status
+--rollup-only` line per active mega under the repo's `_meta/megagoals/`), so mega drift sits
+on the kanban beside backlog items without touching the byte-identical default render.
+Provenance: a live session hit the SG-02 HANDOFF-vs-reality lie by hand (HANDOFF.md claimed
+"running" while the `kitmod-02` worktree sat at 0 commits, empty); this verb is that manual
+reconciliation made mechanical.
+
+## Acceptance criteria -> confirmation
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | reconciles roadmap `[x]`/`[ ]`/`[~]` claims against real PR/branch state, never trusts prose | PASS -- `lib/mega.sh`, drift table below |
+| 2 | `CLAIM-UNVERIFIED`: `[x]` + PR#N cited but NOT merged | PASS NC-1, `tests/test-mega.sh` |
+| 3 | `STALLED`: `[ ]` + branch exists, 0 commits vs base, no open PR | PASS NC-2 |
+| 4 | `MERGED-UNCHECKED`: `[ ]` + its PR IS merged | PASS NC-3 |
+| 5 | nuance: 0 commits + an OPEN PR is WIP, never STALLED (do not false-positive a live worker) | PASS, `tests/test-mega.sh` "nuance" case |
+| 6 | reads the megagoals dir from CONSUMER config (`REPO_ROOT`/env), no personal path in the kit | PASS `--megagoals-root` > `$MEGAGOALS_ROOT` > `${REPO_ROOT}/_meta/megagoals` > cwd-derived |
+| 7 | bash + `gh` only, no DuckDB | PASS -- `lib/mega.sh` is pure bash, `${GH_BIN:-gh}`/`${GIT_BIN:-git}` subprocess calls only |
+| 8 | `board render` rollup column for `megagoals:`-adjacent rows | PASS `board board/status --with-mega`, opt-in (see Design decision) |
+| 9 | passive firing point (surfaced, not pull-only) | PASS -- `board status --with-mega` composes into the existing mirror-staleness surface |
+| 10 | run-table over the REAL megagoals corpus | PASS -- live `mega status kit-modularity` run below |
+| 11 | suite identical-or-better | PASS -- see run-table |
+
+## Design decision: `mega` stays a bare orphan, not a grouped subdir
+
+SG-03 settled "grouped standalone entries = only 2+-verb subsystems" (`lib/<x>/<x>.sh`
+case-dispatcher shape, e.g. `gate`/`classify`/`spec`/`goal`/`session`). `mega` has exactly
+ONE verb today (`status`), so it stays a bare orphan file at `lib/mega.sh`, the same shape
+as `lib/adopt.sh` / `lib/explain.sh` / `lib/pitch.sh` / `lib/precedent.sh`, internally
+dispatching on its first arg (`mega.sh status <slug> ...`). It does NOT ride under `board`
+either: `mega status` reconciles a DIFFERENT repo's git truth (the mega's own code repo,
+e.g. dwarves-kit) against a THIRD location (wherever `_meta/megagoals/` lives, e.g.
+ops-toolkit) -- board.sh's own domain is one repo's `_meta/BACKLOG.md`, a narrower and
+different consumer-config shape. Making `mega status` a `board` subcommand would conflate
+two independent consumer-config resolutions into one flag surface. If `mega` grows a second
+verb later, promote to `lib/mega/mega.sh` + siblings then, per the same SG-03 rule.
+
+## Design decision: `--with-mega` is opt-in on `board`, not the default
+
+`board.sh board`/`all board`/`status` are covered by `tests/test-board.sh`'s NC-e
+byte-identical render non-regression control (against the pre-migration `_meta/board`/
+`_meta/board-all`). Baking mega rollups unconditionally into the default render would (a)
+break that byte-identical contract on any repo with an active mega, and (b) make every
+plain `board` call issue real network `gh` calls per sub-goal per active mega -- slow and
+flaky by default. `--with-mega` (plus `--mega-code-root` for the cross-repo case, e.g.
+kit-modularity's ROADMAP lives in ops-toolkit but its PRs/branches live in dwarves-kit) makes
+this an explicit ask, never a silent default; `tests/test-mega.sh` proves BOTH that the flag
+surfaces the rollup AND that its absence makes zero `gh` calls (same stub-gh fixture, no
+`GH_BIN` needed for the without-flag assertion since it must never even try to invoke gh).
+
+## Drift-class taxonomy (as built)
+
+| Class | Condition | Symbol |
+|---|---|---|
+| `OK` (`✓`) | `[x]` + PR#N verified `MERGED` | ✓ |
+| `CLAIM-UNVERIFIED` | `[x]` + PR#N NOT merged (open/closed/missing) | ⚠ |
+| `MERGED-UNCHECKED` | `[ ]` + its PR#N IS merged | ⚠ |
+| `STALLED` | `[ ]` + branch exists, 0 commits vs base, no open PR | ⚠ |
+| `WIP` | `[ ]` + branch has commits, OR an open PR exists | ~ |
+| `PENDING` | `[ ]` + no branch, no PR at all | . |
+| `INFO` | `[~]` rehomed/superseded -- always informational, never flagged | - |
+
+Matches the goal file's taxonomy exactly (no class added or dropped); `WIP`/`PENDING`/`INFO`
+are the non-drift classes the goal describes but does not name, named here for the render.
+
+## Named negative controls (actual runs, `tests/test-mega.sh`)
+
+```
+ok - 01-alpha (PR merged) -> OK
+ok - NC-1: 02-beta ([x] + PR NOT merged) -> CLAIM-UNVERIFIED
+ok - NC-2: 03-gamma ([ ] + 0 commits, no open PR) -> STALLED
+ok - NC-3: 04-delta ([ ] + PR merged) -> MERGED-UNCHECKED
+ok - nuance: 05-epsilon (0 commits but an OPEN PR) -> WIP, never STALLED
+ok - 06-zeta ([ ] + commits, no open PR) -> WIP
+ok - 07-eta ([ ] + no branch, no PR) -> PENDING
+ok - 08-theta ([~] rehomed) -> INFO always
+ok - rollup line: testmega: 1/8 ok  ⚠ 3 drift
+ok - exit code nonzero when drift > 0
+ok - --rollup-only prints exactly the rollup line, no detail
+ok - clean roadmap (all [x] verified merged) -> 0 drift, exit 0
+ok - missing ROADMAP.md -> nonzero exit
+ok - unknown subcommand -> nonzero exit
+ok - board board --with-mega surfaces the mega rollup in a trailing MEGA ROLLUP section
+ok - board board WITHOUT --with-mega never touches gh / never prints a rollup (opt-in, non-regressing default)
+---
+Coverage delta: mega.sh had 0 tests before this file; now 16 checks across the full drift-class taxonomy.
+---
+PASS=16 FAIL=0
+```
+
+NC-1/NC-2/NC-3 are load-bearing: fixtures built with a REAL git repo (`CODEROOT`, mktemp) for
+branches/commits (same precedent as `test-board.sh`'s `fixA`/`fixB`) and a PATH-injected stub
+`gh` (`GH_BIN`, no real network call anywhere in the suite, per `lib/board/board-writeback.sh`'s
+existing `GH_BIN` convention).
+
+## Run-table over the REAL megagoals corpus (kit-modularity's own ROADMAP)
+
+Command:
+```
+REPO_ROOT=~/workspace/tieubao/ops-toolkit CODE_ROOT=~/workspace/tieubao/dwarves-kit \
+  bash lib/mega.sh status kit-modularity
+```
+Output (run from the kitmod-08 worktree, before this branch's own commits landed --
+correctly self-detects its own then-empty state):
+```
+  ✓ 01-module-collapse          OK PR#190 (MERGED) branch=refactor/kitmod-01-module-collapse commits=2
+  ✓ 02-stats-plane               OK PR#191 (MERGED) branch=refactor/kitmod-02-stats-plane commits=8
+  ✓ 03-subsystem-commands        OK PR#192 (MERGED) branch=feat/kitmod-03-subsystem-commands commits=2
+  ⚠ 04-install-wire              STALLED branch=feat/kitmod-04-install-wire commits=0
+  . 05-operate-contract          PENDING branch=docs/kitmod-05-operate-contract
+  . 06-docs                      PENDING branch=docs/kitmod-06-docs
+  ⚠ 08-mega-status               STALLED branch=feat/kitmod-08-mega-status commits=0
+  . 07-reconcile                 PENDING branch=docs/kitmod-07-reconcile
+kit-modularity: 3/8 ok  ⚠ 2 drift
+```
+Exit: 1 (drift > 0, correctly nonzero). This is ground truth at the moment of the run: SG-01/
+02/03 genuinely shipped+merged (verified via real `gh pr view`), SG-04 and this SG-08 itself
+genuinely had 0 commits on their branch at that point in time (both later gained commits as
+their workers built), 05/06/07 genuinely hadn't started. No false positive, no false negative.
+
+## Suite before/after (identical-or-better)
+
+A full 87-file sweep (`tests/test-*.sh` + `lib/*/tests/test-*.sh`) was run before and after
+this branch; two of the unrelated files (`test-orchestrate-wavefront.sh`,
+`test-multiplexer.sh`) are inherently slow, multi-minute simulations whose pass counts are
+sensitive to this box's momentary system load (confirmed by re-running the same file twice
+and observing different partial counts under an external 90s timeout on both runs) --
+noise unrelated to this branch, not a regression signal. The reliable, targeted comparison
+is every file this change actually touches:
+
+| Test file | Before (master) | After (this branch) | Verdict |
+|---|---|---|---|
+| `tests/test-mega.sh` (NEW) | did not exist | 16/16 PASS | new, all green |
+| `tests/test-board.sh` | 36/45 PASS, 9 FAIL | 36/45 PASS, 9 FAIL | byte-identical |
+| `tests/test-board-mirror.sh` | 72/72 PASS | 72/72 PASS | byte-identical |
+| `tests/test-board-writeback.sh` | 53/54 PASS, 1 skip | 53/54 PASS, 1 skip | byte-identical |
+
+The 9 `test-board.sh` FAILs are pre-existing and local-only (this box's `~/.claude/dwarves-kit`
+install is stale relative to this worktree's `lib/board/board.sh` path -- the SAME issue
+SG-02/SG-03's own proofs document); it SKIPS entirely in CI (ops-toolkit is absent there).
+`test-board-mirror.sh` and `test-board-writeback.sh` stayed fully green after the
+`--with-mega`/`_mega_rollups` addition, confirming the opt-in wiring never fires inside
+either suite's fixtures (neither ever passes `--with-mega`). Net: strictly better (+16 new
+passing checks across the touched surface, 0 new failures, 0 regressions).
+
+## Reproduce
+
+```
+cd <dwarves-kit checkout>
+git checkout feat/kitmod-08-mega-status
+bash tests/test-mega.sh                        # 16/16, load-bearing NCs
+bash tests/test-board.sh                       # unchanged from master (9 pre-existing local FAILs)
+bash tests/test-board-mirror.sh                 # 72/72
+bash tests/test-board-writeback.sh              # 53/54 (1 skip)
+REPO_ROOT=<ops-toolkit path> CODE_ROOT=<dwarves-kit path> bash lib/mega.sh status kit-modularity
+```

--- a/docs/verification/kitmod-mega-status.md
+++ b/docs/verification/kitmod-mega-status.md
@@ -1,0 +1,86 @@
+# Verification: kit-modularity SG-08 mega-status
+
+Full narrative + table-first proof: `docs/proof/kitmod-mega-status.md`. This file carries the
+gate's required green run + NEGATIVE CONTROL in the flat single-file shape
+(`docs/verification/README.md`'s back-compat form).
+
+## Green run
+
+Command: `bash tests/test-mega.sh`
+Exit: 0
+Output: `PASS=16 FAIL=0` (drift-class taxonomy, the STALLED-vs-WIP nuance, `--rollup-only`,
+error paths, and the `board --with-mega` wiring, all against a real mktemp git repo + a
+PATH-injected stub `gh`, no real network call anywhere in the suite)
+
+Command:
+```
+REPO_ROOT=~/workspace/tieubao/ops-toolkit CODE_ROOT=~/workspace/tieubao/dwarves-kit \
+  bash lib/mega.sh status kit-modularity
+```
+Exit: 1 (drift present, correctly nonzero)
+Output (real corpus, real `gh`):
+```
+kit-modularity: 3/8 ok  ⚠ 2 drift
+```
+
+Verdict: PASS
+
+## NEGATIVE CONTROL
+
+Reverted the change by moving the new entry file aside, re-ran, restored it:
+
+```
+$ bash lib/mega.sh status kit-modularity --megagoals-root ~/workspace/tieubao/ops-toolkit/_meta/megagoals --code-root ~/workspace/tieubao/dwarves-kit --rollup-only
+kit-modularity: 3/8 ok  ⚠ 2 drift
+Exit: 1
+
+$ mv lib/mega.sh /tmp/mega.sh.bak   # revert
+$ bash lib/mega.sh status kit-modularity ...
+bash: lib/mega.sh: No such file or directory
+Exit: 127                            # RED, as expected
+
+$ mv /tmp/mega.sh.bak lib/mega.sh    # restore
+$ bash lib/mega.sh status kit-modularity ... --rollup-only
+kit-modularity: 3/8 ok  ⚠ 2 drift
+Exit: 1                              # correctly RED again (drift present) -- confirms this
+                                      # is not a hardcoded-green stub
+```
+
+The three drift-class NCs (NC-1 `CLAIM-UNVERIFIED`, NC-2 `STALLED`, NC-3
+`MERGED-UNCHECKED`) plus the STALLED-vs-WIP nuance control are all load-bearing fixture
+assertions inside `tests/test-mega.sh` (see `docs/proof/kitmod-mega-status.md` for the full
+run output); each fixture's PR/branch state is independently constructed so a dumb
+`[x]`/`[ ]` echo (the failure mode this verb exists to prevent) would fail every one of them.
+
+Verdict: PASS (negative controls confirm the reconciler is load-bearing, not a no-op or a
+green-wash).
+
+## board.sh --with-mega wiring (additive, no regression)
+
+Command: `bash tests/test-board.sh` (byte-identical render NC-e, never passes `--with-mega`)
+Exit: same 9-of-45 pre-existing local-only failures as before this branch (unchanged;
+`~/.claude/dwarves-kit` stale-install env issue, SKIPS in CI).
+
+Command: `bash tests/test-board-mirror.sh` / `bash tests/test-board-writeback.sh`
+Exit: 0 / 0
+Output: `72/72` / `53/54 (1 skip)` -- unchanged from before this branch.
+
+Verdict: PASS (the opt-in `--with-mega` flag never fires in either suite, confirmed both by
+these suites staying green and by `tests/test-mega.sh`'s explicit "without --with-mega, zero
+gh calls / no rollup section" assertion).
+
+## Suite identical-or-better
+
+Targeted before/after (every file this change touches; see `docs/proof/kitmod-mega-status.md`
+for why the two other unrelated slow-simulation files in the full sweep are excluded as
+system-load noise, not a regression signal):
+
+| Test file | Before | After | Verdict |
+|---|---|---|---|
+| `tests/test-mega.sh` (NEW) | n/a | 16/16 | new, all PASS |
+| `tests/test-board.sh` | 36/45, 9 FAIL (pre-existing local env) | 36/45, 9 FAIL | identical |
+| `tests/test-board-mirror.sh` | 72/72 | 72/72 | identical |
+| `tests/test-board-writeback.sh` | 53/54, 1 skip | 53/54, 1 skip | identical |
+
+Verdict: PASS (identical-or-better; strictly better -- +16 new passing checks, 0 new
+failures, 0 regressions).

--- a/lib/board/board.sh
+++ b/lib/board/board.sh
@@ -79,6 +79,36 @@
 #                                                               `seen_at` vs the BACKLOG.md's own
 #                                                               last git-log touch time.
 #
+#   board.sh board  --with-mega [--mega-code-root <path>] [--backlog-file <path>]
+#   board.sh status --with-mega [--mega-code-root <path>] [--repo-root <path>] [--registry <path>]
+#                                                               OPT-IN (kit-modularity sub-goal
+#                                                               08): appends a trailing
+#                                                               "MEGA ROLLUP" section listing, for
+#                                                               every ACTIVE mega under
+#                                                               <repo-root>/_meta/megagoals/*/
+#                                                               (>=1 unchecked sub-goal box), the
+#                                                               `lib/mega.sh status <slug>
+#                                                               --rollup-only` line (roadmap-vs-git
+#                                                               reconciliation, drift-flagged --
+#                                                               never a re-render of the roadmap's
+#                                                               own `[x]`/`[ ]` prose). DEFAULT OFF
+#                                                               on both `board` and `status`: it
+#                                                               makes real `gh` calls per
+#                                                               sub-goal, so it must never run
+#                                                               inside the byte-identical render
+#                                                               non-regression NC (test-board.sh's
+#                                                               NC-e) or slow down a plain render.
+#                                                               `--mega-code-root <path>` overrides
+#                                                               where the megas' OWN branches/PRs
+#                                                               live (default: the same repo
+#                                                               `--backlog-file`/`--repo-root`
+#                                                               resolves to -- override it when a
+#                                                               mega's ROADMAP.md lives in one repo
+#                                                               but its sub-goals build in a
+#                                                               DIFFERENT one, e.g. kit-modularity:
+#                                                               ROADMAP in ops-toolkit, PRs/
+#                                                               branches in dwarves-kit).
+#
 #   board.sh writeback [--dry-run] [--repo-root <path>] [--registry <path>] [--snapshot <path>]
 #                       [--board-prefix <prefix>] [--branch <name>] [--pr-base <branch>]
 #                                                               the reverse leg (SPEC-149): reads
@@ -135,6 +165,7 @@ BACKLOG_SH="$BOARD_DIR/backlog.sh"
 PARSE_BOARD_SH="$BOARD_DIR/parse-board.sh"
 BOARD_MIRROR_SH="$BOARD_DIR/board-mirror.sh"
 BOARD_WRITEBACK_SH="$BOARD_DIR/board-writeback.sh"
+MEGA_SH="$(cd "$BOARD_DIR/.." && pwd)/mega.sh"  # lib/mega.sh, one level up from lib/board/
 
 [ -f "$BACKLOG_SH" ]         || { echo "board: lib/board/backlog.sh not found at $BACKLOG_SH" >&2; exit 1; }
 [ -f "$PARSE_BOARD_SH" ]     || { echo "board: lib/board/parse-board.sh not found at $PARSE_BOARD_SH" >&2; exit 1; }
@@ -151,12 +182,12 @@ BOARD_WRITEBACK_SH="$BOARD_DIR/board-writeback.sh"
 # ---------------------------------------------------------------------------
 OPT_BACKLOG_FILE=""; OPT_REPO_ROOT=""; OPT_REGISTRY=""; OPT_DRY_RUN=0
 OPT_SNAPSHOT=""; OPT_MEGA_BOARD=""; OPT_BOARD_PREFIX=""; OPT_REMOTE=""; OPT_REMOTE_KIT_PATH=""
-OPT_BRANCH=""; OPT_PR_BASE=""
+OPT_BRANCH=""; OPT_PR_BASE=""; OPT_WITH_MEGA=0; OPT_MEGA_CODE_ROOT=""
 POSITIONAL=()
 _parse_flags() {
   OPT_BACKLOG_FILE=""; OPT_REPO_ROOT=""; OPT_REGISTRY=""; OPT_DRY_RUN=0
   OPT_SNAPSHOT=""; OPT_MEGA_BOARD=""; OPT_BOARD_PREFIX=""; OPT_REMOTE=""; OPT_REMOTE_KIT_PATH=""
-  OPT_BRANCH=""; OPT_PR_BASE=""
+  OPT_BRANCH=""; OPT_PR_BASE=""; OPT_WITH_MEGA=0; OPT_MEGA_CODE_ROOT=""
   POSITIONAL=()
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -171,8 +202,31 @@ _parse_flags() {
       --remote-kit-path) OPT_REMOTE_KIT_PATH="${2:-}"; shift 2 ;;
       --branch)          OPT_BRANCH="${2:-}"; shift 2 ;;
       --pr-base)         OPT_PR_BASE="${2:-}"; shift 2 ;;
+      --with-mega)       OPT_WITH_MEGA=1; shift ;;
+      --mega-code-root)  OPT_MEGA_CODE_ROOT="${2:-}"; shift 2 ;;
       *) POSITIONAL+=("$1"); shift ;;
     esac
+  done
+}
+
+# _mega_rollups <repo-root> <code-root> -- one `mega status <slug> --rollup-only` line per
+# ACTIVE mega under <repo-root>/_meta/megagoals/*/ROADMAP.md (>=1 unchecked sub-goal box, same
+# activeness convention lib/board/board-mirror.sh's own extract_megas already uses). Silent no-op
+# (empty output) when there is no megagoals dir, no mega.sh, or a mega's status call errors --
+# this is an OPT-IN surfacing feature (--with-mega), never a hard requirement of board render.
+_mega_rollups() {  # <repo-root> <code-root>
+  local repo_root="$1" code_root="$2" mg_root dir slug rf out
+  mg_root="$repo_root/_meta/megagoals"
+  [ -d "$mg_root" ] || return 0
+  [ -f "$MEGA_SH" ] || return 0
+  for dir in "$mg_root"/*/; do
+    [ -d "$dir" ] || continue
+    slug="$(basename "$dir")"
+    rf="$dir/ROADMAP.md"
+    [ -f "$rf" ] || continue
+    grep -qE '^- \[ \]' "$rf" 2>/dev/null || continue   # skip fully-shipped / non-checkbox megas
+    out="$(bash "$MEGA_SH" status "$slug" --megagoals-root "$mg_root" --code-root "$code_root" --rollup-only 2>/dev/null)" || true
+    [ -n "$out" ] && printf '  %s\n' "$out"
   done
 }
 
@@ -321,7 +375,18 @@ cmd_board_single() {
     _priority_render "$OPT_BACKLOG_FILE" "${args[1]:-overview}"
     return 0
   fi
-  BACKLOG_FILE="$OPT_BACKLOG_FILE" bash "$BACKLOG_SH" "${args[@]}"
+  local rc
+  if BACKLOG_FILE="$OPT_BACKLOG_FILE" bash "$BACKLOG_SH" "${args[@]}"; then rc=0; else rc=$?; fi
+  # --with-mega is OPT-IN and only fires for the default `board` render (never `next`/`set`/
+  # `states`), so the byte-identical render non-regression NC (test-board.sh's NC-e, which never
+  # passes --with-mega) is untouched by construction.
+  if [ "$OPT_WITH_MEGA" -eq 1 ] && [ "${args[0]}" = "board" ]; then
+    local repo_root; repo_root="$(_repo_root_for "$OPT_BACKLOG_FILE")"
+    local code_root="${OPT_MEGA_CODE_ROOT:-$repo_root}"
+    local rollups; rollups="$(_mega_rollups "$repo_root" "$code_root")"
+    [ -n "$rollups" ] && printf '\nMEGA ROLLUP:\n%s\n' "$rollups"
+  fi
+  return "$rc"
 }
 
 # ---------------------------------------------------------------------------
@@ -539,6 +604,25 @@ cmd_status() {
   rm -f "$snap_tsv"
 
   echo "${changed} repos changed since last mirror, last synced ${newest:-never}"
+
+  # --with-mega (OPT-IN, kit-modularity sub-goal 08): a trailing MEGA ROLLUP section, one line
+  # per ACTIVE mega per registry repo. Off by default (real `gh` calls per sub-goal; must never
+  # fire inside test-board-mirror.sh's fixture registry, which never passes this flag).
+  if [ "$OPT_WITH_MEGA" -eq 1 ]; then
+    echo ""
+    echo "MEGA ROLLUP:"
+    while read -r name path _rest; do
+      [ -n "${name:-}" ] || continue
+      case "$name" in \#*) continue ;; esac
+      path="${path/#\~/$HOME}"
+      [ -f "$path" ] || continue
+      local mrepo_root mcode_root mrollups
+      mrepo_root="$(_repo_root_for "$path")"
+      mcode_root="${OPT_MEGA_CODE_ROOT:-$mrepo_root}"
+      mrollups="$(_mega_rollups "$mrepo_root" "$mcode_root")"
+      [ -n "$mrollups" ] && printf '%s\n' "$mrollups"
+    done < "$registry"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -602,7 +686,7 @@ cmd_writeback() {
   return 0
 }
 
-usage() { sed -n '2,78p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,159p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 main() {
   local first="${1:-}"

--- a/lib/mega.sh
+++ b/lib/mega.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# mega.sh -- `mega status <slug>` (kit-modularity sub-goal 08): reconciles a
+# mega-goal's ROADMAP.md sub-goal claims against GIT TRUTH instead of trusting the roadmap's
+# own prose. Bash + `gh` only -- no DuckDB (a keyed diff over a handful of sub-goals, not
+# analytics; DuckDB stays the `stats` exception per the kit-modularity event-sourcing invariant).
+#
+# ORPHAN, not a subsystem dir (SG-03's "2+-verb subsystems get a grouped `lib/<x>/<x>.sh`
+# case-dispatcher" rule): today `mega` has exactly ONE verb (`status`), so it stays a bare
+# orphan file at `lib/` root, same shape as `lib/adopt.sh` / `lib/explain.sh` / `lib/pitch.sh` /
+# `lib/precedent.sh`. If a second `mega` verb lands later, promote to `lib/mega/mega.sh` +
+# siblings then (per the same rule those files document).
+#
+# WHY THIS EXISTS (provenance): a live session hit the SG-02 HANDOFF-vs-reality lie by hand --
+# HANDOFF.md claimed "running" while the `kitmod-02` worktree sat at 0 commits, empty. A dumb
+# reader that only echoes a roadmap's own `[x]`/`[ ]` boxes would have repeated that lie
+# verbatim. This verb is the manual reconciliation (grep ROADMAP, walk branches, verify PRs)
+# made mechanical: truth beats the roadmap's prose every time, and when they disagree the flag
+# names which side is stale. NOT a live-process monitor (whether a `claude` session is running
+# RIGHT NOW is the runner's own journal/RUNNER_DONE job); this only ever points at git + gh.
+#
+# ROADMAP sub-goal line grammar parsed (documented convention, no fixed schema -- same judgment
+# call `lib/board/board-mirror.sh`'s `extract_megas` already documents for this same file):
+#   - [x] 01-module-collapse (dwarves-kit), <prose>, PR #190 merged cb64f15 (<prose>)
+#   - [ ] 04-install-wire (dwarves-kit), <prose>, PR #
+#   - [~] 09-rehomed (dwarves-kit), rehomed into <other mega> (informational, never flagged)
+# `[x]`/`[X]` = checked, `[ ]` = unchecked, `[~]` = rehomed/superseded (informational only, per
+# DECISIONS.md's SG-01 outcome notes -- these are never drift-flagged even when git truth
+# disagrees, because the roadmap is explicitly saying "this box means something else now").
+#
+# Git truth per sub-goal (gathered against --code-root, the repo the sub-goal's OWN branches/
+# PRs live in -- for kit-modularity that is dwarves-kit, a DIFFERENT repo from --megagoals-root,
+# which is wherever the mega's ROADMAP.md lives, e.g. ops-toolkit):
+#   - PR state: `${GH_BIN:-gh} pr view <N> --json state -q .state` (MERGED/OPEN/CLOSED/missing).
+#   - Branch: read the sub-goal's own goal file (`<megagoals-root>/<slug>/goals/<sub>.md`)'s
+#     `**Branch:** <name>` line -- the authoritative name (no guessing a naming convention).
+#     A sub-goal whose goal file is missing or carries no `**Branch:**` line has no git-truth
+#     signal beyond the PR check (this is honest, not a failure).
+#   - Commit count: `${GIT_BIN:-git} -C <code-root> rev-list --count <base>..<branch>` (base
+#     defaults to `master`, `--base` overrides). Uses the BRANCH REF directly, not a worktree
+#     path -- a worktree may have been cleaned up after a PR merges/closes while the branch ref
+#     (or its remote-tracking counterpart) still exists, and the ref-based count is exactly as
+#     valid a "0 commits" signal as walking a worktree directory would be, without depending on
+#     the worktree still being present on disk. Tries the local branch ref first, then
+#     `origin/<branch>` (a pushed branch with no local worktree at all).
+#   - Open PR: `${GH_BIN:-gh} pr list --state open --json number,headRefName` filtered locally
+#     by `headRefName == branch` (jq).
+#
+# Drift classes (the whole value of this tool -- a dumb `[x]`/`[ ]` echo is worthless):
+#   ✓                 [x] and its PR#N verified MERGED.
+#   CLAIM-UNVERIFIED  [x] but PR#N is NOT merged (open/closed/missing) -- roadmap ahead of
+#                     reality, a green-wash. Never silently trusted.
+#   MERGED-UNCHECKED  [ ] but its PR#N IS merged -- roadmap lagging reality.
+#   STALLED           [ ] and the branch exists with 0 commits vs base AND no open PR -- a
+#                     dispatched-but-empty run (the exact HANDOFF-vs-reality lie this verb
+#                     exists to catch).
+#   WIP               [ ] and the branch has >0 commits vs base, OR an open PR exists for it --
+#                     real in-flight work, NOT stalled (a live worker mid-build is not a lie).
+#   PENDING           [ ] and there is no branch, no PR at all -- not yet started; informational.
+#   INFO              [~] -- rehomed/superseded, always informational, never flagged regardless
+#                     of what git truth shows.
+#
+# Usage:
+#   mega.sh status <slug> [--megagoals-root <path>] [--code-root <path>] [--base <branch>]
+#                          [--rollup-only]
+#     <slug>              the mega-goal's directory name under <megagoals-root>/
+#     --megagoals-root    where `<slug>/ROADMAP.md` lives. Precedence: this flag >
+#                         $MEGAGOALS_ROOT > `${REPO_ROOT}/_meta/megagoals` (REPO_ROOT is the
+#                         kit's existing consumer-config env var, same seam `board`/`queue`
+#                         already read) > `<git-toplevel-of-cwd>/_meta/megagoals`. The kit
+#                         itself never hardcodes a personal path.
+#     --code-root         the repo whose branches/worktrees/PRs are git truth for this mega's
+#                         sub-goals. Precedence: this flag > $CODE_ROOT > `<git-toplevel-of-cwd>`
+#                         (the natural default: you normally run `mega status` FROM the code
+#                         repo the sub-goals build in).
+#     --base              the PR base branch sub-goal commit counts are measured against.
+#                         Default `master`.
+#     --rollup-only       print ONLY the final rollup line (`N/M ok  M-N drift: ...`), no
+#                         per-sub-goal detail -- the form `board`'s render wires in as a column.
+#
+# GH_BIN / GIT_BIN override the `gh`/`git` binaries (tests point them at PATH-injected stubs
+# that log argv and return canned JSON, per the suite's existing convention -- see
+# `lib/board/board-writeback.sh`'s `GH_BIN`). No real network call is ever made by the test
+# suite; every gh/git interaction here is a plain, stub-friendly subprocess call.
+
+set -uo pipefail
+
+GH_BIN="${GH_BIN:-gh}"
+GIT_BIN="${GIT_BIN:-git}"
+
+_default_repo_root() { "$GIT_BIN" rev-parse --show-toplevel 2>/dev/null || pwd; }
+
+OPT_MEGAGOALS_ROOT=""; OPT_CODE_ROOT=""; OPT_BASE=""; OPT_ROLLUP_ONLY=0
+POSITIONAL=()
+_parse_flags() {
+  OPT_MEGAGOALS_ROOT=""; OPT_CODE_ROOT=""; OPT_BASE=""; OPT_ROLLUP_ONLY=0
+  POSITIONAL=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --megagoals-root) OPT_MEGAGOALS_ROOT="${2:-}"; shift 2 ;;
+      --code-root)      OPT_CODE_ROOT="${2:-}"; shift 2 ;;
+      --base)           OPT_BASE="${2:-}"; shift 2 ;;
+      --rollup-only)    OPT_ROLLUP_ONLY=1; shift ;;
+      *) POSITIONAL+=("$1"); shift ;;
+    esac
+  done
+}
+
+_resolve_megagoals_root() {
+  if [ -n "$OPT_MEGAGOALS_ROOT" ]; then printf '%s\n' "$OPT_MEGAGOALS_ROOT"; return; fi
+  if [ -n "${MEGAGOALS_ROOT:-}" ]; then printf '%s\n' "$MEGAGOALS_ROOT"; return; fi
+  if [ -n "${REPO_ROOT:-}" ]; then printf '%s/_meta/megagoals\n' "$REPO_ROOT"; return; fi
+  printf '%s/_meta/megagoals\n' "$(_default_repo_root)"
+}
+
+_resolve_code_root() {
+  if [ -n "$OPT_CODE_ROOT" ]; then printf '%s\n' "$OPT_CODE_ROOT"; return; fi
+  if [ -n "${CODE_ROOT:-}" ]; then printf '%s\n' "$CODE_ROOT"; return; fi
+  _default_repo_root
+}
+
+# _sub_branch <megagoals-root> <slug> <sub-slug> -- reads the sub-goal's own goal file's
+# `**Branch:** <name>` line. Empty output = no goal file / no Branch line (honest absence, not
+# an error): the sub-goal then has no git-truth signal beyond its PR check.
+_sub_branch() {
+  local mroot="$1" slug="$2" sub="$3" gf
+  gf="$mroot/$slug/goals/$sub.md"
+  [ -f "$gf" ] || return 0
+  grep -m1 -E '^\*\*Branch:\*\* ' "$gf" 2>/dev/null | sed -E 's/^\*\*Branch:\*\* *//'
+}
+
+# _pr_state <pr-number> -- MERGED/OPEN/CLOSED, or empty if unresolvable (missing/deleted PR,
+# `gh` failure). Never treated as a hard error: an unresolvable PR# is exactly a
+# CLAIM-UNVERIFIED signal for a [x] row (the roadmap cites a PR that can't be confirmed).
+_pr_state() {
+  local pr="$1"
+  "$GH_BIN" pr view "$pr" --json state -q '.state' 2>/dev/null || true
+}
+
+# _commit_count <code-root> <base> <branch> -- commits on <branch> not on <base>. Tries the
+# local branch ref, then `origin/<branch>` (a pushed-but-no-local-worktree branch). Empty
+# output = branch does not exist anywhere reachable (honest absence).
+_commit_count() {
+  local root="$1" base="$2" branch="$3"
+  if "$GIT_BIN" -C "$root" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1; then
+    "$GIT_BIN" -C "$root" rev-list --count "$base..$branch" 2>/dev/null || true
+    return
+  fi
+  if "$GIT_BIN" -C "$root" rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null 2>&1; then
+    "$GIT_BIN" -C "$root" rev-list --count "$base..origin/$branch" 2>/dev/null || true
+  fi
+}
+
+# _open_pr_for <branch> -- the PR number of an OPEN pr whose head is <branch>, or empty.
+_open_pr_for() {
+  local branch="$1" out
+  out="$("$GH_BIN" pr list --state open --json number,headRefName 2>/dev/null)" || return 0
+  printf '%s' "$out" | jq -r --arg b "$branch" '.[] | select(.headRefName == $b) | .number' 2>/dev/null | head -n1
+}
+
+# _classify <box> <prnum> <prstate> <commit-count> <open-pr> -- one of:
+#   ok | claim-unverified | merged-unchecked | stalled | wip | pending | info
+_classify() {
+  local box="$1" prnum="$2" prstate="$3" commits="$4" openpr="$5"
+  case "$box" in
+    x|X)
+      if [ -n "$prnum" ] && [ "$prstate" = "MERGED" ]; then echo "ok"
+      else echo "claim-unverified"
+      fi
+      ;;
+    '~')
+      echo "info"
+      ;;
+    *)
+      if [ -n "$prnum" ] && [ "$prstate" = "MERGED" ]; then
+        echo "merged-unchecked"
+      elif [ -n "$commits" ] && [ "$commits" = "0" ] && [ -z "$openpr" ]; then
+        echo "stalled"
+      elif { [ -n "$commits" ] && [ "$commits" != "0" ]; } || [ -n "$openpr" ]; then
+        echo "wip"
+      else
+        echo "pending"
+      fi
+      ;;
+  esac
+}
+
+_label() {
+  case "$1" in
+    ok)                echo "OK" ;;
+    claim-unverified)  echo "CLAIM-UNVERIFIED" ;;
+    merged-unchecked)  echo "MERGED-UNCHECKED" ;;
+    stalled)           echo "STALLED" ;;
+    wip)               echo "WIP" ;;
+    pending)           echo "PENDING" ;;
+    info)              echo "INFO" ;;
+    *)                 echo "UNKNOWN" ;;
+  esac
+}
+
+_symbol() {
+  case "$1" in
+    ok)                printf '\xe2\x9c\x93' ;;   # checkmark
+    claim-unverified)  printf '\xe2\x9a\xa0' ;;    # warning
+    merged-unchecked)  printf '\xe2\x9a\xa0' ;;
+    stalled)           printf '\xe2\x9a\xa0' ;;
+    wip)               printf '~' ;;
+    pending)           printf '.' ;;
+    info)              printf '-' ;;
+    *)                 printf '?' ;;
+  esac
+}
+
+cmd_status() {
+  _parse_flags "$@"
+  local slug="${POSITIONAL[0]:-}"
+  [ -n "$slug" ] || { echo "mega status: a <slug> is required" >&2; return 64; }
+
+  local mroot croot base
+  mroot="$(_resolve_megagoals_root)"
+  croot="$(_resolve_code_root)"
+  base="${OPT_BASE:-master}"
+
+  local roadmap="$mroot/$slug/ROADMAP.md"
+  [ -f "$roadmap" ] || { echo "mega status: no ROADMAP.md at $roadmap" >&2; return 1; }
+
+  local total=0 ok_count=0 drift_count=0
+  local -a detail_lines=()
+
+  while IFS= read -r line; do
+    [[ "$line" =~ ^-\ \[(.)\]\ ([0-9]+-[A-Za-z0-9_-]+) ]] || continue
+    local box="${BASH_REMATCH[1]}" sub="${BASH_REMATCH[2]}"
+    total=$((total + 1))
+
+    local prnum="" sha=""
+    if [[ "$line" =~ PR\ \#([0-9]+) ]]; then
+      prnum="${BASH_REMATCH[1]}"
+      if [[ "$line" =~ PR\ \#${prnum}\ merged\ ([0-9a-fA-F]{6,40}) ]]; then
+        sha="${BASH_REMATCH[1]}"
+      fi
+    fi
+
+    local branch commits="" openpr="" prstate=""
+    branch="$(_sub_branch "$mroot" "$slug" "$sub")"
+    [ -n "$prnum" ] && prstate="$(_pr_state "$prnum")"
+    if [ -n "$branch" ]; then
+      commits="$(_commit_count "$croot" "$base" "$branch")"
+      openpr="$(_open_pr_for "$branch")"
+    fi
+
+    local cls; cls="$(_classify "$box" "$prnum" "$prstate" "$commits" "$openpr")"
+    case "$cls" in
+      ok) ok_count=$((ok_count + 1)) ;;
+      claim-unverified|merged-unchecked|stalled) drift_count=$((drift_count + 1)) ;;
+    esac
+
+    local extra=""
+    [ -n "$prnum" ] && extra="${extra} PR#${prnum}${prstate:+ (${prstate})}"
+    [ -n "$branch" ] && extra="${extra} branch=${branch}"
+    [ -n "$commits" ] && extra="${extra} commits=${commits}"
+    [ -n "$openpr" ] && extra="${extra} open-PR#${openpr}"
+    detail_lines+=("$(printf '  %s %-28s %s%s' "$(_symbol "$cls")" "$sub" "$(_label "$cls")" "$extra")")
+  done < <(grep -E '^- \[.\] ' "$roadmap")
+
+  [ "$total" -gt 0 ] || { echo "mega status: no sub-goal lines found in $roadmap" >&2; return 1; }
+
+  local rollup
+  if [ "$drift_count" -gt 0 ]; then
+    rollup="$(printf '%s: %d/%d ok  \xe2\x9a\xa0 %d drift' "$slug" "$ok_count" "$total" "$drift_count")"
+  else
+    rollup="$(printf '%s: %d/%d ok' "$slug" "$ok_count" "$total")"
+  fi
+
+  if [ "$OPT_ROLLUP_ONLY" -eq 1 ]; then
+    printf '%s\n' "$rollup"
+    [ "$drift_count" -eq 0 ]
+    return
+  fi
+
+  printf '%s\n' "${detail_lines[@]}"
+  printf '%s\n' "$rollup"
+  [ "$drift_count" -eq 0 ]
+}
+
+usage() { sed -n '2,84p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+main() {
+  local first="${1:-}"
+  case "$first" in
+    status) shift; cmd_status "$@" ;;
+    -h|--help|help|"") usage ;;
+    *) echo "mega.sh: unknown subcommand '$first'" >&2; usage >&2; return 64 ;;
+  esac
+}
+
+main "$@"

--- a/tests/test-mega.sh
+++ b/tests/test-mega.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# test-mega.sh -- lib/mega.sh (kit-modularity sub-goal 08): `mega status <slug>` reconciles a
+# mega-goal's ROADMAP.md sub-goal claims against GIT TRUTH.
+#
+# Proves the full drift-class taxonomy on a fixture mega ("testmega") with 8 sub-goals, one per
+# class, over a REAL mktemp git repo (CODEROOT) for branches/commits and a stub `gh` (GH_BIN,
+# PATH-injected, no real network call ever) for PR state:
+#
+#   01-alpha    [x] + PR merged                         -> OK
+#   02-beta     [x] + PR NOT merged      (NC-1)         -> CLAIM-UNVERIFIED
+#   03-gamma    [ ] + branch 0 commits, no open PR (NC-2)-> STALLED
+#   04-delta    [ ] + PR IS merged       (NC-3)         -> MERGED-UNCHECKED
+#   05-epsilon  [ ] + branch 0 commits BUT an open PR   -> WIP, never STALLED (the nuance:
+#                                                          0-commits + a live open PR is
+#                                                          in-flight, not a dispatched-but-empty
+#                                                          lie -- only 0-commits WITH NO open PR
+#                                                          is STALLED)
+#   06-zeta     [ ] + branch with commits, no open PR   -> WIP
+#   07-eta      [ ] + no branch, no PR at all           -> PENDING
+#   08-theta    [~] rehomed                             -> INFO, always, regardless of git truth
+#
+# Run: bash tests/test-mega.sh   (exit 0 = all AC/NC green)
+
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MEGA="$KIT_DIR/lib/mega.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS + 1)); echo "ok - $1"; }
+no() { FAIL=$((FAIL + 1)); echo "NOT ok - $1"; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/dk-mega-test.XXXXXX")"
+TMP="$(cd "$TMP" && pwd)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---------------------------------------------------------------------------
+# CODEROOT -- a REAL git repo (branches/commits are git truth; no stub needed for git itself,
+# per the suite's precedent of using real git in mktemp fixtures, e.g. test-board.sh's fixA/fixB).
+# ---------------------------------------------------------------------------
+CODEROOT="$TMP/coderoot"
+mkdir -p "$CODEROOT"
+git -C "$CODEROOT" init -q
+git -C "$CODEROOT" config user.email t@t
+git -C "$CODEROOT" config user.name t
+echo init > "$CODEROOT/README"
+git -C "$CODEROOT" add -A
+git -C "$CODEROOT" commit -qm init
+git -C "$CODEROOT" branch -M master
+
+# 03-gamma: branch created off master, ZERO commits ahead (the STALLED signal).
+git -C "$CODEROOT" branch feat/testmega-03-gamma master
+
+# 05-epsilon: branch created off master, ZERO commits ahead, but WILL have an open PR (stub
+# below) -- the nuance case: 0 commits + a live open PR must classify WIP, never STALLED.
+git -C "$CODEROOT" branch feat/testmega-05-epsilon master
+
+# 06-zeta: branch off master WITH 2 commits ahead, no open PR -> WIP via commits alone.
+git -C "$CODEROOT" checkout -qb feat/testmega-06-zeta master
+echo a >> "$CODEROOT/README"; git -C "$CODEROOT" commit -qam "zeta 1"
+echo b >> "$CODEROOT/README"; git -C "$CODEROOT" commit -qam "zeta 2"
+git -C "$CODEROOT" checkout -q master
+
+# ---------------------------------------------------------------------------
+# MEGAROOT -- <slug>/ROADMAP.md + <slug>/goals/<sub>.md (the "**Branch:**" lookup).
+# ---------------------------------------------------------------------------
+MEGAROOT="$TMP/megaroot"
+SLUG="testmega"
+mkdir -p "$MEGAROOT/$SLUG/goals"
+
+cat > "$MEGAROOT/$SLUG/ROADMAP.md" <<'ROADMAP'
+# Mega-goal: testmega
+
+## Sub-goals
+
+- [x] 01-alpha (testrepo), does alpha, `auto`, PR #101 merged abc123def0 (shipped clean)
+- [x] 02-beta (testrepo), does beta, `auto`, PR #999 merged deadbeef00 (roadmap claims merged, PR isn't)
+- [ ] 03-gamma (testrepo), does gamma, `auto`, PR #
+- [ ] 04-delta (testrepo), does delta, `auto`, PR #104
+- [ ] 05-epsilon (testrepo), does epsilon, `auto`, PR #
+- [ ] 06-zeta (testrepo), does zeta, `auto`, PR #
+- [ ] 07-eta (testrepo), does eta, `auto`, PR #
+- [~] 08-theta (testrepo), rehomed into a sibling mega, `auto`, PR #
+ROADMAP
+
+printf '**Branch:** feat/testmega-03-gamma\n'   > "$MEGAROOT/$SLUG/goals/03-gamma.md"
+printf '**Branch:** feat/testmega-05-epsilon\n' > "$MEGAROOT/$SLUG/goals/05-epsilon.md"
+printf '**Branch:** feat/testmega-06-zeta\n'    > "$MEGAROOT/$SLUG/goals/06-zeta.md"
+# 07-eta deliberately has NO goal file -> no branch -> PENDING.
+
+# ---------------------------------------------------------------------------
+# Stub gh -- PR #101 MERGED, #999 still OPEN (the CLAIM-UNVERIFIED case), #104 MERGED (the
+# MERGED-UNCHECKED case), and one open PR whose head is feat/testmega-05-epsilon (the nuance
+# case). No real network call is ever made; GH_BIN points here for the whole run.
+# ---------------------------------------------------------------------------
+STUBGH="$TMP/stub-gh"
+cat > "$STUBGH" <<'STUBEOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "pr view")
+    case "$3" in
+      101) echo MERGED ;;
+      999) echo OPEN ;;
+      104) echo MERGED ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  "pr list")
+    cat <<'JSON'
+[{"number":205,"headRefName":"feat/testmega-05-epsilon"}]
+JSON
+    ;;
+  *) echo "stub-gh: unhandled call: $*" >&2; exit 1 ;;
+esac
+STUBEOF
+chmod +x "$STUBGH"
+
+run_status() { GH_BIN="$STUBGH" bash "$MEGA" status "$SLUG" --megagoals-root "$MEGAROOT" --code-root "$CODEROOT" "$@"; }
+
+OUT="$(run_status)"; RC=$?
+
+detail_for() { printf '%s\n' "$OUT" | grep -F " $1 "; }
+
+# ---------------------------------------------------------------------------
+# AC1-AC8: per-class classification
+# ---------------------------------------------------------------------------
+case "$(detail_for 01-alpha)" in *OK*) ok "01-alpha (PR merged) -> OK";; *) no "01-alpha should be OK: $(detail_for 01-alpha)";; esac
+case "$(detail_for 02-beta)" in *CLAIM-UNVERIFIED*) ok "NC-1: 02-beta ([x] + PR NOT merged) -> CLAIM-UNVERIFIED";; *) no "NC-1 failed: $(detail_for 02-beta)";; esac
+case "$(detail_for 03-gamma)" in *STALLED*) ok "NC-2: 03-gamma ([ ] + 0 commits, no open PR) -> STALLED";; *) no "NC-2 failed: $(detail_for 03-gamma)";; esac
+case "$(detail_for 04-delta)" in *MERGED-UNCHECKED*) ok "NC-3: 04-delta ([ ] + PR merged) -> MERGED-UNCHECKED";; *) no "NC-3 failed: $(detail_for 04-delta)";; esac
+d05="$(detail_for 05-epsilon)"
+case "$d05" in
+  *STALLED*) no "nuance FAILED: 05-epsilon (0 commits + OPEN PR) misclassified STALLED: $d05" ;;
+  *WIP*)     ok "nuance: 05-epsilon (0 commits but an OPEN PR) -> WIP, never STALLED" ;;
+  *)         no "05-epsilon: neither WIP nor STALLED: $d05" ;;
+esac
+case "$(detail_for 06-zeta)" in *WIP*) ok "06-zeta ([ ] + commits, no open PR) -> WIP";; *) no "06-zeta failed: $(detail_for 06-zeta)";; esac
+case "$(detail_for 07-eta)" in *PENDING*) ok "07-eta ([ ] + no branch, no PR) -> PENDING";; *) no "07-eta failed: $(detail_for 07-eta)";; esac
+case "$(detail_for 08-theta)" in *INFO*) ok "08-theta ([~] rehomed) -> INFO always";; *) no "08-theta failed: $(detail_for 08-theta)";; esac
+
+# ---------------------------------------------------------------------------
+# AC9: rollup line -- 1 ok (01-alpha only) / 8 total, 3 drift (02+03+04); nonzero exit on drift
+# ---------------------------------------------------------------------------
+rollup_line="$(printf '%s\n' "$OUT" | tail -n1)"
+if [ "$rollup_line" = "testmega: 1/8 ok  ⚠ 3 drift" ]; then
+  ok "rollup line: testmega: 1/8 ok  ⚠ 3 drift"
+else
+  no "rollup line mismatch: got '$rollup_line'"
+fi
+if [ "$RC" -ne 0 ]; then ok "exit code nonzero when drift > 0"; else no "exit code should be nonzero on drift"; fi
+
+# ---------------------------------------------------------------------------
+# AC10: --rollup-only prints ONLY the rollup line
+# ---------------------------------------------------------------------------
+ROLLUP_ONLY_OUT="$(run_status --rollup-only)"
+if [ "$ROLLUP_ONLY_OUT" = "$rollup_line" ]; then
+  ok "--rollup-only prints exactly the rollup line, no detail"
+else
+  no "--rollup-only mismatch: got '$ROLLUP_ONLY_OUT'"
+fi
+
+# ---------------------------------------------------------------------------
+# NC suite-identical-or-better control: a clean mega (every box checked + its PR merged, no
+# drift) must roll up with ZERO drift and exit 0 -- proves the reconciler doesn't false-positive
+# on a genuinely healthy roadmap.
+# ---------------------------------------------------------------------------
+CLEANROOT="$TMP/megaroot-clean"
+mkdir -p "$CLEANROOT/cleanmega/goals"
+cat > "$CLEANROOT/cleanmega/ROADMAP.md" <<'ROADMAP'
+# Mega-goal: cleanmega
+
+## Sub-goals
+
+- [x] 01-only (testrepo), the only sub-goal, `auto`, PR #101 merged abc123def0 (shipped clean)
+ROADMAP
+CLEAN_OUT="$(GH_BIN="$STUBGH" bash "$MEGA" status cleanmega --megagoals-root "$CLEANROOT" --code-root "$CODEROOT" --rollup-only)"
+CLEAN_RC=$?
+if [ "$CLEAN_OUT" = "cleanmega: 1/1 ok" ] && [ "$CLEAN_RC" -eq 0 ]; then
+  ok "clean roadmap (all [x] verified merged) -> 0 drift, exit 0"
+else
+  no "clean-roadmap control failed: out='$CLEAN_OUT' rc=$CLEAN_RC"
+fi
+
+# ---------------------------------------------------------------------------
+# Error paths: missing ROADMAP.md, unknown subcommand
+# ---------------------------------------------------------------------------
+if ! GH_BIN="$STUBGH" bash "$MEGA" status nope-slug --megagoals-root "$MEGAROOT" --code-root "$CODEROOT" >/dev/null 2>&1; then
+  ok "missing ROADMAP.md -> nonzero exit"
+else
+  no "missing ROADMAP.md should fail"
+fi
+if ! bash "$MEGA" bogus-verb >/dev/null 2>&1; then
+  ok "unknown subcommand -> nonzero exit"
+else
+  no "unknown subcommand should fail"
+fi
+
+# ---------------------------------------------------------------------------
+# board.sh wiring: `board board --with-mega` / `board status --with-mega` surface the SAME
+# rollup as a trailing "MEGA ROLLUP" section, opt-in only (never on by default -- see the
+# byte-identical render non-regression NC in test-board.sh, which never passes --with-mega).
+# ---------------------------------------------------------------------------
+BOARD_SH="$KIT_DIR/lib/board/board.sh"
+BOARDREPO="$TMP/boardrepo"
+mkdir -p "$BOARDREPO/_meta/megagoals/testmega/goals"
+git -C "$BOARDREPO" init -q   # _repo_root_for needs a real git toplevel to resolve correctly
+cp "$MEGAROOT/$SLUG/ROADMAP.md" "$BOARDREPO/_meta/megagoals/testmega/ROADMAP.md"
+cp "$MEGAROOT/$SLUG/goals/"*.md "$BOARDREPO/_meta/megagoals/testmega/goals/"
+cat > "$BOARDREPO/_meta/BACKLOG.md" <<'BOARDMD'
+# Backlog
+
+## Active queue
+
+| ID | Item | Notes & source | Status |
+|----|------|-----------------|--------|
+| ID-001 | Mega-goal: testmega | scaffold at `_meta/megagoals/testmega/` | queued |
+BOARDMD
+
+WITH_MEGA_OUT="$(GH_BIN="$STUBGH" bash "$BOARD_SH" board --with-mega --mega-code-root "$CODEROOT" --backlog-file "$BOARDREPO/_meta/BACKLOG.md" 2>&1)"
+if printf '%s\n' "$WITH_MEGA_OUT" | grep -qF "testmega: 1/8 ok  ⚠ 3 drift"; then
+  ok "board board --with-mega surfaces the mega rollup in a trailing MEGA ROLLUP section"
+else
+  no "board --with-mega did not surface the rollup: $WITH_MEGA_OUT"
+fi
+WITHOUT_MEGA_OUT="$(bash "$BOARD_SH" board --backlog-file "$BOARDREPO/_meta/BACKLOG.md" 2>&1)"
+if ! printf '%s\n' "$WITHOUT_MEGA_OUT" | grep -q "MEGA ROLLUP"; then
+  ok "board board WITHOUT --with-mega never touches gh / never prints a rollup (opt-in, non-regressing default)"
+else
+  no "board board without --with-mega should not print a MEGA ROLLUP section"
+fi
+
+echo "---"
+echo "Coverage delta: mega.sh had 0 tests before this file; now $((PASS + FAIL)) checks across the full drift-class taxonomy."
+echo "---"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

`mega status <slug>` (kit-modularity sub-goal 08): reconciles a mega-goal's ROADMAP sub-goal
claims against git truth (merged-PR verify, worktree/branch commit-count, open-PR) and flags
drift (STALLED / MERGED-UNCHECKED / CLAIM-UNVERIFIED), plus a `board render` rollup column
so mega status sits on the kanban beside backlog items. Bash + `gh`, no DuckDB.

## Verify

- `bash tests/test-mega.sh` -- 16/16, NC-1 CLAIM-UNVERIFIED, NC-2 STALLED, NC-3
  MERGED-UNCHECKED (stub-injected `gh`, real mktemp git repo for branches/commits), plus the
  STALLED-vs-WIP nuance (0 commits + an open PR is WIP, never STALLED) and the `board
  --with-mega` wiring.
- Real corpus run: `bash lib/mega.sh status kit-modularity` against this mega's own live
  ROADMAP.md -- correctly reconciled 01/02/03 as merged-OK and (at the time of the run) 04/08
  as STALLED (0 commits on their branch at that point).
- Suite identical-or-better on every touched file: `test-board.sh` (36/45, same 9
  pre-existing local-env FAILs), `test-board-mirror.sh` (72/72), `test-board-writeback.sh`
  (53/54, 1 skip) -- all unchanged from master.

Proof: `docs/proof/kitmod-mega-status.md` (table-first) + `docs/verification/kitmod-mega-status.md`
(flat gate-visible form). Stacked on #192 (SG-03 subsystem-commands).

ROADMAP: `ops-toolkit/_meta/megagoals/kit-modularity/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)