### PR TITLE
feat(gate): delivery-ratio advisory (proportionality nudge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run docs-wiring no-orphan sweep
         run: bash tests/test-docs-wiring.sh
 
+      - name: Run delivery-ratio advisory tests
+        run: bash tests/test-delivery-ratio.sh
+
       - name: Run layered-install module tests (ID-277 SG-04)
         run: bash tests/test-install-modules.sh
       - name: Golden run (e2e)

--- a/docs/decisions/0033-delivery-ratio-advisory.md
+++ b/docs/decisions/0033-delivery-ratio-advisory.md
@@ -1,0 +1,44 @@
+# 0033 - Delivery-ratio advisory (proportionality nudge, never a gate)
+
+Status: accepted (2026-07-05)
+
+## Context
+
+A 2026-07-05 delivery audit of ~258 mega-goal sub-goals (triggered when a "rewrite the
+README" sub-goal turned out to be a +29-line append) found a real, patterned failure:
+the proof-of-done gate checks that a proof EXISTS, not that delivery is PROPORTIONATE to
+the claim. A thin docs / reconcile / audit sub-goal can pass the gate by wrapping a
+near-zero real change in 200-300 lines of self-grading proof-of-done + verification. The
+rot concentrated exactly in sub-goal types with no external "does it run" signal
+(docs/reconcile), where ceremony fills the void.
+
+## Decision
+
+Add `proof-ledger.sh delivery-ratio <root> <base>`: split the branch's ADDED lines into
+real-deliverable (code + user-facing docs) vs proof/ceremony (proof-of-done, verification,
+specs, impl-notes, ADRs, tests) and print `real=N proof=M | <verdict>`. Wire it as an
+ADVISORY line in the ship-gate hook: fires only on THIN-WARN / NOTICE, silent on OK,
+**never blocks** (no exit 2).
+
+## Why it is advisory, not a gate (the honest limit)
+
+Line count cannot distinguish hollow from load-bearing. The audit itself proved both
+failure directions: a 4-line rule injected into 3 live review surfaces is load-bearing
+(would false-flag), and a 47-line append to a README is thin-for-a-"rewrite" but reads OK
+because it clears the `real < 40` floor (`test-delivery-ratio.sh` CASE4 pins this blind
+spot on purpose). So this is a VISIBILITY nudge for a human/`mega status` to spot-check,
+not a verdict. Making it blocking would reproduce the very mechanical-gate brittleness it
+is meant to compensate for.
+
+The real fix for "claim > delivery" is judgment at review time (a capable model checking
+the diff against the sub-goal's claim), plus routing judgment-heavy docs/design sub-goals
+to a higher model tier and dropping "surgical, not a rewrite" default scoping language
+that makes workers append instead of rework. This ADR is the cheap, always-on half; the
+judgment half lives in the mega scaffolder and the reviewer.
+
+Tunable: `KIT_DELIVERY_RATIO_WARN` (default 3), `KIT_DELIVERY_REAL_FLOOR` (default 40).
+
+## Consequences
+
+- One more advisory line at ship for proof-heavy branches; zero behavior change otherwise.
+- Proof: `docs/verification/delivery-ratio-gate.md`; tests: `tests/test-delivery-ratio.sh` (wired into CI).

--- a/docs/verification/delivery-ratio-gate.md
+++ b/docs/verification/delivery-ratio-gate.md
@@ -1,0 +1,48 @@
+# Verification: delivery-ratio advisory (ADR-0033)
+
+## Acceptance criteria
+
+- `proof-ledger.sh delivery-ratio <root> <base>` splits added lines into real vs proof and prints a verdict.
+- THIN-WARN on the hollow signature (real < 40 AND proof >= 3x real); OK on a substantial real change; NOTICE on a docs/proof-only branch.
+- Advisory: exits 0 always (never blocks); the ship-gate emits it only on THIN-WARN/NOTICE.
+- No regression to the existing gate suites.
+
+## Green run
+
+Command: `bash tests/test-delivery-ratio.sh`
+Exit: 0
+Output: `=== 8 passed, 0 failed ===` (CASE1 THIN-WARN, CASE2 OK, CASE3 NOTICE, CASE4 documented blind-spot, all exit-0)
+Verdict: PASS
+
+Command: `bash tests/test-deployable-done.sh` (no-regression on the sibling gate)
+Exit: 0
+Output: `=== 17/17 passed, 0 failed ===`
+Verdict: PASS
+
+Command: `bash tests/test-hooks.sh` (ship-gate lives here)
+Exit: 0
+Output: `All tests passed.`
+Verdict: PASS
+
+## NEGATIVE CONTROL
+
+Forcing the THIN-WARN verdict to `OK` makes CASE1's THIN-WARN assertion FAIL (the exit-0
+assertion still passes, since the function still exits 0 -- it is advisory), so the suite
+drops from green to one failure:
+
+```
+$ command cp lib/gate/proof-ledger.sh /tmp/pl.bak
+$ sed -i.x 's/verdict="THIN-WARN.*/verdict="OK"/' lib/gate/proof-ledger.sh    # break it
+$ bash tests/test-delivery-ratio.sh | tail -1
+=== 7 passed, 1 failed ===        # RED: CASE1's THIN-WARN grep assertion fails
+$ command cp -f /tmp/pl.bak lib/gate/proof-ledger.sh                          # restore
+$ bash tests/test-delivery-ratio.sh | tail -1
+=== 8 passed, 0 failed ===        # GREEN again
+```
+
+Verdict: PASS (the THIN-WARN branch is load-bearing, not a no-op). Note: `command cp`
+bypasses the interactive `cp -i` shell alias, which silently declines an overwrite.
+
+## Reproduce
+
+`bash tests/test-delivery-ratio.sh` from the repo root.

--- a/hooks/ship-gate.sh
+++ b/hooks/ship-gate.sh
@@ -88,6 +88,15 @@ if [ -f "$PROOF" ] && [ -f "$ROOT/docs/verification/README.md" ]; then
       exit 2
     fi
   fi
+  # delivery-ratio advisory (ID-277 delivery-audit fix; NEVER blocks): surface a proof-heavy
+  # branch -- lots of proof-of-done/verification/spec lines wrapped around a near-zero real
+  # change -- so a reviewer can spot-check delivery vs the sub-goal's claim. Heuristic with real
+  # false positives (a docs sub-goal is proof-heavy by design; a 1-line fix can be load-bearing),
+  # so it is a NUDGE, never a gate: fires only on THIN-WARN/NOTICE, silent on OK.
+  if [ -n "${BASE:-}" ] && [ "${BASE:-}" != "${HEADSHA:-}" ]; then
+    DR=$(bash "$PROOF" delivery-ratio "$ROOT" "$BASE" 2>/dev/null || true)
+    case "$DR" in *THIN-WARN*|*NOTICE*) echo "[advisory] delivery-ratio: $DR" >&2 ;; esac
+  fi
 fi
 
 # SPEC-069 advisory (never blocks), relocated ABOVE the spec check (SPEC-071 / ID-063):

--- a/lib/gate/proof-ledger.sh
+++ b/lib/gate/proof-ledger.sh
@@ -93,6 +93,51 @@ deployable() {
   [ "$(classify "$root" "$base")" = "stateful" ] && echo yes || echo no
 }
 
+# delivery-ratio <root> <base>: ADVISORY. Splits this branch's ADDED lines into
+# "real deliverable" (code + user-facing docs) vs "proof/ceremony" (proof-of-done,
+# verification, specs, impl-notes, ADRs, tests) and flags the hollow signature: a lot
+# of proof wrapped around a near-zero real change. NEVER blocks -- it is a heuristic
+# with real false positives (a legit docs/research sub-goal is proof-heavy by design;
+# a 1-line regex fix can be load-bearing), so it only PRINTS a NOTICE/THIN-WARN/OK line
+# for a reviewer or `mega status` to surface. Rationale: the proof-of-done gate checks
+# that proof EXISTS, not that delivery is PROPORTIONATE, so a thin docs/reconcile
+# sub-goal can pass by padding proof (2026-07-05 delivery audit; ADR "delivery ratio").
+KIT_DELIVERY_RATIO_WARN="${KIT_DELIVERY_RATIO_WARN:-3}"    # proof >= N*real ...
+KIT_DELIVERY_REAL_FLOOR="${KIT_DELIVERY_REAL_FLOOR:-40}"   # ... AND real < FLOOR => THIN-WARN
+delivery_ratio() {
+  local root="${1:-}" base="${2:-}"
+  [ -n "$root" ] && [ -n "$base" ] || { echo "usage: delivery-ratio <root> <base>" >&2; return 64; }
+  git -C "$root" rev-parse --verify -q "$base" >/dev/null 2>&1 \
+    || { echo "real=0 proof=0 | SKIP: base '$base' is not a commit"; return 0; }
+  local real=0 proof=0 add del path
+  while IFS=$'\t' read -r add del path; do
+    [ -n "$path" ] || continue
+    [ "$add" = "-" ] && continue                            # binary file: no line count
+    case "$path" in
+      */proof-of-done.md|docs/proof/*|*/docs/proof/*|docs/verification/*|*/docs/verification/*|docs/specs/*|*/docs/specs/*|docs/implementation-notes/*|*/docs/implementation-notes/*|docs/runs/*|*/docs/runs/*|docs/decisions/*|*/docs/decisions/*|tests/*|*/tests/*)
+        proof=$((proof+add)) ;;
+      *.lock|*/uv.lock|*/package-lock.json|*/pnpm-lock.yaml|*/Cargo.lock|*/go.sum)
+        : ;;                                                # generated lockfiles: ignore
+      *)
+        real=$((real+add)) ;;
+    esac
+  done < <(git -C "$root" diff --numstat "$base"..HEAD 2>/dev/null)
+
+  local verdict
+  if [ "$real" -eq 0 ]; then
+    if [ "$proof" -gt 0 ]; then
+      verdict="NOTICE: docs/proof-only branch -- expected for a docs/research sub-goal, SUSPECT for a build/rewrite/enforce claim"
+    else
+      verdict="OK: no added lines"
+    fi
+  elif [ "$proof" -ge $((KIT_DELIVERY_RATIO_WARN*real)) ] && [ "$real" -lt "$KIT_DELIVERY_REAL_FLOOR" ]; then
+    verdict="THIN-WARN: proof >= ${KIT_DELIVERY_RATIO_WARN}x real and real < ${KIT_DELIVERY_REAL_FLOOR} -- confirm delivery matches the sub-goal's claim (advisory heuristic; false positives exist)"
+  else
+    verdict="OK"
+  fi
+  echo "real=$real proof=$proof | $verdict"
+}
+
 # the verification-log files this branch added/modified (excludes the convention README).
 # Two accepted shapes: the repo-root convention (docs/verification/<slug>.md) AND a proof
 # co-located with its subject anywhere in the tree (any path ending /proof-of-done.md, e.g.
