### PR TITLE
fix(harvest): dedup insights on append

### DIFF
--- a/docs/verification/harvest-dedup-append.md
+++ b/docs/verification/harvest-dedup-append.md
@@ -1,0 +1,119 @@
+# Proof of done: harvest.py dedup-on-append race fix (ID-202)
+
+VERDICT: PASS
+
+Filed originally in ops-toolkit as backlog row ID-202 before `cc-harvest` moved into the
+kit as `hooks/harvest.sh`/`hooks/harvest.py` (kit PR #186). Symptom: re-runs stage the
+same insight repeatedly (observed up to 6x duplicates in a live ledger).
+
+## Acceptance criteria
+
+1. Reproduce the duplicate-staging with a fixture (fake transcript/insight run against
+   `harvest.py`) before touching any code, or stop and report if it does not reproduce.
+2. Root-cause the dedup-on-append path and implement the minimal fix.
+3. Add/extend a test proving a re-run (specifically, a CONCURRENT re-run) does not
+   re-stage, matching the kit's existing bash test-suite shape for hooks.
+4. `tests/test-kit-foldin-hooks.sh` passes; `shellcheck` on `hooks/harvest.sh` is clean.
+
+## Root cause
+
+`_harvest_payload()` in `hooks/harvest.py` computed `existing_slugs(ledger, glossaries)`
+(a **read** of the ledger) and then, in a separate later step, called `append_rows(ledger,
+fresh)` (a **write**) with no lock spanning the two. `harvest.sh` (no-arg / "ledger" mode)
+fires on the `PreCompact` hook, and a single long session (or several parallel subagent
+sessions sharing one repo, hence one ledger file) can trigger CONCURRENT `harvest.py`
+processes against the same ledger. Two or more processes could each read the ledger
+before any of them had appended, each independently decide the same slug was new, and
+each append it, one unlocked "a"-mode write. This is exactly the "up to 6x duplicates"
+symptom: N processes racing the same unlocked read-then-append window all land on the
+same duplicate.
+
+Sequential re-runs were never affected (each run's read reflects the prior run's
+completed write), which is why the bug only shows up under real concurrency, not in a
+simple "run it twice" check , the acceptance-criteria reproduction below has to force
+that concurrency explicitly.
+
+## Reproduction (before the fix)
+
+A fixture extractor (`HARVEST_EXTRACTOR`) that always returns one fixed insight, fired by
+N concurrent `python3 harvest.py` invocations against one throwaway ledger:
+
+- Sequential runs (call twice, one after another): correctly deduped, 0 new on the
+  second call , confirms the bug is concurrency-specific, not a plain dedup miss.
+- 6-8 truly concurrent invocations (background `&` fan-out, a slow fixture extractor to
+  widen the window): duplicate rows landed in the ledger on most runs (both the data row
+  AND, on tighter timing, the table header), non-deterministically (30-90% failure rate
+  run-to-run depending on system load) , confirming the race is real but not reliably
+  assertable via wall-clock subprocess timing alone under a loaded dev box.
+- A deterministic reproduction was then built directly against `_harvest_payload()`:
+  Python threads (not subprocesses) sharing one process, with `threading.Barrier`
+  forcing all N threads to finish extraction at the same instant and a small
+  `time.sleep()` inserted inside `existing_slugs()` to stand in for "no other process
+  has appended yet" (widening the window past any GIL scheduling quantum). Against the
+  pre-fix code this reproduced 8 threads all deciding the slug was new and all
+  appending it, 8/8 times (`dup_count=8`), every time.
+
+This deterministic harness is what ships as the regression test (`tests/test-kit-foldin-hooks.sh`,
+"row 4c").
+
+## Fix
+
+`hooks/harvest.py`: added `_ledger_lock_path(ledger)` (sibling `<ledger>.lock`, same
+pattern as the existing `_archive_path()` helper) and wrapped the read-known-slugs +
+filter + append_rows sequence in `_harvest_payload()` in a blocking exclusive
+`fcntl.flock`. Concurrent invocations now serialize across that lock instead of racing:
+whichever process gets the lock first appends and releases; the next one's
+`existing_slugs()` call (now correctly happening AFTER acquiring the lock) sees the
+just-appended row and skips it. Mirrors the existing `_run_harvest_locked()` pattern used
+by `--stop-trigger`, but blocking rather than non-blocking , this harvest has real work
+to do and should wait its turn, not skip (unlike the stop-trigger single-flight, which
+intentionally skips a still-running harvest).
+
+`tests/test-kit-foldin-hooks.sh`: added "row 4c" , the deterministic threading-barrier
+race described above, embedded as a small `python3` heredoc script (matching existing
+precedent for `python3` use in this test file), asserting exactly 1 occurrence of the
+staged slug and exactly 1 ledger header after 8 concurrent `_harvest_payload()` calls.
+
+## Confirmation run-table (2026-07-09)
+
+| # | Command | Exit | Output |
+|---|---------|------|--------|
+| 1 | `python3 -m py_compile hooks/harvest.py` | 0 | compiles clean |
+| 2 | `shellcheck hooks/harvest.sh tests/test-kit-foldin-hooks.sh` | 0 | no warnings |
+| 3 | `bash tests/test-kit-foldin-hooks.sh` | 0 | `Passed: 51 / 51` (incl. new row 4c) |
+| 4 | `bash tests/test-install-modules.sh` (adjacent suite, unaffected by this change) | 0 | `37 passed, 0 failed` |
+| 5 | row 4c re-run x3 in isolation | 0 | `PASS` all 3 times, deterministic |
+
+## NEGATIVE CONTROL
+
+`git stash` the fix to `hooks/harvest.py` only (test file kept), re-run row 4c 3x:
+
+| Run | dup_count (expect 1) | header_count (expect 1) |
+|---|---|---|
+| 1 | 8 (FAIL) | 1 |
+| 2 | 8 (FAIL) | 1 |
+| 3 | 8 (FAIL) | 2 (FAIL) |
+
+`bash tests/test-kit-foldin-hooks.sh` output on the reverted code:
+```
+FAIL row 4c: 8 concurrent harvests of the same insight stage exactly once (ID-202) (expected '1', got '8')
+```
+`git stash pop` restores the fix; re-running immediately after gives `Passed: 51 / 51`
+again. The test is falsifiable in both directions: it fails on the pre-fix code
+deterministically and passes on the fixed code deterministically.
+
+## Reproduce
+
+```
+cd <dwarves-kit>              # master or this branch
+bash tests/test-kit-foldin-hooks.sh   # 51/51, incl. "row 4c" concurrent-dedup
+shellcheck hooks/harvest.sh
+```
+
+To see the negative control directly:
+```
+git stash push -- hooks/harvest.py
+bash tests/test-kit-foldin-hooks.sh 2>&1 | grep "row 4c"   # FAILs
+git stash pop
+bash tests/test-kit-foldin-hooks.sh 2>&1 | grep "row 4c"   # PASSes
+```

--- a/hooks/harvest.py
+++ b/hooks/harvest.py
@@ -271,6 +271,11 @@ def _archive_path(ledger):
     return base + ".archive" + ext
 
 
+def _ledger_lock_path(ledger):
+    """Sibling lock file next to the active ledger: learned-ledger.md -> learned-ledger.md.lock."""
+    return ledger + ".lock"
+
+
 def cmd_cleanup():
     """--cleanup: move every `flushed:*` row (a learning already routed to its durable home) out
     of the active ledger into a sibling append-only archive. Queued / any non-flushed rows stay.
@@ -355,26 +360,44 @@ def _harvest_payload(payload):
     ledger = os.environ.get("HARVEST_LEDGER", _default_ledger())
     gl_env = os.environ.get("HARVEST_GLOSSARIES")
     glossaries = gl_env.split(":") if gl_env else glob.glob(_default_glossary_glob())
-    known = existing_slugs(ledger, glossaries)
     fuzzy = _fuzzy_threshold()
-
     today = datetime.date.today().isoformat()
-    fresh, seen = [], set()
-    for c in candidates:
-        if not isinstance(c, dict):
-            continue
-        slug = slugify(c.get("item", ""))
-        kind = c.get("kind") if c.get("kind") in KINDS else "insight"
-        home = c.get("home") if c.get("home") in HOMES else "drop"
-        if not slug or slug in known or slug in seen:
-            continue
-        if _is_fuzzy_dup(slug, known, fuzzy) or _is_fuzzy_dup(slug, seen, fuzzy):
-            continue
-        seen.add(slug)
-        fresh.append({"date": today, "item": slug, "kind": kind, "home": home})
 
-    if fresh:
-        append_rows(ledger, fresh)
+    # Dedup-on-append race (ID-202): harvest.sh fires on PreCompact, and a single
+    # long session (or several parallel subagent sessions sharing one repo) can
+    # trigger concurrent harvest.py processes against the SAME ledger. Reading
+    # existing_slugs() and appending were two separate unlocked steps, so two
+    # processes could both read the ledger before either had appended, both decide
+    # the same slug was new, and both append it -- observed as up to 6x duplicates.
+    # Fix: hold a blocking exclusive flock across read-known + append, so concurrent
+    # invocations serialize instead of racing (mirrors _run_harvest_locked's fcntl
+    # pattern, but blocking -- a harvest here has real work to do, unlike the
+    # stop-trigger single-flight which just skips).
+    os.makedirs(os.path.dirname(ledger), exist_ok=True)
+    fresh = []
+    with open(_ledger_lock_path(ledger), "a") as lockf:
+        fcntl.flock(lockf, fcntl.LOCK_EX)
+        try:
+            known = existing_slugs(ledger, glossaries)
+            seen = set()
+            for c in candidates:
+                if not isinstance(c, dict):
+                    continue
+                slug = slugify(c.get("item", ""))
+                kind = c.get("kind") if c.get("kind") in KINDS else "insight"
+                home = c.get("home") if c.get("home") in HOMES else "drop"
+                if not slug or slug in known or slug in seen:
+                    continue
+                if _is_fuzzy_dup(slug, known, fuzzy) or _is_fuzzy_dup(slug, seen, fuzzy):
+                    continue
+                seen.add(slug)
+                fresh.append({"date": today, "item": slug, "kind": kind, "home": home})
+
+            if fresh:
+                append_rows(ledger, fresh)
+        finally:
+            fcntl.flock(lockf, fcntl.LOCK_UN)
+
     print(f"harvest: staged {len(fresh)} new (of {len(candidates)} extracted) -> {ledger}", file=sys.stderr)
     return 0
 

--- a/tests/test-kit-foldin-hooks.sh
+++ b/tests/test-kit-foldin-hooks.sh
@@ -183,6 +183,86 @@ assert_exit "row 4b: --lab-log drafts an entry, exits 0" 0 $RC
 DRAFT=$(cat "$TD/hv-repo/_meta/.lab-log-draft.md" 2>/dev/null)
 assert_contains "row 4b: draft never writes the real LAB_LOG.md" "repo-root-seam" "$DRAFT"
 
+# ID-202: dedup-on-append must survive CONCURRENT invocations sharing one ledger
+# (e.g. parallel subagent sessions each firing PreCompact). Pre-fix, existing_slugs()
+# (read) and append_rows() (write) were two unlocked steps: several concurrent
+# harvest.py processes could each read the ledger before any had appended and all
+# decide the same slug was new, observed as up to 6x duplicates in production.
+#
+# A real subprocess-timing race (N processes + a sleeping fake extractor) is what
+# actually happens in production, but proved too flaky to assert on in THIS test
+# under a loaded dev/CI box: pre-fix failure rate ranged 30-90% run-to-run because
+# process-spawn jitter alone was often enough to scatter arrivals outside the
+# window. So this drives the SAME code path (_harvest_payload) in-process via
+# Python threads with a threading.Barrier forcing simultaneous arrival at the
+# critical section, plus a deterministic sleep inside existing_slugs() standing in
+# for "the write hasn't landed yet" -- this reproduces the exact race 8/8 times
+# pre-fix (dup_count=8) and 8/8 times post-fix (dup_count=1) in manual verification.
+cat >"$TD/hv-race-transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"text","text":"harvest append needs a lock"}]}}
+EOF
+RACE_LEDGER="$TD/hv-race-repo/_meta/learned-ledger.md"
+mkdir -p "$TD/hv-race-repo"
+cat >"$TD/hv-race-test.py" <<PYEOF
+import importlib.util, threading, os, sys, time
+
+KIT_DIR = "$KIT_DIR"
+LEDGER = "$RACE_LEDGER"
+TRANSCRIPT = "$TD/hv-race-transcript.jsonl"
+N = 8
+
+os.environ["HARVEST_LEDGER"] = LEDGER
+os.environ["HARVEST_GLOSSARIES"] = ""
+os.environ["HARVEST_MIN_INTERVAL"] = "0"
+
+spec = importlib.util.spec_from_file_location("harvest_under_test", os.path.join(KIT_DIR, "hooks", "harvest.py"))
+harvest = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(harvest)
+
+barrier = threading.Barrier(N)
+real_extract = harvest.extract_json_array
+real_existing_slugs = harvest.existing_slugs
+
+def patched_extract(text):
+    barrier.wait()  # force all N threads into the vulnerable section at the same instant
+    return real_extract(text)
+
+def patched_existing_slugs(ledger, glossaries):
+    # Stand-in for "no other process has appended yet": widen the read-then-decide
+    # window past any GIL scheduling quantum, so an unlocked caller reliably lets
+    # ALL N threads read a pre-append ledger state.
+    result = real_existing_slugs(ledger, glossaries)
+    time.sleep(0.05)
+    return result
+
+def fake_run_extractor(prompt):
+    return '[{"item":"harvest-dedup-race","kind":"insight","home":"drop","why":"append has no lock"}]'
+
+harvest.extract_json_array = patched_extract
+harvest.existing_slugs = patched_existing_slugs
+harvest.run_extractor = fake_run_extractor
+
+payload = {"transcript_path": TRANSCRIPT}
+
+def worker():
+    harvest._harvest_payload(payload)
+
+threads = [threading.Thread(target=worker) for _ in range(N)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+
+content = open(LEDGER, encoding="utf-8").read() if os.path.exists(LEDGER) else ""
+print(content.count("harvest-dedup-race"))
+print(content.count("| date | item"))
+PYEOF
+RACE_OUT=$(python3 "$TD/hv-race-test.py" 2>/dev/null)
+DUP_COUNT=$(echo "$RACE_OUT" | sed -n '1p')
+HEADER_COUNT=$(echo "$RACE_OUT" | sed -n '2p')
+assert_eq "row 4c: 8 concurrent harvests of the same insight stage exactly once (ID-202)" "1" "$DUP_COUNT"
+assert_eq "row 4c: concurrent harvests never duplicate the ledger header" "1" "$HEADER_COUNT"
+
 # NC: empty stdin never blocks a compaction/session-end.
 RC=0; echo '' | bash "$KIT_DIR/hooks/harvest.sh" >/dev/null 2>&1 || RC=$?
 assert_exit "NC: empty stdin exits 0" 0 $RC


### PR DESCRIPTION
## Root cause

`hooks/harvest.py`'s `_harvest_payload()` staged learnings in two separate,
unlocked steps: read `existing_slugs(ledger, glossaries)`, then later
`append_rows(ledger, fresh)`. `harvest.sh` (no-arg / ledger mode) fires on the
`PreCompact` hook, and a single long session (or several parallel subagent
sessions sharing one repo, hence one ledger file) can trigger CONCURRENT
`harvest.py` processes against the same ledger. Two or more could each read
the ledger before any of them had appended, each independently decide the
same slug was new, and each append it — producing the reported symptom of a
staged insight duplicated up to 6x (originally filed as ops-toolkit backlog
ID-202, before `cc-harvest` moved into the kit as `hooks/harvest.sh` in PR
#186).

Sequential re-runs were never affected (each run's read reflects the prior
run's completed write) — the bug only shows up under real concurrency, which
is why it had to be forced explicitly to reproduce and to regression-test.

## Fix

Added `_ledger_lock_path(ledger)` (sibling `<ledger>.lock`, same pattern as
the existing `_archive_path()` helper) and wrapped the
read-known-slugs → filter → `append_rows` sequence in a **blocking exclusive
`fcntl.flock`**. Concurrent invocations now serialize: whichever process gets
the lock first appends and releases; the next one's `existing_slugs()` call
(now correctly happening *after* acquiring the lock) sees the just-appended
row and skips it. Mirrors the existing `_run_harvest_locked()` pattern used
by `--stop-trigger`, but blocking rather than non-blocking — this harvest has
real work to do and should wait its turn, not skip.

## Verification

Full proof of done at `docs/verification/harvest-dedup-append.md`. Summary:

- **Reproduced first, before any fix**, per the operating instructions: a
  fixture `HARVEST_EXTRACTOR` returning one fixed insight, fired by N
  concurrent `python3 harvest.py` invocations against a throwaway ledger.
  Sequential runs deduped correctly (confirms the bug is concurrency-only);
  6–8 truly concurrent invocations produced duplicate rows (and sometimes a
  duplicate table header) on most runs, but non-deterministically (30–90%
  failure rate depending on system load) — real, but not reliably assertable
  via wall-clock subprocess timing under a loaded box.
- Built a **deterministic** reproduction directly against
  `_harvest_payload()`: Python threads (not subprocesses) with
  `threading.Barrier` forcing simultaneous arrival at the critical section,
  plus a small `time.sleep()` inside `existing_slugs()` standing in for "no
  other process has appended yet". Against the pre-fix code this reproduced
  8 threads all deciding the slug was new and all appending it, **8/8 times**.
  Against the fixed code: exactly 1 append, **8/8 times**.
- This deterministic harness ships as the regression test — "row 4c" in
  `tests/test-kit-foldin-hooks.sh`.

```
$ shellcheck hooks/harvest.sh tests/test-kit-foldin-hooks.sh
(no output — clean)

$ bash tests/test-kit-foldin-hooks.sh
=== harvest.sh (PreCompact / SessionEnd) ===
  PASS row 4: PreCompact-mode harvest stages a learning, exits 0 (exit 0)
  PASS row 4: ledger created at repo-relative default with no ledger dir pre-existing
  PASS row 4b: --lab-log drafts an entry, exits 0 (exit 0)
  PASS row 4b: draft never writes the real LAB_LOG.md
  PASS row 4c: 8 concurrent harvests of the same insight stage exactly once (ID-202)
  PASS row 4c: concurrent harvests never duplicate the ledger header
  ...
Passed: 51 / 51

$ bash tests/test-install-modules.sh   # adjacent suite, unaffected by this change
37 passed, 0 failed
```

Negative control (`git stash` the fix, test file kept):
```
FAIL row 4c: 8 concurrent harvests of the same insight stage exactly once (ID-202) (expected '1', got '8')
```
`git stash pop` restores the fix; immediate re-run gives `51/51` again.

## Scope

`hooks/harvest.py` (the fix; `harvest.sh` is an unchanged thin shim),
`tests/test-kit-foldin-hooks.sh` (the new regression test), and the
proof-of-done doc. No other files touched.

Lane classified `normal` per `lib/classify/lane-classify.sh`; gates recorded
via `lib/gate/gate-ledger.sh` (rid `harvest-dedup-append`) — `spec`/`think`/
`grill`/`review`/`docs` recorded `skipped` with reasons (scoped, pre-specified
bug fix; no spec file authored so the ship-gate's spec-lane check fails open),
`build` recorded `ran`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: `_meta/megagoals/harness-loop/ROADMAP.md` SG-03.