### PR TITLE
docs(operate-contract): refresh AGENTS + WORKFLOW to modular surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,29 @@ When you pause: write the named blocker, state the decision you are not making a
 
 ---
 
+## How the kit composes (subsystem modules)
+
+The kit is a **toolbox of self-contained subsystem modules under `lib/<subsystem>/`**
+(board, classify, gate, goal, queue, session, spec, stats, telemetry, plus the ledger
+substrate and single-purpose orphans), not one appliance you switch on. "tool" vs "lib"
+describes a module's SURFACE (leaf/human vs internal-helper), not its location; there is no
+separate `tools/` tree. Each multi-verb subsystem exposes a **standalone `<subsystem> <verb>`
+command** (`board next`, `gate ledger ...`, `classify ...`, `spec ...`, `goal ...`,
+`session ...`) that forwards to the script owning that verb; the internal
+`bash lib/<subsystem>/<file>.sh` form used throughout the task loop still works unchanged.
+There is no `kit` uber-dispatcher, each command's own `--help` is the discovery surface. The
+read plane is **`stats`**: a stateless projection recomputed on demand from the append-only
+ledger, never a persisted second source of truth.
+
+Adoption is **layered, not all-or-nothing**. `install.sh` wires the essential spine
+unconditionally (the SDD ship discipline: safety-gate, ship-gate, spec-drift-guard,
+secrets-guard, commit-format, anti-rationalization) and opt-in modules only when asked
+(`install.sh --with board,session,stats,...`), recording the enabled set in the consumer's
+`kit.toml [modules]` manifest, an install artifact that records the choice, never read at
+runtime. Full adoption model + rationale: `docs/PHILOSOPHY.md` and `README.md`.
+
+---
+
 ## How a goal is composed (for `commands/assign.md`)
 
 The goal-crafter projects these four zones into a six-section `/goal`. The mapping

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -14,6 +14,19 @@
 Read `AGENTS.md` zone 1 ("Read in this order") for the full ordered list, then
 return here. This file does not restate the list, so the two cannot drift.
 
+## Subsystem modules and install layering
+The kit is composed of self-contained subsystem modules under `lib/<subsystem>/` (board,
+classify, gate, goal, queue, session, spec, stats, telemetry, plus the ledger substrate and
+single-purpose orphans). Each multi-verb subsystem is also callable as a standalone
+`<subsystem> <verb>` command (`board next`, `gate ledger ...`, `spec ...`); the internal
+`bash lib/<subsystem>/<file>.sh` form used throughout this file still works unchanged. There
+is no `tools/` tree and no `kit` uber-dispatcher. Read-side reporting is `stats`, a stateless
+projection recomputed from the append-only ledger (never a persisted second source). Adoption
+is layered: `install.sh` wires the essential spine unconditionally and optional modules opt in
+via `install.sh --with <modules>`, recording the enabled set in the consumer's
+`kit.toml [modules]` manifest. Full composition + adoption model: `AGENTS.md`
+"How the kit composes" and `docs/PHILOSOPHY.md`.
+
 ## Where work comes from (the board)
 
 `_meta/BACKLOG.md` is the kanban board (SPEC-055): one row per work item, the Status column is

