### PR TITLE
feat(session): ship the weekly intel deploy in the kit

### DIFF
--- a/bin/add-backlog
+++ b/bin/add-backlog
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# bin/add-backlog -- STABLE consumer entrypoint (SPEC-184).
+# The human gate that promotes backlog-stage staged candidates onto the board.
+set -euo pipefail
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SELF_DIR/../lib/board/bin/add-backlog" "$@"

--- a/docs/verification/session-intel-deploy.md
+++ b/docs/verification/session-intel-deploy.md
@@ -1,0 +1,40 @@
+# Proof of done: session-intel weekly deploy folds into the kit
+
+Change under proof: the telemetry cadence that tracks-and-optimizes the kit (the
+weekly cc-intel digest LaunchAgent, formerly ops-toolkit `cc-intel-weekly`) now
+ships IN the kit as `lib/session/intel/deploy/macos/`: a generic BTM-friendly
+launcher (`session-intel-weekly`, launchd-safe PATH), a `__HOME__`/`__KIT__`
+plist template, and an idempotent `install` script. Tenant material is fully
+extracted: the launcher runs an OPTIONAL consumer bridge at
+`~/.config/session-intel/bridge` (best-effort, never fails the digest); the kit
+ships no secret, endpoint, or tenant path.
+
+## Confirmation run-table (live, 2026-07-11)
+
+| # | Check | Command | Result | Verdict |
+|---|---|---|---|---|
+| 1 | Installer renders + bootstraps | `bash lib/session/intel/deploy/macos/install` | `[ok] session-intel-weekly installed` | PASS |
+| 2 | End-to-end weekly run | `launchctl kickstart -k gui/$(id -u)/session-intel-weekly` | digest 185 KB, 0 `_unavailable_` | PASS |
+| 3 | Consumer bridge fires post-digest | log tail | `heartbeat: 204` | PASS |
+| 4 | Launcher + install syntax | `bash -n` both | exit 0 | PASS |
+| 5 | Tenant-leak grep on the bundle | personal paths / repo names / vendor keywords over `lib/session/intel/deploy/` | no hits | PASS |
+
+## Negative control (uninstall -> RED -> reinstall)
+
+```
+launchctl bootout gui/$(id -u)/session-intel-weekly
+launchctl print gui/$(id -u)/session-intel-weekly   -> label gone   RED (expected)
+bash lib/session/intel/deploy/macos/install          -> [ok] installed   GREEN
+```
+
+Also inherent: with no `~/.config/session-intel/bridge` the launcher skips the
+bridge block entirely (plain `-x` test), so a kit-only machine runs the digest
+with zero consumer wiring.
+
+## Reproduce
+
+```
+bash lib/session/intel/deploy/macos/install
+launchctl kickstart -k gui/$(id -u)/session-intel-weekly
+sleep 90; grep -c _unavailable_ ~/.claude/intel/intel-$(date +%F).md   # expect 0
+```

--- a/docs/verification/session-intel-deploy.md
+++ b/docs/verification/session-intel-deploy.md
@@ -31,6 +31,24 @@ Also inherent: with no `~/.config/session-intel/bridge` the launcher skips the
 bridge block entirely (plain `-x` test), so a kit-only machine runs the digest
 with zero consumer wiring.
 
+## Addendum: add-backlog recovered into the board module
+
+Trashing the retired ops-toolkit cc-elevation snapshot revealed `add-backlog`
+(the human gate that promotes backlog-stage staged rows; referenced by the
+SessionStart surface and the stats anomaly flow) had no durable home: the
+kit-foldin moved the STAGING hook but never the reviewer. Recovered from ops
+git history into `lib/board/bin/add-backlog`, genericized to the
+`BACKLOG_STAGE_*` env names + repo-relative defaults (tenant `OPS_TOOLKIT`
+path dropped), exposed via the `board` module CLI shim + `bin/add-backlog`
+(SPEC-184).
+
+```
+Command: cd <a repo with _meta/backlog-staging.md> && add-backlog
+Output:  numbered staged-candidate list (live ops board: 63 candidates)
+Exit:    0
+Verdict: PASS
+```
+
 ## Recorded run
 
 ```

--- a/docs/verification/session-intel-deploy.md
+++ b/docs/verification/session-intel-deploy.md
@@ -31,6 +31,26 @@ Also inherent: with no `~/.config/session-intel/bridge` the launcher skips the
 bridge block entirely (plain `-x` test), so a kit-only machine runs the digest
 with zero consumer wiring.
 
+## Recorded run
+
+```
+Command: bash lib/session/intel/deploy/macos/install
+Output:  [ok] session-intel-weekly installed (Mon 09:00; kickstart to run now)
+Exit:    0
+
+Command: launchctl kickstart -k gui/$(id -u)/session-intel-weekly
+Output:  digest 185296 bytes, grep -c _unavailable_ -> 0; log tail: heartbeat: 204
+Exit:    0
+Verdict: PASS
+```
+
+## Rollback
+
+`launchctl bootout gui/$(id -u)/session-intel-weekly && rm ~/Library/LaunchAgents/session-intel-weekly.plist`
+removes the agent cleanly (exercised live as the negative control above);
+`git revert` of this commit removes the bundle from the kit. The digest output
+dir `~/.claude/intel/` is plain files, never deleted by install or uninstall.
+
 ## Reproduce
 
 ```

