### PR TITLE
fix(test): match TOKENS marker to substrate emission + wire into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run meta integrity tests
         run: bash tests/test-meta.sh
 
+      - name: Run docs-wiring no-orphan sweep
+        run: bash tests/test-docs-wiring.sh
+
       - name: Run layered-install module tests (ID-277 SG-04)
         run: bash tests/test-install-modules.sh
       - name: Golden run (e2e)

--- a/tests/test-docs-wiring.sh
+++ b/tests/test-docs-wiring.sh
@@ -74,7 +74,7 @@ assert "AC6: Model: -> --model routing fires (live call site in lib/queue/orches
 
 _wired "$ORCH" 'bash "$LIB_ROOT/gate/gate-ledger.sh" tokens'
 assert "AC7: token capture records via gate-ledger.sh (live call site in lib/queue/orchestrate.sh)" $?
-_wired "$LEDGER" "printf '%s | TOKENS | %s\n'"
+_wired "$LEDGER" "printf '%s | TOKENS | %s'"
 assert "AC7: the TOKENS ledger marker is emitted (live call site in lib/gate/gate-ledger.sh)" $?
 
 _wired "$ORCH" '_tier4_close "$dir" "$roadmap"'


### PR DESCRIPTION
Convergence-gate finding from the kit-modularity mega (ID-277).

`test-docs-wiring.sh` AC7 greps `lib/gate/gate-ledger.sh` for the literal `printf '%s | TOKENS | %s\n'`. SG-02's ledger-substrate extraction now routes the TOKENS marker through `append_run_line` (which adds the newline), so the emission is `printf '%s | TOKENS | %s'` (no inline `\n`) and the fixed-string assertion went stale. The marker is still emitted with a live call site; only the test pattern was pinned to the old byte form.

This slipped every per-PR CI run because `test-docs-wiring` was **not in the CI test list**. This PR:
- updates the AC7 assertion to match the substrate-routed emission (22/22 local),
- adds `test-docs-wiring` to `.github/workflows/test.yml` so the no-orphan sweep runs on every push.

Verify: `bash tests/test-docs-wiring.sh` → 22/22; this PR's own CI run now executes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