--- a/docs/proof/kitmod-operate-contract.md
+++ b/docs/proof/kitmod-operate-contract.md
@@ -1,0 +1,65 @@
+# Proof of done: operate-contract refresh (kit-modularity SG-05)
+
+Refresh `AGENTS.md` + `WORKFLOW.md` (the operate-contract an adopting agent reads
+first) to the post-modularity surface: standalone `<subsystem> <verb>` commands,
+`stats` (not `ledger-observatory`), the layered `install.sh --with` model + the
+per-consumer `kit.toml [modules]` manifest, and self-contained subsystem modules
+(the retired lib-vs-tools framing). Docs-only, load-bearing (rung 2).
+
+## Acceptance criteria
+
+| # | Criterion | Status |
+|---|---|---|
+| AC1 | No retired-surface token survives as a LIVE reference in either file: `ledger-observatory`, `bash tools/`, `tools/<x>/` invocation paths, an all-hooks / "wires everything by default" install description, a lib-vs-tools split framing | PASS |
+| AC2 | The new surface is positively referenced in BOTH files: `stats`, `<subsystem> <verb>`, `install.sh --with`, `kit.toml [modules]`, subsystem modules | PASS |
+| AC3 | Every `lib/<subsystem>/*.sh` path referenced in either file resolves on disk (no dangling path from the SG-01 restructure) | PASS |
+| AC4 | `kit:doc-verifier` finds zero contradictions between the two files and the live codebase | PASS |
+| AC5 | Surgical: lane/gate semantics unchanged; only additive composition notes + the already-swept paths | PASS |
+
+## Implementation
+
+The SG-01..04 merges (call-site sweep for the alias removal, the `stats` rename,
+the `tools/` fold) had ALREADY updated every `lib/...sh` path reference and removed
+every retired token from both files as a side effect. So AC1/AC3 were satisfied on
+arrival (confirmed, not assumed, by the audit below). The SG-05 delta is AC2: neither
+file POSITIVELY described the new composable surface. Added one concise composition
+note to each:
+
+- `AGENTS.md`: new appendix `## How the kit composes (subsystem modules)` after zone 4,
+  before `## How a goal is composed`. Names the subsystem-module structure, the standalone
+  `<subsystem> <verb>` commands (additive over the internal path form), the `stats` read
+  plane, the no-uber-dispatcher rule, and the layered `install.sh --with` + `kit.toml [modules]`
+  adoption model, pointing to PHILOSOPHY/README for the full model.
+- `WORKFLOW.md`: new section `## Subsystem modules and install layering` right after
+  `## Required reading`. The WORKFLOW-relevant slice of the same surface, pointing back to
+  the AGENTS.md appendix for the full composition note (no duplication of the adoption model).
+
+No lane, gate, phase, or state-machine text was touched.
+
+## Confirmation run-table
+
+| # | Check | Command | Result |
+|---|---|---|---|
+| 1 | AC1 retired tokens (green run) | `grep -nE 'ledger-observatory\|bash tools/\|tools/[a-z]\|all-hooks install\|wires everything' AGENTS.md WORKFLOW.md` | no matches (clean) |
+| 2 | AC1 per-token counts | `grep -cE '<tok>' AGENTS.md WORKFLOW.md` | ledger-observatory 0 / bash tools/ 0 / tools/[a-z] 0 / all-hooks install 0 / wires everything 0 |
+| 3 | AC2 new tokens (both files) | `grep -c '<tok>' AGENTS.md WORKFLOW.md` | stats A3/W2 · `<subsystem> <verb>` A1/W1 · `--with` A1/W1 · `[modules]` A1/W1 · subsystem-module A2/W1 · kit.toml A1/W1 |
+| 4 | AC3 path existence | `[ -e lib/<sub>/<file>.sh ]` over all 19 referenced paths | all 19 exist |
+| 5 | AC4 doc-verifier | `kit:doc-verifier` agent over both files vs codebase | PASS, 0 contradictions |
+
+### Negative control
+
+The NC is the AC1 audit itself: a grep for each retired token across both files
+returns ZERO live references (check #1/#2 above, empty output). This distinguishes
+a real refresh from a cosmetic one, if a retired name had survived as a live
+instruction, the grep would surface it. All five retired-token classes return 0.
+Positive control (AC2, check #3): the new tokens ARE present in both files, so the
+zero is genuine absence of the OLD surface, not an empty file.
+
+### Reproduce
+
+```
+cd <worktree>
+grep -nE 'ledger-observatory|bash tools/|tools/[a-z]|all-hooks install|wires everything' AGENTS.md WORKFLOW.md   # -> no output
+for t in stats '<subsystem> <verb>' '--with' '[modules]' 'subsystem module' 'kit.toml'; do echo "$t: A=$(grep -c -e "$t" AGENTS.md) W=$(grep -c -e "$t" WORKFLOW.md)"; done
+for f in $(grep -ohE 'lib/[A-Za-z0-9_./-]+\.sh' AGENTS.md WORKFLOW.md | sort -u); do [ -e "$f" ] && echo "OK $f" || echo "MISSING $f"; done
+```

--- a/docs/verification/kitmod-operate-contract.md
+++ b/docs/verification/kitmod-operate-contract.md
@@ -1,0 +1,50 @@
+# Verification: operate-contract refresh (kit-modularity SG-05)
+
+Flat back-compat proof shape for the ship-gate. Canonical proof:
+`docs/proof/kitmod-operate-contract.md`.
+
+## What was verified
+
+`AGENTS.md` + `WORKFLOW.md` refreshed to the post-modularity surface. Retired-surface
+tokens carry zero live references; the new surface (standalone `<subsystem> <verb>`,
+`stats`, layered `install.sh --with` + `kit.toml [modules]`, subsystem modules) is
+positively referenced in both files.
+
+## Green run (retired tokens -> zero, the negative control)
+
+```
+$ grep -nE 'ledger-observatory|bash tools/|tools/[a-z]|all-hooks install|wires everything' AGENTS.md WORKFLOW.md
+(no output)
+
+per-token counts across both files:
+  ledger-observatory  0
+  bash tools/         0
+  tools/[a-z]         0
+  all-hooks install   0
+  wires everything    0
+```
+
+## Positive control (new tokens present, both files)
+
+```
+stats:            AGENTS=3 WORKFLOW=2
+<subsystem> <verb>: AGENTS=1 WORKFLOW=1
+--with:           AGENTS=1 WORKFLOW=1
+[modules]:        AGENTS=1 WORKFLOW=1
+subsystem module: AGENTS=2 WORKFLOW=1
+kit.toml:         AGENTS=1 WORKFLOW=1
+```
+
+## Path existence (SG-01 restructure did not leave a dangling path)
+
+All 19 unique `lib/<subsystem>/*.sh` paths referenced in the two files resolve on disk
+(board, classify, gate, goal, queue, session, spec, telemetry subsystems).
+
+## doc-verifier
+
+`kit:doc-verifier` over both files vs the live codebase: PASS, 0 contradictions.
+
+## Result
+
+PASS. Zero stale references; new command/install surface correctly represented;
+lane/gate semantics unchanged (surgical).


### PR DESCRIPTION
Refresh the operate-contract (`AGENTS.md` + `WORKFLOW.md`) to the new surface: standalone subsystem commands, `stats`, layered install/`[modules]`, subsystem modules. Zero stale references.

The SG-01..04 call-site sweeps (alias removal, `stats` rename, `tools/` fold) had already removed every retired token and repointed every `lib/<subsystem>/*.sh` path in both files. The SG-05 delta is positively describing the new composable surface, which neither file did yet: added one concise composition note to each (`AGENTS.md` "How the kit composes", `WORKFLOW.md` "Subsystem modules and install layering"). Surgical, no lane/gate semantics touched.

Verify: grep-audit (retired tokens -> zero live refs, both files) + kit:doc-verifier (PASS, 0 contradictions) + all 19 referenced `lib` paths exist. Proof: `docs/proof/kitmod-operate-contract.md` + `docs/verification/kitmod-operate-contract.md`. Stacked on #193.

ROADMAP: `ops-toolkit/_meta/megagoals/kit-modularity/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
