### PR TITLE
Apply advisor P5/P6 to harness-ops scaffold before launch

### DIFF
--- a/_meta/megagoals/harness-ops/NOTES.md
+++ b/_meta/megagoals/harness-ops/NOTES.md
@@ -7,7 +7,14 @@
 ## Proposed additions
 
 - 2026-07-06: after Track A lands, consider promoting the config as the default runtime knobs across ALL env-var call sites (a sweep), not just ledger/mega, discovered while scoping 02/03.
+- 2026-07-06 (advisor P6): a permanent CI lint asserting NO hot-path hook sources kit-config.sh (grep hook dirs for `kit_config_get`/`source.*kit-config`) , the hybrid-read contract is load-bearing for every later sub-goal; without a standing lint it regresses the moment someone wires a hook to a new knob. HIGH.
+- 2026-07-06 (advisor P6): a two-way schema-reality test , every `[impl]` key in kit.toml has a `kit_config_get` call site AND every live `kit_config_get` has a schema entry. 08 only proves inert keys stay inert; this catches the opposite drift (an `[impl]` key gone dead, a live read with no schema). HIGH.
+- 2026-07-06 (advisor P6): sweep ALL adopted consumer repos (dfoundation, console-labs, ...) for `$DWARVES_KIT/lib/` deep-path refs, not just ops-toolkit's board , 05's proof only covers the board, but the board-break is a CLASS; file a follow-up/backlog row per repo found. HIGH.
+- 2026-07-06 (advisor P6): a rollback-tested revert path for 12-root-slim (per-file "revert this commit + rerun full suite"), cheap given the per-file commit split already planned, high blast-radius item. MED.
+- 2026-07-06 (advisor P6): turn 07's doc-vs-code check into a STANDING CI test , a "cold adopt" run on a scratch project diffing injected files vs consumer-contract.md , so the contract can't silently drift from adopt.sh. MED.
+- 2026-07-06 (advisor P6): enforce 13→09/11 with a PR check that FAILS if `docs/proof/` or `docs/runs/` still exists at merge time (belt-and-suspenders on the Depends-on fix). MED.
 
 ## Event log
 
 2026-07-06 · scaffolded · harness-ops, 13 sub-goals across 2 tracks (A config-layer 8, B docs-restructure 5). 01-config-resolver already BUILT (c84cda5 on feat/config-layer). Track A design: docs/specs/DECISION-BRIEF-config-layer.md; Track B design: the 2026-07-06 docs+root audits.
