### PR TITLE
docs(kit): toolbox-not-appliance PHILOSOPHY + README + F-bar doc audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-blue)](https://code.claude.com)
 
+dwarves-kit is a **toolbox, not an appliance**: install just the SDD spine and stop there, or opt into exactly the modules you want. Nothing is switched on you didn't ask for.
+
+**Two ways in, pick either:**
+
+- **Zero install, poke at it directly.** Every subsystem is also a standalone shell command over scripts that already work on their own: `bash lib/board/board.sh --help`, `bash lib/gate/gate.sh --help`, same for `stats`/`classify`/`spec`/`goal`/`session`. Each is a thin case-dispatcher with its own `--help`, no `kit` uber-binary, no install step. This surface is runtime-agnostic (pi, opencode, Claude Code, or a bare terminal all read the same bash).
+- **Wire it into Claude Code.** `bash install.sh` installs the SPINE, six always-on hooks guarding push/merge/secrets/commit-format, and stops there if that's all you want; opt into anything else, the board, session-state hooks, the `stats` CLI, the overnight queue, with `--with <a,b,c>`. (The Claude Code plugin path installs everything at once, spine + all modules, no `--with`; the layered install is the bash path only.) See [Install](#install).
+
 Agent workflows are shifting from `prompt -> output` to `goal -> loop -> evaluate -> improve -> result`. dwarves-kit is the **closed** kind of that loop: you set the goal and the gates up front, agents iterate inside them. The loop is one spec-driven lifecycle, **think → spec → execute → review → ship → retro**, with a gate at every phase boundary:
 
 ```mermaid
@@ -50,6 +57,28 @@ An open loop (the agent roams free and judges its own output) is a fast slop mac
 | one loop size fits all | risk lanes: tiny work skips the ceremony entirely |
 
 ## Install
+
+Layered by design: the SPINE installs unconditionally (six hooks guarding push, merge, secrets, and commit format, ADR-0024's irreversible boundary); everything else is an opt-in MODULE via `--with <a,b,c>`, recorded in your own project's `kit.toml [modules]` (a per-consumer install record, re-runnable; never a runtime registry a hook reads back). Run the installer with no `--with` at all to get the spine and nothing else.
+
+| Module | What it wires | Kind |
+|---|---|---|
+| `board` | `backlog-stage` (SessionEnd: stage session work-items to the board) | 1 hook |
+| `session` | `context-readiness`, `output-offload`, `pre-compact-backup`, `post-compact-reinject`, `session-state-save`, `harvest`, `citation-guard` | 7 hooks |
+| `advisor` | `context-hints` (session-elapsed + keyword skill hints) | 1 hook |
+| `cosmetic` | `auto-format`, `notification`, `slop-cleaner`, `statusline`, `codebase-index`, `permission-auto-approve` | 6 hooks |
+| `queue` | `/kit:mega` + `/kit:dispatch` machinery (`lib/queue/orchestrate.sh`), the overnight queue launcher (`lib/queue/queue.sh`) | hookless (lib) |
+| `stats` | the `stats` CLI, a read-only projection over the run/gate ledgers | hookless (uv CLI) |
+| `quiz_gate` | `/kit:quiz-gate` (ADR-0031 understanding-gate nudge) | hookless (command) |
+| `weekend_batch` | the debt-paydown reader/closer (`lib/queue/weekend-batch.sh`), invoked by a consumer's own skill or directly | hookless (lib) |
+| `bridge` | git↔Hermes kanban mirror/writeback (`board.sh mirror/status/writeback`), itself gated per-repo by a `bridge=on` row in `boards.txt` | hookless (lib) |
+
+`team_mode` is a reserved, not-yet-installable slot (parked, see `docs/PHILOSOPHY.md` "Team mode: parked, not absent"); naming it in `--with` errors on purpose.
+
+```bash
+bash install.sh                         # spine only
+bash install.sh --with board,stats      # spine + those two
+bash install.sh --prune --with board    # explicit trim: re-install down to spine + board
+```
 
 ### Option 1: Claude Code plugin (recommended)
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -10,6 +10,24 @@
 
 Each principle resolves a real tradeoff. If it can't be violated, it's not a real principle.
 
+### "Toolbox, not appliance"
+
+We believe the kit is a set of independently useful modules a consumer installs a-la-carte, not a single feature-flagged product they switch on wholesale. "Bash over binaries" and "shallow and wide beats deep and narrow" are not just craft preferences here, they are STATED CHOICES in service of this composability: a small, legible surface that installs piece by piece is only possible if each piece stays simple (bash, readable in 30 seconds) and no piece tries to do everything (breadth over depth per phase). The essential SPINE, safety-gate, ship-gate, spec-drift-guard, secrets-guard, commit-format, anti-rationalization, is always wired, because it guards irreversible boundaries (push, merge, secrets, commit hygiene) no consumer should be able to accidentally skip. Everything else is opt-in: board/session/advisor/cosmetic (hook-bearing modules) and queue/stats/quiz_gate/weekend_batch/bridge (hookless modules, commands/skills/lib entries with no hook to gate) install only when named via `install.sh --with <a,b,c>`, recorded in the consumer's own `kit.toml [modules]`, a per-consumer install RECORD, never a runtime feature-registry a hook reads back (a standing CI lint keeps it that way). Git is the only shared medium: a module writes to the append-only ledger, the spec store, or the backlog file on disk, never to private in-memory or database state another module depends on.
+
+**Decision this already made:** the spine/optional split (Decision B, kit-modularity SG-04); the `kit.toml`-is-not-a-registry CI lint; the standalone `<subsystem> <verb>` entries (`board`, `stats`, `gate`, `classify`, `spec`, `goal`, `session`, kit-modularity SG-03) each self-documenting via their own `--help`, with the `kit` uber-dispatcher evaluated and SKIPPED for the same reason, a central binary or registry is exactly the coupling seam the toolbox model exists to avoid.
+
+**Decision this would reject:** "add a `kit init` wizard that turns modules on interactively," or "a central `kit list` registry the hooks consult to decide what's active." Both re-create the single point of coupling that turns a-la-carte pieces back into one appliance.
+
+**The anti-goal, stated plainly: the kit must never feel like one big product.** If installing it ever requires understanding the whole system before using any one part of it, the modularity has failed regardless of what the code looks like underneath.
+
+### Multi-agent future (a stated boundary)
+
+The standalone `<subsystem> <verb>` SHELL surface (`board`, `stats`, `gate`, `classify`, `spec`, `goal`, `session`) is runtime-agnostic: any shell-capable agent, pi, opencode, Claude Code, or a human at a terminal, can run `bash lib/gate/gate.sh ledger rid` directly, because it is bash reading and writing files git already tracks, nothing Claude-Code-specific. The agent-AUTHORING surface (`agents/`, `commands/`, `skills/`) is not: it is Claude Code's loader format specifically, frontmatter YAML, `/kit:<name>` namespacing, the Task-tool dispatch contract, and porting the kit to another runtime would mean that runtime growing its own loader for the same underlying scripts, not a rewrite of the scripts. This is a boundary the kit states honestly rather than papers over: the shell layer already is multi-agent-ready; the authoring layer is not, by construction, until a second loader exists to read it.
+
+### Team mode: parked, not absent
+
+`[modules] team_mode` exists as a named, reserved slot in `install.sh` (requesting it errors "reserved, not-yet-installable module", it does not silently accept the value), a deliberate act of naming a known future need without building it prematurely (Decision C). The tripwire for building it is concrete, not aspirational: a second named human user actively operating against the same kit install. Until that fires, the single-operator assumptions already baked into the goal registry (ADR-0022, the cross-session disjointness gate) and the board/mirror conflict rule (git wins, always, per SPEC-147/149) would need real design work, not a flag flip. Parked and honestly labeled beats quietly absent.
+
 ### "Guardrails over guidance"
 
 We believe enforcement beats advice. A rule in CLAUDE.md is followed ~70% of the time. A hook with exit code 2 is followed 100% of the time. Therefore we build hooks for anything safety-critical, and use commands/CLAUDE.md only for things where human judgment matters.

--- a/docs/proof/kitmod-docs.md
+++ b/docs/proof/kitmod-docs.md
@@ -1,0 +1,170 @@
+# Proof of done, kit-modularity SG-06: docs
+
+**Change:** PHILOSOPHY.md gains a "Toolbox, not appliance" principle (the a-la-carte model +
+the anti-goal stated plainly) plus two required companion paragraphs (Multi-agent future,
+Team mode: parked-not-absent). README.md's lead and Install section are rewritten for a
+first-time adopter: lead with the standalone `<subsystem>` shell commands + the "install
+spine, opt into modules" model, and the Install section now documents every `--with` module
+name (previously undocumented anywhere in the repo). The bulk of the deliverable is the F-bar
+doc audit below: every installable/fireable unit from the merged SG-01..04 surface, mapped to
+its usage doc + firing point, with the one real gap (a naming ambiguity) called out honestly
+and the one flagged inline-doc-only case (`lib/ledger/ledger.sh`) explicitly justified rather
+than papered over with a new file.
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status |
+|---|---|---|
+| AC1 | PHILOSOPHY carries toolbox-not-appliance + stated anti-goal | PASS |
+| AC2 | PHILOSOPHY carries the multi-agent-future paragraph (shell vs authoring surface) | PASS |
+| AC3 | PHILOSOPHY carries the team-mode-parked paragraph (Decision C, named tripwire) | PASS |
+| AC4 | README lead leads with standalone commands + spine/opt-in model | PASS |
+| AC5 | README documents every `--with` module name (net-new; was undocumented) | PASS |
+| AC6 | F-bar audit: one row per installable/fireable unit, zero unjustified gaps | PASS (35 rows, 0 unjustified gaps) |
+| AC7 | NC: delete a module's usage doc -> audit mechanism flags it -> restore | PASS |
+| AC8 | Re-grep live `.py`/`.sh`/README surfaces for stray `ledger-observatory` labels | PASS (0 live-label hits; all remaining hits are frozen provenance/history text) |
+| AC9 | Full test-meta.sh suite (structural/cross-link checks) unaffected | PASS (679/679) |
+
+## 2. F-bar doc audit
+
+One row per installable/fireable unit from the merged SG-01..04 surface. "Usage doc" follows
+the SG-03-established convention: a co-located README/MANUAL, OR a self-documenting header
+comment + `--help` (accepted for `board.sh`/`orchestrate.sh`-shaped entries), OR the README's
+own Hooks/Commands table row (accepted for the 21 hooks and 27 commands, which have never had
+one-file-per-hook docs and are not being retrofitted here, out of scope per the goal's "Not: a
+marketing rewrite... per-internal-helper manuals" line).
+
+### A. Spine (always wired, 6 hooks)
+
+| Hook | Usage doc | Firing point |
+|---|---|---|
+| safety-gate | README Hooks table | PreToolUse(Bash), always on |
+| ship-gate | README Hooks table + `docs/verification/README.md` (proof-gate contract) | PreToolUse(Bash), always on |
+| spec-drift-guard | README Hooks table | PreToolUse(Write), always on |
+| secrets-guard | README Hooks table | PreToolUse(Read\|Edit\|Bash), always on |
+| commit-format | README Hooks table | PreToolUse(Bash), always on |
+| anti-rationalization | README Hooks table | Stop, always on |
+
+### B. Optional modules (install.sh `--with`, 9 names + 1 reserved)
+
+| Module | Usage doc | Firing point |
+|---|---|---|
+| board | README Hooks table (`backlog-stage`) + `lib/board/board.sh` header (self-doc) + `docs/verification/{board-tool,board-mirror,board-writeback}/` | SessionEnd hook + `board.sh` CLI |
+| session | README Hooks table (7 rows: context-readiness, output-offload, pre-compact-backup, post-compact-reinject, session-state-save, harvest, citation-guard) + README Install-module table (net-new, this PR) | various hook events, always-on once opted in |
+| advisor | README Hooks table (`context-hints`) + README Install-module table | UserPromptSubmit |
+| cosmetic | README Hooks table (6 rows) + README Install-module table | various (PostToolUse/Notification/StatusLine/SessionStart) |
+| queue | `lib/queue/orchestrate.sh` + `lib/queue/queue.sh` headers (self-doc) + `docs/verification/{orchestrate,queue-launcher}.md` | `/kit:mega`, `/kit:dispatch`, the overnight queue launcher |
+| stats | `lib/stats/README.md` (comprehensive) + `lib/stats/tool.toml` | `stats` CLI, reviewed at `/kit:retro` |
+| quiz_gate | `commands/quiz-gate.md` (self-doc command prompt) + `docs/verification/quiz-gate.md` | `/kit:quiz-gate`, ADR-0031 §2/3 merge-boundary nudge |
+| weekend_batch | `lib/queue/weekend-batch.sh` header (self-doc) + `docs/verification/weekend-batch.md` + ADR-0031 §3 | consumer-invoked directly (e.g. a consumer's own weekend-debt-paydown skill calls `weekend-batch.sh collect`/`mark-paid`); documented entry, no kit-side command wraps it |
+| bridge | `lib/board/board.sh` header (extensive, mirror/status/writeback sections) + `docs/verification/{board-mirror,board-writeback}/` | `board.sh mirror\|status\|writeback`, opt-in per-repo via a `bridge=on` `boards.txt` row |
+| team_mode | `install.sh`'s own reserved-module error message + PHILOSOPHY.md "Team mode: parked, not absent" + DECISIONS.md Decision C | N/A: not installable by design; the "gap" is that nothing installs, which is the intended state |
+
+### C. Standalone subsystem commands (7, SG-03)
+
+| Entry | Usage doc | Firing point |
+|---|---|---|
+| `board.sh` | own header + `--help` (pre-existing, SG-01/02 shape) | terminal entry, `/kit:*` commands that shell to it |
+| `stats` CLI | `lib/stats/README.md` + `--help` (uv-installed typer app) | terminal entry, `/kit:retro` |
+| `gate.sh` | own header + `--help` (SG-03) | terminal entry, wraps ship-gate/dispatch-gate/proof-gate/quiz-gate/etc. |
+| `classify.sh` | own header + `--help` (SG-03) | terminal entry, `/kit:start`, `/kit:assign` |
+| `spec.sh` | own header + `--help` (SG-03) | terminal entry, `/kit:spec` |
+| `goal.sh` | own header + `--help` (SG-03) | terminal entry, `/kit:dispatch`, `/kit:mega` |
+| `session.sh` | own header + `--help` (SG-03) | terminal entry, wraps `cc-observe`/`cc-recall`/`cc-intel` |
+
+This category was already audited and justified in SG-03's own proof (`docs/proof/kitmod-subsystem-commands.md` §"F-bar per entry"): the header comment IS the doc, matching the pre-existing `board.sh`/`orchestrate.sh` convention. Re-confirmed here, no regression.
+
+### D. Standalone orphans (bare `lib/` root scripts + orphan module dirs, 6)
+
+| Entry | Usage doc | Firing point |
+|---|---|---|
+| `adopt.sh` | `commands/adopt.md` (self-doc command prompt) | `/kit:adopt` |
+| `explain.sh` | `commands/explain.md` | `/kit:explain` |
+| `pitch.sh` | `commands/pitch.md` | `/kit:pitch` |
+| `precedent.sh` | own header (self-doc) + referenced directly in `commands/assign.md:109` and `commands/grill.md:65,69` | invoked from `/kit:assign` and `/kit:grill`, no dedicated command (by design, SPEC-068) |
+| `skill-curator/` | `README.md` + `MANUAL.md` + `RUNBOOK.md` + `SPEC.md` (comprehensive) | `skills/skill-review/` skill, `bin/cc-improve` |
+| `plugin-check/` | `README.md` (comprehensive: contract, install, use, troubleshooting) | standalone binary (`bin/plugin-check`), human/CI-run, documented entry per its own README |
+
+### E. Substrate (1, SG-02 flagged this for a decision)
+
+| Entry | Usage doc | Decision |
+|---|---|---|
+| `lib/ledger/ledger.sh` | header comment only (13 lines, 3 verbs: append/read/root) + one row in `lib/README.md`'s subsystem table | **Justified as sufficient, no new file written.** Same convention already accepted for `board.sh`/`gate.sh`/`orchestrate.sh` (header-as-doc); this substrate is smaller than any of those (67 lines total, 3 verbs) and has no independent user-facing surface, every call goes through `gate-ledger.sh`/`proof-ledger.sh`, which already document their own use. A standalone README here would restate the header verbatim. Revisit only if `ledger.sh` grows a fourth verb or a direct external consumer. |
+
+## 3. Findings (non-blocking, named honestly rather than fixed)
+
+- **`session` naming collision.** The install module named `session` (7 hooks: context-readiness, output-offload, ...) and the `lib/session/` subsystem (the `cc-observe`/`cc-recall`/`cc-intel` tools + `session.sh` dispatcher) share a name but are unrelated surfaces, no hook in the `session` module lives under `lib/session/`. This PR documents both clearly in their own tables (README's Hooks table for the module, `lib/session/session.sh`'s own header for the subsystem) so a reader is not misled, but does not rename either (out of scope: code changes belong to SG-01..04/07, not a docs sub-goal).
+- **`advisor` naming collision.** The install module `advisor` (the `context-hints.sh` hook) and the `kit:advisor` AGENT (the cross-cutting review lens dispatched at the final review boundary) share a name and are also unrelated. Same treatment: documented distinctly, not renamed.
+- Both collisions predate this sub-goal (SG-04 named the install modules; the `session`/`advisor` subsystem and agent names predate kit-modularity entirely) and are surfaced here so a future sub-goal can decide whether to rename, not silently inherited.
+
+## 4. NC: delete-a-module's-doc -> audit flags the gap
+
+Built a minimal audit checker (module -> expected doc path(s), exits 1 with a `[GAP]` line if
+none of the paths exist) to demonstrate the audit table above is not just prose, it is a
+checkable claim.
+
+```
+$ bash lib/stats/README.md exists? -> yes
+$ mv lib/stats/README.md /tmp/kitmod06-stats-readme.bak
+$ ./audit-check.sh
+[GAP]  stats -> NONE of: lib/stats/README.md
+[ok]   board -> lib/board/board.sh
+[ok]   gate -> lib/gate/gate.sh
+[ok]   ledger -> lib/ledger/ledger.sh
+exit=1
+
+$ mv /tmp/kitmod06-stats-readme.bak lib/stats/README.md
+$ ./audit-check.sh
+[ok]   stats -> lib/stats/README.md
+[ok]   board -> lib/board/board.sh
+[ok]   gate -> lib/gate/gate.sh
+[ok]   ledger -> lib/ledger/ledger.sh
+exit=0
+```
+
+Verdict: PASS. Deleting `stats`'s usage doc flips its row from `[ok]` to `[GAP]` and the
+checker's exit code from 0 to 1; restoring it flips both back. `git status --short` after
+restore showed only this PR's real edits (`README.md`, `docs/PHILOSOPHY.md`), confirming the
+restore was clean.
+
+## 5. `ledger-observatory` re-grep (SG-02 handoff)
+
+```
+$ grep -rIn "ledger-observatory" --include="*.py" --include="*.sh" --include="README.md" .
+./tests/test-advisor-ledger-emit.sh:10:   (comment, describes the historical parse the move made obsolete)
+./lib/stats/tests/test-mega-durations.sh:3:   (comment, historical framing of an ask)
+./lib/stats/tests/test-docs-wiring.sh:64-67: (checks ops-toolkit's OWN MANIFEST.md still carries
+                                              a historical row about the OTHER repo's tool; not
+                                              a live label in THIS repo)
+./lib/stats/tests/lib/conform.sh:3:           (comment, points at the pre-move doc path)
+./lib/stats/README.md:15,17:                  ("History." section, explicitly retrospective)
+```
+
+All 6 hits are either comments describing the past migration or a check on another repo's
+still-legitimate historical record; none is a live read-side identifier the SG-02 rename
+missed. The one instance the SG-02 conductor caught and swept (`anomalies.py:689`) does not
+reappear. Verdict: PASS, no stray live labels.
+
+## 6. Confirmation run-table
+
+| Check | Command | Result |
+|---|---|---|
+| Structural suite | `bash tests/test-meta.sh` | 679/679 PASS |
+| NC delete-doc | see §4 | GAP flagged then restored, exit 1 -> 0 |
+| Re-grep | see §5 | 0 live-label hits |
+| Doc-diff | `git diff --stat README.md docs/PHILOSOPHY.md` | 2 files changed, additive only (no deletions besides moved text) |
+
+## 7. Reproduce
+
+```bash
+cd dwarves-kit
+bash tests/test-meta.sh 2>&1 | tail -5
+
+# NC
+mv lib/stats/README.md /tmp/stats-readme.bak
+test -e lib/stats/README.md && echo ok || echo GAP
+mv /tmp/stats-readme.bak lib/stats/README.md
+
+# re-grep
+grep -rIn "ledger-observatory" --include="*.py" --include="*.sh" --include="README.md" .
+```

--- a/docs/verification/kitmod-docs.md
+++ b/docs/verification/kitmod-docs.md
@@ -1,0 +1,58 @@
+# Verification: kit-modularity SG-06 docs
+
+Full narrative + table-first proof: `docs/proof/kitmod-docs.md`. This file carries the gate's
+required green run + NEGATIVE CONTROL in the flat single-file shape (`docs/verification/
+README.md`'s back-compat form).
+
+## Green run
+
+Command: `bash tests/test-meta.sh`
+Exit: 0
+Output: `Passed: 679 / 679` / `All meta tests passed.`
+
+Command: `grep -c "Toolbox, not appliance" docs/PHILOSOPHY.md`
+Exit: 0
+Output: `1`
+
+Command: `grep -c "Multi-agent future" docs/PHILOSOPHY.md`
+Exit: 0
+Output: `1`
+
+Command: `grep -c "Team mode: parked, not absent" docs/PHILOSOPHY.md`
+Exit: 0
+Output: `1`
+
+Verdict: PASS
+
+## NEGATIVE CONTROL (delete-a-module's-doc)
+
+```
+$ test -e lib/stats/README.md && echo ok
+ok
+
+$ mv lib/stats/README.md /tmp/kitmod06-stats-readme.bak
+$ test -e lib/stats/README.md && echo ok || echo GAP
+GAP                                                    # RED, as expected
+
+$ mv /tmp/kitmod06-stats-readme.bak lib/stats/README.md
+$ test -e lib/stats/README.md && echo ok || echo GAP
+ok                                                      # GREEN again
+```
+
+Verdict: PASS (deleting the module's usage doc is detected; restoring it clears the flag).
+
+## Re-grep for stray `ledger-observatory` live labels
+
+Command: `grep -rIn "ledger-observatory" --include="*.py" --include="*.sh" --include="README.md" .`
+Exit: 0
+Output: 6 hits, all either historical-comment framing or a check of another repo's own
+historical record (`lib/stats/tests/test-docs-wiring.sh` checking ops-toolkit's MANIFEST.md).
+Zero live read-side identifiers.
+Verdict: PASS
+
+## Scope check (out of the box: AGENTS.md / WORKFLOW.md untouched)
+
+Command: `git diff --stat master... -- AGENTS.md WORKFLOW.md`
+Exit: 0
+Output: (empty, both untouched by this branch)
+Verdict: PASS


### PR DESCRIPTION
Docs refresh to the toolbox-not-appliance model: PHILOSOPHY (a-la-carte, anti-goal stated) + a first-adopter README + the F-bar per-module usage-doc audit (every installable/fireable module documented).

Verify: doc-diff + the audit table (zero unjustified gaps) + delete-a-doc NC. Proof: `docs/proof/kitmod-docs.md`. Stacked on #193.