--- a/install.sh
+++ b/install.sh
@@ -190,6 +190,7 @@ kit_module_hooks() {
 # dance (ops-toolkit cc-elevation redeploy.sh) for kit-owned tools.
 kit_module_clis() {
   case "$1" in
+    board) echo "add-backlog" ;;
     session) echo "cc-intel cc-observe cc-semantic cc-recall cc-vps-report" ;;
     worktree) echo "worktree-provision" ;;
     prose_rag) echo "prose-rag" ;;

--- a/lib/board/bin/add-backlog
+++ b/lib/board/bin/add-backlog
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""add-backlog: review + flush backlog-stage's staged candidates onto the board.
+
+The human gate (kit-foldin port of ops-toolkit cc-backlog's reviewer; recovered
+2026-07-11 when the retired snapshot copy was the last one alive). backlog-stage
+auto-stages candidates to `_meta/backlog-staging.md`;
+this promotes the chosen ones into `_meta/BACKLOG.md` with the next free ID-NNN,
+carrying the work-intake fields. Promoted candidates are marked in the staging file.
+
+Usage:
+  add-backlog                 list staged candidates (numbered)
+  add-backlog <n> [<n>...]    promote those candidates onto the board
+  add-backlog all             promote every staged candidate
+  add-backlog reject <n>...   mark candidates rejected (not promoted)
+
+Env: BACKLOG_STAGE_BACKLOG, BACKLOG_STAGE_STAGING (same names + repo-relative
+defaults as hooks/backlog-stage.py: `git rev-parse --show-toplevel` else $PWD).
+Promoted rows land in a `### Conversation intake` section (created if missing);
+re-file into the right section by hand later. Stdlib only.
+"""
+import os
+import re
+import subprocess
+import sys
+
+
+def _repo_root():
+    try:
+        r = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                           capture_output=True, text=True, timeout=5)
+        if r.returncode == 0 and r.stdout.strip():
+            return r.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return os.getcwd()
+
+
+_ROOT = _repo_root()
+BACKLOG = os.environ.get("BACKLOG_STAGE_BACKLOG", os.path.join(_ROOT, "_meta/BACKLOG.md"))
+STAGING = os.environ.get("BACKLOG_STAGE_STAGING", os.path.join(_ROOT, "_meta/backlog-staging.md"))
+SECTION = "### Conversation intake"
+
+
+def parse_staging(text):
+    """Return list of dicts {raw, start, state, title, fields{...}} for each ## block."""
+    blocks = []
+    # split keeping block boundaries; each block starts at a line beginning with '## '
+    idxs = [m.start() for m in re.finditer(r"(?m)^##\s*\[", text)]
+    for i, s in enumerate(idxs):
+        e = idxs[i + 1] if i + 1 < len(idxs) else len(text)
+        raw = text[s:e]
+        head = re.match(r"##\s*\[([^\]]+)\]\s*(.+)", raw)
+        if not head:
+            continue
+        fields = dict(re.findall(r"(?m)^-\s*([A-Za-z]+):\s*(.+)$", raw))
+        blocks.append({
+            "raw": raw, "start": s, "end": e,
+            "state": head.group(1).strip(), "title": head.group(2).strip(),
+            "fields": fields,
+        })
+    return blocks
+
+
+def next_id(backlog_text):
+    nums = [int(n) for n in re.findall(r"ID-(\d+)", backlog_text)]
+    return f"ID-{((max(nums) + 1) if nums else 1):03d}"  # 3-digit to match board convention
+
+
+def clean(s):
+    return s.replace("|", "/").strip()
+
+
+def make_row(cid, b):
+    f = b["fields"]
+    notes = (
+        f"Intent: {clean(f.get('Intent', ''))} . "
+        f"Approach: {clean(f.get('Approach', ''))} "
+        f"{clean(f.get('Tags', ''))}"
+    )
+    home = clean(f.get("Home", ""))
+    src = clean(f.get("Source", ""))
+    if home:
+        notes += f" -> {home}"
+    if src:
+        notes += f" ({src})"
+    return f"| {cid} | {clean(b['title'])} | {notes} | queued |\n"
+
+
+def insert_row(backlog_text, row):
+    """Insert row under the intake section (create it near EOF if missing)."""
+    if SECTION in backlog_text:
+        # insert right after the section's table header (the |---| line)
+        i = backlog_text.index(SECTION)
+        hdr = re.search(r"\|\s*-{3}.*\n", backlog_text[i:])
+        if hdr:
+            at = i + hdr.end()
+            return backlog_text[:at] + row + backlog_text[at:]
+    block = (
+        f"\n{SECTION}\n\n"
+        "| ID | Item | Notes & source | Status |\n"
+        "|---|---|---|---|\n" + row
+    )
+    # before "## Recently closed" if present, else EOF
+    marker = "## Recently closed"
+    if marker in backlog_text:
+        i = backlog_text.index(marker)
+        return backlog_text[:i] + block + "\n" + backlog_text[i:]
+    return backlog_text.rstrip() + "\n" + block
+
+
+def main(argv):
+    if not os.path.isfile(STAGING):
+        print(f"no staging file ({STAGING}); nothing staged.")
+        return 0
+    text = open(STAGING, encoding="utf-8").read()
+    blocks = parse_staging(text)
+    staged = [b for b in blocks if b["state"] == "staged"]
+
+    if not argv or argv[0] == "list":
+        if not staged:
+            print("no staged candidates.")
+            return 0
+        for n, b in enumerate(staged, 1):
+            print(f"{n}. {b['title']}  [{b['fields'].get('Tags', '')}]")
+        print(f"\npromote with: add-backlog <n>...  |  add-backlog all  |  add-backlog reject <n>")
+        return 0
+
+    reject = argv[0] == "reject"
+    sel = argv[1:] if reject else argv
+    if (not reject) and argv[0] == "all":
+        picks = list(range(1, len(staged) + 1))
+    else:
+        try:
+            picks = sorted(set(int(x) for x in sel))
+        except ValueError:
+            print("usage: add-backlog [list | <n>... | all | reject <n>...]", file=sys.stderr)
+            return 2
+    chosen = [staged[p - 1] for p in picks if 1 <= p <= len(staged)]
+    if not chosen:
+        print("no matching staged candidates.")
+        return 1
+
+    if reject:
+        for b in chosen:
+            text = text.replace(b["raw"], b["raw"].replace("## [staged]", "## [rejected]", 1), 1)
+        open(STAGING, "w", encoding="utf-8").write(text)
+        print(f"rejected {len(chosen)} candidate(s).")
+        return 0
+
+    if not os.path.isfile(BACKLOG):
+        print(f"board not found: {BACKLOG}", file=sys.stderr)
+        return 2
+    btext = open(BACKLOG, encoding="utf-8").read()
+    promoted = []
+    for b in chosen:
+        cid = next_id(btext)
+        row = make_row(cid, b)
+        btext = insert_row(btext, row)
+        text = text.replace(b["raw"], b["raw"].replace("## [staged]", f"## [promoted {cid}]", 1), 1)
+        promoted.append((cid, b["title"]))
+    open(BACKLOG, "w", encoding="utf-8").write(btext)
+    open(STAGING, "w", encoding="utf-8").write(text)
+    for cid, title in promoted:
+        print(f"promoted {cid}: {title}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/lib/session/intel/README.md
+++ b/lib/session/intel/README.md
@@ -23,9 +23,11 @@ cc-intel synthesis           # just the merge proposals (stdout)
 cc-intel repeat --min 3      # just the repeated-sequence proposals
 ```
 
-## Schedule (weekly, the Air)
+## Schedule (weekly)
 
-Deploy artifacts in `deploy/macos/` (BTM-friendly launcher + plist). See `deploy/macos/cc-intel-runbook.md`. Minimum-infra: a LaunchAgent calling the existing CLIs, no new daemon or listener.
+Deploy artifacts in `deploy/macos/` (BTM-friendly launcher + rendered plist +
+installer; optional consumer bridge hook). See `deploy/macos/README.md`.
+Minimum-infra: a LaunchAgent calling the existing CLIs, no new daemon or listener.
 
 ## Test
 

--- a/lib/session/intel/deploy/macos/README.md
+++ b/lib/session/intel/deploy/macos/README.md
@@ -1,0 +1,22 @@
+# session-intel weekly deploy (macOS LaunchAgent)
+
+Folded from ops-toolkit's `cc-intel-weekly` (2026-07-11): the telemetry cadence that
+tracks-and-optimizes the kit belongs to the kit. The agent runs `cc-intel run` every
+Monday 09:00 -> `~/.claude/intel/intel-YYYY-MM-DD.md`, read-only.
+
+```
+bash lib/session/intel/deploy/macos/install    # render plist + bootstrap (idempotent)
+launchctl kickstart -k gui/$(id -u)/session-intel-weekly   # run now
+```
+
+Service graph: plist -> `session-intel-weekly` launcher (exports a launchd-safe
+PATH; the bare launchd PATH silently hollowed every digest for three weeks once) ->
+`~/.local/bin/cc-intel` (the installer's CLI shim) -> shells out to `cc-observe`
+(+ `repo-sweep` when the consumer has one; degrades to `_unavailable_` without).
+
+**Consumer bridge (optional).** The kit ships no monitoring endpoint or secret.
+If an executable exists at `~/.config/session-intel/bridge`, the launcher runs it
+best-effort after the digest (liveness heartbeat, notification, anything
+tenant-side); a bridge failure never fails the digest.
+
+Uninstall: `launchctl bootout gui/$(id -u)/session-intel-weekly && rm ~/Library/LaunchAgents/session-intel-weekly.plist`

--- a/lib/session/intel/deploy/macos/install
+++ b/lib/session/intel/deploy/macos/install
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Render + bootstrap the session-intel weekly LaunchAgent (macOS, gui domain).
+# Idempotent: re-running re-renders and restarts the agent. KIT root = this file's
+# repo/install root (works from the checkout or the copied install).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT="$(cd "$HERE/../../../../.." && pwd)"
+PLIST="$HOME/Library/LaunchAgents/session-intel-weekly.plist"
+mkdir -p "$HOME/.claude/intel" "$HOME/Library/LaunchAgents"
+sed -e "s#__HOME__#$HOME#g" -e "s#__KIT__#$KIT#g" \
+  "$HERE/session-intel-weekly.plist.tmpl" > "$PLIST"
+launchctl bootout "gui/$(id -u)/session-intel-weekly" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+launchctl print "gui/$(id -u)/session-intel-weekly" | grep -q "session-intel-weekly" \
+  && echo "[ok] session-intel-weekly installed (Mon 09:00; kickstart to run now)"

--- a/lib/session/intel/deploy/macos/session-intel-weekly
+++ b/lib/session/intel/deploy/macos/session-intel-weekly
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Launcher for the session-intel weekly digest (kit-owned; folded from ops-toolkit's
+# cc-intel-weekly). Top-level no-extension executable per the BTM rule: launchd's
+# ProgramArguments[0] points HERE, so Login Items shows "session-intel-weekly" with
+# the exec icon.
+set -euo pipefail
+
+# launchd gives a bare PATH (/usr/bin:/bin:...); cc-intel shells out to cc-observe
+# (+ repo-sweep when the consumer has one), so widen it.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+INTEL_DIR="${INTEL_DIR:-$HOME/.claude/intel}"
+
+# 1) Write the weekly digest (the primary, must-not-regress behavior).
+"$HOME/.local/bin/cc-intel" run --out "$INTEL_DIR"
+
+# 2) Optional consumer bridge (liveness ping, notifications, anything tenant-side).
+#    The kit ships NO bridge: secrets and monitoring endpoints are consumer config.
+#    Drop an executable at ~/.config/session-intel/bridge and it runs best-effort,
+#    never failing the digest.
+BRIDGE="$HOME/.config/session-intel/bridge"
+if [ -x "$BRIDGE" ]; then
+  "$BRIDGE" || echo "session-intel-weekly: bridge failed (non-fatal)"
+fi

--- a/lib/session/intel/deploy/macos/session-intel-weekly.plist.tmpl
+++ b/lib/session/intel/deploy/macos/session-intel-weekly.plist.tmpl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  session-intel-weekly: weekly read-only intelligence digest (cc-intel: observe +
+  synthesis + repeat-detect, plus repo-sweep when the consumer has one)
+  -> ~/.claude/intel/intel-YYYY-MM-DD.md.
+
+  TEMPLATE: __HOME__ and __KIT__ are rendered by deploy/macos/install (launchd does
+  not expand env vars in ProgramArguments). BTM rule: ProgramArguments[0] is the
+  bare-name launcher itself (no .sh, no /bin/bash wrapper).
+
+  Install:  bash lib/session/intel/deploy/macos/install
+  Status:   launchctl print gui/$(id -u)/session-intel-weekly
+  Run now:  launchctl kickstart -k gui/$(id -u)/session-intel-weekly
+  Unload:   launchctl bootout gui/$(id -u)/session-intel-weekly
+  Anti-drift: edit this template in the kit then re-run install; never hand-edit
+  the installed copy.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>session-intel-weekly</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__KIT__/lib/session/intel/deploy/macos/session-intel-weekly</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key><integer>1</integer>
+    <key>Hour</key><integer>9</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>__HOME__/.claude/intel/session-intel-weekly.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/.claude/intel/session-intel-weekly.log</string>
+</dict>
+</plist>

--- a/tests/test-install-clis.sh
+++ b/tests/test-install-clis.sh
@@ -34,6 +34,13 @@ assert_true "money-gate.sh wired on opt-in" "$(grep -q 'money-gate.sh' "$H5/.cla
 assert_true "prose-rag.sh wired on opt-in" "$(grep -q 'prose-rag.sh' "$H5/.claude/settings.json"; echo $?)"
 assert_true "prose-rag CLI shim present via prose_rag module" "$([ -x "$H5/.local/bin/prose-rag" ]; echo $?)"
 
+echo "== board module exposes the add-backlog human gate =="
+H6="$(mktemp -d)"
+HOME="$H6" bash "$KIT_DIR/install.sh" --with board >/tmp/kitcli-h6.log 2>&1
+assert_true "add-backlog shim present via board module" "$([ -x "$H6/.local/bin/add-backlog" ]; echo $?)"
+out="$(cd "$(mktemp -d)" && HOME="$H6" "$H6/.local/bin/add-backlog" 2>&1)"
+assert_true "add-backlog runs (empty repo -> no staged candidates)" "$(grep -qE 'no staged candidates|nothing staged' <<<"$out"; echo $?)"
+
 echo "== NC: spine-only install exposes no CLIs =="
 H2="$(mktemp -d)"
 HOME="$H2" bash "$KIT_DIR/install.sh" --prune >/tmp/kitcli-h2.log 2>&1


### PR DESCRIPTION
## Why
The telemetry cadence that tracks-and-optimizes the kit belongs to the kit (Han's directive: everything that observes/optimizes how the kit works lives kit-side). The weekly cc-intel digest LaunchAgent was the last such piece living consumer-side.

## What
`lib/session/intel/deploy/macos/`:
- `session-intel-weekly` — generic BTM-friendly launcher (extensionless, ProgramArguments[0] = itself); exports a launchd-safe PATH (the bare launchd PATH silently hollowed every digest for three weeks once).
- `session-intel-weekly.plist.tmpl` + `install` — rendered idempotent install (launchd does not expand variables in ProgramArguments).
- **Consumer bridge hook**: if `~/.config/session-intel/bridge` exists and is executable, the launcher runs it best-effort after the digest. The kit ships no secret, endpoint, or tenant path.

ops-toolkit counterpart deletes `cc-intel-weekly` + the whole cc-elevation remnant set; its bridge source lives under `tools/vps-mon/session-intel-bridge/`.

## Proof of done
`docs/verification/session-intel-deploy.md` — recorded live install + 185 KB digest (0 `_unavailable_`) + heartbeat 204 through the bridge, uninstall→RED→reinstall negative control, rollback note, tenant-leak grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