+2026-07-06 · advisor pre-launch · P5 critique + P6 over-suggest. P5: 1 CRITICAL (install.sh has no docs/ copy step , goal 12 root-slim would 404 every installed consumer's WORKFLOW/MANUAL/CHANGELOG pointer; FIXED , 12 now requires the install-copy step + an installed-stub test) + 3 MAJOR (cross-track lib/adopt.sh collision 05↔12 , noted + sequenced; goal 13 Depends-on said "none" vs prose "after 09/11" , FIXED to `09, 11`; goal 12 undercounted readers , FIXED with a mandatory repo-wide grep + prose dangling-check) + 1 MINOR (brief named a nonexistent lint file , FIXED to test-install-modules.sh). NO flat-lib-path bug (subdir paths correct this time). P6: 6 suggestions → ## Proposed additions. Scaffold now launch-ready.

--- a/_meta/megagoals/harness-ops/ROADMAP.md
+++ b/_meta/megagoals/harness-ops/ROADMAP.md
@@ -34,8 +34,8 @@ Single-repo (dwarves-kit, kit-adopted). Run from dwarves-kit cwd via the SDD lan
 
 - 01 done (resolver). 02, 03, 08 depend on 01, independent of each other → parallel wave after 01.
 - 04 depends on 01 (resolver reads the reconciled manifest). 05 depends on 04 (stable interface + adopt repoint). 06 depends on 05 (project override + adopt). 07 depends on 05+06 (documents the final contract).
-- Track B is independent of Track A (different files). 09 (integrity, gate) is standalone. 10, 11, 13 are independent doc-moves-with-repoint. 12 (root-slim) is the biggest B item, standalone.
-- Cross-track: none. A and B can run as parallel streams.
+- Track B is mostly independent of Track A. 09 (integrity, gate) is standalone. 10, 11 are independent doc-moves-with-repoint. 12 (root-slim) is the biggest B item. 13 depends on 09 + 11 (its README refresh must reflect the final tree).
+- **Cross-track collision (advisor P5 #2): `lib/adopt.sh:72-83` is edited by BOTH 05 (Track A, stable-interface) and 12 (Track B, root-slim).** They are NOT fully parallel. Land 05 before 12, or the second-to-merge rebases and reconciles that block by hand (auto-bottom-up does not detect file-level overlap). Every other file is disjoint across tracks.
 
 ## Assumptions (front-loaded)
 

--- a/_meta/megagoals/harness-ops/goals/05-stable-interface.md
+++ b/_meta/megagoals/harness-ops/goals/05-stable-interface.md
@@ -21,6 +21,7 @@ Design-bearing (2 approaches: a thin `kit` dispatcher vs installed per-subsystem
 
 - Enumerate every consumer reach into `$DWARVES_KIT/lib/...` (grep across ops-toolkit + the adopt-injected CLAUDE.md block); confirm they'd break on a lib move.
 - Build the stable entrypoint (dispatcher or installed commands); repoint the adopt contract (`lib/adopt.sh`'s CLAUDE.md block + WORKFLOW/AGENTS pointers) to it.
+- **Cross-track overlap (advisor P5 #2):** `lib/adopt.sh:72-83` (the WORKFLOW pointer text) is ALSO edited by Track B's 12-root-slim (which repoints it to the new docs/ bulk). These two touch the SAME lines. This sub-goal (05) must land BEFORE 12, OR whichever merges second does a mandatory rebase + manual reconcile of that block (auto-bottom-up merge does NOT detect file-level cross-track overlap). Coordinate: 05 references the stable entrypoint; 12 references the docs/ bulk location; the final adopt.sh block must carry BOTH.
 - Repoint `_meta/board` / `board-all` (and any other consumer shim) to the stable form.
 - Test (negative control): rename an internal lib file, assert the consumer call still resolves via the stable entrypoint. Capture the run-table.
 

--- a/_meta/megagoals/harness-ops/goals/12-root-slim.md
+++ b/_meta/megagoals/harness-ops/goals/12-root-slim.md
@@ -15,16 +15,24 @@ The 3 giant machine-parsed root files stop overwhelming a newcomer WITHOUT break
 
 ## Design
 
-Design-bearing: WHERE the bulk lands + HOW the stub/pointer is shaped is a real choice, and the blast radius is large (runtime gate parsing). The spec's `## Design` names, per file: the new bulk path, which readers repoint, and the stub contract. Do the 3 files as SEPARATE commits within the PR so a break is bisectable. Readers to repoint (from the 2026-07-06 root audit): WORKFLOW → `lib/gate/gate-ledger.sh`, `lib/gate/dispatch-gate.sh`, `lib/gate/proof-table-gen.py`, `install.sh`, `lib/adopt.sh`; MANUAL → `tests/test-meta.sh`, `commands/draft-agent.md`; CHANGELOG → `commands/ship.md`, `commands/kit-health.md`, `commands/dispatch.md`.
+Design-bearing: WHERE the bulk lands + HOW the stub/pointer is shaped is a real choice, and the blast radius is large (runtime gate parsing). The spec's `## Design` names, per file: the new bulk path, which readers repoint, and the stub contract. Do the 3 files as SEPARATE commits within the PR so a break is bisectable.
+
+Readers to repoint , this list is a STARTING POINT, NOT exhaustive (advisor P5): the audit named WORKFLOW → `lib/gate/gate-ledger.sh`, `lib/gate/dispatch-gate.sh`, `lib/gate/proof-table-gen.py`, `install.sh`, `lib/adopt.sh`; MANUAL → `tests/test-meta.sh`, `commands/draft-agent.md`; CHANGELOG → `commands/ship.md`, `commands/kit-health.md`. But a repo-wide grep finds MORE: WORKFLOW has ~30 refs incl. a FUNCTIONAL `lib/queue/orchestrate.sh:1357` no-orphan lint (scans WORKFLOW.md as a corpus), ~13 test files, and ~10 `commands/*.md` PROSE pointers; CHANGELOG's real readers include `commands/docs.md` (missed above), and `commands/dispatch.md` only mentions it in prose (not a parse target). The `commands/*.md` prose class is the dangerous one , a stale prose pointer produces NO test failure.
+
+**CRITICAL (advisor P5): `install.sh` copies only `lib WORKFLOW.md AGENTS.md` to the install location (`install.sh:241`), NEVER `docs/`.** If you only repoint the stub without adding a `docs/`-bulk copy step to `install.sh`, every INSTALLED consumer (the real `$KIT_ROOT` path, not the dev checkout this loop runs from) gets a root stub pointing at a `docs/WORKFLOW.md` that was never copied → a 404 for every installed user, and NO current test catches it. The install-copy step + a test on the INSTALLED copy's pointer are mandatory, not optional.
 
 ## How to close the loop
 
-- Per file: move the bulk to `docs/<name>.md` (or a `docs/` home), leave a thin root stub pointing at it, repoint EVERY reader listed above (grep to confirm none missed).
-- Run the FULL suite (`tests/`) , especially test-meta (MANUAL parse), the gate tests (WORKFLOW parse), ship/kit-health (CHANGELOG). All must stay green.
-- Negative control per file: point a reader at the old root bulk path, assert it now fails (proving the bulk really moved + the repoint is load-bearing).
-- Capture the run-table (suite green + the 3 repoints).
+- **MANDATORY reader discovery (P5 #4):** before touching anything, run `grep -rn 'WORKFLOW\.md\|MANUAL\.md\|CHANGELOG\.md' --include='*.sh' --include='*.md' --include='*.py' . | grep -v '^./WORKFLOW.md\|^./MANUAL.md\|^./CHANGELOG.md'` and repoint EVERY hit (the audit list is a starting point only). Do NOT trust the enumerated list.
+- Per file: move the bulk to `docs/<name>.md`, leave a thin root stub pointing at the new path, repoint every discovered reader.
+- **`install.sh` docs-copy (P5 #1, CRITICAL):** add a step so `install.sh` copies the new `docs/<bulk>` files to the install location alongside the stub (today it copies only `lib WORKFLOW.md AGENTS.md` at `:241`). Without this, installed consumers get a stub pointing at an uncopied `docs/` file (404).
+- Run the FULL suite (`tests/`) , test-meta (MANUAL parse), gate tests (WORKFLOW parse incl. the orchestrate.sh:1357 no-orphan lint), ship/kit-health (CHANGELOG). All green.
+- Negative control per file: point a reader at the old root bulk path, assert it now fails (repoint is load-bearing).
+- **Installed-copy test (P5 #1):** a NEW test that runs `install.sh` into a temp `$KIT_ROOT` and asserts the installed stub's pointer RESOLVES (the bulk was copied), not just the dev-repo copy.
+- **Prose dangling-ref check (P5 #4):** grep `commands/*.md` for stale root-path prose pointers (invisible to the test suite); assert none remain.
+- Capture the run-table (suite green + install-copy test + the repoints).
 
-**Done =** each of WORKFLOW/MANUAL/CHANGELOG is a thin root stub + bulk-in-docs with every reader repointed, the FULL test suite is green, and the per-file negative control proves the repoint is real (captured run-table).
+**Done =** each of WORKFLOW/MANUAL/CHANGELOG is a thin root stub + bulk-in-docs with EVERY reader (grep-discovered, not just the audit list) repointed, `install.sh` copies the bulk so the INSTALLED stub resolves (new test green), the full suite is green, `commands/*.md` prose has no dangling root pointer, and the per-file negative control proves the repoint is real (captured run-table).
 
 **Kit-adopted repo? Record the gates** (dwarves-kit cwd, `bash lib/classify/lane-classify.sh classify "..."` → full; record via `bash lib/gate/gate-ledger.sh`).
 

--- a/_meta/megagoals/harness-ops/goals/13-doc-tidy.md
+++ b/_meta/megagoals/harness-ops/goals/13-doc-tidy.md
@@ -4,7 +4,7 @@
 **Time budget:** 1-2 hours
 **Proof:** the moved files at their new homes + `docs/README.md` map matches the real tree + nothing load-bearing broke. Rung 1-2 (mostly safe doc-moves; a check that no reader referenced a moved path).
 **Design:** obvious
-**Depends on:** none (Track B; but land after 09/11 so the README map reflects the final tree)
+**Depends on:** 09, 11 (its README map must reflect the post-fold, post-move tree; the conductor reads this field mechanically, so the dep is real, not just prose , advisor P5 #3)
 Model: sonnet
 **Branch:** fix/harness-ops-13-doc-tidy
 **PR base:** main

--- a/docs/specs/DECISION-BRIEF-config-layer.md
+++ b/docs/specs/DECISION-BRIEF-config-layer.md
@@ -17,8 +17,8 @@ team-collaboration posture , with a kit-wide default that a project can override
 
 - A `kit.toml` ALREADY exists but is a **write-only install manifest** at
   `~/.claude/dwarves-kit/kit.toml` (`install.sh` writes `<module> = true|false`).
-  A lint (`tests/test-no-runtime-manifest-read.sh`) FAILS if any **hook** reads it
-  at runtime. It forbids hook reads, not command reads.
+  A lint (the "no hooks/*.sh reads kit.toml" assertion in `tests/test-install-modules.sh`)
+  FAILS if any **hook** reads it at runtime. It forbids hook reads, not command reads.
 - Every real runtime knob is an **env var**. The ONLY resolver precedent is
   `lib/telemetry/kit-log-dir.sh` (`kit_resolve_log_dir`, env-precedence, fatal-on-empty),
   plus `lib/mega.sh`'s `_resolve_*` helpers. There is **no** `lib/config/` and **no**
@@ -79,7 +79,7 @@ its performance rationale (no TOML parse on every Bash call).
    paths. Expose a stable entrypoint (a `kit <sub> <verb>` dispatcher or installed `board`
    command) so internal reorg never breaks a consumer again. In scope for this spec or a
    tight sibling; it is the durable fix for the board-shim class of bug.
-3. **Lint scope confirmation.** Confirm `test-no-runtime-manifest-read.sh` is hook-scoped;
+3. **Lint scope confirmation.** Confirm the kit.toml-read lint in `tests/test-install-modules.sh` is hook-scoped;
    if it forbids ALL runtime reads, either scope it to hooks or point the resolver at a
    separate runtime-config file.
 4. **Consumer-contract doc.** Produce `docs/consumer-contract.md` (the 4 adopt files +


### PR DESCRIPTION
Pre-launch advisor pass on the harness-ops mega. P5: 1 CRITICAL (install.sh docs-copy gap in goal 12 root-slim) + 3 MAJOR (adopt.sh cross-track collision 05<->12, goal 13 Depends-on, goal 12 reader undercount) + 1 MINOR (brief lint filename); all applied. P6: 6 ideas to NOTES. No flat-lib-path bug. See NOTES ## Event log. 🤖 Generated with [Claude Code](https://claude.com/claude-code)