### PR TITLE
feat(mega): report verb, the mechanical RUN_REPORT telemetry generator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,5 +176,8 @@ jobs:
       - name: Run mega review dashboard tests (SPEC-197, harness-loop sub-goal 07)
         run: bash tests/test-mega-review.sh
 
+      - name: Run mega report generator tests
+        run: bash tests/test-mega-report.sh
+
       - name: Run config-registry drift + bin/config tests (SPEC-198, harness-loop sub-goal 08)
         run: bash tests/test-config-registry.sh

--- a/_meta/megagoals/harness-loop/REVIEW.html
+++ b/_meta/megagoals/harness-loop/REVIEW.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>mega review: harness-loop</title><style>:root { color-scheme: light dark; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #fafafa; color: #111827; margin: 2rem; line-height: 1.4; max-width: 72rem;
+}
+h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+h2 { font-size: 1.05rem; margin: 0; }
+.meta { color: #6b7280; font-size: 0.85rem; margin-bottom: 1.5rem; }
+table { border-collapse: collapse; width: 100%; font-size: 0.85rem; margin: 0.5rem 0 1rem; }
+th, td { border: 1px solid #374151; padding: 0.35rem 0.55rem; text-align: left; }
+th { background: #f0f0f0; font-weight: 600; }
+tr:nth-child(even) { background: #f5f5f5; }
+.empty { color: #6b7280; font-style: italic; }
+.badge { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 0.75rem; font-size: 0.75rem;
+  font-weight: 600; margin-left: 0.5rem; }
+.att-ok .badge, .badge.ok { background: #dcfce7; color: #166534; }
+.att-info .badge, .badge.info { background: #e5e7eb; color: #374151; }
+.att-wip .badge, .badge.wip { background: #dbeafe; color: #1e40af; }
+.att-pending .badge, .badge.pending { background: #e5e7eb; color: #374151; }
+.att-bad .badge, .badge.bad { background: #fee2e2; color: #991b1b; }
+.att-unknown .badge, .badge.unknown { background: #fef3c7; color: #92400e; }
+details { border: 1px solid #374151; border-radius: 0.4rem; margin-bottom: 0.6rem; padding: 0.4rem 0.7rem; }
+details.att-bad, details.att-unknown { border-left: 5px solid #dc2626; }
+details.att-wip, details.att-pending { border-left: 5px solid #2563eb; }
+details.att-ok { border-left: 5px solid #16a34a; }
+details.att-info { border-left: 5px solid #9ca3af; }
+summary { cursor: pointer; font-weight: 600; }
+.subline { color: #6b7280; font-size: 0.85rem; margin: 0.3rem 0; }
+.banner { background: #fef3c7; color: #92400e; border: 1px solid #f59e0b; border-radius: 0.4rem;
+  padding: 0.6rem 0.9rem; margin-bottom: 1rem; }
+footer { margin-top: 2rem; padding-top: 0.75rem; border-top: 1px solid #374151; font-size: 0.85rem; }
+@media (prefers-color-scheme: dark) {
+  body { background: #111827; color: #f9fafb; }
+  th { background: #1f2937; }
+  tr:nth-child(even) { background: #1a2233; }
+  th, td { border-color: #4b5563; }
+  details { border-color: #4b5563; }
+  .banner { background: #422006; color: #fde68a; border-color: #b45309; }
+  footer { border-color: #4b5563; }
+}</style></head><body><h1>mega review: harness-loop</h1><p class="meta">generated 2026-07-12T05:33:57Z &middot; a projection over the run ledger + gh + proof paths, never a stored source of truth (SPEC-197). Re-render to refresh.</p><details class="att-ok">
+<summary><h2 style="display:inline">[x] 01-loop-taxonomy</h2><span class="badge ok">OK</span></summary>
+<p class="subline">ADR-0034 opens with a full surface CENSUS (bin/, skills/, daemons) + target-state tables, then locks naming/scope/modularity (learn subsystem, retro-vs-propose vocabulary, legs-as-metadata registry, front-door verb fences, `-propose` suffix, bin/ one-grammar consolidation, the kit-skill rule, the one-scheduler decision), `gate`, PR #236 (open + HELD for Han, per gate policy; Done = PR open, the gate click is Han&#x27;s)</p>
+<p class="subline">PR #236 (MERGED) &middot; CI: passing, merged 2026-07-12T03:27:14Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/236">https://github.com/dwarvesf/dwarves-kit/pull/236</a> &middot; branch=`docs/loop-01-taxonomy`</p>
+<table>
+<thead><tr><th>Phase</th><th>When</th><th>State</th><th>Reason</th></tr></thead>
+<tbody>
+<tr><td>grill</td><td>2026-07-11T20:34:44Z</td><td>skipped</td><td>reason=home-turf: the mega-goal file 01-loop-taxonomy.md IS the grilled contract (advisor P5/P6 already ran on the scaffold)</td></tr>
+<tr><td>think</td><td>2026-07-11T20:34:44Z</td><td>ran</td><td>brief §4 working positions attacked, not transcribed; census-first per goal file</td></tr>
+<tr><td>spec</td><td>2026-07-11T20:34:44Z</td><td>ran</td><td>decision record IS the spec by design (ROADMAP assumption 2: 01 is ADR-0034, no code spec); zero code</td></tr>
+<tr><td>design-record</td><td>2026-07-11T20:34:44Z</td><td>ran</td><td>ADR-0034: 10 decision areas each with Rejected; census + target-state tables</td></tr>
+<tr><td>test-plan</td><td>2026-07-11T20:34:44Z</td><td>skipped</td><td>docs-only ADR; the named negative check is the collision grep-audit (appendix table)</td></tr>
+<tr><td>build</td><td>2026-07-11T20:34:44Z</td><td>ran</td><td>ADR authored; collision audit executed live at a6c5a9e: zero collisions on every locked name</td></tr>
+<tr><td>review</td><td>2026-07-11T20:34:44Z</td><td>ran</td><td>advisor P5: 1 CRITICAL + 2 MAJOR + 3 MINOR, applied/dispositioned per NOTES.md</td></tr>
+<tr><td>docs</td><td>2026-07-11T20:34:44Z</td><td>ran</td><td>the artifact is the doc; mega records (ROADMAP/NOTES/DECISIONS/HANDOFF) updated in same PR</td></tr>
+<tr><td>ship</td><td>2026-07-11T20:36:13Z</td><td>ran</td><td>gate PR opened + HELD for Han per gate merge policy; ADR-0034 at b262d58</td></tr>
+</tbody></table>
+<p class="subline">tokens: <span class="empty">-</span> (no TOKENS line recorded)</p>
+<p class="subline">proof-of-done: <span class="empty">(unlinked -- best-effort search found no file; check RUN_REPORT.md)</span></p>
+</details>
+<details class="att-ok">
+<summary><h2 style="display:inline">[x] 02-outcome-emit-sweep</h2><span class="badge ok">OK</span></summary>
+<p class="subline">OUTCOME timing brackets wired at the missing gate call sites so `stats mega-durations` + digest time-to-done stop reading honest-zero, `auto`, PR #237, merged 76fbafe (2026-07-12; CI green both OS on PR head; proof docs/verification/loop-02-outcome-emit.md)</p>
+<p class="subline">PR #237 (MERGED) &middot; CI: passing, merged 2026-07-11T20:50:51Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/237">https://github.com/dwarvesf/dwarves-kit/pull/237</a> &middot; branch=`feat/loop-02-outcome-emit`</p>
+<table>
+<thead><tr><th>Phase</th><th>When</th><th>State</th><th>Reason</th></tr></thead>
+<tbody>
+<tr><td>grill</td><td>2026-07-11T20:22:36Z</td><td>skipped</td><td>reason=density-low: mechanical inventory-driven emit sweep, SPEC-129 pattern already established, no unknowns to interview</td></tr>
+<tr><td>think</td><td>2026-07-11T20:22:36Z</td><td>skipped</td><td>goal pre-validated by harness-loop mega-goal decision brief; no product-framing question remains</td></tr>
+<tr><td>spec</td><td>2026-07-11T20:23:50Z</td><td>ran</td><td>SPEC-193-outcome-emit-sweep approved, tasks=3 (brackets, lint, fixture proof)</td></tr>
+<tr><td>design-record</td><td>2026-07-11T20:23:50Z</td><td>ran</td><td>design-bearing=no (pure emit-coverage wiring, no schema/component change)</td></tr>
+<tr><td>test-plan</td><td>2026-07-11T20:23:50Z</td><td>skipped</td><td>reason=mechanical coverage sweep with a fixed inventory list; the standing lint IS the test plan</td></tr>
+<tr><td>build</td><td>2026-07-11T20:38:47Z</td><td>ran</td><td>22 sites bracketed across 15 command files; tests=pass</td></tr>
+<tr><td>review</td><td>2026-07-11T20:38:47Z</td><td>skipped</td><td>reason=solo mechanical sweep, no team review lane invoked; self-verified via shellcheck + full 46-file suite + new 51-assertion lint</td></tr>
+<tr><td>docs</td><td>2026-07-11T20:38:47Z</td><td>ran</td><td>SPEC-193, proof-of-done, CI workflow entry added; README/CLAUDE.md unaffected (no public-surface change)</td></tr>
+<tr><td>ship</td><td>2026-07-11T20:43:38Z</td><td>ran</td><td>22 sites bracketed, standing lint added, fixture proof-of-done, full suite green</td></tr>
+<tr><td>review</td><td>2026-07-11T20:46:25Z</td><td>ran</td><td>lead merge-gate review: 22-site bracket pattern uniform, ship exemption load-bearing NC verified in proof, caught= rule sane; impl-notes added 67a3e8d</td></tr>
+</tbody></table>
+<p class="subline">tokens: <span class="empty">-</span> (no TOKENS line recorded)</p>
+<p class="subline">proof-of-done: <a href="docs/verification/loop-02-outcome-emit.md">docs/verification/loop-02-outcome-emit.md</a></p>
+</details>
+<details class="att-ok">
+<summary><h2 style="display:inline">[x] 03-harvest-dedup-land</h2><span class="badge ok">OK</span></summary>
+<p class="subline">PR #226 (harvest flock dedup) reviewed + merged, regression row 4c green on master, `auto`, PR #226, merged a6c5a9e (2026-07-12; post-merge suite 51/51 on master)</p>
+<p class="subline">PR #226 (MERGED) &middot; CI: passing, merged 2026-07-11T20:16:52Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/226">https://github.com/dwarvesf/dwarves-kit/pull/226</a> &middot; branch=(none,</p>
+<p class="empty">(no ledger rows for this sub-goal)</p>
+<p class="subline">proof-of-done: <span class="empty">(unlinked -- best-effort search found no file; check RUN_REPORT.md)</span></p>
+</details>
+<details class="att-bad" open>
+<summary><h2 style="display:inline">[ ] 04-surface-consolidation</h2><span class="badge bad">MERGED-UNCHECKED</span></summary>
+<p class="subline">the ADR-0034 target surface becomes reality in one wave: `lib/learn/` + `bin/learn`; bin/ regrouped to one `&lt;subsystem&gt; &lt;verb&gt;` grammar (session-* 5-&gt;1, add-backlog -&gt; `board promote`, missing spec/goal/stats/mega/queue entries created); stats skill relocated; all call-sites repointed (dotfiles companion PR), zero alias shims, `auto`, PR #239 (open, stacked on #236&#x27;s branch; merges after #236; companions dotfiles#213 + ops-toolkit#796)</p>
+<p class="subline">PR #239 (MERGED) &middot; CI: passing, merged 2026-07-12T03:51:38Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/239">https://github.com/dwarvesf/dwarves-kit/pull/239</a> &middot; branch=`feat/loop-04-surface-consol`</p>
+<table>
+<thead><tr><th>Phase</th><th>When</th><th>State</th><th>Reason</th><th>Caught</th><th>Duration (s)</th></tr></thead>
+<tbody>
+<tr><td>grill</td><td>2026-07-11T21:41:39Z</td><td>skipped</td><td>reason=home-turf: mega-dispatched sub-goal; branches resolved upstream by ADR-0034 + the goal contract (SG-01 grill)</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>think</td><td>2026-07-11T21:41:39Z</td><td>skipped</td><td>design locked upstream: ADR-0034 census + decisions 1/7/8 are the think/design record</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>design</td><td>2026-07-11T21:41:39Z</td><td>skipped</td><td>design is ADR-0034 (goal file: Design obvious, executes the ADR)</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>design-critique</td><td>2026-07-11T21:41:39Z</td><td>skipped</td><td>ADR-0034 critiqued at SG-01 (advisor P5); this sub-goal executes it</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>ui-design</td><td>2026-07-11T21:41:39Z</td><td>skipped</td><td>no UI surface in this change</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>spec</td><td>2026-07-11T21:41:40Z</td><td>ran</td><td>SPEC-194 written (number pre-reserved by the mega dispatch)</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>validate</td><td>2026-07-11T21:41:40Z</td><td>skipped</td><td>spec is a 1:1 projection of the approved ADR-0034 target census; adversarial pass done on the ADR at SG-01</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>design-record</td><td>2026-07-11T21:41:40Z</td><td>ran</td><td>ADR-0034 is the design record (pre-existing, approved-for-run)</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>test-plan</td><td>2026-07-11T21:41:40Z</td><td>ran</td><td>AC1-AC8 matrix in SPEC-194 + proof contract from the goal file</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>build</td><td>2026-07-11T21:41:50Z</td><td>ran</td><td>regroup executed: weekend-batch-&gt;lib/learn, bin/learn+session dispatchers, board promote fold, 5 new subsystem entries, stats skill relocated, call-sites repointed</td><td>false</td><td>0</td></tr>
+<tr><td>review</td><td>2026-07-11T21:51:08Z</td><td>ran</td><td>review-team per SPEC-069: architecture lens clean (0 findings); test-coverage lens 4 MAJOR + 2 MINOR coverage gaps, closed by tests/test-bin-forwarders.sh + CI wiring</td><td>true</td><td>0</td></tr>
+<tr><td>docs</td><td>2026-07-11T21:51:08Z</td><td>ran</td><td>README module table + layout, docs/consumer-contract.md entrypoint table, docs/WORKFLOW.md weekend-batch pointers, module READMEs, skill Install sections</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>think</td><td>2026-07-11T21:52:07Z</td><td>override</td><td>performed upstream: ADR-0034 (SG-01) is this run&#x27;s think/design record; goal file marks Design=obvious, executes the ADR</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>design</td><td>2026-07-11T21:52:08Z</td><td>override</td><td>design is ADR-0034 decisions 1/7/8, approved upstream at SG-01; this run executes it verbatim</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>design-critique</td><td>2026-07-11T21:52:08Z</td><td>override</td><td>ADR-0034 was adversarially reviewed at SG-01 (advisor P5); re-critiquing the executed copy would duplicate it</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>validate</td><td>2026-07-11T21:52:08Z</td><td>override</td><td>spec is a 1:1 projection of the approved ADR-0034 census; validation happened on the ADR at SG-01</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>ship</td><td>2026-07-11T21:52:08Z</td><td>ran</td><td>PR opened stacked on docs/loop-01-taxonomy; merge withheld by design (mega delegate flow, lead merges after PR #236)</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>reflect</td><td>2026-07-11T21:52:08Z</td><td>override</td><td>retro is mega-level: lead records DECISIONS.md/ROADMAP on sub-goal completion; per-run reflect happens post-merge</td><td>n/a</td><td>n/a</td></tr>
+</tbody></table>
+<p class="subline">tokens: <span class="empty">-</span> (no TOKENS line recorded)</p>
+<p class="subline">proof-of-done: <a href="docs/verification/generated/loop-04-surface-consol.md">docs/verification/generated/loop-04-surface-consol.md</a></p>
+</details>
+<details class="att-bad" open>
+<summary><h2 style="display:inline">[ ] 05-retro-cycle</h2><span class="badge bad">MERGED-UNCHECKED</span></summary>
+<p class="subline">`learn propose` (stats-window aggregate → sonnet interpret → adversarial check → cited, deduped staging) + the recurring `kit-retro-YYYY-WW` queue goal template + `[features] auto_improvement` flipped to [impl] with the SPEC-188 lint amended, `auto`, PR #243 (open, stacked on SG-04&#x27;s branch; merges after #239)</p>
+<p class="subline">PR #243 (MERGED) &middot; CI: passing, merged 2026-07-12T04:40:23Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/243">https://github.com/dwarvesf/dwarves-kit/pull/243</a> &middot; branch=`feat/loop-05-retro-cycle`</p>
+<table>
+<thead><tr><th>Phase</th><th>When</th><th>State</th><th>Reason</th></tr></thead>
+<tbody>
+<tr><td>spec</td><td>2026-07-11T22:13:13Z</td><td>ran</td><td>SPEC-195 drafted: learn propose 3-stage design</td></tr>
+<tr><td>build</td><td>2026-07-11T22:26:46Z</td><td>ran</td><td>propose.py + staging_format.py + tests green (31/31 propose, 9/9 lint, 453 hooks, 683 meta)</td></tr>
+<tr><td>review</td><td>2026-07-11T22:44:46Z</td><td>ran</td><td>spec-validate 9 findings folded (dedup-order, empty-figure grounding, rid fallback, sanitize, guard-stays-stronger); live run 1 staged + 3 NCs green</td></tr>
+<tr><td>ship</td><td>2026-07-11T22:44:46Z</td><td>ran</td><td>full suite green 33+9+453+683; live run PASS; recheck dispatched</td></tr>
+</tbody></table>
+<p class="subline">tokens: <span class="empty">-</span> (no TOKENS line recorded)</p>
+<p class="subline">proof-of-done: <a href="docs/verification/loop-05-retro-cycle.md">docs/verification/loop-05-retro-cycle.md</a></p>
+</details>
+<details class="att-bad" open>
+<summary><h2 style="display:inline">[ ] 06-staging-drain</h2><span class="badge bad">MERGED-UNCHECKED</span></summary>
+<p class="subline">`learn drain` renders staging grouped + age-sorted + evidence-first; 30d rows move to `[expired]` (never deleted); promote/reject flow unchanged, `auto`, PR #241 (open, stacked on SG-04&#x27;s branch; merges after #239)</p>
+<p class="subline">PR #241 (MERGED) &middot; CI: passing, merged 2026-07-12T04:05:19Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/241">https://github.com/dwarvesf/dwarves-kit/pull/241</a> &middot; branch=`feat/loop-06-staging-drain`</p>
+<table>
+<thead><tr><th>Phase</th><th>When</th><th>State</th><th>Reason</th></tr></thead>
+<tbody>
+<tr><td>grill</td><td>2026-07-11T22:04:28Z</td><td>skipped</td><td>reason=home-turf: kit-adopted repo, dwarves-kit working on itself, harness-loop mega-goal sub-goal dispatch</td></tr>
+<tr><td>think</td><td>2026-07-11T22:04:28Z</td><td>skipped</td><td>obvious design per goal file (_meta/megagoals/harness-loop/goals/06-staging-drain.md: Design: obvious)</td></tr>
+<tr><td>design</td><td>2026-07-11T22:04:28Z</td><td>skipped</td><td>obvious design per goal file; render + a dated in-place relabel within one file, ADR-0034 decision 1 names the verb</td></tr>
+<tr><td>design-critique</td><td>2026-07-11T22:04:28Z</td><td>skipped</td><td>obvious design, no design block required</td></tr>
+<tr><td>design-record</td><td>2026-07-11T22:04:28Z</td><td>skipped</td><td>obvious design, no design block required</td></tr>
+<tr><td>spec</td><td>2026-07-11T22:18:37Z</td><td>ran</td><td>docs/specs/SPEC-196-staging-drain.md written, obvious-design lane per goal file</td></tr>
+<tr><td>validate</td><td>2026-07-11T22:18:37Z</td><td>skipped</td><td>reason=operator-wave: single-agent sub-goal dispatch, no interactive /kit:spec-validate run; lead reviews at PR per the mega&#x27;s stacked-PR contract</td></tr>
+<tr><td>test-plan</td><td>2026-07-11T22:18:37Z</td><td>ran</td><td>Test plan section in SPEC-196 (AC1-AC4 categories); tests/test-learn-drain.sh implements 23 assertions across 8 AC groups</td></tr>
+<tr><td>build</td><td>2026-07-11T22:18:37Z</td><td>ran</td><td>lib/learn/staging-format.py, lib/learn/drain.py, lib/learn/drain.sh, learn.sh drain case wired; 48/48 CI-listed suites + new test-learn-drain.sh green</td></tr>
+<tr><td>review</td><td>2026-07-11T22:18:37Z</td><td>skipped</td><td>reason=operator-wave: PR opened, held for lead review after SG-04 per the mega&#x27;s stacked-PR contract; never auto-merged</td></tr>
+<tr><td>docs</td><td>2026-07-11T22:18:37Z</td><td>ran</td><td>docs/implementation-notes/loop-06-staging-drain.md + docs/verification/loop-06-staging-drain.md committed</td></tr>
+</tbody></table>
+<p class="subline">tokens: <span class="empty">-</span> (no TOKENS line recorded)</p>
+<p class="subline">proof-of-done: <a href="docs/verification/loop-06-staging-drain.md">docs/verification/loop-06-staging-drain.md</a></p>
+</details>
+<details class="att-ok">
+<summary><h2 style="display:inline">[x] 07-mega-review-dashboard</h2><span class="badge ok">OK</span></summary>
+<p class="subline">`mega review --html &lt;slug&gt;` composes the shipped stats render formatters into one static sign-off page, wired at TIER-4 close, `auto`, PR #238, merged c2eb239 (2026-07-12; CI green both OS; proof docs/verification/loop-07-mega-dashboard.md + 3 screenshots docs/proof/loop-07-mega-dashboard/)</p>
+<p class="subline">PR #238 (MERGED) &middot; CI: passing, merged 2026-07-11T21:48:34Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/238">https://github.com/dwarvesf/dwarves-kit/pull/238</a> &middot; branch=`feat/loop-07-mega-dashboard`</p>
+<table>
+<thead><tr><th>Phase</th><th>When</th><th>State</th><th>Reason</th></tr></thead>
+<tbody>
+<tr><td>grill</td><td>2026-07-11T21:42:33Z</td><td>skipped</td><td>reason=home-turf: sub-goal file 07-mega-review-dashboard.md pre-resolves the compose scope, verb form, wiring point, and screenshot targets</td></tr>
+<tr><td>think</td><td>2026-07-11T21:42:33Z</td><td>skipped</td><td>sub-goal file&#x27;s Outcome section is the resolved think-lite output; the mega&#x27;s ROADMAP + DECISION-BRIEF WS-2 2b already settled the &#x27;compose already-shipped surfaces, no new lens&#x27; approach</td></tr>
+<tr><td>design</td><td>2026-07-11T21:42:33Z</td><td>ran</td><td>SPEC-197 Design section: data-source join diagram (ROADMAP+goal-files -&gt; mega.sh status shelled-out -&gt; rid -&gt; ledger via proof-table-gen.py parse_ledger import -&gt; gh pr view -&gt; render), 3 approaches considered, chosen approach + rationale</td></tr>
+<tr><td>design-critique</td><td>2026-07-11T21:42:33Z</td><td>skipped</td><td>solo delegate build; no UI/product surface (data-fidelity-critical not taste-critical); architecture lens covered by the post-build kit:code-reviewer dispatch</td></tr>
+<tr><td>spec</td><td>2026-07-11T21:42:33Z</td><td>ran</td><td>docs/specs/SPEC-197-mega-review-dashboard.md written: Problem, 3 approaches considered + chosen, Design (mermaid join diagram), Technical Design, Scope, Verification, After state, 8-item Decision Log</td></tr>
+<tr><td>validate</td><td>2026-07-11T21:42:33Z</td><td>skipped</td><td>solo delegate run inside a gated-final mega; the mega&#x27;s own TIER-4 close (integration-verifier + review-team + advisor over the assembled wave) supersedes a standalone spec-validate pass here, per ROADMAP Assumption 5</td></tr>
+<tr><td>design-record</td><td>2026-07-11T21:42:33Z</td><td>ran</td><td>co-located in SPEC-197&#x27;s Design section + Decision Log (8 DEC items); no separate ADR needed (additive composition, not a taxonomy/naming decision)</td></tr>
+<tr><td>test-plan</td><td>2026-07-11T21:42:33Z</td><td>ran</td><td>SPEC-197 Verification section + tests/test-mega-review.sh (26 checks: honest-empty NC, rid isolation, TOKENS summation, attention open/collapsed, footer honest-dash-vs-real-zero, OUTCOME-only honest-degrade) + tests/test-tier4-close.sh extension (4 checks: wiring NC both directions)</td></tr>
+<tr><td>build</td><td>2026-07-11T21:42:45Z</td><td>ran</td><td>lib/mega-review.py (new, compose engine); lib/mega.sh (+review verb, +--html/--out flags); lib/queue/orchestrate.sh (+16 lines, TIER-4 close wiring, best-effort/non-fatal); 3 screenshots rendered from REAL archived-mega ledger data (harness-ops, kit-modularity) via headless Playwright/Chromium</td></tr>
+<tr><td>review</td><td>2026-07-11T21:42:45Z</td><td>ran</td><td>escalated per SPEC-069 (touches lib/queue/orchestrate.sh, an enforcement surface): 2 parallel fresh-context subagent lenses -- kit:security-reviewer (PASS, 1 MINOR: slug path-traversal hardening, FIXED) and kit:code-reviewer architecture+test-coverage lens (PASS, 2 LOW: regex-coupling cross-pointer comment ADDED, dead _dash() helper REMOVED). Both findings closed before ship.</td></tr>
+<tr><td>docs</td><td>2026-07-11T21:42:45Z</td><td>ran</td><td>docs/specs/SPEC-197-mega-review-dashboard.md, docs/verification/loop-07-mega-dashboard.md (proof-of-done), docs/implementation-notes/loop-07-mega-dashboard.md (6 dated deviation/decision entries), lib/mega.sh usage comment block + 2 cross-pointer comments (DEC-001 gap, _label coupling)</td></tr>
+<tr><td>reflect</td><td>2026-07-11T21:42:45Z</td><td>ran</td><td>the two review findings (slug hardening, dead code) were both cheap-to-fix LOW/MINOR severity, closed in-loop rather than deferred; the local vs UTC date bug (caught by the test suite itself, not a reviewer) is the one finding worth carrying forward as a house lesson: always trace the ACTUAL writer&#x27;s date convention before assuming UTC</td></tr>
+<tr><td>think</td><td>2026-07-11T21:43:13Z</td><td>override</td><td>sub-goal file&#x27;s own Outcome section is the resolved think output (WS-2 2b of DECISION-BRIEF-harness-loop.md already settled compose-not-new-lens); a standalone think session would re-derive an already-settled call</td></tr>
+<tr><td>design-critique</td><td>2026-07-11T21:43:13Z</td><td>override</td><td>no UI/product surface to critique (data-fidelity composition, not a visual/product design); the post-build kit:code-reviewer dispatch&#x27;s architecture lens (PASS, see review gate) covers the same non-obvious-risk question a design-critique session would ask</td></tr>
+<tr><td>validate</td><td>2026-07-11T21:43:13Z</td><td>override</td><td>solo delegate run inside a gated-final mega whose own TIER-4 close runs integration-verifier + review-team + advisor over the ASSEMBLED wave (ROADMAP Assumption 5); a standalone spec-validate 6-lens pass here would duplicate that convergence gate ahead of when the wave is even assembled</td></tr>
+<tr><td>ship</td><td>2026-07-11T21:44:54Z</td><td>ran</td><td>PR #238 opened base=master head=feat/loop-07-mega-dashboard</td></tr>
+</tbody></table>
+<p class="subline">tokens: <span class="empty">-</span> (no TOKENS line recorded)</p>
+<p class="subline">proof-of-done: <a href="docs/verification/loop-07-mega-dashboard.md">docs/verification/loop-07-mega-dashboard.md</a></p>
+</details>
+<details class="att-bad" open>
+<summary><h2 style="display:inline">[ ] 08-config-surface</h2><span class="badge bad">MERGED-UNCHECKED</span></summary>
+<p class="subline">`bin/config list|get|explain` with provenance (env &gt; project &gt; kit-root &gt; default) + status tags + the checked-in env↔key registry + drift lint, `auto`, PR #240 (open, stacked on #236&#x27;s branch; merges after #236)</p>
+<p class="subline">PR #240 (MERGED) &middot; CI: passing, merged 2026-07-12T03:51:44Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/240">https://github.com/dwarvesf/dwarves-kit/pull/240</a> &middot; branch=`feat/loop-08-config-surface`</p>
+<table>
+<thead><tr><th>Phase</th><th>When</th><th>State</th><th>Reason</th></tr></thead>
+<tbody>
+<tr><td>think</td><td>2026-07-11T21:13:14Z</td><td>ran</td><td>ADR-0034 (accepted taxonomy decision) already pins the registry home (lib/config/module-registry.md), the front-door fence (bin/config read/explain, resolver untouched), and the module-leg table this sub-goal implements</td></tr>
+<tr><td>grill</td><td>2026-07-11T21:13:21Z</td><td>skipped</td><td>reason=operator-wave: mega-goal sub-goal dispatched with scope fully bearing from goals/08-config-surface.md + ADR-0034</td></tr>
+<tr><td>design</td><td>2026-07-11T21:41:31Z</td><td>ran</td><td>registry schema (module-legs + env&lt;-&gt;key superset + allowlist + known-gaps) authored in SPEC-198&#x27;s Design block, per goal instruction</td></tr>
+<tr><td>spec</td><td>2026-07-11T21:41:31Z</td><td>ran</td><td>docs/specs/SPEC-198-config-surface.md written</td></tr>
+<tr><td>design-record</td><td>2026-07-11T21:41:31Z</td><td>ran</td><td>SPEC-198 Design block is the design record; ADR-0034 decisions 3/4 are the upstream design authority this sub-goal implements against</td></tr>
+<tr><td>test-plan</td><td>2026-07-11T21:41:32Z</td><td>ran</td><td>5 ACs derived from goal&#x27;s Done= line before/during build: drift-lint-green, drift-lint-NC, module-leg-completeness, completeness-NC, bin/config functional smoke incl. provenance fixture</td></tr>
+<tr><td>build</td><td>2026-07-11T21:41:32Z</td><td>ran</td><td>lib/config/module-registry.md, lib/config/config.sh, bin/config, tests/lib/contract-lint.sh (manifest_diff_flat added), tests/test-config-registry.sh, .github/workflows/test.yml wiring</td></tr>
+<tr><td>review</td><td>2026-07-11T21:53:21Z</td><td>ran</td><td>fresh-context multi-lens review: 5 hard fences verified, 7 registry rows spot-checked accurate, 2 MAJOR + 2 MINOR found and fixed (machine-dirty get output, set-but-empty env win, allowlist header leak, silent missing-registry success); suite 14-&gt;19 assertions, regression green</td></tr>
+<tr><td>design-critique</td><td>2026-07-11T21:53:21Z</td><td>skipped</td><td>reason=covered-by-review: the bearing design (registry schema) was critiqued in the same fresh-context review pass that attacked the implementation; no separate critique session in an autonomous run</td></tr>
+<tr><td>validate</td><td>2026-07-11T21:53:21Z</td><td>skipped</td><td>ADR-0034 (already operator-reviewed, decisions 3+4) pins this spec&#x27;s design; adversarial validation ran as the post-build fresh-context review instead</td></tr>
+<tr><td>docs</td><td>2026-07-11T21:53:21Z</td><td>ran</td><td>SPEC-198 + proof-of-done + implementation-notes written and updated post-review; no other doc claims affected (README/MANUAL inventory untouched by a new bin entry is SG-04&#x27;s consolidation territory)</td></tr>
+<tr><td>design-critique</td><td>2026-07-11T21:54:27Z</td><td>override</td><td>autonomous stacked-PR sub-goal: the bearing design&#x27;s critique ran inside the fresh-context multi-lens review pass (2 MAJOR + 2 MINOR found and fixed), not as a separate interactive /kit:design session</td></tr>
+<tr><td>validate</td><td>2026-07-11T21:54:27Z</td><td>override</td><td>spec design is pinned by operator-reviewed ADR-0034 decisions 3+4; adversarial validation ran post-build as the fresh-context review against implementation AND spec rather than a pre-build /kit:spec-validate</td></tr>
+<tr><td>ship</td><td>2026-07-11T21:54:59Z</td><td>ran</td><td>3 feature commits + 1 review-fix commit; push + stacked PR (base docs/loop-01-taxonomy) opened by this run, merge withheld per stacked-PR contract</td></tr>
+<tr><td>reflect</td><td>2026-07-11T21:54:59Z</td><td>ran</td><td>retro: (1) the drift lint caught 4 real gaps in its own PR&#x27;s authoring, the structural fix works; (2) first-draft get output leaked human markdown into the scripting contract, caught only by fresh-context review, keep the review round; (3) seed-regex prefix families undercount real env vars (~18 outside the family), noted as known-gaps for a future structural lint</td></tr>
+</tbody></table>
+<p class="subline">tokens: <span class="empty">-</span> (no TOKENS line recorded)</p>
+<p class="subline">proof-of-done: <a href="docs/verification/loop-08-config-surface.md">docs/verification/loop-08-config-surface.md</a></p>
+</details>
+<details class="att-ok">
+<summary><h2 style="display:inline">[x] 09-onboard-wizard</h2><span class="badge ok">OK</span></summary>
+<p class="subline">`/kit:onboard` interactive first-run orchestrator (detect install mode, offer adopt, module picker, consumer-knob capture, plugin-gap disclosure, welcome tour), `gate`, PR #242 (open + HELD for Han, stacked on SG-08&#x27;s branch; gate Done = PR open, the gate click is Han&#x27;s)</p>
+<p class="subline">PR #242 (MERGED) &middot; CI: passing, merged 2026-07-12T04:40:32Z &middot; <a href="https://github.com/dwarvesf/dwarves-kit/pull/242">https://github.com/dwarvesf/dwarves-kit/pull/242</a> &middot; branch=`feat/loop-09-onboard-wizard`</p>
+<table>
+<thead><tr><th>Phase</th><th>When</th><th>State</th><th>Reason</th></tr></thead>
+<tbody>
+<tr><td>think</td><td>2026-07-11T22:07:53Z</td><td>skipped</td><td>think done at mega level; ADR-0034 harness-loop taxonomy decision 4 is the design record for the onboard fence</td></tr>
+<tr><td>design</td><td>2026-07-11T22:07:54Z</td><td>ran</td><td>flow state diagram + fence table in SPEC-199 Design block</td></tr>
+<tr><td>ui-design</td><td>2026-07-11T22:07:54Z</td><td>skipped</td><td>no UI surface; onboard is a terminal-interactive command</td></tr>
+<tr><td>spec</td><td>2026-07-11T22:07:54Z</td><td>ran</td><td>SPEC-199 drafted: onboard orchestrator, detection helper, flow state diagram</td></tr>
+<tr><td>grill</td><td>2026-07-11T22:08:16Z</td><td>skipped</td><td>reason=operator-wave: sub-goal from harness-loop mega decomposition; banks in goal file + ADR-0034</td></tr>
+<tr><td>design-critique</td><td>2026-07-11T22:18:23Z</td><td>ran</td><td>spec-validate reviewer 5 (solution-design/extensibility): orchestrator-only, fences honored, no reimplementation</td></tr>
+<tr><td>validate</td><td>2026-07-11T22:18:23Z</td><td>ran</td><td>NEEDS REVISION -&gt; revised: 1 critical (adopt-sequencing) + 4 warnings applied; reviewer 6 PASS; VALIDATED</td></tr>
+<tr><td>design-record</td><td>2026-07-11T22:18:23Z</td><td>ran</td><td>design-bearing=yes; Design block has state diagram + fence table + chosen approach (reviewer 6 PASS)</td></tr>
+<tr><td>test-plan</td><td>2026-07-11T22:18:23Z</td><td>ran</td><td>detector AC1-9 + 3 transcript scenarios + decline-NC + rung-3 recheck + advisor P5 (SPEC-199 Verification)</td></tr>
+<tr><td>build</td><td>2026-07-11T22:30:35Z</td><td>ran</td><td>commands/onboard.md + lib/onboard-detect.sh + tests (detector AC1-9, scenario-b re-execution harness) + doc/count syncs</td></tr>
+<tr><td>review</td><td>2026-07-11T22:39:44Z</td><td>ran</td><td>multi-lens (SPEC-069, lib/ touched): security SHIP; architecture 2 CRITICAL (leg promise, AC9) both fixed; advisor P5 1 CRITICAL (plugin dead-hook disclosure) + 1 MAJOR (stats knob honesty) both applied; rung-3 recheck round-1 FAIL caught AC9, round-2 re-run green</td></tr>
+<tr><td>docs</td><td>2026-07-11T22:39:44Z</td><td>ran</td><td>SPEC-199 decision log, verification summary (14-row run table + 4 verdicts), 3 transcripts + decline-NC, MANUAL/README/architecture/WORKFLOW syncs, impl notes</td></tr>
+<tr><td>ship</td><td>2026-07-11T22:39:44Z</td><td>ran</td><td>4 commits; push + stacked PR (base feat/loop-08-config-surface) opened by this run; GATE sub-goal: PR held for Han&#x27;s UX review, never merged</td></tr>
+<tr><td>reflect</td><td>2026-07-11T22:39:44Z</td><td>ran</td><td>retro: (1) rung-3 recheck earned its cost, round-1 caught a real AC9 regression a self-review missed; (2) capture-first transcripts surfaced two real adjacent defects (adopt.sh stale module set, dead hook paths on plugin machines) that reading code did not; (3) promising registry data through a surface that cannot emit it (the leg column) is a spec-time drift class worth a lint someday</td></tr>
+</tbody></table>
+<p class="subline">tokens: <span class="empty">-</span> (no TOKENS line recorded)</p>
+<p class="subline">proof-of-done: <a href="docs/verification/generated/loop-09-onboard-wizard.md">docs/verification/generated/loop-09-onboard-wizard.md</a></p>
+</details>
+<details class="att-pending" open>
+<summary><h2 style="display:inline">[ ] 10-front-door-truth</h2><span class="badge pending">PENDING</span></summary>
+<p class="subline">README reorganized around the five legs + tables truth-matched (agents 25, skills per ADR §8) + weekly digest folded into session-intel + the ONE kit scheduler (single weekly LaunchAgent + declarative jobs list; per-job plists retire), `auto` (held as final PR under gated-final), PR #</p>
+<p class="subline">branch=`docs/loop-10-front-door`</p>
+<p class="empty">(no ledger rows for this sub-goal)</p>
+<p class="subline">proof-of-done: <span class="empty">(unlinked -- best-effort search found no file; check RUN_REPORT.md)</span></p>
+</details><footer><div>staged candidates: 4</div><div>learned-ledger queued: -</div><div>unpaid debt (7d window): 1</div></footer></body></html>

--- a/commands/mega.md
+++ b/commands/mega.md
@@ -315,10 +315,17 @@ already reads it -- see `agents/advisor.md` "Ledger visibility" for the one shar
 both dispatch sites follow.
 
 **Close the run visibly (mirrors the skill's close).** When the loop finishes (or
-halts at a `gate!`), emit `<dir>/RUN_REPORT.md` -- ASCII gantt + per-sub-goal gate
-matrix + the callable stack, markdown-only -- and render the timeline + totals in
-chat. The report reads from the rid ledger (`lib/gate/gate-ledger.sh`) and the roadmap
-checkboxes, never from transcripts.
+halts at a `gate!`), emit `<dir>/RUN_REPORT.md` with the three REQUIRED telemetry
+blocks -- worker-minutes-by-model, the per-sub-goal gate-coverage matrix
+(`●` recorded-ran · `○` skipped/override-with-reason · `-` n/a), and the callable
+stack -- then the prose (Outcome table, Incidents & lessons, Evidence, Close-out),
+and render the totals in chat. **Generate the mechanical blocks, never hand-build
+them**: `bin/mega report <slug>` renders the header, the gate matrix, any ledgered
+token totals, and the callable-stack skeleton straight from the rid ledgers +
+ROADMAP (read-only; `--out` to write; `--rid-map` when a branch slug defies the
+token match). The conductor fills only the [FILL] stubs (run mode, wave grouping,
+worker models, incidents) -- the parts only it knows. The report reads from the rid
+ledger and the roadmap checkboxes, never from transcripts.
 
 ## Consolidate mode (remega, mirrors the skill's mode)
 

--- a/docs/verification/mega-report.md
+++ b/docs/verification/mega-report.md
@@ -1,0 +1,39 @@
+# Proof of done , `mega report` (the RUN_REPORT telemetry generator)
+
+## Why (the fold-in gap)
+
+`/kit:mega` and the mega-goal skill both required a telemetry close ("gate matrix +
+callable stack, read from the rid ledger"), but no code could render it , the
+presentation lived as conductor habit from the pre-fold era and died in the migration
+(harness-loop's matrix was rebuilt with throwaway python by hand, Han flagged it
+2026-07-12). `mega report <slug>` makes the close mechanical.
+
+## Confirmation run-table
+
+| Check | Command | Exit: | Result |
+|---|---|---|---|
+| Hermetic suite (15 checks) | `bash tests/test-mega-report.sh` | Exit: 0 | PASS 15/15 |
+| Live dogfood on the real mega | `bin/mega report harness-loop` | Exit: 0 | PASS , matrix matches the hand-built RUN_REPORT for every rid-backed row |
+| Existing verbs unregressed | `bash tests/test-mega.sh` + `bash tests/test-mega-review.sh` | Exit: 0 | PASS both |
+
+## NEGATIVE CONTROL
+
+1. **Rid-less sub-goal renders honest dashes, never a guess**: fixture sub-goal 02 has no
+   ledger; its row carries zero `●` cells and the literal `(no rid ledger matched)` flag.
+2. **A body SPEC cross-ref is NOT attributed**: the fixture goal file carries `SPEC-123`
+   on its `**Proof:**` line and `SPEC-999` in the body; the row shows 123, and a grep for
+   999 in the row fails (this is the exact misattribution the live ROADMAP produced:
+   SG-05 briefly showed SPEC-188 from "the SPEC-188 lint amended").
+3. **Unknown ledger gate cannot silently vanish**: the planted `mystery-gate` row lands in
+   an explicit `extra ledger gates` note, not in any column.
+4. **Read-only over sources**: the fixture ledger's shasum is byte-identical after two
+   generator runs (one with `--out`).
+
+## Reproduce
+
+```bash
+bash tests/test-mega-report.sh
+bin/mega report harness-loop   # live render against the real ledgers
+```
+
+Verdict: PASS

--- a/lib/config/module-registry.md
+++ b/lib/config/module-registry.md
@@ -209,6 +209,7 @@ prefix match. The drift lint (`tests/test-config-registry.sh`) treats a hit
 against any of these bare tokens as covered without a registry row.
 
 | Token | Why excluded |
+| KIT_LOG_DIR | the RESOLVED ledger root, exported by `lib/telemetry/kit-log-dir.sh` for child tools (`mega review`/`mega report` read it); operators configure `KIT_LEDGER_DIR` / `[ledger].location`, never this |
 |---|---|
 | BACKLOG_DIR | `lib/board/backlog.sh`: computed via `pwd`, script-local. |
 | BACKLOG_SH | `lib/board/board.sh`: computed path, not env-overridable. |

--- a/lib/mega-report.py
+++ b/lib/mega-report.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""mega-report.py -- the python half of `mega report <slug>` (the RUN_REPORT generator).
+
+Renders the telemetry skeleton of a mega-goal's RUN_REPORT.md from the two mechanical
+sources -- the rid ledgers (gate-ledger rows under $KIT_LOG_DIR/runs/) and the mega's
+ROADMAP.md -- and emits labeled STUBS for the sections only the conductor knows
+(worker minutes, callable stack, incidents). Markdown to stdout; --out writes a file.
+
+Why this exists (the fold-in gap, Han 2026-07-12): /kit:mega and the mega-goal skill
+both required a telemetry close ("gate matrix + callable stack, read from the rid
+ledger"), but no code could RENDER it -- the presentation lived as conductor habit from
+the pre-fold era and died in the migration; harness-loop's matrix got rebuilt by hand.
+This makes the close mechanical: the same three blocks, every run, from the ledger.
+
+Read-only over every source. The ONLY write is --out, and only when passed.
+
+Rid resolution per sub-goal: the ledger rid is the branch slug (SPEC-070), which the
+ROADMAP does not carry, so we match runs/<rid>.log by token: the rid must contain the
+sub-goal's name tokens (the NN- prefix stripped). Ambiguity -> the longest-name match;
+none -> an honest all-"-" row (never a guess). --rid-map "SG=rid,SG=rid" overrides.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# Column order mirrors the WORKFLOW lane x phase matrix; "validate" is the ledger's
+# short name for spec-validate (both appear in live corpora, fold them together).
+GATES = [
+    ("gr", ["grill"]),
+    ("th", ["think"]),
+    ("de", ["design"]),
+    ("dc", ["design-critique"]),
+    ("sp", ["spec"]),
+    ("sv", ["spec-validate", "validate"]),
+    ("dr", ["design-record"]),
+    ("tp", ["test-plan"]),
+    ("bu", ["build"]),
+    ("re", ["review"]),
+    ("do", ["docs"]),
+    ("sh", ["ship"]),
+    ("rf", ["reflect"]),
+]
+KNOWN = {name for _, names in GATES for name in names}
+LEGEND = ("gr grill · th think · de design · dc design-critique · sp spec · "
+          "sv spec-validate · dr design-record · tp test-plan · bu build · "
+          "re review · do docs · sh ship · rf reflect")
+
+SUBGOAL_RE = re.compile(r"^- \[(x| )\] (\d+[A-Za-z]?)-([a-z0-9-]+)")
+PR_RE = re.compile(r"PR #(\d+)")
+SHA_RE = re.compile(r"merged ([0-9a-f]{7,40})")
+SPEC_RE = re.compile(r"SPEC-(\d+)")
+TOKENS_RE = re.compile(r"in=(\d+) out=(\d+)")
+
+
+def parse_roadmap(path):
+    subgoals = []
+    for line in open(path, encoding="utf-8"):
+        m = SUBGOAL_RE.match(line)
+        if not m:
+            continue
+        checked, num, name = m.group(1) == "x", m.group(2), m.group(3)
+        pr = PR_RE.search(line)
+        sha = SHA_RE.search(line)
+        subgoals.append({
+            "num": num, "name": name, "checked": checked,
+            "pr": pr.group(1) if pr else None,
+            "sha": sha.group(1)[:7] if sha else None,
+            "spec": None,  # resolved from the goal file, ROADMAP prose is unreliable
+            "tag": "gate" if "`gate`" in line else ("auto" if "`auto`" in line else "?"),
+            "gate": "`gate`" in line,
+            "line": line.rstrip(),
+        })
+    return subgoals
+
+
+def resolve_spec(sg, mega_dir):
+    """SPEC-ref from the goal file's own **Proof:** line ONLY. Anywhere else (ROADMAP
+    prose, goal-file body) names OTHER specs ('the SPEC-188 lint amended', a SPEC-097
+    cross-ref) and misattributes; a spec-less sub-goal honestly renders '-'."""
+    import glob as _g
+    for gf in _g.glob(os.path.join(mega_dir, "goals", sg["num"] + "-*.md")):
+        for line in open(gf, encoding="utf-8"):
+            if line.startswith("**Proof:**"):
+                m = SPEC_RE.search(line)
+                return m.group(1) if m else None
+    return None
+
+
+def resolve_rid(sg, rids, rid_map, log_dir=""):
+    key = f"{sg['num']}-{sg['name']}"
+    if key in rid_map:
+        return rid_map[key]
+    # token match: every hyphen token of the name must appear in the rid; prefer the
+    # rid sharing the most tokens, then the shortest (least extra baggage).
+    tokens = sg["name"].split("-")
+    num_tag = sg["num"] + "-"
+    scored = []
+    for rid in rids:
+        hits = sum(1 for t in tokens if t in rid)
+        if not hits:
+            continue
+        bonus = 2 if num_tag in rid else 0
+        scored.append((hits + bonus, -len(rid), rid, hits))
+    if not scored:
+        return None
+    scored.sort(reverse=True)
+    top_score = scored[0][0]
+    tied = [t for t in scored if t[0] == top_score]
+    if len(tied) > 1 and log_dir:
+        # tie-break by richest ledger: the rid with the most GATE rows is the run of
+        # record (a stray same-name branch, e.g. an operator reconcile rid, has few/none)
+        def gate_rows(rid):
+            led = parse_ledger(log_dir, rid)
+            return len(led["gates"]) if led else -1
+        tied.sort(key=lambda t: gate_rows(t[2]), reverse=True)
+        best, hits = tied[0][2], tied[0][3]
+    else:
+        best, hits = scored[0][2], scored[0][3]
+    # require at least half the NAME tokens to hit, else honest-miss
+    return best if hits * 2 >= len(tokens) else None
+
+
+def parse_ledger(log_dir, rid):
+    rows, tok_in, tok_out = {}, 0, 0
+    path = os.path.join(log_dir, "runs", rid + ".log")
+    if not os.path.isfile(path):
+        return None
+    for line in open(path, encoding="utf-8", errors="replace"):
+        parts = [c.strip() for c in line.split("|")]
+        if len(parts) >= 5 and parts[1] == "GATE":
+            rows[parts[2]] = parts[3]  # last write wins (append-only, last is current)
+        elif len(parts) >= 3 and parts[1] == "TOKENS":
+            m = TOKENS_RE.search(line)
+            if m:
+                tok_in += int(m.group(1)); tok_out += int(m.group(2))
+    return {"gates": rows, "tok_in": tok_in, "tok_out": tok_out}
+
+
+def cell(rows, names):
+    for n in names:
+        v = rows.get(n)
+        if v == "ran":
+            return "●"
+        if v in ("skipped", "override"):
+            return "○"
+    return "-"
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="mega report")
+    ap.add_argument("slug")
+    ap.add_argument("--megagoals-root", required=True)
+    ap.add_argument("--log-dir", default=os.environ.get("KIT_LOG_DIR", ""))
+    ap.add_argument("--rid-map", default="", help="NN-name=rid,... overrides")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    mega_dir = os.path.join(args.megagoals_root, args.slug)
+    roadmap = os.path.join(mega_dir, "ROADMAP.md")
+    if not os.path.isfile(roadmap):
+        sys.stderr.write(f"mega report: no ROADMAP.md at {roadmap}\n")
+        return 1
+    if not args.log_dir:
+        sys.stderr.write("mega report: KIT_LOG_DIR unresolved (pass --log-dir)\n")
+        return 1
+
+    rid_map = dict(kv.split("=", 1) for kv in args.rid_map.split(",") if "=" in kv)
+    runs_dir = os.path.join(args.log_dir, "runs")
+    rids = [f[:-4] for f in os.listdir(runs_dir)] if os.path.isdir(runs_dir) else []
+
+    subgoals = parse_roadmap(roadmap)
+    if not subgoals:
+        sys.stderr.write("mega report: no sub-goal lines parsed from ROADMAP.md\n")
+        return 1
+
+    built = sum(1 for s in subgoals if s["checked"])
+    merged = sum(1 for s in subgoals if s["sha"])
+    held = [s for s in subgoals if s["pr"] and not s["sha"]]
+    held_note = f" · #{held[-1]['pr']} final open + held" if held else ""
+
+    out = []
+    out.append(f"`RUN_REPORT , {args.slug} ({built}/{len(subgoals)} built · {merged} merged{held_note})`")
+    out.append("")
+    out.append("### Worker minutes by model")
+    out.append("")
+    out.append("```")
+    out.append("<model> |<bar>| ~Nm (N%)  <runs> , <what ran there>   [FILL: conductor knowledge;")
+    out.append("token totals below come from the ledger where TOKENS rows exist, honest-dash otherwise]")
+
+    tok_lines = []
+    for sg in subgoals:
+        rid = resolve_rid(sg, rids, rid_map, args.log_dir)
+        led = parse_ledger(args.log_dir, rid) if rid else None
+        sg["rid"], sg["led"] = rid, led
+        if led and (led["tok_in"] or led["tok_out"]):
+            tok_lines.append(f"{sg['num']}-{sg['name']}: in={led['tok_in']} out={led['tok_out']} (rid {rid})")
+    out.extend(tok_lines if tok_lines else ["ledgered tokens: , (no TOKENS rows in any matched rid)"])
+    out.append("```")
+    out.append("")
+    out.append("### Gate coverage (● recorded-ran · ○ skipped/override-with-reason · - n/a), from each rid's gate-ledger rows")
+    out.append("")
+    out.append("```")
+    header = " " * 20 + " ".join(ab for ab, _ in GATES) + "   tag   SPEC"
+    out.append(header)
+    extras = []
+    for sg in subgoals:
+        led = sg["led"]
+        if led is None:
+            cells = "  ".join("-" for _ in GATES)
+            note = "(no rid ledger matched)" if sg["rid"] is None else f"(rid {sg['rid']}: no log)"
+        else:
+            cells = "  ".join(cell(led["gates"], names) for _, names in GATES)
+            unknown = sorted(set(led["gates"]) - KNOWN)
+            note = ""
+            if unknown:
+                extras.append(f"{sg['num']}-{sg['name']}: extra ledger gates {unknown}")
+        label = f"{sg['num']} {sg['name']}"[:19]
+        tag = sg["tag"].ljust(5)
+        spec = resolve_spec(sg, mega_dir) or "-"
+        flag = "  (GATE)" if sg["gate"] else ""
+        out.append(f"{label:<20}{cells}   {tag} {spec}{flag} {note}".rstrip())
+    out.append("```")
+    out.append(LEGEND + ".")
+    for e in extras:
+        out.append(f"note: {e}")
+    out.append("[FILL: one line , did any gate REQUIREMENT change anywhere? it should read \"none\".]")
+    out.append("")
+    out.append("### Callable stack")
+    out.append("")
+    out.append("```")
+    out.append("[FILL: conductor tree , run mode line (subagent-delegate / claude -p / inline),")
+    out.append("one node per wave, one child per worker. Mechanical skeleton from the ROADMAP:]")
+    for sg in subgoals:
+        pr = f"#{sg['pr']}" if sg["pr"] else "PR ,"
+        sha = f"merged {sg['sha']}" if sg["sha"] else ("open + held" if sg["pr"] else ",")
+        out.append(f"├─ {sg['num']} {sg['name']:<22} <model>  {pr:<6} {sha}")
+    out.append("```")
+    out.append("")
+    out.append("### Incidents & lessons")
+    out.append("")
+    out.append("[FILL from NOTES.md ## Event log + ## Active blockers: only what the harness")
+    out.append("actually caught, numbered, each ending in the lesson baked forward.]")
+    out.append("")
+
+    text = "\n".join(out) + "\n"
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        print(f"mega report: wrote {args.out}")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/mega.sh
+++ b/lib/mega.sh
@@ -4,6 +4,10 @@
 # own prose. Bash + `gh` only -- no DuckDB (a keyed diff over a handful of sub-goals, not
 # analytics; DuckDB stays the `stats` exception per the kit-modularity event-sourcing invariant).
 #
+# Verbs: `status` (roadmap-vs-git reconcile) · `review --html` (the sign-off dashboard) ·
+# `report` (the RUN_REPORT telemetry generator: header + gate matrix + callable-stack
+# skeleton from the rid ledgers; --out, --rid-map).
+#
 # ORPHAN, not a subsystem dir (SG-03's "2+-verb subsystems get a grouped `lib/<x>/<x>.sh`
 # case-dispatcher" rule): `mega` gained a second verb (`review`, SPEC-197 / harness-loop SG-07)
 # but STAYS a bare orphan file here deliberately -- the directory-promotion (`lib/mega/mega.sh` +
@@ -109,15 +113,16 @@ GIT_BIN="${GIT_BIN:-git}"
 _default_repo_root() { "$GIT_BIN" rev-parse --show-toplevel 2>/dev/null || pwd; }
 
 OPT_MEGAGOALS_ROOT=""; OPT_CODE_ROOT=""; OPT_BASE=""; OPT_ROLLUP_ONLY=0
-OPT_HTML=0; OPT_OUT=""
+OPT_HTML=0; OPT_OUT=""; OPT_RID_MAP=""
 POSITIONAL=()
 _parse_flags() {
   OPT_MEGAGOALS_ROOT=""; OPT_CODE_ROOT=""; OPT_BASE=""; OPT_ROLLUP_ONLY=0
-  OPT_HTML=0; OPT_OUT=""
+  OPT_HTML=0; OPT_OUT=""; OPT_RID_MAP=""
   POSITIONAL=()
   while [ $# -gt 0 ]; do
     case "$1" in
       --megagoals-root) OPT_MEGAGOALS_ROOT="${2:-}"; shift 2 ;;
+      --rid-map)        OPT_RID_MAP="${2:-}"; shift 2 ;;
       --code-root)      OPT_CODE_ROOT="${2:-}"; shift 2 ;;
       --base)           OPT_BASE="${2:-}"; shift 2 ;;
       --rollup-only)    OPT_ROLLUP_ONLY=1; shift ;;
@@ -337,6 +342,29 @@ cmd_review() {
   python3 "$self_dir/mega-review.py" "${py_args[@]}"
 }
 
+# cmd_report: the bash launcher half of `mega report <slug>` -- the RUN_REPORT telemetry
+# generator. Fold-in gap fix (Han 2026-07-12): the close contract required a gate matrix +
+# callable stack "read from the rid ledger", but no code could render them; the presentation
+# lived as conductor habit from the pre-fold era and died in the migration (harness-loop's
+# matrix got rebuilt by hand). Same delegation shape as cmd_review: resolve KIT_LOG_DIR via
+# the ONE resolver, exec the sibling .py. Read-only; --out is the only write, when passed.
+cmd_report() {
+  _parse_flags "$@"
+  local slug="${POSITIONAL[0]:-}"
+  [ -n "$slug" ] || { echo "mega report: a <slug> is required" >&2; return 64; }
+
+  local mroot; mroot="$(_resolve_megagoals_root)"
+  local self_dir; self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck source=lib/telemetry/kit-log-dir.sh
+  source "$self_dir/telemetry/kit-log-dir.sh" || { echo "mega report: lib/telemetry/kit-log-dir.sh missing or unreadable" >&2; return 1; }
+  local log_dir; log_dir="$(kit_resolve_log_dir)" || return 1
+
+  local -a py_args=("$slug" --megagoals-root "$mroot" --log-dir "$log_dir")
+  [ -n "$OPT_OUT" ] && py_args+=(--out "$OPT_OUT")
+  [ -n "$OPT_RID_MAP" ] && py_args+=(--rid-map "$OPT_RID_MAP")
+  python3 "$self_dir/mega-report.py" "${py_args[@]}"
+}
+
 usage() { sed -n '2,102p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 main() {
@@ -344,6 +372,7 @@ main() {
   case "$first" in
     status) shift; cmd_status "$@" ;;
     review) shift; cmd_review "$@" ;;
+    report) shift; cmd_report "$@" ;;
     -h|--help|help|"") usage ;;
     *) echo "mega.sh: unknown subcommand '$first'" >&2; usage >&2; return 64 ;;
   esac

--- a/tests/test-mega-report.sh
+++ b/tests/test-mega-report.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# test-mega-report.sh -- `mega report <slug>` (the RUN_REPORT telemetry generator).
+# Hermetic: a temp megagoals root + a temp KIT_LOG_DIR; never touches the live ledgers.
+# Proves: header counts, matrix cell vocabulary (ran/skip/absent), the honest all-dash
+# row for a rid-less sub-goal (NC), Proof-line-only SPEC resolution (NC: a body cross-ref
+# is NOT attributed), the extra-gate note, --out, and read-only-over-sources.
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0; FAIL=0
+ok()  { echo "  ok: $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL: $1" >&2; FAIL=$((FAIL+1)); }
+assert_grep()   { if grep -qF "$2" <<<"$3"; then ok "$1"; else bad "$1 (missing: $2)"; fi; }
+assert_nogrep() { if grep -qF "$2" <<<"$3"; then bad "$1 (unexpected: $2)"; else ok "$1"; fi; }
+
+TD="$(mktemp -d)"
+MROOT="$TD/megagoals"; LOGS="$TD/logs"
+mkdir -p "$MROOT/demo/goals" "$LOGS/runs"
+
+cat > "$MROOT/demo/ROADMAP.md" <<'EOF'
+# Mega-goal: demo
+## Sub-goals
+- [x] 01-alpha-widget, builds the widget, `auto`, PR #10 merged abc1234 (green)
+- [ ] 02-beta-nothing, never started, `gate`, PR #
+EOF
+
+cat > "$MROOT/demo/goals/01-alpha-widget.md" <<'EOF'
+# Sub-goal 01: alpha-widget
+**Proof:** run-table (SPEC-123): fixture green. Body cross-ref below must NOT win.
+See also SPEC-999 (a dependency, not this sub-goal's spec).
+EOF
+
+cat > "$LOGS/runs/feat-01-alpha-widget.log" <<'EOF'
+2026-07-12T01:00:00Z | START | lane=normal classified=normal type=spec-feature repo=demo
+2026-07-12T01:01:00Z | GATE | spec | ran | fixture
+2026-07-12T01:02:00Z | GATE | build | ran | fixture
+2026-07-12T01:03:00Z | GATE | grill | skipped | home-turf
+2026-07-12T01:04:00Z | GATE | mystery-gate | ran | not-in-vocabulary
+2026-07-12T01:05:00Z | TOKENS | in=100 out=200
+EOF
+LEDGER_BEFORE="$(shasum "$LOGS/runs/feat-01-alpha-widget.log")"
+
+OUT="$(python3 "$KIT_DIR/lib/mega-report.py" demo --megagoals-root "$MROOT" --log-dir "$LOGS" 2>&1)"; RC=$?
+
+echo "== header + matrix from a real fixture ledger =="
+[ $RC -eq 0 ] && ok "exit 0" || bad "exit $RC"
+assert_grep "header counts 1/2 built · 1 merged" "(1/2 built · 1 merged)" "$OUT"
+ROW01="$(grep '^01 ' <<<"$OUT")"
+assert_grep "ran gates render ●" "●" "$ROW01"
+assert_grep "skipped gate renders ○" "○" "$ROW01"
+assert_grep "auto/gate tag column present" "auto" "$ROW01"
+assert_grep "SPEC comes from the Proof line" "123" "$ROW01"
+assert_nogrep "NC: a body SPEC cross-ref is NOT attributed" "999" "$ROW01"
+assert_grep "unknown ledger gate lands in the extras note" "mystery-gate" "$OUT"
+assert_grep "TOKENS rows surface in the worker-minutes block" "in=100 out=200" "$OUT"
+
+echo "== NC: a sub-goal with no rid renders honest dashes, never a guess =="
+ROW02="$(grep '^02 ' <<<"$OUT")"
+assert_grep "rid-less row is flagged" "(no rid ledger matched)" "$ROW02"
+assert_nogrep "rid-less row has zero ● cells" "●" "$ROW02"
+
+echo "== --out + read-only contract =="
+python3 "$KIT_DIR/lib/mega-report.py" demo --megagoals-root "$MROOT" --log-dir "$LOGS" --out "$TD/r.md" >/dev/null 2>&1
+[ -s "$TD/r.md" ] && ok "--out writes the report file" || bad "--out produced nothing"
+[ "$(shasum "$LOGS/runs/feat-01-alpha-widget.log")" = "$LEDGER_BEFORE" ] \
+  && ok "source ledger byte-identical after both runs (read-only)" \
+  || bad "source ledger MUTATED"
+
+echo "== launcher: bin/mega report dispatches =="
+USAGE_OUT="$(bash "$KIT_DIR/bin/mega" report 2>&1)"; URC=$?
+[ $URC -ne 0 ] && ok "report without a slug refuses (exit $URC)" || bad "slug-less report exited 0"
+assert_grep "refusal names the requirement" "a <slug> is required" "$USAGE_OUT"
+
+echo
+echo "TOTAL: $((PASS+FAIL))   PASS: $PASS   FAIL: $FAIL"
+[ $FAIL -eq 0 ]


### PR DESCRIPTION
## Outcome

Closes the fold-in gap Han diagnosed: the migration moved mega execution into the kit, but the close-of-workflow presentation (gate matrix + callable stack + worker minutes) never became kit CODE, it lived as conductor habit and died in the move (harness-loop's matrix was hand-built with throwaway python).

`bin/mega report <slug>` renders the RUN_REPORT telemetry mechanically from the rid ledgers + ROADMAP, read-only. The conductor fills only labeled [FILL] stubs (run mode, waves, models, incidents), the parts only it knows.

## Verify

| Check | Result |
|---|---|
| `bash tests/test-mega-report.sh` | 15/15 (4 negative controls: rid-less = honest dashes; body SPEC cross-ref not attributed; unknown gate surfaces in a note; sources byte-identical) |
| `bin/mega report harness-loop` (live dogfood) | matrix matches the hand-built RUN_REPORT for every rid-backed row |
| `test-mega.sh` + `test-mega-review.sh` | green, verbs unregressed |

Proof: `docs/verification/mega-report.md`. Companion: dotfiles #214 (skill-side telemetry contract) — this is the kit-side half; `commands/mega.md`'s close paragraph now points at the generator, keeping the never-diverge mirror honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)