### PR TITLE
test(config): guard reserved [features]/[team] keys as inert

### DIFF
--- a/docs/specs/SPEC-188-reserved-keys-guard.md
+++ b/docs/specs/SPEC-188-reserved-keys-guard.md
@@ -1,0 +1,78 @@
+# SPEC-188: reserved-keys-guard ([features]/[team] stay honestly inert)
+
+Status: SHIPPED (test + doc-tags confirmed)
+Lane: normal
+Backlog: harness-ops sub-goal 08 (`_meta/megagoals/harness-ops/goals/08-reserved-keys-guard.md`)
+Branch: feat/harness-ops-08-reserved
+Relates-to: SPEC-183 (manifest-reconcile, the `kit.toml` chain that ships these
+sections), `lib/config/kit-config.sh` (the resolver)
+
+## Problem
+
+`kit.toml` (repo-root, SPEC-183) ships two forward-looking-but-not-built sections:
+`[features]` (`auto_improvement`, `learning_ledger`) and `[team]` (`actor_identity`,
+`attestation`, `ci_recheck`, `spec_reservation`, `policy`, `onboarding`, `pilot`). Both
+are resolver-readable via `kit_config_get` (the resolver reads whatever section/key is
+asked, unconditionally). Nothing GUARANTEED, before this sub-goal, that flipping one of
+these keys stays a genuine no-op: a reader could plausibly assume a status-tag comment
+is enough, but nothing tested it, and a future change could silently wire a key without
+anyone noticing it had graduated from documentation-only to live.
+
+## Design
+
+**Confirm, then lock with a test.** This sub-goal does not build anything new; it
+verifies the current state (no live code path reads `features.*`/`team.*`) and adds a
+standing test so a future accidental wire-up fails CI instead of shipping silently.
+
+- **Grep-based no-live-path lint** (`tests/test-reserved-config-guard.sh`), mirroring
+  SPEC-183's hooks-only `kit.toml` lint: assert no file under `lib/`, `commands/`, or
+  `hooks/` calls `kit_config_get features.<key>` or `kit_config_get team.<key>` for any
+  of the nine reserved keys.
+- **Load-bearing NC for the lint itself**: a planted fake consumer that DOES call
+  `kit_config_get team.actor_identity` is caught by the same grep, so the lint is proven
+  to catch a real violation, not vacuously green.
+- **Resolver-readable, positive check**: a project `.kit.toml` setting
+  `[features] auto_improvement = true` and `[team] actor_identity = true` resolves via
+  `kit_config_get` to `"true"` -- the keys ARE reachable, by design (a future consumer
+  can read them without any resolver change).
+- **Behavioral negative control (the goal's Rung-2 proof)**: run two spine surfaces
+  (`lib/config/kit-config.sh selftest`, `lib/classify/lane-classify.sh classify`) once
+  under baseline config and once under the project override flipping both reserved
+  keys to `true`; assert byte-identical output. If either key had a live path, one of
+  these runs would differ.
+- **Status-tag documentation check**: `kit.toml`'s comments already carry `[design]` on
+  `auto_improvement` and every `[team].*` key, and `[consumer]` on `learning_ledger`
+  (SPEC-183's status-tag legend); the test greps for these tags so a future edit that
+  drops a tag (making an inert key look live) fails.
+
+No code under `lib/`, `commands/`, or `hooks/` changes. `kit.toml` itself is untouched
+(sub-goal 04 owns its shape; this sub-goal only confirms + tests its existing tags).
+
+## Scope edges
+
+**In:** the inert-key guard test, confirming the existing status-tag documentation.
+**Out:** actually building `auto_improvement`/`learning_ledger`/`[team].*` (their own
+future work, each with its own design doc referenced in `kit.toml`'s comments).
+**Not:** wiring any reserved key to a live path, removing the reserved keys, changing
+`kit.toml`'s section shape.
+
+## Verification
+
+1. `bash tests/test-reserved-config-guard.sh` -- new, all green (9 assertions: no-live-
+   path lint x2 incl. its own load-bearing NC, resolver-readable x2, inert-flip-NC x2,
+   status-tag documentation x3).
+2. `bash lib/config/kit-config.sh selftest` -- unchanged resolver mechanics, still green
+   (regression check; this spec does not touch the resolver).
+3. `bash tests/test-install-modules.sh` -- unchanged, still green (regression check;
+   confirms this sub-goal did not disturb SPEC-183's manifest chain).
+
+## After state
+
+- A new standing test (`tests/test-reserved-config-guard.sh`) proves, with a captured
+  run-table, that `[features]`/`[team]` keys are resolver-readable but inert: flipping
+  either `auto_improvement` or `actor_identity` changes no observed behavior across two
+  representative spine commands.
+- The lint's own load-bearing-ness is demonstrated (a planted live-path read IS caught).
+- The status tags (`[design]`/`[consumer]`) on these keys are asserted by the test, so
+  a future edit that silently drops one fails CI instead of shipping unnoticed.
+- Proof: `docs/verification/reserved-keys-guard/proof-of-done.md`.

--- a/docs/verification/reserved-keys-guard/proof-of-done.md
+++ b/docs/verification/reserved-keys-guard/proof-of-done.md
@@ -1,0 +1,90 @@
+# Proof of done: reserved-keys-guard (SPEC-188, harness-ops sub-goal 08)
+
+## Acceptance criteria -> run-table
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| AC1 | No live code path reads `[features]`/`[team]` keys under `lib/`, `commands/`, `hooks/` | PASS | "NC no-live-path" block, grep across all 9 reserved keys, 0 hits |
+| AC2 | The no-live-path lint is load-bearing, not vacuously green | PASS | "NC lint-load-bearing" block: a planted `kit_config_get team.actor_identity` call in a scratch dir IS caught by the same grep |
+| AC3 | The reserved keys are resolver-readable (a future consumer can read them with no resolver change) | PASS | `kit_config_get features.auto_improvement` / `kit_config_get team.actor_identity` resolve to `true` via a project `.kit.toml` override |
+| AC4 | Rung-2 negative control: flipping an inert key changes no observed behavior | PASS | two spine surfaces (`kit-config.sh selftest`, `lane-classify.sh classify`) run byte-identical baseline vs. flipped-config |
+| AC5 | Status tags document the reserved keys as `[design]`/`[consumer]`, not live | PASS | grep on `kit.toml`: `auto_improvement` -> `[design]`, `learning_ledger` -> `[consumer]`, all 7 `[team]` keys -> `[design]` |
+| AC6 | No regression to the config resolver or the manifest chain | PASS | `kit-config.sh selftest` (6/6) + `test-install-modules.sh` (37/37) unchanged |
+
+**Total: 9/9 PASS in `tests/test-reserved-config-guard.sh`. Regression: 6/6 + 37/37 unchanged, 0 FAIL.**
+
+## What this confirms (not builds)
+
+`kit.toml`'s `[features]`/`[team]` sections (shipped by SPEC-183) are documentation-only
+today: the resolver (`lib/config/kit-config.sh`) will happily return any value asked of
+it, but no command, lib, or hook branches on `features.auto_improvement`,
+`features.learning_ledger`, or any `team.*` key. This sub-goal locks that fact behind a
+standing test so a future change that silently wires one of these keys to a real code
+path fails CI instead of shipping as an undocumented surprise.
+
+## Confirmation run (positive: current tree)
+
+Command: `bash tests/test-reserved-config-guard.sh`
+Exit: 0
+
+```
+== NC no-live-path: nothing under lib/, commands/, hooks/ branches on [features]/[team] ==
+  PASS  no lib/commands/hooks file reads a [features]/[team] key (leaked: none)
+== NC lint-load-bearing: the grep genuinely catches a planted live-path read ==
+  PASS  NC: planted live-path read of team.actor_identity is caught by the same grep
+== resolver-readable: kit_config_get surfaces reserved keys via project override ==
+  PASS  resolver reads project override features.auto_improvement=true
+  PASS  resolver reads project override team.actor_identity=true
+== NC inert-flip-changes-nothing: flipping the reserved keys touches no observed behavior ==
+  PASS  config-resolver selftest identical baseline vs inert-key-flipped (features.auto_improvement, team.actor_identity)
+  PASS  lane-classify output identical baseline vs inert-key-flipped
+== status tags: kit.toml documents the reserved keys as [design]/[consumer], not live ==
+  PASS  kit.toml: auto_improvement tagged [design]
+  PASS  kit.toml: learning_ledger tagged [consumer]
+  PASS  kit.toml: all [team] keys tagged [design] (untagged: none)
+
+== 9 run, 9 passed, 0 failed ==
+```
+
+Full log: `/tmp/proof-run-188.log` (this run).
+
+## Negative control (revert the test, or plant a real live-path read)
+
+Two ways this test would go RED, both verified live during authoring:
+
+1. **A future accidental wire-up**: if any file under `lib/`, `commands/`, or `hooks/`
+   started calling `kit_config_get features.auto_improvement` (or any other reserved
+   key), the "NC no-live-path" assertion fails immediately (grep finds the file).
+   Demonstrated by the planted `fake-team-consumer.sh` in AC2 -- the identical grep
+   pattern this test's first assertion uses DOES catch it.
+2. **A dropped status tag**: if `kit.toml` lost the `[design]` tag on any `[team]` key
+   or the `[consumer]` tag on `learning_ledger` (e.g. a careless edit that reformatted
+   the comments), the "status tags" block's grep assertions fail. Confirmed by manually
+   stripping the `# [design]` suffix from one `[team]` line during authoring and
+   re-running: `FAIL  kit.toml: all [team] keys tagged [design] (untagged: actor_identity)`.
+
+## Regression (resolver + manifest chain unaffected)
+
+```
+$ bash lib/config/kit-config.sh selftest
+ok   project overrides kit-root
+ok   kit-root default when no proj
+ok   inline comment stripped
+ok   commented key -> caller default
+ok   missing key -> caller default
+ok   missing section -> empty
+PASS kit-config selftest
+
+$ bash tests/test-install-modules.sh
+... (37 assertions unchanged) ...
+== 37 passed, 0 failed ==
+```
+
+## Reproduce
+
+```
+cd <repo>
+bash tests/test-reserved-config-guard.sh   # new, this sub-goal
+bash lib/config/kit-config.sh selftest     # regression
+bash tests/test-install-modules.sh         # regression
+```

--- a/tests/test-reserved-config-guard.sh
+++ b/tests/test-reserved-config-guard.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test-reserved-config-guard.sh -- harness-ops sub-goal 08 (reserved-keys-guard).
+#
+# The forward-looking-but-not-built config surface -- [features] (auto_improvement,
+# learning_ledger) and all of [team].* -- must stay HONESTLY INERT: resolver-readable
+# via kit_config_get, but with NO live code path (flipping one changes no behavior).
+# This is the opposite failure mode from test-install-modules.sh's [modules] lint:
+# there the concern is "no OPTIONAL module wired without being asked"; here it is
+# "these specific keys must never be wired at all yet, and that must be documented,
+# not a silent no-op a user mistakes for a working toggle."
+#
+# Run: bash tests/test-reserved-config-guard.sh
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
+assert_true() { if [ "$2" -eq 0 ]; then ok "$1"; else bad "$1"; fi; }
+
+RESERVED_FEATURES_KEYS="auto_improvement learning_ledger"
+RESERVED_TEAM_KEYS="actor_identity attestation ci_recheck spec_reservation policy onboarding pilot"
+
+# ============================================================
+echo "== NC no-live-path: nothing under lib/, commands/, hooks/ branches on [features]/[team] =="
+# ============================================================
+# Mirrors the hooks-only-kit.toml lint in test-install-modules.sh: a grep-based
+# STANDING assertion, not a registry. Any kit_config_get call addressing
+# features.<key> or team.<key> would be a live code path -- out of scope for this
+# sub-goal (see goal file "Not: wiring any reserved key to a live path").
+LIVE_HITS=""
+for k in $RESERVED_FEATURES_KEYS; do
+  hits="$(grep -rln "kit_config_get[[:space:]]*['\"]\\?features\\.$k" "$KIT_DIR/lib" "$KIT_DIR/commands" "$KIT_DIR/hooks" 2>/dev/null || true)"
+  [ -n "$hits" ] && LIVE_HITS="$LIVE_HITS$hits"$'\n'
+done
+for k in $RESERVED_TEAM_KEYS; do
+  hits="$(grep -rln "kit_config_get[[:space:]]*['\"]\\?team\\.$k" "$KIT_DIR/lib" "$KIT_DIR/commands" "$KIT_DIR/hooks" 2>/dev/null || true)"
+  [ -n "$hits" ] && LIVE_HITS="$LIVE_HITS$hits"$'\n'
+done
+assert_true "no lib/commands/hooks file reads a [features]/[team] key (leaked: ${LIVE_HITS:-none})" "$([ -z "$LIVE_HITS" ]; echo $?)"
+
+# ============================================================
+echo "== NC lint-load-bearing: the grep genuinely catches a planted live-path read =="
+# ============================================================
+# A vacuously-green lint proves nothing (SPEC-183's same NC pattern). Plant a fake
+# consumer that DOES call kit_config_get team.actor_identity and confirm the same
+# grep this test uses would flag it.
+FAKE_DIR="$(mktemp -d)"; trap 'rm -rf "$FAKE_DIR"' EXIT
+mkdir -p "$FAKE_DIR/lib/fake"
+cat > "$FAKE_DIR/lib/fake/fake-team-consumer.sh" <<'EOF'
+#!/usr/bin/env bash
+v="$(kit_config_get team.actor_identity false)"
+EOF
+PLANTED_HIT="$(grep -rln "kit_config_get[[:space:]]*['\"]\\?team\\.actor_identity" "$FAKE_DIR/lib" 2>/dev/null || true)"
+assert_true "NC: planted live-path read of team.actor_identity is caught by the same grep" "$([ -n "$PLANTED_HIT" ]; echo $?)"
+
+# ============================================================
+echo "== resolver-readable: kit_config_get surfaces reserved keys via project override =="
+# ============================================================
+PROJ="$(mktemp -d)"
+cat > "$PROJ/.kit.toml" <<'TOML'
+[features]
+auto_improvement = true
+[team]
+actor_identity = true
+TOML
+export KIT_PROJECT_ROOT="$PROJ" KIT_CONFIG_ROOT="$KIT_DIR"
+# shellcheck source=/dev/null
+source "$KIT_DIR/lib/config/kit-config.sh"
+V1="$(kit_config_get features.auto_improvement false)"
+V2="$(kit_config_get team.actor_identity false)"
+assert_true "resolver reads project override features.auto_improvement=true" "$([ "$V1" = "true" ]; echo $?)"
+assert_true "resolver reads project override team.actor_identity=true" "$([ "$V2" = "true" ]; echo $?)"
+
+# ============================================================
+echo "== NC inert-flip-changes-nothing: flipping the reserved keys touches no observed behavior =="
+# ============================================================
+# Behavioral negative control: run a representative spine surface (the config
+# resolver's own selftest, plus the [modules] lane classifier) once with the
+# BASELINE kit-root config, once with the project override above flipping
+# features.auto_improvement / team.actor_identity to true, and diff the output.
+# If either key had a live path, one of these two runs would differ.
+BASE_OUT="$(unset KIT_PROJECT_ROOT; KIT_CONFIG_ROOT="$KIT_DIR" bash "$KIT_DIR/lib/config/kit-config.sh" selftest 2>&1)"
+FLIP_OUT="$(KIT_PROJECT_ROOT="$PROJ" KIT_CONFIG_ROOT="$KIT_DIR" bash "$KIT_DIR/lib/config/kit-config.sh" selftest 2>&1)"
+assert_true "config-resolver selftest identical baseline vs inert-key-flipped (features.auto_improvement, team.actor_identity)" "$([ "$BASE_OUT" = "$FLIP_OUT" ]; echo $?)"
+
+BASE_LANE="$(bash "$KIT_DIR/lib/classify/lane-classify.sh" classify "guard reserved inert config keys" 2>&1)"
+FLIP_LANE="$(KIT_PROJECT_ROOT="$PROJ" bash "$KIT_DIR/lib/classify/lane-classify.sh" classify "guard reserved inert config keys" 2>&1)"
+assert_true "lane-classify output identical baseline vs inert-key-flipped" "$([ "$BASE_LANE" = "$FLIP_LANE" ]; echo $?)"
+
+# ============================================================
+echo "== status tags: kit.toml documents the reserved keys as [design]/[consumer], not live =="
+# ============================================================
+KIT_TOML="$KIT_DIR/kit.toml"
+assert_true "kit.toml: auto_improvement tagged [design]" "$(grep -qE 'auto_improvement[[:space:]]*=.*#[[:space:]]*\[design\]' "$KIT_TOML"; echo $?)"
+assert_true "kit.toml: learning_ledger tagged [consumer]" "$(grep -qE 'learning_ledger[[:space:]]*=.*#[[:space:]]*\[consumer\]' "$KIT_TOML"; echo $?)"
+TEAM_UNTAGGED=""
+for k in $RESERVED_TEAM_KEYS; do
+  grep -qE "^$k[[:space:]]*=.*#[[:space:]]*\[design\]" "$KIT_TOML" || TEAM_UNTAGGED="$TEAM_UNTAGGED $k"
+done
+assert_true "kit.toml: all [team] keys tagged [design] (untagged:${TEAM_UNTAGGED:- none})" "$([ -z "$TEAM_UNTAGGED" ]; echo $?)"
+
+echo ""
+echo "== $((PASS+FAIL)) run, $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Guards the forward-looking reserved keys (`[features]`, `[team].*`): resolver-readable but inert + documented, with a test proving an inert-key flip changes nothing. Part of `harness-ops` (Track A), see ROADMAP.md.

## Test plan
- `bash tests/test-reserved-config-guard.sh` — 9/9 PASS (no-live-path lint + its own load-bearing NC, resolver-readable check, inert-flip behavioral NC, status-tag check)
- `bash lib/config/kit-config.sh selftest` — 6/6 PASS (regression)
- `bash tests/test-install-modules.sh` — 37/37 PASS (regression)
