### PR TITLE
feat(config): wire [ledger] section through kit-config resolver

### DIFF
--- a/docs/verification/wire-ledger.md
+++ b/docs/verification/wire-ledger.md
@@ -1,0 +1,82 @@
+# Proof of done: wire-ledger (SPEC-186, harness-ops sub-goal 02)
+
+Behavioral change: the `[ledger]` config section is now live. `lib/telemetry/kit-log-dir.sh`
+(`kit_resolve_log_dir`) and `lib/gate/proof-ledger.sh` (`KIT_DELIVERY_RATIO_WARN` /
+`KIT_DELIVERY_REAL_FLOOR`) source `lib/config/kit-config.sh` and insert config as the layer
+BETWEEN the env var and the hardcoded default: `env > project .kit.toml > kit-root kit.toml >
+hardcoded default`. `location = "isolated"` resolves to `$PWD/.kit/logs`; `"shared"` (or unset)
+to the XDG default; any other value is treated as an explicit path. An explicit env var
+(`KIT_LEDGER_DIR`, `KIT_DELIVERY_RATIO_WARN`, `KIT_DELIVERY_REAL_FLOOR`) still wins over both
+config layers, back-compat preserved.
+
+## Green run
+
+Command: `bash /tmp/ho02-proof.sh <repo-root>` (isolated/shared/env-wins run-table script,
+transcribed below)
+
+```
+== NC1: [ledger] location=isolated resolves under $PWD/.kit/logs ==
+  location=isolated -> /var/folders/.../tmp.AydX1pVImY/.kit/logs
+  PASS isolated resolves to PWD/.kit/logs
+== NC2: [ledger] location=shared resolves to XDG default ==
+  location=shared -> /Users/tieubao/.local/state/dwarves-kit/logs
+  PASS shared resolves to XDG default
+== NC3 (negative control): KIT_LEDGER_DIR env wins over BOTH config values ==
+  KIT_LEDGER_DIR=/var/folders/.../tmp.AydX1pVImY/env-wins-dir + location=shared -> /var/folders/.../tmp.AydX1pVImY/env-wins-dir
+  PASS env wins over config (location=shared still in file)
+== NC4: [ledger] delivery_ratio_warn / delivery_real_floor read through proof-ledger.sh ==
+  config ratio=7 floor=5 -> ratio=7 floor=5
+  PASS config values read through resolver
+== NC5 (negative control): KIT_DELIVERY_RATIO_WARN env wins over config's 7 ==
+  KIT_DELIVERY_RATIO_WARN=99 (config says 7) -> ratio=99
+  PASS env wins over config for delivery thresholds too
+== NC6: unset config + no env -> hardcoded defaults (3 / 40) unchanged ==
+  no config, no env -> ratio=3 floor=40
+  PASS hardcoded default preserved (3/40)
+
+ALL PASS
+```
+Exit: 0
+
+Command: `bash lib/config/kit-config.sh selftest`
+Exit: 0
+Output: `PASS kit-config selftest` (6/6 checks, unchanged, confirms the resolver itself is
+untouched by this wiring)
+
+Command: `bash tests/test-install-modules.sh`
+Exit: 0
+Output (tail): `== 21 passed, 0 failed ==` , includes "STANDING ANTI-DRIFT LINT: no hook reads
+kit.toml at runtime" (PASS, leaked: none). Confirms no hot hook reaches `kit-config.sh`
+transitively through this change (`kit-log-dir.sh` and `proof-ledger.sh` are sourced only by
+non-hook commands: `gate-ledger.sh`, `lane-classify.sh`, `ledger.sh`, `precedent.sh`,
+`lane-telemetry.sh`, `mega-merge.sh`, `weekend-batch.sh`, `proof-table-gen.sh`; none are hooks).
+
+Command: `bash tests/test-ledger-substrate.sh && bash tests/test-delivery-ratio.sh && bash tests/test-ledger-durability.sh && bash tests/test-advisor-ledger-emit.sh`
+Exit: 0
+Output (tail): `9 passed, 0 failed` / `8 passed, 0 failed` / `35/35 passed, 0 failed` /
+`27/27 passed, 0 failed` , confirms zero regression on the existing env-var precedence,
+delivery-ratio, ledger-substrate, and advisor-ledger-emit suites.
+
+## NEGATIVE CONTROL
+
+Two negative controls, both exercised live (NC3 and NC5 above), not asserted:
+
+- **NC3**: `KIT_LEDGER_DIR` set to an explicit dir while `.kit.toml` still says
+  `location = "shared"` -> resolves to the ENV path, not XDG. Config never wins over an
+  explicit env var.
+- **NC5**: `KIT_DELIVERY_RATIO_WARN=99` set while `.kit.toml` says `delivery_ratio_warn = 7`
+  -> resolves to `99`, not `7`. Same precedence contract for the delivery thresholds.
+
+Both negative controls PASS: env beats config in every code path this sub-goal touched.
+
+## Reproduce
+
+```bash
+cd dwarves-kit
+bash lib/config/kit-config.sh selftest
+bash tests/test-install-modules.sh
+bash tests/test-ledger-substrate.sh
+bash tests/test-delivery-ratio.sh
+```
+
+VERDICT: PASS

