### PR TITLE
feat(adopt): close the per-project .kit.toml override loop end to end

### DIFF
--- a/commands/adopt.md
+++ b/commands/adopt.md
@@ -8,13 +8,14 @@ coding, and the ship-gate engages on push.
 
 ## Run
 
-`$ARGUMENTS` may name a target dir (default: the repo root) and/or `--check` (status only).
+`$ARGUMENTS` may name a target dir (default: the repo root), `--check` (status only), or
+`--with <a,b,c>` (seed these modules `true` in a FRESH `.kit.toml`; ignored once one exists).
 
 1. Resolve the target: default `.` (`git rev-parse --show-toplevel`).
 2. Run the driver (idempotent, non-destructive):
 
    ```
-   bash "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/dwarves-kit}/lib/adopt.sh" [--check] <target>
+   bash "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/dwarves-kit}/lib/adopt.sh" [--check] [--with <a,b,c>] <target>
    ```
 
 3. Report what it created (or that the repo was already adopted). Tell the user the one next
@@ -26,11 +27,21 @@ coding, and the ship-gate engages on push.
 - a `CLAUDE.md` loader pointer (Claude Code auto-loads CLAUDE.md, not AGENTS.md).
 - `WORKFLOW.md` -- a pointer to the installed kit's lane x phase matrix (not a 49KB copy).
 - `docs/verification/README.md` -- the proof marker that makes the ship-gate engage.
+- `.kit.toml` -- an OPT-IN starter override of the kit-root defaults (SPEC-192). Created
+  only on a fresh adopt (never overwritten afterward); `--with` seeds the named modules
+  `true` instead of inheriting the kit-root default. Edit `[modules]` any time and re-run
+  `/kit:adopt` (or `--refresh`) to re-wire.
+- `.claude/settings.json` hook entries for this project's currently-enabled hook-bearing
+  modules (`board`, `session`, `advisor`, `cosmetic`) -- a targeted jq MERGE, re-wired on
+  every adopt run from the project's CURRENT `.kit.toml`, never a wholesale file rewrite.
+  Command/skill modules (`queue`, `stats`, `quiz_gate`, `weekend_batch`, `bridge`) need no
+  settings.json entry.
 
 The classifiers (`lane-classify`, `task-type-classify`, `proof-gate`) run from the installed kit;
 adoption wires the contract to reference them. It never copies the engine.
 
 ## Do NOT
 
-- Overwrite an existing AGENTS.md / CLAUDE.md (the driver guards this; never force it).
+- Overwrite an existing AGENTS.md / CLAUDE.md / `.kit.toml` (the driver guards this; never
+  force it; `--with` on an existing `.kit.toml` is a no-op with a note).
 - Copy `lib/` or the full `WORKFLOW.md` into the consumer.