@@ -263,5 +308,6 @@ case "$cmd" in
   override)      override "$@" ;;
   is-overridden) is_overridden "$@" ;;
   deployable)    deployable "$@" ;;
-  *) echo "usage: proof-ledger.sh {classify|check|override|is-overridden|deployable} ..." >&2; exit 64 ;;
+  delivery-ratio) delivery_ratio "$@" ;;
+  *) echo "usage: proof-ledger.sh {classify|check|override|is-overridden|deployable|delivery-ratio} ..." >&2; exit 64 ;;
 esac

--- a/tests/test-delivery-ratio.sh
+++ b/tests/test-delivery-ratio.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# test-delivery-ratio.sh -- the ADVISORY delivery-ratio verb on proof-ledger.sh.
+# It splits a branch's ADDED lines into real-deliverable vs proof/ceremony and prints
+# a NOTICE/THIN-WARN/OK line. It is ADVISORY: it must NEVER exit nonzero (no blocking).
+# Run: bash tests/test-delivery-ratio.sh
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PL="$KIT_DIR/lib/gate/proof-ledger.sh"
+pass=0; fail=0
+assert() { if [ "$2" -eq 0 ]; then echo "  PASS $1"; pass=$((pass+1)); else echo "  FAIL $1"; fail=$((fail+1)); fi; }
+
+# a throwaway git repo with a base commit + one branch commit staged by the caller.
+mkrepo() { local d; d="$(mktemp -d)"; git -C "$d" init -q; git -C "$d" config user.email t@t; git -C "$d" config user.name t; \
+  echo seed > "$d/seed"; git -C "$d" add -A; git -C "$d" commit -qm base; echo "$d"; }
+
+echo "=== delivery-ratio (advisory) ==="
+
+# CASE 1 THIN: 6 real lines under 220 proof lines (the #197-shape hollow signature).
+D1="$(mkrepo)"; mkdir -p "$D1/lib/gate" "$D1/docs/proof"
+printf 'a\nb\nc\nd\ne\nf\n' > "$D1/lib/gate/thing.sh"
+seq 220 > "$D1/docs/proof/kitmod.md"
+git -C "$D1" add -A; git -C "$D1" commit -qm work
+OUT1="$(bash "$PL" delivery-ratio "$D1" HEAD~1)"; RC1=$?
+echo "  case1: $OUT1"
+printf '%s' "$OUT1" | grep -q 'real=6 proof=220'; assert "CASE1: counts 6 real / 220 proof" $?
+printf '%s' "$OUT1" | grep -q 'THIN-WARN'; assert "CASE1: flags THIN-WARN (real<40 AND proof>=3x)" $?
+assert "CASE1: exit 0 (advisory never blocks)" $RC1
+
+# CASE 2 OK: substantial real code (60 lines) with proportionate proof.
+D2="$(mkrepo)"; mkdir -p "$D2/lib" "$D2/tests"
+seq 60 > "$D2/lib/feature.sh"; seq 30 > "$D2/tests/test-feature.sh"
+git -C "$D2" add -A; git -C "$D2" commit -qm work
+OUT2="$(bash "$PL" delivery-ratio "$D2" HEAD~1)"
+echo "  case2: $OUT2"
+printf '%s' "$OUT2" | grep -q 'real=60 proof=30'; assert "CASE2: counts 60 real / 30 proof (tests=proof)" $?
+printf '%s' "$OUT2" | grep -qE '\| OK'; assert "CASE2: substantial real change => OK" $?
+
+# CASE 3 NOTICE: docs/proof-only branch (real=0) -- fine for a docs sub-goal, suspect for a build claim.
+D3="$(mkrepo)"; mkdir -p "$D3/docs/verification"
+seq 40 > "$D3/docs/verification/x.md"
+git -C "$D3" add -A; git -C "$D3" commit -qm work
+OUT3="$(bash "$PL" delivery-ratio "$D3" HEAD~1)"
+echo "  case3: $OUT3"
+printf '%s' "$OUT3" | grep -q 'real=0 proof=40'; assert "CASE3: counts 0 real / 40 proof" $?
+printf '%s' "$OUT3" | grep -q 'NOTICE'; assert "CASE3: docs-only => NOTICE (not a hard verdict)" $?
+
+# CASE 4 [HONEST LIMIT, documented]: a 47-line append (the real #195 shape) is NOT flagged
+# because real(47) >= floor(40). Line-count cannot tell a thin-for-a-"rewrite" 47-line append
+# from a genuine 47-line change; this is why the verb is a VISIBILITY nudge, not a verdict.
+D4="$(mkrepo)"; mkdir -p "$D4/docs/proof"
+seq 47 > "$D4/README.md"; seq 228 > "$D4/docs/proof/x.md"
+git -C "$D4" add -A; git -C "$D4" commit -qm work
+OUT4="$(bash "$PL" delivery-ratio "$D4" HEAD~1)"
+echo "  case4 (known blind spot): $OUT4"
+printf '%s' "$OUT4" | grep -qE '\| OK'; assert "CASE4: 47-real append reads OK (documented blind spot: floor=40)" $?
+
+echo "=== $pass passed, $fail failed ==="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
The systemic half of the 2026-07-05 delivery-audit fix (ID-277 follow-up).

