### PR TITLE
docs: add consumer-contract.md onboarding page

### DIFF
--- a/docs/consumer-contract.md
+++ b/docs/consumer-contract.md
@@ -1,0 +1,81 @@
+# Consumer contract
+
+What a project or machine needs so an adopted repo works with the dwarves-kit. This is the
+onboarding page, not a tutorial: read `AGENTS.md` (the operate-contract itself) and
+`WORKFLOW.md` (the lane x phase gate matrix) for how to work once adopted.
+
+## The 4 files `/kit:adopt` injects
+
+`lib/adopt.sh` (driven by `/kit:adopt`) writes these into the target repo, idempotently. All
+four are **non-destructive**: none is overwritten by a re-run or `--refresh`.
+
+| File | What it is | Copy or pointer | Refreshed? |
+|---|---|---|---|
+| `AGENTS.md` | The operate-contract itself | Full copy from the kit | Never (created once, then hands-off) |
+| `CLAUDE.md` (managed block) | `@AGENTS.md` import + the classify/gate one-liners, inside `<!-- kit:adopt --> ... <!-- /kit:adopt -->` markers | Generated block, appended | Yes, on `--refresh` (block replaced; rest of the file untouched) |
+| `WORKFLOW.md` | Pointer to the installed kit's lane x phase gate matrix | Pointer only (never the 49KB kit copy) | Yes, on `--refresh` |
+| `docs/verification/README.md` | The proof-of-done marker; its presence opts the repo into the ship-gate | Generated stub | Never |
+
+Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md`, which is why the loader block exists: it
+`@AGENTS.md`-imports the real contract so an agent session actually reads it.
+
+## The `KIT_LEDGER_DIR` knob
+
+One root, shared by the write-side ledger and the read-side `stats` projection. Precedence
+(`lib/telemetry/kit-log-dir.sh`):
+
+1. `$KIT_LEDGER_DIR` env var, explicit (empty is a fatal error, never silent fall-through).
+2. `$DWARVES_KIT_LOG_DIR` env var, back-compat alias.
+3. `[ledger].location` in `.kit.toml` (project) / `kit.toml` (kit-root): `"isolated"` ->
+   `$PWD/.kit/logs`, `"shared"`/unset -> the XDG default, anything else -> that literal path.
+4. `${XDG_STATE_HOME:-$HOME/.local/state}/dwarves-kit/logs` -- the hardcoded default, outside
+   `~/.claude` so a plugin reinstall can never wipe the corpus.
+
+Pick **shared** (default) when several adopted projects should feed one run corpus for
+`/kit:retro` and the effectiveness eval. Pick **isolated** (or an explicit path) when a
+project's ledger must not mix with anything else on the machine.
+
+## The optional `<project>/.kit.toml` override
+
+Seeded once by `/kit:adopt` (opt-in; never overwritten after creation; `--with a,b,c` seeds
+those modules `true` instead of inheriting the kit-root default). Only the keys you set win;
+everything you omit inherits the kit-root `kit.toml` default (`lib/config/kit-config.sh`,
+project keys win).
+
+Re-run `/kit:adopt` (or `lib/adopt.sh --refresh`) after hand-editing `[modules]` to re-wire
+`.claude/settings.json` -- adopt reads `.kit.toml` at adopt time; no hook reads it at
+hook-fire time. Hook-bearing modules (`board`, `session`, `advisor`, `cosmetic`) get their
+hook added/removed from the project's `settings.json` via a targeted `jq` merge (every other
+entry in that file is preserved). Command/skill modules (`queue`, `stats`, `quiz_gate`,
+`weekend_batch`, `bridge`) have no hook and never touch `settings.json`.
+
+## The stable entrypoint
+
+Reference `$DWARVES_KIT/bin/<name>`, never a deep `lib/<subsystem>/<file>.sh` path (SPEC-184).
+The adopt-injected `CLAUDE.md` block already does this for you:
+
+| Stable entrypoint | Forwards to |
+|---|---|
+| `bin/board` | `lib/board/board.sh` |
+| `bin/classify` | `lib/classify/classify.sh` |
+| `bin/gate` | `lib/gate/gate.sh` |
+
+A consumer that points at `bin/<name>` survives an internal `lib/` reorg unchanged; a consumer
+that reaches a deep lib path does not.
+
+## Doc-vs-code check
+
+The 4 files this page names are exactly the 4 files `lib/adopt.sh` injects (`.kit.toml` and the
+`settings.json` wiring are documented above as separate, opt-in mechanisms, not part of the
+4-file base contract):
+
+```
+$ grep -n '^# [0-9]\. ' lib/adopt.sh
+# 1. AGENTS.md -- the operate-contract. NEVER overwritten (even on --refresh).
+# 2. WORKFLOW.md pointer -- create if absent; --refresh overwrites to current. Write atomically
+# 3. CLAUDE.md loader (@AGENTS.md import) -- append once; --refresh replaces the managed block.
+# 4. proof marker -- presence opts this repo into the ship-gate. NEVER overwritten.
+```
+
+This doc's table lists `AGENTS.md`, `CLAUDE.md` (managed block), `WORKFLOW.md`,
+`docs/verification/README.md` -- matching adopt.sh's numbered steps 1-4 one for one. No drift.

--- a/docs/verification/consumer-contract-doc/proof-of-done.md
+++ b/docs/verification/consumer-contract-doc/proof-of-done.md
@@ -1,0 +1,75 @@
+# Proof of done: consumer-contract-doc (harness-ops sub-goal 07)
+
+Lane: full · rid: `harness-ops-07-contract-doc` · Type: docs (docs-only, no code change)
+
+## Acceptance criteria
+
+| # | Criterion (from `Done =`, goal 07) | Met |
+|---|---|---|
+| A1 | `docs/consumer-contract.md` exists | yes |
+| A2 | It names the 4 adopt-injected files (AGENTS.md copy, CLAUDE.md kit-block, WORKFLOW.md pointer, docs/verification/README.md marker) | yes |
+| A3 | It documents the `KIT_LEDGER_DIR` knob (shared vs per-project) | yes |
+| A4 | It documents the optional `<project>/.kit.toml` override (SPEC-192) | yes |
+| A5 | It documents the stable `bin/` entrypoint (SPEC-184) | yes |
+| A6 | Doc-vs-code check: the doc's named file list matches exactly what `lib/adopt.sh` injects | yes (captured below) |
+
+## Implementation
+
+- `docs/consumer-contract.md`: one skimmable page, table-first. Sourced directly from
+  `lib/adopt.sh` (the 4-file inject + the `.kit.toml`/settings.json mechanism),
+  `lib/telemetry/kit-log-dir.sh` (the `KIT_LEDGER_DIR` precedence), `SPEC-192-project-override.md`
+  (the `.kit.toml` seed/wire loop), and `SPEC-184-stable-consumer-interface.md` (the `bin/`
+  forwarders).
+- No code touched. Scope per the goal: `docs/consumer-contract.md` only; adopt mechanics and
+  the config schema stay owned by goals 05/06.
+
+## Doc-vs-code check (run verbatim)
+
+`lib/adopt.sh`'s own numbered comments are the ground truth for what it injects:
+
+```
+$ grep -n '^# [0-9]\. ' lib/adopt.sh
+57:# 1. AGENTS.md -- the operate-contract. NEVER overwritten (even on --refresh).
+64:# 2. WORKFLOW.md pointer -- create if absent; --refresh overwrites to current. Write atomically
+72:# 3. CLAUDE.md loader (@AGENTS.md import) -- append once; --refresh replaces the managed block.
+90:# 4. proof marker -- presence opts this repo into the ship-gate. NEVER overwritten.
+```
+
+`docs/consumer-contract.md`'s "The 4 files `/kit:adopt` injects" table lists, in the same
+order: `AGENTS.md`, `CLAUDE.md` (managed block), `WORKFLOW.md`, `docs/verification/README.md`.
+One-to-one match against adopt.sh's numbered steps 1-4. No drift.
+
+Everything adopt.sh does AFTER step 4 (`.kit.toml` seed, `.claude/settings.json` hook wiring)
+is documented separately in this page under "The optional `.kit.toml` override", explicitly
+called out as opt-in / not part of the base 4-file contract, matching the goal's own framing
+("the 4 adopt-injected files ... the `KIT_LEDGER_DIR` knob ... the optional `.kit.toml`
+override" as three distinct things).
+
+## Confirmation run-table
+
+| Check | Command | Result |
+|---|---|---|
+| Doc exists | `test -f docs/consumer-contract.md` | PASS |
+| Doc-vs-code (adopt's 4 injected files == doc's named 4 files) | `grep -n '^# [0-9]\. ' lib/adopt.sh` vs. the doc's file table | PASS (see above) |
+| Gate ledger check (full lane) | `bash lib/gate/gate-ledger.sh check full harness-ops-07-contract-doc` | exit 0 |
+
+## Reproduce
+
+```
+cd dwarves-kit
+grep -n '^# [0-9]\. ' lib/adopt.sh
+cat docs/consumer-contract.md
+bash lib/gate/gate-ledger.sh check full harness-ops-07-contract-doc
+```
+
+## Deviations from the goal contract
+
+- The goal text said "Classify... (expect normal)". `bash lib/classify/lane-classify.sh
+  classify "..."` actually returned `full`. Recorded gates for the full-lane required set;
+  three (design-critique, spec, test-plan) are genuinely inapplicable to a one-page docs
+  artifact with `Design: obvious` and were recorded as human overrides with reasons rather
+  than silently skipped, so `gate-ledger.sh check full` passes honestly.
+- No SPEC-193 was written: the goal file itself (`_meta/megagoals/harness-ops/goals/
+  07-consumer-contract-doc.md`) is the spec-of-record for this docs-only change; the goal's
+  own Scope explicitly excludes re-documenting adopt mechanics or the config schema (those
+  already have SPEC-192/SPEC-184), so there was no new design surface to spec.


### PR DESCRIPTION
Adds `docs/consumer-contract.md`, one page for onboarding a new project/machine (4 adopt files + KIT_LEDGER_DIR + optional `.kit.toml` + the stable entrypoint), verified against what `lib/adopt.sh` injects. Part of `harness-ops` (Track A), see ROADMAP.md.