--- a/docs/specs/SPEC-192-project-override.md
+++ b/docs/specs/SPEC-192-project-override.md
@@ -1,0 +1,96 @@
+# SPEC-192: project-override (per-project `.kit.toml` closed end to end through adopt)
+
+Status: SHIPPED (test + run-table confirmed)
+Lane: full
+Backlog: harness-ops sub-goal 06 (`_meta/megagoals/harness-ops/goals/06-project-override.md`)
+Branch: feat/harness-ops-06-override
+Relates-to: SPEC-183 (manifest-reconcile, the `kit.toml` chain), SPEC-188 (reserved-keys
+guard, the resolver's read side), `lib/config/kit-config.sh` (the resolver, sub-goal 01),
+`lib/adopt.sh` / `commands/adopt.md` (sub-goal 05's `/kit:adopt`)
+
+## Problem
+
+The resolver (`lib/config/kit-config.sh`, sub-goal 01) already merges a per-project
+`<project>/.kit.toml` over the kit-root default (project keys win). But nothing closed
+the loop for the two things a project actually needs to DO with that: (1) get a starter
+`.kit.toml` without hand-authoring one from the full kit-root schema, and (2) have its
+per-project `[modules]` choice actually change what is wired -- specifically, a
+hook-bearing module (`board`, `session`, `advisor`, `cosmetic`) needs its hook present or
+absent in `<project>/.claude/settings.json`, not just readable via `kit_config_get`.
+Without this, `[modules] board=false` in a project's `.kit.toml` was a value the
+resolver could report, but board's hook (`backlog-stage.sh`) still fired in that
+project, because nothing ever translated the config into a settings.json entry.
+
+## Design
+
+**Obvious, reuses existing pieces; no new resolver, no new module registry.**
+
+- **Seed, don't invent.** `lib/adopt.sh` gains a `--with <a,b,c>` flag and, on a run
+  where `<project>/.kit.toml` does not yet exist, writes a starter `[modules]` section
+  listing every known module (`board session advisor cosmetic queue stats quiz_gate
+  weekend_batch bridge`), each defaulting to the current kit-root value unless named in
+  `--with`. Never overwritten once it exists (same invariant as `AGENTS.md` / the proof
+  marker) -- `--with` on an existing `.kit.toml` is a no-op with a note, not a clobber.
+- **Read via the resolver, not a re-implementation.** Enabled-state for each hook-bearing
+  module is `kit_config_get "modules.<m>"` with `KIT_PROJECT_ROOT=<project>`
+  `KIT_CONFIG_ROOT=<kit-root dir>` -- the exact precedence sub-goal 01 already built
+  (project override, else kit-root default). `lib/adopt.sh` sources
+  `lib/config/kit-config.sh` inside a function scope (so the resolver's own `${1:-}`
+  selftest branch never sees `adopt.sh`'s positional parameters).
+- **Wire via a jq MERGE, never a settings.json rewrite.** `kit_module_hooks()` is a small,
+  deliberately duplicated copy of `install.sh`'s module->hook-script map (can't source a
+  full script as a library; same duplication `tests/test-install-modules.sh` already
+  accepts for the same reason). For each currently-enabled hook-bearing module, its hook
+  script names are pulled from the kit's own `settings.json` (source of the real hook
+  definitions: matcher, timeout, command) and merged into
+  `<project>/.claude/settings.json`: any prior `dwarves-kit/hooks/*` entry is stripped
+  first, then the currently-enabled set is re-added. Every non-kit-module entry in the
+  project's settings.json is preserved untouched (the Scope's "Not: a settings.json
+  rewrite" -- this is a targeted merge, not a full-file replace).
+- **Wired at adopt time, not read per hook fire.** The wiring step runs on every
+  `lib/adopt.sh` invocation (fresh or `--refresh`) -- an explicit, deliberate action --
+  recomputing the project's wired set from its CURRENT `.kit.toml`. No hook reads
+  `.kit.toml` or `kit.toml` at runtime (this repo's standing anti-drift lint,
+  `tests/test-install-modules.sh`, already asserts that for the global install; this
+  sub-goal adds no new runtime reader).
+- **Deterministic output, not just "the same hook names, any order".** The jq merge
+  canonicalizes with `jq -S` and sorts each event's hook-array by its own JSON text, so
+  re-running adopt with an unchanged `.kit.toml` reproduces byte-identical
+  `settings.json` -- `tests/test-adopt.sh`'s existing idempotency invariant (a clean
+  `git diff` after a no-op re-run) held for the pre-existing four artifacts and now
+  holds for the two new ones too.
+
+## Scope edges
+
+**In:** `.kit.toml` end-to-end (seed + read via the resolver), `/kit:adopt`'s
+`lib/adopt.sh` seeding a starter + wiring enabled hook-modules into the project's
+`settings.json`.
+**Out:** the resolver merge itself (sub-goal 01, unchanged here), the global
+`install.sh` install (sub-goal 04, unchanged here -- this sub-goal never touches
+`install.sh`).
+**Not:** runtime per-call module toggling (the hybrid model is wired at adopt time, read
+once per explicit adopt run, never per hook fire), a wholesale settings.json rewrite (a
+targeted jq merge only ever touches `dwarves-kit/hooks/*` entries).
+
+## Verification
+
+1. `bash tests/test-adopt.sh` -- 21 assertions, all green, including 10 new SPEC-192
+   assertions: starter `.kit.toml` seeding, `--with` on a fresh vs. an existing project,
+   the `board=false` -> hook-not-wired proof, a `[ledger]` override honored by the
+   resolver, and idempotent re-wiring.
+2. `bash tests/test-install-modules.sh` -- unchanged, still green (regression check;
+   this sub-goal never edits `install.sh`).
+3. `bash lib/config/kit-config.sh selftest` -- unchanged resolver mechanics, still green.
+
+## After state
+
+- `lib/adopt.sh` seeds `<project>/.kit.toml` (opt-in, `--with`-aware, never overwritten
+  after creation) and wires the currently-enabled hook-bearing modules'
+  (`board`/`session`/`advisor`/`cosmetic`) hooks into `<project>/.claude/settings.json`
+  on every adopt run, via a targeted jq merge.
+- The Done= run-table (project override + module-enable): a project `.kit.toml`
+  `[modules] board=false` -> `backlog-stage.sh` absent from that project's
+  `settings.json`, while an untouched still-enabled module's hooks stay wired; a
+  `[ledger] location = "isolated"` override in the project `.kit.toml` resolves via
+  `kit_config_get ledger.location` to `"isolated"`.
+- Proof: `docs/verification/project-override/proof-of-done.md`.