**Problem:** the proof-of-done gate checks that proof EXISTS, not that delivery is *proportionate* to the claim. A thin docs/reconcile sub-goal can pass by wrapping a near-zero real change in 200-300 lines of self-grading proof.

**This PR:** `proof-ledger.sh delivery-ratio <root> <base>` splits a branch's added lines into real-deliverable vs proof/ceremony and prints `real=N proof=M | <verdict>`. Wired as a **ship-gate advisory** (fires only on THIN-WARN/NOTICE, **never blocks**).

**Honest about its limit:** line-count cannot tell hollow from load-bearing — a 4-line rule injection is load-bearing, a 47-line "rewrite" append is thin. `test-delivery-ratio.sh` CASE4 pins that blind spot on purpose. So it is a *visibility nudge for a human/`mega status` to spot-check*, not a verdict. The real fix (judgment at review + model-tier routing) is separate.

**Verify:**
- `bash tests/test-delivery-ratio.sh` → 8/8 (THIN-WARN / OK / NOTICE / documented-blind-spot, all exit-0), wired into CI.
- Negative control (force verdict to OK → CASE1 fails → restore → green) in `docs/verification/delivery-ratio-gate.md`.
- No regression: `test-deployable-done` 17/17, `test-hooks` green, `test-meta` green.
- Self-demo: this branch reads `real=59 proof=150 | OK` (proportionate proof on a real change → correctly not flagged).

ADR-0033. Advisory-only; zero behavior change to any existing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
