### PR TITLE
docs(mega): tier docs sub-goals -- rewrite gets opus + pitch

### DIFF
--- a/commands/mega.md
+++ b/commands/mega.md
@@ -142,7 +142,11 @@ so the existing driver can walk it unmodified):
   lines, value only, no trailing comment -- the driver greps `^Model:` and takes
   the whole rest of the line as the tier. **`Model:` defaults to `sonnet`**
   (SPEC-107 cheap-first); route `opus` for planning/design-dominant hard
-  reasoning, `haiku` for trivial mechanical work, DELETE the line to deliberately
+  reasoning AND for a docs/design sub-goal that REWRITES for cohesion or
+  persuasion (not a light append) -- write those with the `/kit:pitch`
+  discipline (outcome-first, evidence-grounded; delete the stale narrative,
+  do not just append) so the presentation convinces; a small docs update
+  stays `sonnet`. `haiku` for trivial mechanical work, DELETE the line to deliberately
   inherit the parent tier. Each sub-goal also names a **`Design:` field**
   (`bearing | obvious`, ADR-0031 §1: `bearing` means the executor's spec MUST
   carry a non-empty `## Design` block and `/kit:spec-validate` refuses VALIDATED


### PR DESCRIPTION
(b) of the 2026-07-05 delivery-audit fix. HELD for review (edits the scaffolder surface).

Docs sub-goals aren't one tier. A **light docs update stays `sonnet`**; a **docs/design sub-goal that REWRITES for cohesion or persuasion** (not a light append) routes to **`opus`** and is written with the **`/kit:pitch` discipline** (outcome-first, evidence-grounded, delete the stale narrative rather than append) so the presentation actually convinces.

This is the judgment half the delivery audit pointed at: the append-only "surgical, not a rewrite" framing + a cheap tier is what produced thin docs sub-goals oversold as rewrites. Mirrors the `plan-for-mega-goal` skill (paired dotfiles PR).

Verify: `test-meta` green, `test-mega-reconcile` 35/35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