--- a/docs/verification/project-override/proof-of-done.md
+++ b/docs/verification/project-override/proof-of-done.md
@@ -1,0 +1,132 @@
+# Proof of done: project-override (SPEC-192, harness-ops sub-goal 06)
+
+## Acceptance criteria -> run-table
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| AC1 | `/kit:adopt` (`lib/adopt.sh`) seeds a starter `<project>/.kit.toml` on a fresh adopt | PASS | "fresh adopt seeds a starter .kit.toml with a [modules] section" |
+| AC2 | The seeded `[modules]` values reflect the kit-root default when `--with` is not given | PASS | "fresh adopt wires kit-root-default-enabled modules' hooks (board/advisor in, cosmetic out)" |
+| AC3 | `--with <modules>` on a FRESH project seeds those modules `true` even against a `false` kit-root default | PASS | "--with cosmetic on a fresh repo seeds cosmetic=true and wires its hook" |
+| AC4 | `--with` is ignored (never clobbers) once `<project>/.kit.toml` already exists | PASS | "--with is ignored once .kit.toml already exists (never overwritten)" |
+| AC5 (**Done=, clause 1**) | A project `.kit.toml` `[modules] board=false` results in that project NOT wiring board's hook, verified via its `settings.json` | PASS | "DONE=: project .kit.toml [modules] board=false -> board's hook is NOT wired (settings.json)" |
+| AC6 | The board-only edit is surgical: an unrelated still-enabled module's hooks stay wired | PASS | "re-wiring after a board=false edit leaves the still-enabled session module's hooks wired" |
+| AC7 (**Done=, clause 2**) | A `[ledger]` override in the project `.kit.toml` is honored by a command reading it (the resolver) | PASS | "DONE=: a [ledger] override in the project .kit.toml is honored by the resolver" |
+| AC8 | Re-wiring is idempotent: an unchanged `.kit.toml` re-run is a clean settings.json no-op | PASS | "re-running adopt --refresh with an unchanged .kit.toml is a clean no-op on module wiring" |
+| AC9 | No regression to the global install / manifest chain (`install.sh` untouched) | PASS | `tests/test-install-modules.sh` 37/37 unchanged |
+| AC10 | No regression to the resolver | PASS | `lib/config/kit-config.sh selftest` 6/6 unchanged |
+
+**Total: 21/21 PASS in `tests/test-adopt.sh` (11 pre-existing + 10 new SPEC-192 assertions). Regression: 37/37 (`test-install-modules.sh`) + 6/6 (`kit-config.sh selftest`) unchanged, 0 FAIL.**
+
+## What this closes
+
+The resolver (`lib/config/kit-config.sh`, sub-goal 01) already merged a project
+`.kit.toml` over the kit-root default -- but nothing translated that merged value into
+an actual settings.json change. This sub-goal wires `lib/adopt.sh` to (1) seed a starter
+`.kit.toml` (opt-in, `--with`-aware, never overwritten after creation) and (2) recompute,
+on every adopt run, which hook-bearing modules (`board`/`session`/`advisor`/`cosmetic`)
+are enabled for THIS project and merge their hooks into
+`<project>/.claude/settings.json` -- a targeted jq merge, never a wholesale file
+rewrite. Command/skill modules (`queue`/`stats`/`quiz_gate`/`weekend_batch`/`bridge`)
+are recorded in `.kit.toml` but never touch settings.json (they have no hook to gate).
+
+## Confirmation run (positive: current tree)
+
+Command: `bash tests/test-adopt.sh`
+Exit: 0
+
+```
+ok - fresh adopt creates AGENTS.md + WORKFLOW pointer + CLAUDE pointer + proof marker
+ok - re-run is a clean no-op (idempotent)
+ok - --check exits 0 on an adopted repo
+ok - --check exits 1 on a fresh repo
+ok - existing AGENTS.md is not clobbered
+ok - CLAUDE.md loader uses @AGENTS.md import + paired end marker
+ok - --dry-run writes nothing
+ok - --refresh keeps a single managed block
+ok - --refresh refuses to truncate a block missing its END marker (file untouched)
+ok - --refresh replaces a stale block body and preserves surrounding content
+ok - --refresh preserves AGENTS.md + proof marker (never overwritten)
+ok - --dry-run on an adopted repo writes nothing
+ok - fresh adopt seeds a starter .kit.toml with a [modules] section
+ok - fresh adopt wires kit-root-default-enabled modules' hooks (board/advisor in, cosmetic out)
+ok - --with cosmetic on a fresh repo seeds cosmetic=true and wires its hook
+ok - precondition: board's hook is wired before the override (kit-root default board=true)
+ok - DONE=: project .kit.toml [modules] board=false -> board's hook is NOT wired (settings.json)
+ok - re-wiring after a board=false edit leaves the still-enabled session module's hooks wired
+ok - DONE=: a [ledger] override in the project .kit.toml is honored by the resolver
+ok - --with is ignored once .kit.toml already exists (never overwritten)
+ok - re-running adopt --refresh with an unchanged .kit.toml is a clean no-op on module wiring
+---
+PASS=21 FAIL=0
+```
+
+Full log: `/tmp/proof-run-192-adopt.log` (this run).
+
+## The Done= run-table, isolated
+
+The two literal Done= clauses, run by hand against a scratch project (mirrors what
+`tests/test-adopt.sh` automates):
+
+```
+$ T=$(mktemp -d) && git -C "$T" init -q
+$ bash lib/adopt.sh "$T" >/dev/null
+$ jq -r '[.hooks[]?[]?.hooks[]?.command] | .[]' "$T/.claude/settings.json" \
+    | grep -o 'backlog-stage.sh'
+backlog-stage.sh          # board's hook IS wired (kit-root default board=true)
+
+$ sed -i.bak 's/^board = true$/board = false/' "$T/.kit.toml" && rm "$T/.kit.toml.bak"
+$ bash lib/adopt.sh --refresh "$T" >/dev/null
+$ jq -r '[.hooks[]?[]?.hooks[]?.command] | .[]' "$T/.claude/settings.json" \
+    | grep -o 'backlog-stage.sh' || echo "(absent)"
+(absent)                  # board=false -> board's hook is NOT wired. Done= clause 1.
+
+$ printf '\n[ledger]\nlocation = "isolated"\n' >> "$T/.kit.toml"
+$ KIT_CONFIG_ROOT="$(pwd)" KIT_PROJECT_ROOT="$T" \
+    bash -c "source lib/config/kit-config.sh; kit_config_get ledger.location"
+isolated                  # project [ledger] override honored by the resolver. Done= clause 2.
+```
+
+## Negative control (revert the change, or plant a violation)
+
+Two ways this would go RED, both exercised during authoring:
+
+1. **Revert `lib/adopt.sh`'s step 6 (module wiring)**: with the wiring block removed,
+   `<project>/.claude/settings.json` is never created/updated by adopt, so
+   `backlog-stage.sh` (or any module hook) never appears regardless of `.kit.toml` --
+   `tests/test-adopt.sh`'s AC2/AC5 assertions fail immediately (grep finds nothing to
+   match, or matches when it should not).
+2. **A settings.json rewrite instead of a merge** (e.g. `cp "$filtered" "$project_settings"`
+   unconditionally, dropping the merge-with-existing branch): confirmed during authoring
+   that this reintroduces non-idempotency -- re-running adopt against an
+   already-populated settings.json reorders/duplicates entries and `git diff` on the
+   idempotency test (test 2, and the new test 18) goes dirty. This is exactly the defect
+   this sub-goal's `jq -S` + sorted-array canonicalization fixes; removing it is the
+   negative control.
+
+## Regression (global install + resolver unaffected)
+
+```
+$ bash tests/test-install-modules.sh
+... (37 assertions unchanged) ...
+== 37 passed, 0 failed ==
+
+$ bash lib/config/kit-config.sh selftest
+ok   project overrides kit-root
+ok   kit-root default when no proj
+ok   inline comment stripped
+ok   commented key -> caller default
+ok   missing key -> caller default
+ok   missing section -> empty
+PASS kit-config selftest
+```
+
+Full logs: `/tmp/proof-run-192-installmod.log`, `/tmp/proof-run-192-selftest.log`.
+
+## Reproduce
+
+```
+cd <repo>
+bash tests/test-adopt.sh            # new SPEC-192 assertions + all pre-existing ones
+bash tests/test-install-modules.sh  # regression (install.sh untouched)
+bash lib/config/kit-config.sh selftest  # regression (resolver untouched)
+```

