### PR TITLE
fix(session): resolve entrypoint paths with realpath so symlinks work

### DIFF
--- a/docs/verification/symlink-realpath.md
+++ b/docs/verification/symlink-realpath.md
@@ -1,0 +1,39 @@
+# Proof of done: session bins work through symlinks (realpath fix)
+
+Change: `abspath(__file__)` -> `realpath(__file__)` in the five session
+entrypoints (intel, observe, semantic, recall bin + `cc_recall.py`), so a
+`~/.local/bin` symlink to a session CLI resolves the kit repo root instead of
+crashing with `cannot locate the kit repo root (lib/session not found)`.
+
+## Confirmation run-table
+
+| # | Check | Command | Exit | Verdict |
+|---|---|---|---|---|
+| 1 | Symlinked cc-intel runs | `ln -s $KIT/lib/session/intel/bin/cc-intel $t/cc-intel && $t/cc-intel --help` | 0 | PASS |
+| 2 | Symlinked cc-observe runs | `ln -s $KIT/lib/session/observe/bin/cc-observe $t/cc-observe && $t/cc-observe --help` | 0 | PASS |
+| 3 | parse-transcript suite | `bash lib/session/tests/test-parse-transcript.sh` | 0 (7/7) | PASS |
+| 4 | observe smoke | `bash lib/session/observe/tests/smoke.sh` | 0 (40/40) | PASS |
+| 5 | vps-report suite | `bash lib/session/observe/tests/test-vps-report.sh` | 0 (6/6) | PASS |
+| 6 | intel smoke | `bash lib/session/intel/tests/smoke.sh` | 0 (8/8) | PASS |
+| 7 | recall tests | `python3 lib/session/recall/tests/test_recall.py` | 0 (OK) | PASS |
+
+## Negative control (revert -> RED -> restore)
+
+```
+git checkout origin/master -- lib/session/intel/bin/cc-intel   # revert the fix
+$t/cc-intel --help    -> exit 1, "cannot locate the kit repo root"   RED (expected)
+git checkout HEAD -- lib/session/intel/bin/cc-intel             # restore the fix
+$t/cc-intel --help    -> exit 0                                      GREEN
+```
+
+Run live on the Air 2026-07-11 (session wiring cc-intel/cc-observe from the
+retired ops-toolkit cc-elevation snapshot to the kit install; the symlink crash
+was the discovery incident).
+
+## Reproduce
+
+```
+t=$(mktemp -d)
+ln -s "$PWD/lib/session/intel/bin/cc-intel" "$t/cc-intel"
+"$t/cc-intel" --help          # exit 0 on this branch; exit 1 on origin/master
+```

--- a/lib/session/intel/bin/cc-intel
+++ b/lib/session/intel/bin/cc-intel
@@ -32,7 +32,7 @@ def _repo_root():
     """Walk up from this file to find the kit repo root (the dir holding
     lib/session/). Repo-relative per DECISIONS.md's adapter-default invariant:
     no hardcoded ops-toolkit/personal path, no CONSUMER_ROOT env."""
-    d = os.path.dirname(os.path.abspath(__file__))
+    d = os.path.dirname(os.path.realpath(__file__))
     for _ in range(8):
         if os.path.isdir(os.path.join(d, "lib", "session")):
             return d

--- a/lib/session/observe/bin/cc-observe
+++ b/lib/session/observe/bin/cc-observe
@@ -41,7 +41,7 @@ def _repo_root():
     """Walk up from this file to find the kit repo root (the dir holding
     lib/session/). Repo-relative per DECISIONS.md's adapter-default invariant:
     no hardcoded ops-toolkit/personal path, no CONSUMER_ROOT env."""
-    d = os.path.dirname(os.path.abspath(__file__))
+    d = os.path.dirname(os.path.realpath(__file__))
     for _ in range(8):
         if os.path.isdir(os.path.join(d, "lib", "session")):
             return d

--- a/lib/session/observe/bin/cc-semantic
+++ b/lib/session/observe/bin/cc-semantic
@@ -33,7 +33,7 @@ def _repo_root():
     """Walk up from this file to find the kit repo root (the dir holding
     lib/session/). Repo-relative per DECISIONS.md's adapter-default invariant:
     no hardcoded ops-toolkit/personal path, no CONSUMER_ROOT env."""
-    d = os.path.dirname(os.path.abspath(__file__))
+    d = os.path.dirname(os.path.realpath(__file__))
     for _ in range(8):
         if os.path.isdir(os.path.join(d, "lib", "session")):
             return d

--- a/lib/session/recall/bin/cc-recall
+++ b/lib/session/recall/bin/cc-recall
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 from cc_recall import main  # noqa: E402
 
 raise SystemExit(main())

--- a/lib/session/recall/cc_recall.py
+++ b/lib/session/recall/cc_recall.py
@@ -22,7 +22,7 @@ def _repo_root():
     """Walk up from this file to find the kit repo root (the dir holding
     lib/session/). Repo-relative per DECISIONS.md's adapter-default invariant:
     no hardcoded ops-toolkit/personal path, no CONSUMER_ROOT env."""
-    d = os.path.dirname(os.path.abspath(__file__))
+    d = os.path.dirname(os.path.realpath(__file__))
     for _ in range(8):
         if os.path.isdir(os.path.join(d, "lib", "session")):
             return d


### PR DESCRIPTION
## Why
`_repo_root()` in the session bins walks up from `abspath(__file__)`, which keeps the symlink's own location. Exposing any session CLI via a `~/.local/bin` symlink (the natural install shape on a consumer machine) crashed with `cannot locate the kit repo root (lib/session not found)`. Hit for real on the Air 2026-07-11 while re-pointing cc-intel/cc-observe from the retired ops-toolkit cc-elevation snapshot to the kit install.

## What
`abspath(__file__)` -> `realpath(__file__)` in the five session entrypoints (intel, observe, semantic, recall bin + module). No behavior change for direct invocation.

## Proof of done
`docs/verification/symlink-realpath.md`: 7-row green run-table (symlinked bins + all five session suites) and a live negative control (revert -> exit 1 RED -> restore -> GREEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)