--- a/lib/gate/proof-ledger.sh
+++ b/lib/gate/proof-ledger.sh
@@ -38,6 +38,11 @@ source "$LIB_ROOT/telemetry/kit-log-dir.sh" || { echo "FATAL: lib/telemetry/kit-
 # The ONE append substrate (SPEC-182): the override write routes through ledger_append.
 # shellcheck source=lib/ledger/ledger.sh
 source "$LIB_ROOT/ledger/ledger.sh" || { echo "FATAL: lib/ledger/ledger.sh missing or unreadable" >&2; exit 1; }
+# The config-layer resolver (SPEC-186 [ledger] wiring): the delivery-ratio thresholds below
+# read through it. kit-log-dir.sh already sources it, but source directly too so this file's
+# dependency on kit-config.sh is explicit, not incidental to another lib's internals.
+# shellcheck source=lib/config/kit-config.sh
+source "$LIB_ROOT/config/kit-config.sh" || { echo "FATAL: lib/config/kit-config.sh missing or unreadable" >&2; exit 1; }
 kit_migrate_log_dir || true
 LOG_DIR="$(kit_resolve_log_dir)" || exit 1
 OVERRIDE_LOG="$LOG_DIR/proof-overrides.log"
@@ -102,8 +107,11 @@ deployable() {
 # for a reviewer or `mega status` to surface. Rationale: the proof-of-done gate checks
 # that proof EXISTS, not that delivery is PROPORTIONATE, so a thin docs/reconcile
 # sub-goal can pass by padding proof (2026-07-05 delivery audit; ADR "delivery ratio").
-KIT_DELIVERY_RATIO_WARN="${KIT_DELIVERY_RATIO_WARN:-3}"    # proof >= N*real ...
-KIT_DELIVERY_REAL_FLOOR="${KIT_DELIVERY_REAL_FLOOR:-40}"   # ... AND real < FLOOR => THIN-WARN
+# Precedence (SPEC-186 [ledger] wiring): env var > project .kit.toml > kit-root kit.toml >
+# hardcoded default, via kit_config_get. An explicit env var still wins over config, same
+# back-compat contract as kit_resolve_log_dir.
+KIT_DELIVERY_RATIO_WARN="${KIT_DELIVERY_RATIO_WARN:-$(kit_config_get ledger.delivery_ratio_warn 3)}"    # proof >= N*real ...
+KIT_DELIVERY_REAL_FLOOR="${KIT_DELIVERY_REAL_FLOOR:-$(kit_config_get ledger.delivery_real_floor 40)}"   # ... AND real < FLOOR => THIN-WARN
 delivery_ratio() {
   local root="${1:-}" base="${2:-}"
   [ -n "$root" ] && [ -n "$base" ] || { echo "usage: delivery-ratio <root> <base>" >&2; return 64; }

--- a/lib/telemetry/kit-log-dir.sh
+++ b/lib/telemetry/kit-log-dir.sh
@@ -17,13 +17,24 @@
 [ -n "${_KIT_LOG_DIR_SOURCED:-}" ] && return 0
 _KIT_LOG_DIR_SOURCED=1
 
-# The durable default and precedence (SPEC-182, kit-modularity SG-02): the ledger root is
-# ONE root shared by both planes (the write-side append substrate and the read-side `stats`
-# projection). Precedence:
-#   1. $KIT_LEDGER_DIR   -- the canonical knob (essential-tier config, per-consumer root).
+# The config-layer resolver (lib/config/kit-config.sh), sourced best-effort: it is a command-
+# time lib, never read by a hot hook, and this file is itself sourced by non-hook commands
+# only (gate-ledger.sh, proof-ledger.sh, lane-classify.sh, ...) -- see docs/proof-of-done.md
+# for the `hooks/*.sh` grep confirming no hook reaches this transitively.
+_KIT_LOG_DIR_SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/config/kit-config.sh
+source "$_KIT_LOG_DIR_SELF/../config/kit-config.sh" || { echo "kit-log-dir: lib/config/kit-config.sh missing or unreadable" >&2; return 1; }
+
+# The durable default and precedence (SPEC-182, kit-modularity SG-02; [ledger] wiring SPEC-186):
+# the ledger root is ONE root shared by both planes (the write-side append substrate and the
+# read-side `stats` projection). Precedence:
+#   1. $KIT_LEDGER_DIR      -- the canonical knob (essential-tier config, per-consumer root).
 #   2. $DWARVES_KIT_LOG_DIR -- back-compat alias (the pre-SPEC-182 name; every existing
 #      test pin + the live corpus still resolve through it unchanged).
-#   3. ${XDG_STATE_HOME:-$HOME/.local/state}/dwarves-kit/logs -- host-generic default,
+#   3. [ledger].location in .kit.toml (project) / kit.toml (kit-root), via kit-config.sh:
+#      "isolated" -> $PWD/.kit/logs; "shared" (or unset/empty) -> the XDG default below;
+#      any other value is treated as an explicit path.
+#   4. ${XDG_STATE_HOME:-$HOME/.local/state}/dwarves-kit/logs -- the hardcoded default,
 #      outside ~/.claude entirely, so no ~/.claude/dwarves-kit* reinstall can touch it.
 # A set-but-EMPTY $KIT_LEDGER_DIR is a FATAL clean error, never a silent fall-through: an
 # empty root would make every writer append to a relative `runs/...` path in the caller's cwd
@@ -39,7 +50,12 @@ kit_resolve_log_dir() {
   elif [ -n "${DWARVES_KIT_LOG_DIR:-}" ]; then
     printf '%s' "$DWARVES_KIT_LOG_DIR"
   else
-    printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/dwarves-kit/logs"
+    local loc; loc="$(kit_config_get ledger.location "shared")"
+    case "$loc" in
+      isolated) printf '%s' "$PWD/.kit/logs" ;;
+      shared|"") printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}/dwarves-kit/logs" ;;
+      *) printf '%s' "$loc" ;;
+    esac
   fi
 }
 


### PR DESCRIPTION
Wires the `[ledger]` config section through the kit-config resolver (env > project > kit-root > default), keeping env-var back-compat. Verify: the isolated/shared/env-wins run-table. Part of `harness-ops` (Track A), see ROADMAP.md.

Proof: `docs/verification/wire-ledger.md`