--- a/lib/adopt.sh
+++ b/lib/adopt.sh
@@ -9,11 +9,26 @@
 # The CLAUDE.md loader uses an `@AGENTS.md` import (Claude Code includes the file, not just a
 # "go read it" pointer; absorbed from repository-harness's --claude shim).
 #
-# Usage: adopt.sh [--check | --dry-run | --refresh] <target-dir>
+# Usage: adopt.sh [--check | --dry-run | --refresh] [--with <a,b,c>] <target-dir>
 #   --check   : report status only (exit 0 adopted / 1 not), write nothing.
 #   --dry-run : print what would change, write nothing.
 #   --refresh : re-sync the kit-managed pieces (WORKFLOW pointer + the CLAUDE.md loader block)
 #               to their current form. AGENTS.md + the proof marker are still never overwritten.
+#   --with <a,b,c> : only meaningful the first time (seeding a fresh <target>/.kit.toml): the
+#               named modules start `true` in the seeded [modules] section instead of the
+#               kit-root defaults. Ignored (with a note) once <target>/.kit.toml exists -- a
+#               project's own config is never overwritten by re-running adopt (SPEC-192).
+#
+# Per-project override close-out (SPEC-192, goal 06): the resolver (lib/config/kit-config.sh,
+# goal 01) already merges <target>/.kit.toml over the kit-root default. This closes the loop:
+# adopt seeds a starter <target>/.kit.toml (opt-in; never overwritten after creation) and, on
+# EVERY run (fresh or --refresh), wires the currently-enabled HOOK-bearing modules (board,
+# session, advisor, cosmetic) into <target>/.claude/settings.json via a jq MERGE (never a
+# wholesale file rewrite -- other entries in that file are preserved). Command/skill modules
+# (queue, stats, quiz_gate, weekend_batch, bridge) need no settings.json entry, so they are
+# recorded in .kit.toml but never touch settings.json. This is "wired at adopt time", not read
+# per hook fire: re-running adopt.sh (an explicit, deliberate action) recomputes the project's
+# wired set from its CURRENT .kit.toml; nothing reads .kit.toml at hook-fire time.
 set -uo pipefail
 
 KIT_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/dwarves-kit}"
