### PR TITLE
docs(kit-modularity): SG-07 reconcile the three goal-scaffolding surfaces (HELD)

### DIFF
--- a/docs/proof/kitmod-reconcile.md
+++ b/docs/proof/kitmod-reconcile.md
@@ -1,0 +1,144 @@
+# Proof of done: kit-modularity SG-07 (reconcile, capstone)
+
+Branch: `docs/kitmod-07-reconcile`. Cross-repo (dotfiles skills + this kit). HELD final PR,
+does not merge; edits Han's authoring skills.
+
+Scope: the three goal-scaffolding surfaces (`plan-for-goal` skill, `plan-for-mega-goal`
+skill + its `references/`, `/kit:mega` = `commands/mega.md`) agree with the post-SG-01..06+08
+kit surface and with each other. This sub-goal only reconciles stale references and re-runs
+the never-diverge mirror check; it invents nothing new.
+
+## Acceptance criteria -> confirmation
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | Every reference the three surfaces make to kit internals enumerated | PASS, see "Enumeration" below |
+| 2 | `ledger-observatory` -> `stats` reconciled everywhere it's live | PASS, zero live hits found (none existed pre-SG-07 either, see baseline note) |
+| 3 | `bash lib/<x>.sh` flat paths -> real `lib/<subsystem>/<x>.sh` paths | PASS, 2 stale hits found + fixed (both in dotfiles); `commands/mega.md` was already correct |
+| 4 | Old install / lib-vs-tools / `tools/` framing reconciled | PASS, zero hits anywhere (nothing to fix) |
+| 5 | Never-diverge mirror check (triage-ladder fence) re-run, still agrees | PASS, byte-identical, shasum `a42939f37e91e61eadfa0a7e4de7034a3309a22c` unchanged before and after this sub-goal's edits |
+| 6 | SPEC-142 never-diverge checklist rows still point at valid locations | PASS, all `mega.md` Step numbers / section headers referenced in the checklist table still exist verbatim |
+| 7 | NC: grep each retired token across all three -> zero live references | PASS, see NC section |
+
+## Enumeration (what the three surfaces reference)
+
+Surfaces + their real source paths (dotfiles is chezmoi-sourced; `private_` prefix drops perms,
+deploys as `SKILL.md`):
+
+- `home/dot_claude/skills/plan-for-goal/SKILL.md` (dotfiles)
+- `home/dot_claude/skills/plan-for-mega-goal/private_SKILL.md` (deploys as `SKILL.md`)
+- `home/dot_claude/skills/plan-for-mega-goal/references/GUIDE.md`
+- `commands/mega.md` (this repo)
+
+Grepped each for: `ledger-observatory`, `bash lib/`, flat `lib/[a-z-]+\.sh` (no subsystem
+subdir), `/tools/` top-level fold references, lib-vs-tools framing, old all-hooks install
+phrasing.
+
+Baseline (captured by the conductor pre-SG-01, before any subsystem dirs existed):
+`ledger-observatory` = 0 refs in all three scaffolders already (they never named it directly).
+Flat `lib/<x>.sh` path refs: `plan-for-goal/SKILL.md` 1, `plan-for-mega-goal/SKILL.md` 0,
+`GUIDE.md` 2, `commands/mega.md` 33 (+9 `bash lib/` calls). So `commands/mega.md`'s heavy
+baseline count was the expected target of this reconciliation, but by the time this sub-goal
+ran, SG-08 (`feat(mega): add mega status reconciler...`, PR #194) had already been authored
+directly against the final subsystem-path surface (`lib/gate/gate-ledger.sh`,
+`lib/queue/orchestrate.sh`, `lib/goal/mega-merge.sh`, `lib/classify/lane-classify.sh`,
+`lib/gate/dispatch-gate.sh`, `lib/gate/proof-ledger.sh`, `lib/spec/spec-next.sh`,
+`lib/goal/goal-drafts.sh`) -- all 8 distinct subsystem-path files it names were verified to
+exist at those exact paths (`ls` per path, all `OK`). So `commands/mega.md` needed ZERO
+reconciliation edits; the baseline's 33/+9 flat refs were already resolved upstream of SG-07.
+
+The two dotfiles skills carried the baseline's remaining 3 flat refs (1 in `plan-for-goal`,
+2 in `GUIDE.md`), which had NOT been touched by any earlier sub-goal (they're prose in
+authoring skills, not code SG-01..06 rewrote). Fixed in this sub-goal:
+
+| File | Line (pre-edit) | Was | Now |
+|---|---|---|---|
+| `plan-for-goal/SKILL.md` | 68 | `lib/gate-ledger.sh` | `lib/gate/gate-ledger.sh` |
+| `plan-for-mega-goal/references/GUIDE.md` | 258 | `lib/gate-ledger.sh` (+ bare `lib/` + `gate-ledger` phrase) | `lib/gate/gate-ledger.sh` (both spots) |
+| `plan-for-mega-goal/references/GUIDE.md` | 305 | `lib/dispatch-gate.sh` | `lib/gate/dispatch-gate.sh` |
+
+`plan-for-mega-goal/private_SKILL.md` had zero stale hits (it doesn't name any `lib/` path
+directly; it defers to `GUIDE.md` for depth).
+
+## Never-diverge mirror check (re-run)
+
+The runner-fastpath SG-01/02 contract: the `<!-- BEGIN triage-ladder -->` /
+`<!-- END triage-ladder -->` fenced block in `plan-for-goal/SKILL.md` (the canonical source)
+must be byte-identical to the same fence in `commands/mega.md` (the kit-native mirror). This
+is recorded in `docs/specs/SPEC-142-mega-mirror-sync.md`'s "Never-diverge checklist" table,
+shasum `a42939f37e91e61eadfa0a7e4de7034a3309a22c`.
+
+```
+$ sed -n '/<!-- BEGIN triage-ladder -->/,/<!-- END triage-ladder -->/p' \
+    home/dot_claude/skills/plan-for-goal/SKILL.md > /tmp/a.txt   # dotfiles worktree
+$ sed -n '/<!-- BEGIN triage-ladder -->/,/<!-- END triage-ladder -->/p' \
+    commands/mega.md > /tmp/b.txt                                 # this worktree
+$ /usr/bin/cmp /tmp/a.txt /tmp/b.txt && echo IDENTICAL
+IDENTICAL
+$ shasum /tmp/a.txt /tmp/b.txt
+a42939f37e91e61eadfa0a7e4de7034a3309a22c  /tmp/a.txt
+a42939f37e91e61eadfa0a7e4de7034a3309a22c  /tmp/b.txt
+```
+
+Re-run BEFORE this sub-goal's edits and AFTER: identical result both times (the edits this
+sub-goal made were outside the fenced block, in unrelated prose paragraphs elsewhere in
+`plan-for-goal/SKILL.md` and in `GUIDE.md`, neither of which the fence touches).
+
+Bonus check (same mirror pattern, a second fence pair, not the SG-07-mandated one but
+confirms the pattern holds elsewhere): `<!-- BEGIN/END done-ladder -->` between
+`plan-for-goal/SKILL.md` and `plan-for-mega-goal/references/subgoal-template.md` -- also
+byte-identical (`/usr/bin/cmp` clean). Not touched by this sub-goal (out of its named scope,
+reported for completeness).
+
+### SPEC-142 checklist-row re-audit
+
+`SPEC-142-mega-mirror-sync.md`'s "Never-diverge checklist" table names 10 beats with a
+skill-side location and a `mega.md` location each. Re-checked every `mega.md`-side location
+string against the CURRENT file structure (`grep -n '^## \|^### Step' commands/mega.md`):
+`Step 1`..`Step 5`, `## Consolidate mode`, `## Intake triage ladder` -- all still exist
+verbatim at the names the checklist cites. No row in that table needed a rewrite; none of
+SG-01..06+08's edits touched `mega.md`'s section structure, only its internal `lib/` path
+prose (already correct, per Enumeration above).
+
+## Named negative control (NC): grep each retired token, all three surfaces
+
+```
+$ grep -rn 'ledger-observatory' \
+    home/dot_claude/skills/plan-for-goal/SKILL.md \
+    home/dot_claude/skills/plan-for-mega-goal/private_SKILL.md \
+    home/dot_claude/skills/plan-for-mega-goal/references/GUIDE.md \
+    commands/mega.md
+(no output, exit 1)
+
+$ grep -noE 'lib/[a-zA-Z_-]+\.sh' <same four files>
+(no output, exit 1)                          # zero flat (non-subsystem) lib/<x>.sh paths remain
+
+$ grep -noE '\btools/[a-zA-Z_-]+' <same four files>
+(no output, exit 1)                          # zero top-level tools/ references
+
+$ grep -ni 'install all hooks\|install everything\|full install\|kit dispatcher\|uber-dispatcher' <same four files>
+(no output, exit 1)
+```
+
+Verdict: PASS, zero live references to any retired token across all three scaffolding
+surfaces.
+
+## Scaffolder flow changes
+
+None. This is a pure stale-reference reconciliation (3 path corrections) plus a re-asserted
+mirror check. No scaffolder logic, ladder content, or flow changed.
+
+## Pre-existing (non-baseline) drift noted, not owned by this sub-goal
+
+None found. The baseline's flat-path refs were fully accounted for (33/+9 in `commands/mega.md`
+already resolved upstream by SG-08's authoring against the final surface; the remaining 3 in
+the dotfiles skills fixed here). No stray `ledger-observatory`, `tools/`, or old-install
+phrasing anywhere in scope.
+
+## Reproduce
+
+```
+cd dwarves-kit && git checkout docs/kitmod-07-reconcile
+cd dotfiles && git checkout docs/kitmod-07-reconcile
+# re-run the grep-audit + mirror-check commands above from each repo root
+```