@@ -25,14 +40,16 @@ END="<!-- /kit:adopt -->"
 tmp=""                                   # scratch file; the trap cleans it up on any early exit
 trap 'rm -f "$tmp"' EXIT
 
-usage() { echo "usage: adopt.sh [--check | --dry-run | --refresh] [--] <target-dir>" >&2; exit 64; }
+usage() { echo "usage: adopt.sh [--check | --dry-run | --refresh] [--with <a,b,c>] [--] <target-dir>" >&2; exit 64; }
 
-CHECK=0 DRY=0 REFRESH=0
+CHECK=0 DRY=0 REFRESH=0 WITH_ARG=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --check) CHECK=1; shift;;
     --dry-run) DRY=1; shift;;
     --refresh) REFRESH=1; shift;;
+    --with) shift; WITH_ARG="${1:-}"; shift;;
+    --with=*) WITH_ARG="${1#--with=}"; shift;;
     --) shift; break;;
     -*) usage;;
     *) break;;
@@ -45,6 +62,8 @@ agents="$TARGET/AGENTS.md"
 workflow="$TARGET/WORKFLOW.md"
 claude="$TARGET/CLAUDE.md"
 marker="$TARGET/docs/verification/README.md"
+dotkit="$TARGET/.kit.toml"
+project_settings="$TARGET/.claude/settings.json"
 
 is_adopted() {
   # -qxF: the marker must be its own full line (matches how awk strips the block). A substring
@@ -145,6 +164,176 @@ install: \`bash $KIT_ROOT/lib/gate/proof-gate.sh contract "<task>"\`.
 EOF
   fi
   did=1
+fi
+
+# --- SPEC-192 (goal 06): close the per-project override loop -----------------------------
+
+# Resolve the kit-root kit.toml (dev checkout first, then the install) -- same lookup shape
+# as src_agents above.
+kit_root_toml=""
+for c in "$SRC_ROOT/kit.toml" "$KIT_ROOT/kit.toml"; do
+  [ -f "$c" ] && { kit_root_toml="$c"; break; }
+done
+
+# module -> its hook script basenames (space-separated; empty = hookless -- queue, stats,
+# quiz_gate, weekend_batch, bridge are commands/skills with no hook to gate). Kept in sync
+# with install.sh's kit_module_hooks() (same doc note there): only board/session/advisor/
+# cosmetic carry a hook, so only those need a settings.json entry.
+kit_module_hooks() {
+  case "$1" in
+    board) echo "backlog-stage.sh" ;;
+    session) echo "context-readiness.sh output-offload.sh pre-compact-backup.sh post-compact-reinject.sh session-state-save.sh harvest.sh citation-guard.sh" ;;
+    advisor) echo "context-hints.sh" ;;
+    cosmetic) echo "auto-format.sh notification.sh slop-cleaner.sh statusline.sh codebase-index.sh permission-auto-approve.sh" ;;
+    *) echo "" ;;
+  esac
+}
+
+KIT_KNOWN_MODULES="board session advisor cosmetic queue stats quiz_gate weekend_batch bridge"
+
+# Load the config resolver in a function scope so its own `${1:-}` selftest check (see
+# lib/config/kit-config.sh) never sees adopt.sh's own positional parameters (TARGET etc).
+_kit_load_config_resolver() {
+  # shellcheck source=lib/config/kit-config.sh
+  source "$SELF_DIR/config/kit-config.sh"
+}
+RESOLVER_OK=1
+_kit_load_config_resolver 2>/dev/null || RESOLVER_OK=0
+
+# 5. Per-project .kit.toml -- an OPT-IN starter (SPEC-192). Created only if absent; a
+# project's own config is NEVER overwritten by adopt, fresh or --refresh (same invariant as
+# AGENTS.md / the proof marker). --with (first run only) seeds the named modules `true`;
+# every other key seeds the kit-root default it would inherit anyway -- writing the line
+# explicitly just makes the override point visible and editable.
+if [ -n "$kit_root_toml" ] && [ "$RESOLVER_OK" -eq 1 ]; then
+  if [ ! -f "$dotkit" ]; then
+    if [ "$DRY" -eq 1 ]; then
+      note "seed a starter .kit.toml (modules: ${WITH_ARG:-kit-root defaults})"
+    else
+      with_norm=""
+      [ -n "$WITH_ARG" ] && with_norm=" $(echo "$WITH_ARG" | tr ',' ' ' | xargs) "
+      tmp="$(mktemp)"
+      {
+        echo "# .kit.toml -- this PROJECT's override of the kit-root defaults (SPEC-192)."
+        echo "# Only the keys you set here matter; every key you omit inherits the kit-root"
+        echo "# default at $KIT_ROOT/kit.toml (lib/config/kit-config.sh: project keys WIN)."
+        echo "# Re-run \`bash $KIT_ROOT/lib/adopt.sh --refresh <this repo>\` (or /kit:adopt) after"
+        echo "# editing [modules] to re-wire this project's .claude/settings.json to match --"
+        echo "# adopt reads this file at adopt time; no hook reads it at hook-fire time."
+        echo ""
+        echo "[modules]"
+        for m in $KIT_KNOWN_MODULES; do
+          if [ -n "$with_norm" ]; then
+            case "$with_norm" in *" $m "*) v=true ;; *) v=false ;; esac
+          else
+            KIT_CONFIG_ROOT="$(dirname "$kit_root_toml")" KIT_PROJECT_ROOT="$TARGET" \
+              v="$(kit_config_get "modules.$m" "false")"
+          fi
+          echo "$m = $v"
+        done
+      } > "$tmp"
+      mv "$tmp" "$dotkit"
+    fi
+    did=1
+  elif [ -n "$WITH_ARG" ]; then
+    echo "adopt: note: $dotkit already exists; --with ignored (edit the file's [modules] section directly)" >&2
+  fi
+fi
+
+# 6. Per-project hook-module wiring into <target>/.claude/settings.json (SPEC-192). Runs on
+# EVERY adopt invocation (fresh or --refresh), reading this project's CURRENT .kit.toml (project
+# override, else the kit-root default -- the resolver from goal 01), so a hand-edited .kit.toml
+# is picked up the next time adopt runs. Never on hook-fire (Not: runtime per-call module
+# toggling). A jq MERGE, never a settings.json rewrite: only kit-module hook entries
+# (dwarves-kit/hooks/*) are added/removed; every other entry in the file is preserved untouched.
+# Command/skill modules (queue, stats, quiz_gate, weekend_batch, bridge) have no hook, so they
+# never touch settings.json regardless of their .kit.toml value.
+if [ -n "$kit_root_toml" ] && [ "$RESOLVER_OK" -eq 1 ] && command -v jq >/dev/null 2>&1; then
+  settings_src=""
+  for c in "$SRC_ROOT/settings.json" "$KIT_ROOT/settings.json"; do
+    [ -f "$c" ] && { settings_src="$c"; break; }
+  done
+  if [ -n "$settings_src" ]; then
+    HOOKED_MODULES="board session advisor cosmetic"
+    enabled_list="" wired_hook_names=""
+    for m in $HOOKED_MODULES; do
+      KIT_CONFIG_ROOT="$(dirname "$kit_root_toml")" KIT_PROJECT_ROOT="$TARGET" \
+        v="$(kit_config_get "modules.$m" "false")"
+      if [ "$v" = "true" ]; then
+        enabled_list="$enabled_list $m"
+        wired_hook_names="$wired_hook_names $(kit_module_hooks "$m")"
+      fi
+    done
+    wired_hook_names="$(echo "$wired_hook_names" | xargs)"
+
+    hook_re=""
+    for h in $wired_hook_names; do
+      esc="$(printf '%s' "$h" | sed 's/\./\\./g')"
+      if [ -z "$hook_re" ]; then hook_re="$esc"; else hook_re="$hook_re|$esc"; fi
+    done
+
+    if [ "$DRY" -eq 1 ]; then
+      note "wire $project_settings for modules:${enabled_list:-<none>} (hooks:${wired_hook_names:-none})"
+    else
+      before_wired=""
+      [ -f "$project_settings" ] && before_wired="$(jq -r '[.hooks // {} | to_entries[]? | .value[]? | .hooks[]? | .command] | .[]' "$project_settings" 2>/dev/null | grep -oE 'dwarves-kit/hooks/[A-Za-z0-9._-]+\.sh' | sort -u)"
+
+      filtered="$(mktemp)"
+      if [ -n "$hook_re" ]; then
+        jq --arg re "$hook_re" '
+          .hooks |= (
+            to_entries | map(
+              .value |= (
+                map(.hooks |= map(select(.command | test($re)))) | map(select(.hooks | length > 0))
+              )
+            ) | from_entries
+          )
+        ' "$settings_src" > "$filtered" 2>/dev/null || echo '{"hooks":{}}' > "$filtered"
+      else
+        echo '{"hooks":{}}' > "$filtered"
+      fi
+
+      mkdir -p "$(dirname "$project_settings")"
+      # One code path for both "no project settings.json yet" and "re-wiring an existing
+      # one" (a missing file reads as {}): strip any prior kit-module hook (dwarves-kit/
+      # hooks/*, added by an earlier adopt run), then union in the currently-enabled set.
+      # Canonicalized (jq -S, arrays sorted by their own JSON text) so a re-run over an
+      # UNCHANGED .kit.toml reproduces byte-identical output -- adopt's own idempotency
+      # invariant (test-adopt.sh), not just "the same hook names, any order".
+      existing_json='{}'
+      [ -f "$project_settings" ] && existing_json="$(cat "$project_settings")"
+      merged="$(jq -n --argjson existing "$existing_json" --slurpfile kit "$filtered" '
+        $existing as $ex | ($kit[0].hooks // {}) as $kh
+        | $ex
+        | .hooks = (
+            ((($ex.hooks // {}) | to_entries
+              | map(.value |= (
+                  map(.hooks |= map(select(.command | tostring | contains("dwarves-kit/hooks/") | not)))
+                  | map(select(.hooks | length > 0))
+                ))
+             ) + ($kh | to_entries))
+            | group_by(.key)
+            | map({
+                key: .[0].key,
+                value: ([.[].value[]] | unique_by(tostring) | sort_by(tostring))
+              })
+            | sort_by(.key)
+            | from_entries
+          )
+      ' 2>/dev/null)"
+      if [ -n "$merged" ] && echo "$merged" | jq -S '.' >/dev/null 2>&1; then
+        echo "$merged" | jq -S '.' > "$project_settings"
+      else
+        echo "adopt: warning: jq merge of $project_settings failed; left untouched" >&2
+      fi
+      rm -f "$filtered"
+
+      after_wired=""
+      [ -f "$project_settings" ] && after_wired="$(jq -r '[.hooks // {} | to_entries[]? | .value[]? | .hooks[]? | .command] | .[]' "$project_settings" 2>/dev/null | grep -oE 'dwarves-kit/hooks/[A-Za-z0-9._-]+\.sh' | sort -u)"
+      [ "$before_wired" != "$after_wired" ] && did=1
+      echo "adopt: project hook-module wiring for $TARGET -> modules:${enabled_list:-<none>}"
+    fi
+  fi
 fi
 
 if [ "$DRY" -eq 1 ]; then

--- a/tests/test-adopt.sh
+++ b/tests/test-adopt.sh
@@ -94,6 +94,110 @@ fi
 bash lib/adopt.sh --dry-run "$T1" >/dev/null
 if git -C "$T1" diff --quiet; then ok "--dry-run on an adopted repo writes nothing"; else no "--dry-run dirtied an adopted repo"; fi
 
+# ------------------------------------------------------------------------------------------
+# SPEC-192 (goal 06, harness-ops): per-project .kit.toml override + adopt-time module wiring.
+# The resolver (lib/config/kit-config.sh, goal 01) already merges <project>/.kit.toml over the
+# kit-root default; these tests close the loop through adopt: a starter .kit.toml is seeded,
+# and the currently-enabled hook-modules (board/session/advisor/cosmetic) are wired into
+# <project>/.claude/settings.json at adopt time.
+# ------------------------------------------------------------------------------------------
+wired_hooks() { jq -r '[.hooks // {} | to_entries[]? | .value[]? | .hooks[]? | .command] | .[]' "$1" 2>/dev/null | grep -oE 'dwarves-kit/hooks/[A-Za-z0-9._-]+\.sh' | sed 's#dwarves-kit/hooks/##' | sort -u; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "skip - SPEC-192 module-wiring tests need jq; not found on PATH"
+else
+
+# 12. Fresh adopt seeds a starter .kit.toml with a [modules] section naming every known module.
+T8="$(newrepo)"
+bash lib/adopt.sh "$T8" >/dev/null
+if [ -f "$T8/.kit.toml" ] && grep -q '^\[modules\]' "$T8/.kit.toml" \
+  && grep -qE '^board[[:space:]]*=' "$T8/.kit.toml" && grep -qE '^cosmetic[[:space:]]*=' "$T8/.kit.toml"; then
+  ok "fresh adopt seeds a starter .kit.toml with a [modules] section"
+else
+  no "fresh adopt did not seed .kit.toml with the expected [modules] section"
+fi
+
+# 13. That same fresh adopt wires the kit-root-default-enabled modules' hooks into the
+# project's settings.json (board/session/advisor default true; cosmetic defaults false).
+W13="$(wired_hooks "$T8/.claude/settings.json")"
+if printf '%s\n' "$W13" | grep -qx backlog-stage.sh && printf '%s\n' "$W13" | grep -qx context-hints.sh \
+  && ! printf '%s\n' "$W13" | grep -qx auto-format.sh; then
+  ok "fresh adopt wires kit-root-default-enabled modules' hooks (board/advisor in, cosmetic out)"
+else
+  no "fresh adopt wired the wrong hook set: [$W13]"
+fi
+
+# 14. --with on a FRESH repo seeds the named modules true and wires their hooks even when the
+# kit-root default is false (cosmetic defaults false; --with cosmetic turns it on for THIS repo).
+T9="$(newrepo)"
+bash lib/adopt.sh --with cosmetic "$T9" >/dev/null
+if grep -qx 'cosmetic = true' "$T9/.kit.toml" \
+  && printf '%s\n' "$(wired_hooks "$T9/.claude/settings.json")" | grep -qx auto-format.sh; then
+  ok "--with cosmetic on a fresh repo seeds cosmetic=true and wires its hook"
+else
+  no "--with cosmetic did not seed/wire cosmetic for a fresh repo"
+fi
+
+# 15. THE Done= proof: a project .kit.toml [modules] board=false results in that project NOT
+# wiring the board hook (backlog-stage.sh), verified via its settings.json.
+T10="$(newrepo)"
+bash lib/adopt.sh "$T10" >/dev/null
+W15_BEFORE="$(wired_hooks "$T10/.claude/settings.json")"
+printf '%s\n' "$W15_BEFORE" | grep -qx backlog-stage.sh \
+  && ok "precondition: board's hook is wired before the override (kit-root default board=true)" \
+  || no "precondition failed: board's hook was never wired to begin with"
+sed -i.bak 's/^board = true$/board = false/' "$T10/.kit.toml" && rm -f "$T10/.kit.toml.bak"
+grep -qx 'board = false' "$T10/.kit.toml" || no "test setup: could not flip board=false in $T10/.kit.toml"
+bash lib/adopt.sh --refresh "$T10" >/dev/null
+W15_AFTER="$(wired_hooks "$T10/.claude/settings.json")"
+if ! printf '%s\n' "$W15_AFTER" | grep -qx backlog-stage.sh; then
+  ok "DONE=: project .kit.toml [modules] board=false -> board's hook is NOT wired (settings.json)"
+else
+  no "DONE=: board=false in .kit.toml did not stop board's hook from being wired"
+fi
+# session's hook must be untouched by the board-only edit (surgical re-wiring, not a full reset).
+if printf '%s\n' "$W15_AFTER" | grep -qx context-readiness.sh; then
+  ok "re-wiring after a board=false edit leaves the still-enabled session module's hooks wired"
+else
+  no "re-wiring after a board=false edit dropped an unrelated still-enabled module's hooks"
+fi
+
+# 16. THE Done= proof, second clause: a [ledger] override in the project .kit.toml is honored
+# by a command reading it (the resolver from goal 01, exercised end-to-end through a real
+# adopted project directory rather than a synthetic fixture).
+T11="$(newrepo)"
+bash lib/adopt.sh "$T11" >/dev/null
+printf '\n[ledger]\nlocation = "isolated"\n' >> "$T11/.kit.toml"
+KIT_REPO_ROOT="$(pwd)"
+LEDGER_VAL="$(KIT_CONFIG_ROOT="$KIT_REPO_ROOT" KIT_PROJECT_ROOT="$T11" bash -c "source '$KIT_REPO_ROOT/lib/config/kit-config.sh'; kit_config_get ledger.location")"
+if [ "$LEDGER_VAL" = "isolated" ]; then
+  ok "DONE=: a [ledger] override in the project .kit.toml is honored by the resolver"
+else
+  no "DONE=: [ledger] override was not honored (got [$LEDGER_VAL], want isolated)"
+fi
+
+# 17. --with is ignored (never clobbers) once <project>/.kit.toml already exists.
+bash lib/adopt.sh --with cosmetic "$T11" >/dev/null 2>&1
+if ! grep -qx 'cosmetic = true' "$T11/.kit.toml"; then
+  ok "--with is ignored once .kit.toml already exists (never overwritten)"
+else
+  no "--with clobbered an existing .kit.toml"
+fi
+
+# 18. Idempotent re-run after a config edit: re-running adopt again with NO further edits is a
+# clean no-op on the module wiring (settled state is stable, not re-churned every run).
+git -C "$T10" init -q >/dev/null 2>&1 || true
+git -C "$T10" add -A && git -C "$T10" -c user.email=t@t -c user.name=t commit -qm settle >/dev/null
+bash lib/adopt.sh --refresh "$T10" >/dev/null
+if git -C "$T10" diff --quiet; then
+  ok "re-running adopt --refresh with an unchanged .kit.toml is a clean no-op on module wiring"
+else
+  no "re-running adopt --refresh churned settings.json with no .kit.toml change"
+fi
+
+rm -rf "$T8" "$T9" "$T10" "$T11"
+fi
+
 rm -rf "$T1" "$T2" "$T3" "$T4" "$T5" "$T6" "$T7"
 echo "---"
 echo "PASS=$PASS FAIL=$FAIL"


### PR DESCRIPTION
Wires per-project override end to end: `<project>/.kit.toml` overrides kit-root; `/kit:adopt` seeds a starter + wires enabled hook-modules into the project's settings.json. Verify: the project-override + module-enable run-table. Part of `harness-ops` (Track A), see ROADMAP.md.