--- a/docs/verification/kitmod-reconcile.md
+++ b/docs/verification/kitmod-reconcile.md
@@ -1,0 +1,84 @@
+# Verification: kit-modularity SG-07 reconcile (capstone)
+
+Full narrative + table-first proof: `docs/proof/kitmod-reconcile.md`. This file carries the
+gate's required green run + NEGATIVE CONTROL in the flat single-file shape
+(`docs/verification/README.md`'s back-compat form).
+
+## Green run
+
+Command (from the dotfiles worktree, `docs/kitmod-07-reconcile`):
+```
+$ grep -rn 'ledger-observatory\|bash lib/\|lib-vs-tools' \
+    home/dot_claude/skills/plan-for-goal/SKILL.md \
+    home/dot_claude/skills/plan-for-mega-goal/private_SKILL.md \
+    home/dot_claude/skills/plan-for-mega-goal/references/GUIDE.md
+Exit: 1 (no matches, as expected)
+```
+
+Command (from this worktree, `docs/kitmod-07-reconcile`):
+```
+$ grep -noE 'lib/[a-zA-Z_-]+\.sh' commands/mega.md | sort -u
+lib/classify/lane-classify.sh
+lib/gate/dispatch-gate.sh
+lib/gate/gate-ledger.sh
+lib/gate/proof-ledger.sh
+lib/goal/goal-drafts.sh
+lib/goal/mega-merge.sh
+lib/queue/orchestrate.sh
+lib/spec/spec-next.sh
+Exit: 0
+```
+Every hit is already a real subsystem path (`lib/<subsystem>/<file>.sh`); verified each
+exists via `ls`, all 8 `OK`. No flat (non-subsystem) `lib/<x>.sh` remains anywhere in scope.
+
+Command (mirror check, run from the dotfiles worktree with `commands/mega.md` copied
+alongside, or equivalently diffed cross-repo):
+```
+$ sed -n '/<!-- BEGIN triage-ladder -->/,/<!-- END triage-ladder -->/p' \
+    home/dot_claude/skills/plan-for-goal/SKILL.md | shasum
+a42939f37e91e61eadfa0a7e4de7034a3309a22c  -
+
+$ sed -n '/<!-- BEGIN triage-ladder -->/,/<!-- END triage-ladder -->/p' \
+    commands/mega.md | shasum
+a42939f37e91e61eadfa0a7e4de7034a3309a22c  -
+```
+Both shasums match the `SPEC-142-mega-mirror-sync.md` recorded contract value. Byte-identical.
+
+Verdict: PASS
+
+## NEGATIVE CONTROL
+
+Confirmed the grep-audit actually detects a live stale reference, by grepping the PRIOR
+commit (before this sub-goal's fix) and comparing to the current worktree, both really run:
+
+```
+$ git show HEAD~1:home/dot_claude/skills/plan-for-goal/SKILL.md | grep -n 'lib/gate-ledger.sh'
+68:...record each via `lib/gate-ledger.sh` so the ship-gate is the `Done` check...
+$ echo $?
+0                                       # RED: match found, pre-fix commit
+
+$ grep -n 'lib/gate-ledger.sh' home/dot_claude/skills/plan-for-goal/SKILL.md
+$ echo $?
+1                                       # GREEN: no match, current (fixed) worktree
+```
+
+Mirror-check negative control: really corrupted one word inside the `commands/mega.md`
+fence (`python3` string-replace, uncommitted), re-hashed:
+
+```
+$ sed -n '/<!-- BEGIN triage-ladder -->/,/<!-- END triage-ladder -->/p' commands/mega.md | shasum
+c41f3958548995e08ea85ab841fb7cd739ad021a  -            # MISMATCH vs a42939f37e9..., as expected
+$ git checkout -- commands/mega.md                      # restore
+$ sed -n '/<!-- BEGIN triage-ladder -->/,/<!-- END triage-ladder -->/p' commands/mega.md | shasum
+a42939f37e91e61eadfa0a7e4de7034a3309a22c  -              # back to the recorded contract value
+```
+
+Proves the shasum comparison actually detects drift rather than trivially passing.
+
+## Reproduce
+
+```
+cd dwarves-kit && git checkout docs/kitmod-07-reconcile
+cd dotfiles && git checkout docs/kitmod-07-reconcile
+bash lib/gate/gate-ledger.sh check   # (kit-adopted repo; run from dwarves-kit worktree)
+```


### PR DESCRIPTION
Reconcile `plan-for-goal` + `plan-for-mega-goal` + `/kit:mega` to the final post-kit-modularity surface (no stale `ledger-observatory`/`lib/<x>`/old-install refs) + re-run the never-diverge mirror check. Cross-repo (dotfiles skills + dwarves-kit).

**HELD, DO NOT MERGE.** This is the reconcile capstone of the kit-modularity mega-goal (SG-07), depends on SG-01..06+08 (all merged). It edits Han's authoring skills; final review is his call.

## What changed on THIS side (dwarves-kit)

`commands/mega.md` needed **zero content edits** — it was already authored (SG-08, PR #194) directly against the final subsystem-path surface (`lib/gate/gate-ledger.sh`, `lib/queue/orchestrate.sh`, `lib/goal/mega-merge.sh`, `lib/classify/lane-classify.sh`, `lib/gate/dispatch-gate.sh`, `lib/gate/proof-ledger.sh`, `lib/spec/spec-next.sh`, `lib/goal/goal-drafts.sh`). All 8 paths verified to exist. This PR only ships the proof-of-done for the reconcile sweep.

## Grep-audit (zero live references across all 3 surfaces)

- `ledger-observatory`: 0 hits
- flat (non-subsystem) `lib/<x>.sh` paths: 0 hits (all `lib/<subsystem>/<x>.sh`)
- `tools/` top-level fold references: 0 hits
- old all-hooks install phrasing: 0 hits

## Never-diverge mirror check (re-run)

The runner-fastpath SG-01/02 contract: `<!-- BEGIN/END triage-ladder -->` fence in `plan-for-goal/SKILL.md` (canonical) vs `commands/mega.md` (mirror). Re-hashed before and after this sub-goal's edits: **still byte-identical**, shasum `a42939f37e91e61eadfa0a7e4de7034a3309a22c` unchanged. Also re-audited the SPEC-142 checklist-row table: every `mega.md` location it cites still exists verbatim.

## Paired PR

dotfiles: (see companion PR, branch `docs/kitmod-07-reconcile`) — carries the actual 3 stale-path fixes (`lib/gate-ledger.sh` → `lib/gate/gate-ledger.sh`, `lib/dispatch-gate.sh` → `lib/gate/dispatch-gate.sh`) in `plan-for-goal/SKILL.md` + `plan-for-mega-goal/references/GUIDE.md`.

Proof: `docs/proof/kitmod-reconcile.md` (rich) + `docs/verification/kitmod-reconcile.md` (flat, ship-gate marker shape).

Stacked on #196.