### PR TITLE
feat(session): session-audit, LLM deep-audit verb with chained metric-diff reports

### DIFF
--- a/docs/verification/implementation-notes/session-audit.md
+++ b/docs/verification/implementation-notes/session-audit.md
@@ -2,6 +2,28 @@
 
 Delta from `lib/session/audit/SPEC.md`; decisions the spec did not pin down.
 
+## 2026-07-14 17:10 Triage speaks the staging currency, not a bespoke row
+
+Context: the first triage cut printed its own kanban row shape
+(`| ?? | change | ... | queued |`) to stdout. A full-repo ETL inventory (19
+pipelines) showed the kit already has ONE proposal currency: `## [staged]`
+blocks in `_meta/backlog-staging.md`, rendered by `lib/learn/staging-format.py`
+and used by BOTH `learn propose` and `stats anomalies --propose`, with
+`board promote` as the human gate (ADR-0034 decision 1).
+Decision: triage now renders through `staging-format.render_block` and dedups
+via `existing_keys` (staging + board), appending to the same buffer. The audit
+fields map: change -> title, effect/finding -> Intent, change + metric contract
+-> Approach, confidence -> `#u-*` tag, report+owner+finding -> Source citation.
+`--dry-run` prints and writes nothing.
+Why: a third proposal currency for the same Learn gate is exactly the
+fragmentation this work set out to kill; dedup against rejected/expired states
+comes free with the shared grammar (a weekly audit MUST NOT re-propose what a
+human already rejected).
+Alternatives: keep the kanban rows and teach `board` to ingest them (rejected:
+two grammars, one gate).
+Impact: triage's contract changed before anyone consumed it (verb is unreleased
+in this PR); smoke grows 18 -> 24 with idempotence + dry-run negative controls.
+
 ## 2026-07-14 14:30 Vocabulary reconciliation (five legs, not a new taxonomy)
 
 Context: the first cut of `docs/feedback-loop.md` named its own five stages

--- a/docs/verification/implementation-notes/session-audit.md
+++ b/docs/verification/implementation-notes/session-audit.md
@@ -1,0 +1,54 @@
+# Implementation notes: session-audit
+
+Delta from `lib/session/audit/SPEC.md`; decisions the spec did not pin down.
+
+## 2026-07-14 14:30 Vocabulary reconciliation (five legs, not a new taxonomy)
+
+Context: the first cut of `docs/feedback-loop.md` named its own five stages
+(COLLECT -> REPORT -> TRIAGE -> ENHANCE -> MEASURE), a parallel vocabulary to
+the kit's canonical five legs (ADR-0034 Specify/Execute/Observe/Govern/Learn),
+whose Learn leg already owns the propose gate (`learn propose`, `stats
+anomalies --propose`, `/kit:retro`).
+Decision: rewrote the doc in leg terms; `run` = the deep Observe pass, `triage`
+= a Learn-leg proposer under the same propose-don't-dispose rule (ADR-0034
+decision 2/5). The five stage words survive only as lowercase prose.
+Why: one engine one truth; a second taxonomy for the same loop is exactly the
+drift the kit-fold contract forbids.
+Alternatives: keep both vocabularies cross-referenced (rejected: two names for
+one thing is how docs rot).
+Impact: feedback-loop.md, audit README, module-registry row.
+
+## 2026-07-14 14:35 No kit.toml audit sub-toggle
+
+Context: the config surface (SPEC-198) could carry a `session.audit` toggle.
+Decision: none added; the coarse `[modules] session = true` covers it, and the
+audit only runs when explicitly invoked (no hook, no cron inside the kit), so
+there is nothing to toggle off.
+Why: no config for a value that never changes; an unused knob is debt.
+Impact: if a consumer later schedules audits from a kit-owned hook, revisit.
+
+## 2026-07-14 14:40 No slash command; dispatcher wiring only
+
+Context: the session subsystem has no slash-command surface at all (none of
+the 32 commands/ call session-*), and an audit run costs ~$3.5 and ~10 min.
+Decision: wire `session.sh audit)` (the one-grammar entry, ADR-0034 decision 7)
+plus registry/env rows; do NOT add a /kit:audit command or an onboard-wizard
+offer in this PR.
+Why: an expensive weekly/on-demand CLI fits the existing session-module shape;
+a slash command invites casual per-session runs of a $3.5 tool. Onboard wizard
+touch is a separate surface with its own spec (SPEC-199) and review.
+Alternatives: /kit:audit thin wrapper (parked; add if usage shows demand).
+Impact: reachable as `session audit run|triage` wherever the session module's
+PATH shim is installed; onboard/config wizard integration stays open debt,
+logged in the PR description.
+
+## 2026-07-14 14:45 Digest overlap left standing, with a named fold path
+
+Context: three weekly artifacts now read the same transcripts (stats digest
+numeric scorecard; session-intel deterministic digest; the audit report).
+Decision: coexist for now; feedback-loop.md documents the division of labor
+and names the fold path (audit report becomes a session-intel source) instead
+of building it.
+Why: session-intel is deterministic-by-design (its README forbids LLM inside);
+folding an LLM artifact in deserves its own decision, not a rider.
+Impact: revisit when the third digest demonstrably annoys.

--- a/lib/config/module-registry.md
+++ b/lib/config/module-registry.md
@@ -29,7 +29,7 @@ it is not a row here either , the completeness rule is scoped to
 | Module | Primary leg | Notes |
 |---|---|---|
 | board | Specify | spanner: input side (Specify) + staging/promote (Learn) |
-| session | Observe | spanner: capture side (Observe) + harvest (Learn) |
+| session | Observe | spanner: capture side (Observe) + harvest (Learn); `session audit` is the deep Observe pass (LLM audit, `run`) + a Learn-leg proposer (`triage`) |
 | advisor | Govern | |
 | cosmetic | (none) | orthogonal to the loop; statusline |
 | queue | Execute | |
@@ -148,6 +148,8 @@ real reader consumes it today (all rows below are, except where noted).
 | CC_SI_CURATOR_CMD | env-only | (real `claude -p`) | [impl] | session | Override the curator's model-invocation command (test injection point). |
 | CC_SI_REVIEWER_CMD | env-only | (real `claude -p`) | [impl] | session | Override the async reviewer's model-invocation command. |
 | DWARVES_KIT_SESSION_MARKER | env-only | `/tmp/.dwarves-kit-session-start` | [impl] | session | Path of the session-start marker file. |
+| SESSION_AUDIT_CMD | env-only | `claude -p --model <M> --allowedTools Bash,Read,Grep,Glob --output-format json` | [impl] | session | Agent runtime `session audit run` pipes its rendered prompt to; tests inject fixtures here. |
+| SESSION_AUDIT_DATE | env-only | (today) | [impl] | session | Report-date override (YYYY-MM-DD) for deterministic tests. |
 
 ### gate
 

--- a/lib/session/audit/README.md
+++ b/lib/session/audit/README.md
@@ -42,6 +42,12 @@ bash tests/smoke.sh    # -> smoke: all passed
 
 ## Notes
 
+- **Model floor is Sonnet.** A 3-way tier run (2026-07-14, same prompt/corpus)
+  showed Haiku fails the schema-discovery step outright: it reported token
+  usage, tool errors, and sidechain markers as absent from the transcripts (all
+  three exist) and then recommended instrumentation for data already there. The
+  discipline in the prompt does not compensate below Sonnet. Opus buys sharper
+  judgment and self-corrected measurements at similar cost.
 - Runtime overridable via `SESSION_AUDIT_CMD` (prompt piped to stdin; must emit
   `--output-format json`); tests inject fixtures, no live model needed.
 - Degrades to `_unavailable_` on any runtime failure; never fabricates a report.

--- a/lib/session/audit/README.md
+++ b/lib/session/audit/README.md
@@ -23,10 +23,11 @@ Division of labor in `lib/session/`: `session-observe` = deterministic parsing,
 agentic evidence for change decisions** (weekly / on demand). Measured on a
 3-day window: ~$3.5 and ~10 min on Sonnet.
 
-This is the COLLECT/REPORT/TRIAGE engine of the kit's usage feedback loop
-(COLLECT -> REPORT -> TRIAGE -> ENHANCE -> MEASURE); the full stage contract is
-`docs/feedback-loop.md`. ENHANCE is the kit's normal lanes; MEASURE is the next
-run's {PREV} diff.
+In five-leg terms (ADR-0034): `run` is the deep **Observe** pass for usage
+telemetry, `triage` is a **Learn**-leg proposer (same propose-don't-dispose
+gate as `learn propose`); the enhance work is the ordinary Specify -> Execute
+-> Govern lanes, and the measure step is the next run's {PREV} metric diff.
+Full path contract: `docs/feedback-loop.md`.
 
 ## Use
 

--- a/lib/session/audit/README.md
+++ b/lib/session/audit/README.md
@@ -1,0 +1,50 @@
+# session-audit
+
+An LLM deep-audit over Claude Code session transcripts: renders the co-located
+`prompt.md` and hands it to an agent runtime that explores the JSONL itself
+(schema-first, jq aggregates, at most K deep-reads). One dated report per run;
+the previous report is auto-passed back so every run opens with a metric diff
+against the last. Propose-don't-dispose: it writes the report and nothing else.
+
+The prompt's shape is the point (borrowed from forensic log-audit practice):
+
+| Discipline | What it buys |
+|---|---|
+| Learn the schema first | no false negatives from guessed field names |
+| Evidence tiers (HIGH/MEDIUM/LOW) | HIGH rows are re-runnable counts, verified to reproduce exactly |
+| No dark buckets | any error bucket >10% must be decomposed (a generic "Exit code 1" pile is a hole, not a finding) |
+| Per-hook block attribution | a hook block names its gate: different owners, different fixes |
+| Owner tags (kit / user-habit / harness / instrumentation) | the report answers "who changes what" directly |
+| Metric contract per recommendation | metric + current value + re-run command, so the NEXT audit verifies the fix moved it |
+| {PREV} diff | audits chain into an improve-measure-improve loop |
+
+Division of labor in `lib/session/`: `session-observe` = deterministic parsing,
+`session-semantic` = cheap LLM topic signal (cron), **`session-audit` = expensive
+agentic evidence for change decisions** (weekly / on demand). Measured on a
+3-day window: ~$3.5 and ~10 min on Sonnet.
+
+## Use
+
+```bash
+session-audit run                          # 7-day window, sonnet, ~/.claude/intel/audit-YYYY-MM-DD.md
+session-audit run --days 3 --model opus    # heavier judgment pass
+session-audit run --out ./reports --json   # machine-readable status
+```
+
+`--pricing-file` overrides the built-in per-model price table when list prices
+drift.
+
+## Test
+
+```bash
+bash tests/smoke.sh    # -> smoke: all passed
+```
+
+## Notes
+
+- Runtime overridable via `SESSION_AUDIT_CMD` (prompt piped to stdin; must emit
+  `--output-format json`); tests inject fixtures, no live model needed.
+- Degrades to `_unavailable_` on any runtime failure; never fabricates a report.
+- Provenance: ops-toolkit `experiments/log-intel-prompt-v2/` (2026-07-14), where
+  the prompt beat the thin clustering prompt head-to-head and its HIGH-tier
+  claims reproduced exactly on independent re-run.

--- a/lib/session/audit/README.md
+++ b/lib/session/audit/README.md
@@ -23,13 +23,24 @@ Division of labor in `lib/session/`: `session-observe` = deterministic parsing,
 agentic evidence for change decisions** (weekly / on demand). Measured on a
 3-day window: ~$3.5 and ~10 min on Sonnet.
 
+This is the COLLECT/REPORT/TRIAGE engine of the kit's usage feedback loop
+(COLLECT -> REPORT -> TRIAGE -> ENHANCE -> MEASURE); the full stage contract is
+`docs/feedback-loop.md`. ENHANCE is the kit's normal lanes; MEASURE is the next
+run's {PREV} diff.
+
 ## Use
 
 ```bash
 session-audit run                          # 7-day window, sonnet, ~/.claude/intel/audit-YYYY-MM-DD.md
 session-audit run --days 3 --model opus    # heavier judgment pass
 session-audit run --out ./reports --json   # machine-readable status
+session-audit triage                       # newest report's recommendations -> kanban proposal rows (stdout)
 ```
+
+`triage` is propose-only: it prints `| ?? | change | audit ref · owner · metric | queued |`
+rows; a human assigns real IDs and pastes accepted rows into the consumer's
+`BACKLOG.md`. It reads the report's machine-triage json footer (the prompt
+requires one; reports from older prompt versions degrade to `_none_`).
 
 `--pricing-file` overrides the built-in per-model price table when list prices
 drift.

--- a/lib/session/audit/README.md
+++ b/lib/session/audit/README.md
@@ -32,16 +32,23 @@ Full path contract: `docs/feedback-loop.md`.
 ## Use
 
 ```bash
-session-audit run                          # 7-day window, sonnet, ~/.claude/intel/audit-YYYY-MM-DD.md
-session-audit run --days 3 --model opus    # heavier judgment pass
-session-audit run --out ./reports --json   # machine-readable status
-session-audit triage                       # newest report's recommendations -> kanban proposal rows (stdout)
+session audit run                          # 7-day window, sonnet, ~/.claude/intel/audit-YYYY-MM-DD.md
+session audit run --days 3 --model opus    # heavier judgment pass
+session audit triage                       # stage the newest report's recommendations as proposals
+session audit triage --dry-run             # print the blocks, write nothing
 ```
 
-`triage` is propose-only: it prints `| ?? | change | audit ref · owner · metric | queued |`
-rows; a human assigns real IDs and pastes accepted rows into the consumer's
-`BACKLOG.md`. It reads the report's machine-triage json footer (the prompt
-requires one; reports from older prompt versions degrade to `_none_`).
+`triage` is propose-only and speaks the kit's ONE proposal currency: it appends
+`## [staged]` blocks to `_meta/backlog-staging.md` through
+`lib/learn/staging-format.py` (ADR-0034 decision 1), exactly like `learn
+propose` and `stats anomalies --propose`. The metric contract rides on
+`Approach` (it is what the next audit re-runs), the report + owner ride on
+`Source` (the citation). Dedup is against every staging state + the board, so a
+rejected proposal never returns on the next weekly audit. The human gate is
+unchanged: review with `learn drain`, accept with `board promote`.
+
+It reads the report's machine-triage json footer (the prompt requires one;
+reports from older prompt versions degrade to `_none_`).
 
 `--pricing-file` overrides the built-in per-model price table when list prices
 drift.

--- a/lib/session/audit/SPEC.md
+++ b/lib/session/audit/SPEC.md
@@ -32,6 +32,12 @@ each run opens with a metric diff: the collector-to-enhancement feedback loop.
   cost. Accepts both object-form and array-form runtime JSON.
 - `{PREV}` = newest existing `audit-*.md` in `--out`, else "none provided for
   this run".
+- `triage [--out DIR] [--report F] [--json]`: extracts the newest (or given)
+  report's machine-triage json footer (the LAST fenced json block that parses
+  as a list of {change, owner, ...}) and prints kanban proposal rows
+  (`| ?? | change | audit ref · owner · metric | queued |`). Propose-only:
+  stdout, never writes a board. Degrades: no report -> "no audit report found";
+  no valid footer -> `_none_`.
 - Degrades to `_unavailable_` (exit 0, no report) when the runtime is missing,
   fails, or returns unparseable output; never fabricates.
 - Propose-only: writes nothing but the report. Read-only over transcripts (the

--- a/lib/session/audit/SPEC.md
+++ b/lib/session/audit/SPEC.md
@@ -1,0 +1,58 @@
+# SPEC: session-audit
+
+## Problem
+
+The session subsystem can locate waste deterministically (session-observe) and
+cluster topics cheaply (session-semantic), but neither produces evidence strong
+enough to drive changes: no verifiable citations, no owner (is a fix the kit's,
+the user's, or the harness's?), no dollar attribution, and no way for a later
+run to check whether a fix moved anything. The 2026-07-14 head-to-head
+(ops-toolkit `experiments/log-intel-prompt-v2/`) showed a forensic-style agentic
+prompt closes all four gaps: its HIGH-tier numbers reproduced exactly on
+independent re-run, and it surfaced kit-actionable findings (ship-gate as the
+top named friction; Edit-before-Read as the top tool error) that the thin
+prompt structurally cannot see.
+
+## Solution
+
+`session-audit run` renders the co-located `prompt.md` (forensic-audit shape:
+schema-first exploration, evidence tiers HIGH/MEDIUM/LOW, no dark buckets,
+per-hook block attribution, owner-tagged recommendations each carrying a metric
+contract) and pipes it to an agent runtime that explores the transcripts itself.
+One dated report per run; the previous report is auto-passed as `{PREV}` so
+each run opens with a metric diff: the collector-to-enhancement feedback loop.
+
+## Contract
+
+- `run [--root D] [--days N] [--deep-read K] [--model M] [--out DIR] [--pricing-file F] [--json]`:
+  renders `prompt.md` ({ROOT}, {DAYS}, {K}, {PRICING}, {PREV}), pipes it to
+  `SESSION_AUDIT_CMD` (default `claude -p --model M --allowedTools
+  Bash,Read,Grep,Glob --output-format json`), writes `DIR/audit-YYYY-MM-DD.md`
+  (header comment: date, root, days, model, cost, prev) and prints the path +
+  cost. Accepts both object-form and array-form runtime JSON.
+- `{PREV}` = newest existing `audit-*.md` in `--out`, else "none provided for
+  this run".
+- Degrades to `_unavailable_` (exit 0, no report) when the runtime is missing,
+  fails, or returns unparseable output; never fabricates.
+- Propose-only: writes nothing but the report. Read-only over transcripts (the
+  prompt instructs it; the allowed-tools list carries no Write/Edit).
+- Cost is a feature decision: measured ~$3.5 and ~10 min per run on Sonnet over
+  a 3-day window. Weekly or on-demand, never per-session.
+
+## Non-goals
+
+- Replacing session-semantic's cheap cron slot (78x slower, ~70x cost).
+- Acting on the recommendations (human reviews; owner tags route them).
+- Scheduling itself.
+- Guaranteeing LOW/MEDIUM-tier stability across runs (only HIGH-tier rows are
+  reproducible by construction; the report labels the rest as estimates).
+
+## Verification
+
+```bash
+bash lib/session/audit/tests/smoke.sh   # -> smoke: N passed, 0 failed
+```
+
+Covers: report write + header params, full placeholder substitution, PREV
+chaining across runs, array-form runtime JSON, degrade on failing command and
+on garbage output.

--- a/lib/session/audit/SPEC.md
+++ b/lib/session/audit/SPEC.md
@@ -32,12 +32,17 @@ each run opens with a metric diff: the collector-to-enhancement feedback loop.
   cost. Accepts both object-form and array-form runtime JSON.
 - `{PREV}` = newest existing `audit-*.md` in `--out`, else "none provided for
   this run".
-- `triage [--out DIR] [--report F] [--json]`: extracts the newest (or given)
-  report's machine-triage json footer (the LAST fenced json block that parses
-  as a list of {change, owner, ...}) and prints kanban proposal rows
-  (`| ?? | change | audit ref · owner · metric | queued |`). Propose-only:
-  stdout, never writes a board. Degrades: no report -> "no audit report found";
-  no valid footer -> `_none_`.
+- `triage [--out DIR] [--report F] [--staging F] [--backlog F] [--dry-run] [--json]`:
+  extracts the newest (or given) report's machine-triage json footer (the LAST
+  fenced json block that parses as a list of {change, owner, ...}) and appends
+  one `## [staged]` block per non-duplicate recommendation to the staging buffer
+  via `lib/learn/staging-format.py` (the kit's ONE proposal grammar, ADR-0034
+  decision 1). Metric contract -> `Approach`; report + owner -> `Source`. Dedup
+  by normalized title against every staging state + the board (read-only), so
+  re-runs are idempotent and a rejected proposal never re-stages. The ONLY write
+  is the staging buffer; `--dry-run` writes nothing. Human gate: `learn drain`
+  (review), `board promote` (accept). Degrades: no report -> "no audit report
+  found"; no valid footer -> `_none_`.
 - Degrades to `_unavailable_` (exit 0, no report) when the runtime is missing,
   fails, or returns unparseable output; never fabricates.
 - Propose-only: writes nothing but the report. Read-only over transcripts (the

--- a/lib/session/audit/bin/session-audit
+++ b/lib/session/audit/bin/session-audit
@@ -36,6 +36,9 @@ DEFAULT_MODEL = "sonnet"
 DEFAULT_CMD = ("claude -p --model {model} "
                "--allowedTools Bash,Read,Grep,Glob --output-format json")
 # Per-million-token list prices; override with --pricing-file when they drift.
+# Models absent here (e.g. fable-5, no public list rate) are deliberately NOT
+# guessed: the prompt makes the audit report their share and mark $ totals as
+# a floor. Supply a rate via --pricing-file once one is authoritative.
 DEFAULT_PRICING = """\
   sonnet: input $3.00, output $15.00, cache-read $0.30, cache-write $3.75
   haiku:  input $1.00, output $5.00,  cache-read $0.10, cache-write $1.25

--- a/lib/session/audit/bin/session-audit
+++ b/lib/session/audit/bin/session-audit
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""session-audit: LLM deep-audit over Claude Code session transcripts.
+
+The agentic sibling of session-intel's deterministic digest: renders the
+co-located prompt.md (schema-first exploration, evidence tiers, owner-tagged
+recommendations with metric contracts) and hands it to an agent runtime
+(`claude -p` by default) that explores the transcripts itself with jq. Writes
+ONE dated report; the previous report is auto-passed as {PREV} so each run
+opens with a metric diff against the last (the improve-measure-improve loop).
+
+Propose-don't-dispose: writes only the report file, never edits transcripts,
+boards, or ledgers. Expensive by design (measured ~$3.5/run on Sonnet over a
+3-day window); run weekly or on demand, not per-session -- session-semantic
+stays the cheap cron signal.
+
+  session-audit run [--root D] [--days N] [--deep-read K] [--model M]
+                    [--out DIR] [--pricing-file F] [--json]
+
+Env for tests: SESSION_AUDIT_CMD (shell string; the rendered prompt is piped to
+its stdin, and it must print the runtime's --output-format json), and
+SESSION_AUDIT_DATE (YYYY-MM-DD). If the command is missing or fails, degrades
+to `_unavailable_`; it never fabricates a report. Stdlib only.
+"""
+import argparse
+import datetime
+import glob
+import json
+import os
+import shlex
+import subprocess
+import sys
+
+DEFAULT_ROOT = os.path.expanduser("~/.claude/projects")
+DEFAULT_OUT = os.path.expanduser("~/.claude/intel")
+DEFAULT_MODEL = "sonnet"
+DEFAULT_CMD = ("claude -p --model {model} "
+               "--allowedTools Bash,Read,Grep,Glob --output-format json")
+# Per-million-token list prices; override with --pricing-file when they drift.
+DEFAULT_PRICING = """\
+  sonnet: input $3.00, output $15.00, cache-read $0.30, cache-write $3.75
+  haiku:  input $1.00, output $5.00,  cache-read $0.10, cache-write $1.25
+  opus:   input $15.00, output $75.00, cache-read $1.50, cache-write $18.75"""
+
+
+def _today():
+    d = os.environ.get("SESSION_AUDIT_DATE")
+    return d if d else datetime.date.today().isoformat()
+
+
+def render_prompt(root, days, deep_read, pricing, prev):
+    tpl_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "prompt.md")
+    with open(tpl_path) as f:
+        t = f.read()
+    subs = {"{ROOT}": root, "{DAYS}": str(days), "{K}": str(deep_read),
+            "{PRICING}": pricing, "{PREV}": prev}
+    for k, v in subs.items():
+        t = t.replace(k, v)
+    return t
+
+
+def latest_report(out_dir):
+    reports = sorted(glob.glob(os.path.join(out_dir, "audit-*.md")))
+    return reports[-1] if reports else None
+
+
+def parse_runtime_json(text):
+    """Extract the result payload from `--output-format json`: a single object,
+    or (some CLI versions) an array whose last element is the result object."""
+    try:
+        d = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(d, list):
+        d = d[-1] if d and isinstance(d[-1], dict) else None
+    if not isinstance(d, dict) or not isinstance(d.get("result"), str):
+        return None
+    return d
+
+
+def run_agent(prompt, model):
+    cmd = os.environ.get("SESSION_AUDIT_CMD", DEFAULT_CMD.format(model=model))
+    try:
+        r = subprocess.run(shlex.split(cmd), input=prompt, capture_output=True,
+                           text=True, timeout=3600)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    return parse_runtime_json(r.stdout)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(prog="session-audit",
+                                description="LLM deep-audit (propose-only) over CC session transcripts.")
+    sub = p.add_subparsers(dest="verb", required=True)
+    r = sub.add_parser("run", help="run the audit and write a dated report")
+    r.add_argument("--root", default=DEFAULT_ROOT)
+    r.add_argument("--days", type=int, default=7)
+    r.add_argument("--deep-read", type=int, default=5)
+    r.add_argument("--model", default=DEFAULT_MODEL)
+    r.add_argument("--out", default=DEFAULT_OUT)
+    r.add_argument("--pricing-file")
+    r.add_argument("--json", action="store_true")
+    args = p.parse_args(argv)
+
+    pricing = DEFAULT_PRICING
+    if args.pricing_file:
+        with open(args.pricing_file) as f:
+            pricing = f.read().rstrip()
+
+    os.makedirs(args.out, exist_ok=True)
+    prev = latest_report(args.out)
+    prompt = render_prompt(args.root, args.days, args.deep_read, pricing,
+                           prev if prev else "none provided for this run")
+
+    res = run_agent(prompt, args.model)
+    if res is None:
+        print(json.dumps({"status": "unavailable"}) if args.json
+              else "session-audit: _unavailable_ (no runtime / command failed / unparseable output)")
+        return 0
+
+    date = _today()
+    path = os.path.join(args.out, f"audit-{date}.md")
+    cost = res.get("total_cost_usd")
+    dur = res.get("duration_ms")
+    header = (f"<!-- session-audit {date} · root {args.root} · days {args.days} "
+              f"· model {args.model} · cost ${cost if cost is not None else '?'} "
+              f"· prev {prev if prev else 'none'} -->\n\n")
+    with open(path, "w") as f:
+        f.write(header + res["result"].rstrip() + "\n")
+
+    if args.json:
+        print(json.dumps({"status": "ok", "report": path, "prev": prev,
+                          "total_cost_usd": cost, "duration_ms": dur}, indent=2))
+    else:
+        print(f"session-audit: wrote {path}"
+              + (f"  (${cost:.2f}, {dur / 1000:.0f}s)" if cost is not None and dur else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/session/audit/bin/session-audit
+++ b/lib/session/audit/bin/session-audit
@@ -92,6 +92,59 @@ def run_agent(prompt, model):
     return parse_runtime_json(r.stdout)
 
 
+def extract_recommendations(report_text):
+    """Pull the LAST fenced ```json block (the machine-triage footer the prompt
+    demands) and validate it as a list of recommendation objects."""
+    blocks, in_block, cur = [], False, []
+    for line in report_text.splitlines():
+        s = line.strip()
+        if not in_block and s.startswith("```json"):
+            in_block, cur = True, []
+        elif in_block and s.startswith("```"):
+            in_block = False
+            blocks.append("\n".join(cur))
+        elif in_block:
+            cur.append(line)
+    for raw in reversed(blocks):
+        try:
+            d = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(d, list) and all(isinstance(r, dict) and r.get("change") and r.get("owner") for r in d):
+            return d
+    return None
+
+
+def cmd_triage(args):
+    report = args.report or latest_report(args.out)
+    if not report or not os.path.exists(report):
+        print(json.dumps({"status": "empty"}) if args.json
+              else "session-audit triage: no audit report found (run `session-audit run` first)")
+        return 0
+    with open(report) as f:
+        recs = extract_recommendations(f.read())
+    name = os.path.basename(report)
+    if recs is None:
+        print(json.dumps({"status": "no_block", "report": name}) if args.json
+              else f"session-audit triage: _none_ (no machine-triage json block in {name}; "
+                   "older report format, or the run dropped the footer)")
+        return 0
+    if args.json:
+        print(json.dumps({"status": "ok", "report": name, "proposals": recs}, indent=2))
+        return 0
+    print(f"# session-audit triage: {len(recs)} proposals from {name} (PROPOSALS ONLY,")
+    print("# review, then paste accepted rows into your board's BACKLOG.md with real IDs)")
+    for r in recs:
+        m = r.get("metric") or {}
+        notes = f"audit {name} · owner:{r.get('owner')}"
+        if m.get("name"):
+            notes += f" · metric {m['name']}={m.get('current', '?')}"
+        if r.get("confidence"):
+            notes += f" · confidence:{r['confidence']}"
+        print(f"| ?? | {r['change']} | {notes} | queued |")
+    return 0
+
+
 def main(argv=None):
     p = argparse.ArgumentParser(prog="session-audit",
                                 description="LLM deep-audit (propose-only) over CC session transcripts.")
@@ -104,7 +157,14 @@ def main(argv=None):
     r.add_argument("--out", default=DEFAULT_OUT)
     r.add_argument("--pricing-file")
     r.add_argument("--json", action="store_true")
+    t = sub.add_parser("triage", help="extract the latest report's recommendations as kanban proposal rows")
+    t.add_argument("--out", default=DEFAULT_OUT)
+    t.add_argument("--report", help="a specific report file (default: newest audit-*.md in --out)")
+    t.add_argument("--json", action="store_true")
     args = p.parse_args(argv)
+
+    if args.verb == "triage":
+        return cmd_triage(args)
 
     pricing = DEFAULT_PRICING
     if args.pricing_file:

--- a/lib/session/audit/bin/session-audit
+++ b/lib/session/audit/bin/session-audit
@@ -8,13 +8,22 @@ recommendations with metric contracts) and hands it to an agent runtime
 ONE dated report; the previous report is auto-passed as {PREV} so each run
 opens with a metric diff against the last (the improve-measure-improve loop).
 
-Propose-don't-dispose: writes only the report file, never edits transcripts,
-boards, or ledgers. Expensive by design (measured ~$3.5/run on Sonnet over a
-3-day window); run weekly or on demand, not per-session -- session-semantic
-stays the cheap cron signal.
+Propose-don't-dispose: `run` writes only the report file; `triage` writes only
+the staging buffer (a human promotes with `board promote`). Neither touches a
+board, a ledger, or a transcript. Expensive by design (measured ~$3.5/run on
+Sonnet over a 3-day window); run weekly or on demand, not per-session --
+session-semantic stays the cheap cron signal.
+
+`triage` emits the kit's ONE proposal currency: `## [staged]` blocks via
+lib/learn/staging-format.py (ADR-0034 decision 1), deduped against every
+staging state + the board, exactly like `learn propose` and `stats
+anomalies --propose`. The metric contract rides on Approach, the report +
+owner ride on Source.
 
   session-audit run [--root D] [--days N] [--deep-read K] [--model M]
                     [--out DIR] [--pricing-file F] [--json]
+  session-audit triage [--out DIR] [--report F] [--staging F] [--backlog F]
+                       [--dry-run] [--json]
 
 Env for tests: SESSION_AUDIT_CMD (shell string; the rendered prompt is piped to
 its stdin, and it must print the runtime's --output-format json), and
@@ -43,6 +52,20 @@ DEFAULT_PRICING = """\
   sonnet: input $3.00, output $15.00, cache-read $0.30, cache-write $3.75
   haiku:  input $1.00, output $5.00,  cache-read $0.10, cache-write $1.25
   opus:   input $15.00, output $75.00, cache-read $1.50, cache-write $18.75"""
+
+
+def _repo_root():
+    """Walk up to the kit repo root (the dir holding lib/session/), same
+    repo-relative rule the other session tools use: no hardcoded personal path."""
+    d = os.path.dirname(os.path.realpath(__file__))
+    for _ in range(8):
+        if os.path.isdir(os.path.join(d, "lib", "session")):
+            return d
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    raise RuntimeError("session-audit: cannot locate the kit repo root (lib/session not found)")
 
 
 def _today():
@@ -115,6 +138,47 @@ def extract_recommendations(report_text):
     return None
 
 
+def _staging_format():
+    """Load the kit's ONE staging-block grammar (ADR-0034 decision 1). Hyphenated
+    filename, so it needs the importlib dance drain.py/propose.py already use."""
+    import importlib.util
+    p = os.path.join(_repo_root(), "lib", "learn", "staging-format.py")
+    spec = importlib.util.spec_from_file_location("staging_format", p)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _default_staging():
+    return os.environ.get("BACKLOG_STAGE_STAGING") or os.path.join(
+        _repo_root(), "_meta", "backlog-staging.md")
+
+
+def _default_backlog():
+    return os.environ.get("BACKLOG_STAGE_BACKLOG") or os.path.join(
+        _repo_root(), "_meta", "BACKLOG.md")
+
+
+def to_candidate(rec, report_name, date):
+    """One audit recommendation -> the kit's staging-candidate dict. The metric
+    contract rides on Approach (it is what a later audit re-runs) and the report
+    + owner ride on Source (they are the citation)."""
+    m = rec.get("metric") or {}
+    approach = rec.get("change", "")
+    if m.get("name"):
+        approach += (f" · metric {m['name']} now {m.get('current', '?')}"
+                     f"; re-run: {m.get('rerun', '?')}")
+    return {
+        "title": rec.get("change", "").strip(),
+        "intent": rec.get("effect") or rec.get("finding") or "(no effect stated)",
+        "approach": approach,
+        "u": {"high": "hi", "medium": "mid", "low": "lo"}.get(str(rec.get("confidence", "")).lower(), "lo"),
+        "f": "mid",
+        "source": (f"session audit {date} | report={report_name} "
+                   f"owner={rec.get('owner', '?')} finding=\"{rec.get('finding', '')}\""),
+    }
+
+
 def cmd_triage(args):
     report = args.report or latest_report(args.out)
     if not report or not os.path.exists(report):
@@ -129,19 +193,49 @@ def cmd_triage(args):
               else f"session-audit triage: _none_ (no machine-triage json block in {name}; "
                    "older report format, or the run dropped the footer)")
         return 0
+
+    sf = _staging_format()
+    staging, backlog = args.staging or _default_staging(), args.backlog or _default_backlog()
+    # Dedup against EVERY staging state (staged/expired/rejected/promoted) + the board,
+    # so a rejected proposal never comes back on the next weekly audit.
+    existing = sf.existing_keys(("staging", staging), ("board", backlog))
+    date = _today()
+    blocks, staged, skipped = [], [], []
+    for rec in recs:
+        cand = to_candidate(rec, name, date)
+        key = sf.norm(cand["title"])
+        if not cand["title"] or key in existing:
+            skipped.append(cand["title"])
+            continue
+        block = sf.render_block(cand)
+        if block is None:
+            continue
+        existing.add(key)
+        blocks.append(block)
+        staged.append(cand["title"])
+
+    if blocks and not args.dry_run:
+        exists = os.path.isfile(staging)
+        parent = os.path.dirname(staging)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(staging, "a", encoding="utf-8") as fh:
+            if not exists:
+                fh.write("# Backlog staging\n\n")
+            fh.writelines(blocks)
+
     if args.json:
-        print(json.dumps({"status": "ok", "report": name, "proposals": recs}, indent=2))
+        print(json.dumps({"status": "ok", "report": name, "staged": staged,
+                          "skipped_duplicate": skipped,
+                          "staging": None if args.dry_run else staging,
+                          "dry_run": bool(args.dry_run)}, indent=2))
         return 0
-    print(f"# session-audit triage: {len(recs)} proposals from {name} (PROPOSALS ONLY,")
-    print("# review, then paste accepted rows into your board's BACKLOG.md with real IDs)")
-    for r in recs:
-        m = r.get("metric") or {}
-        notes = f"audit {name} · owner:{r.get('owner')}"
-        if m.get("name"):
-            notes += f" · metric {m['name']}={m.get('current', '?')}"
-        if r.get("confidence"):
-            notes += f" · confidence:{r['confidence']}"
-        print(f"| ?? | {r['change']} | {notes} | queued |")
+    if args.dry_run:
+        sys.stdout.write("".join(blocks) or "session-audit triage: nothing new to stage\n")
+        return 0
+    where = staging if blocks else "(nothing new)"
+    print(f"session-audit triage: staged {len(staged)}, skipped {len(skipped)} duplicate "
+          f"-> {where}\n  promote with: board promote <n>   (review first: learn drain)")
     return 0
 
 
@@ -157,9 +251,12 @@ def main(argv=None):
     r.add_argument("--out", default=DEFAULT_OUT)
     r.add_argument("--pricing-file")
     r.add_argument("--json", action="store_true")
-    t = sub.add_parser("triage", help="extract the latest report's recommendations as kanban proposal rows")
+    t = sub.add_parser("triage", help="stage the latest report's recommendations as backlog proposals")
     t.add_argument("--out", default=DEFAULT_OUT)
     t.add_argument("--report", help="a specific report file (default: newest audit-*.md in --out)")
+    t.add_argument("--staging", help="staging file (default <repo>/_meta/backlog-staging.md)")
+    t.add_argument("--backlog", help="board file, read-only, for dedup (default <repo>/_meta/BACKLOG.md)")
+    t.add_argument("--dry-run", action="store_true", help="print the blocks, write nothing")
     t.add_argument("--json", action="store_true")
     args = p.parse_args(argv)
 

--- a/lib/session/audit/docs/feedback-loop.md
+++ b/lib/session/audit/docs/feedback-loop.md
@@ -1,0 +1,58 @@
+# The usage feedback loop
+
+The kit improves itself from evidence, not vibes. This page is the contract for
+how usage telemetry becomes a shipped enhancement, and how the next audit proves
+the enhancement worked. Five stages; the first two and the last are this tool's
+job, the middle two are the kit's normal operating lanes.
+
+```
+COLLECT ──> REPORT ──> TRIAGE ──> ENHANCE ──> MEASURE
+   │           │          │           │           │
+ session-    audit-     session-    normal      next run's
+ observe /   YYYY-MM-   audit       kit lanes   {PREV} metric
+ semantic /  DD.md      triage      (board row  diff: did the
+ audit       (owner     (kanban     -> spec ->  metric move?)
+ (this       tags +     proposal    execute ->
+ tool)       metric     rows,       ship)
+             contracts) human
+                        accepts)
+```
+
+## Stage contracts
+
+1. **COLLECT.** `session-observe` (deterministic parsing, free), `session-semantic`
+   (cheap LLM topic signal, cron), `session-audit run` (expensive agentic deep
+   audit, weekly / on demand). Read-only over transcripts, always.
+2. **REPORT.** One dated file per audit run. Every recommendation carries an
+   OWNER (`kit` | `user-habit` | `harness` | `instrumentation`) and a METRIC
+   CONTRACT (name, current value, exact re-run command). The report closes with
+   a machine-readable json footer of the same rows. Only HIGH-tier findings are
+   stable currency across runs; MEDIUM/LOW are leads, labeled as such.
+3. **TRIAGE.** `session-audit triage` extracts the footer into kanban proposal
+   rows (`| ?? | change | audit ref · owner · metric | queued |`). PROPOSALS
+   ONLY: a human reviews, assigns real IDs, and pastes accepted rows into the
+   consumer repo's `BACKLOG.md`. Rejected rows die here; nothing auto-files.
+4. **ENHANCE.** An accepted row is ordinary kit work: it flows queued -> speccing
+   -> executing -> shipped through the normal lanes and gates. Nothing special;
+   the audit only supplied the evidence and the metric.
+5. **MEASURE.** The next `session-audit run` receives the previous report as
+   `{PREV}` automatically and MUST open with a metric-by-metric diff: for each
+   earlier recommendation, did its metric move? A fix whose metric did not move
+   goes back to TRIAGE as a new finding, with the failed attempt as context.
+
+## Cadence
+
+Weekly, riding the consumer's existing session-intel schedule slot (no new
+daemon, no listener). On-demand runs are fine any time; {PREV} chaining keeps
+the diff meaningful regardless of spacing.
+
+## Invariants
+
+- Propose-don't-dispose at every joint: the audit writes reports, triage writes
+  stdout, only a human writes the board.
+- Claims never exceed evidence; a recommendation without a metric contract is
+  not triage-able and should be treated as prose, not a proposal.
+- The loop measures itself: hook-block counts, error decomposition, and
+  delegation shape in each report include the friction this very process
+  generates (the 2026-07-14 baseline run caught its own ship-gate and
+  commit-format blocks).

--- a/lib/session/audit/docs/feedback-loop.md
+++ b/lib/session/audit/docs/feedback-loop.md
@@ -31,12 +31,15 @@ to it.
    CONTRACT (name, current value, exact re-run command), and the report closes
    with a machine-readable json footer of the same rows. Only HIGH-tier
    findings are stable currency across runs; MEDIUM/LOW are leads.
-2. **Learn (propose).** `session audit triage` extracts the footer into kanban
-   proposal rows (`| ?? | change | audit ref · owner · metric | queued |`).
-   Same propose-don't-dispose gate as `learn propose` and `stats anomalies
-   --propose` (ADR-0034 decision 2/5): a human reviews, assigns real IDs, and
-   pastes accepted rows into the consumer repo's `BACKLOG.md`. Rejected rows
-   die here; nothing auto-files.
+2. **Learn (propose).** `session audit triage` turns the footer into the kit's
+   ONE proposal currency: `## [staged]` blocks appended to
+   `_meta/backlog-staging.md` via `lib/learn/staging-format.py` (ADR-0034
+   decision 1), byte-compatible with `learn propose` and `stats anomalies
+   --propose`. The metric contract rides on `Approach`, the report + owner on
+   `Source`. Dedup runs against every staging state (staged/expired/rejected/
+   promoted) + the board, so a rejected proposal never returns. Human gate
+   unchanged (ADR-0034 decision 2/5): review with `learn drain`, accept with
+   `board promote`. Nothing auto-files.
 3. **Specify -> Execute -> Govern (enhance).** An accepted row is ordinary kit
    work through the normal lanes and gates. Nothing special; the audit only
    supplied the evidence and the metric.

--- a/lib/session/audit/docs/feedback-loop.md
+++ b/lib/session/audit/docs/feedback-loop.md
@@ -1,44 +1,63 @@
-# The usage feedback loop
+# The usage-telemetry path around the five legs
 
-The kit improves itself from evidence, not vibes. This page is the contract for
-how usage telemetry becomes a shipped enhancement, and how the next audit proves
-the enhancement worked. Five stages; the first two and the last are this tool's
-job, the middle two are the kit's normal operating lanes.
+The kit's improvement cycle is the five legs (ADR-0034): **Specify -> Execute ->
+Observe -> Govern -> Learn**, feedback closing Learn back into Specify. This
+page does NOT define a new cycle; it names how session-audit rides that loop
+for one signal class: usage telemetry from CC session transcripts. One engine,
+one truth: where an existing leg verb already owns a step, this tool defers
+to it.
 
 ```
-COLLECT ──> REPORT ──> TRIAGE ──> ENHANCE ──> MEASURE
-   │           │          │           │           │
- session-    audit-     session-    normal      next run's
- observe /   YYYY-MM-   audit       kit lanes   {PREV} metric
- semantic /  DD.md      triage      (board row  diff: did the
- audit       (owner     (kanban     -> spec ->  metric move?)
- (this       tags +     proposal    execute ->
- tool)       metric     rows,       ship)
-             contracts) human
-                        accepts)
+              (existing legs)                     (this tool's contribution)
+
+ Specify ──► Execute ──► Observe ────────────────  session-audit run
+    ▲                      │                       = the deep Observe pass:
+    │                      ▼                         dated report, owner tags,
+    │                    Govern                      metric contracts
+    │                      │
+    └────── Learn ◄────────┘                       session-audit triage
+            (propose gate)                         = a Learn-leg proposer:
+                                                     report footer -> kanban
+                                                     proposal rows, human accepts
 ```
 
-## Stage contracts
+## The steps, in leg terms
 
-1. **COLLECT.** `session-observe` (deterministic parsing, free), `session-semantic`
-   (cheap LLM topic signal, cron), `session-audit run` (expensive agentic deep
-   audit, weekly / on demand). Read-only over transcripts, always.
-2. **REPORT.** One dated file per audit run. Every recommendation carries an
+1. **Observe (collect + report).** Three depths, same leg: `session observe`
+   (deterministic parsing, free), `session semantic` (cheap LLM topic signal,
+   cron), `session audit run` (expensive agentic deep audit, weekly / on
+   demand). The audit writes one dated report; every recommendation carries an
    OWNER (`kit` | `user-habit` | `harness` | `instrumentation`) and a METRIC
-   CONTRACT (name, current value, exact re-run command). The report closes with
-   a machine-readable json footer of the same rows. Only HIGH-tier findings are
-   stable currency across runs; MEDIUM/LOW are leads, labeled as such.
-3. **TRIAGE.** `session-audit triage` extracts the footer into kanban proposal
-   rows (`| ?? | change | audit ref · owner · metric | queued |`). PROPOSALS
-   ONLY: a human reviews, assigns real IDs, and pastes accepted rows into the
-   consumer repo's `BACKLOG.md`. Rejected rows die here; nothing auto-files.
-4. **ENHANCE.** An accepted row is ordinary kit work: it flows queued -> speccing
-   -> executing -> shipped through the normal lanes and gates. Nothing special;
-   the audit only supplied the evidence and the metric.
-5. **MEASURE.** The next `session-audit run` receives the previous report as
-   `{PREV}` automatically and MUST open with a metric-by-metric diff: for each
-   earlier recommendation, did its metric move? A fix whose metric did not move
-   goes back to TRIAGE as a new finding, with the failed attempt as context.
+   CONTRACT (name, current value, exact re-run command), and the report closes
+   with a machine-readable json footer of the same rows. Only HIGH-tier
+   findings are stable currency across runs; MEDIUM/LOW are leads.
+2. **Learn (propose).** `session audit triage` extracts the footer into kanban
+   proposal rows (`| ?? | change | audit ref · owner · metric | queued |`).
+   Same propose-don't-dispose gate as `learn propose` and `stats anomalies
+   --propose` (ADR-0034 decision 2/5): a human reviews, assigns real IDs, and
+   pastes accepted rows into the consumer repo's `BACKLOG.md`. Rejected rows
+   die here; nothing auto-files.
+3. **Specify -> Execute -> Govern (enhance).** An accepted row is ordinary kit
+   work through the normal lanes and gates. Nothing special; the audit only
+   supplied the evidence and the metric.
+4. **Observe again (measure).** The next `session audit run` receives the
+   previous report as `{PREV}` automatically and MUST open with a
+   metric-by-metric diff: for each earlier recommendation, did its metric
+   move? A fix whose metric did not move returns to the Learn gate as a new
+   finding, with the failed attempt as context.
+
+## Division of labor inside Observe (why three tools + stats coexist)
+
+| Surface | Reads | Depth | Cadence |
+|---|---|---|---|
+| `stats` `sessions` table + `stats digest` | transcripts, numeric allowlist ONLY (SPEC-135 privacy wall) | scorecard numbers | weekly |
+| `session observe` / `session intel` | transcripts, content-adjacent detail | deterministic usage/friction views + digest | weekly cron |
+| `session audit run` | transcripts, agentic exploration | evidence-tiered findings + owner-tagged recommendations | weekly / on demand |
+
+The audit is the only layer that produces *change decisions with metric
+contracts*; the other two stay cheap and deterministic. Known debt: three
+weekly artifacts overlap at the raw-count layer; if that hurts, fold the audit
+report in as a `session intel` source rather than minting a fourth digest.
 
 ## Cadence
 
@@ -49,7 +68,8 @@ the diff meaningful regardless of spacing.
 ## Invariants
 
 - Propose-don't-dispose at every joint: the audit writes reports, triage writes
-  stdout, only a human writes the board.
+  stdout, only a human writes the board (ADR-0034 decision 2/5, same rule
+  SPEC-195 enforces for `learn propose`).
 - Claims never exceed evidence; a recommendation without a metric contract is
   not triage-able and should be treated as prose, not a proposal.
 - The loop measures itself: hook-block counts, error decomposition, and

--- a/lib/session/audit/docs/proof-of-done.md
+++ b/lib/session/audit/docs/proof-of-done.md
@@ -1,0 +1,71 @@
+# Proof of Done: session-audit
+
+**Feature:** LLM deep-audit verb over CC session transcripts (forensic prompt + chained metric-diff reports).
+**Date:** 2026-07-14 · **Lane:** full · **Host:** Hans-Air-M4 (macOS 26.5) · **Provenance:** ops-toolkit `experiments/log-intel-prompt-v2/`
+
+Deterministic (fixture runtime via `SESSION_AUDIT_CMD` + `SESSION_AUDIT_DATE`), so the
+smoke is the proof. Live-model quality was validated in the origin experiment
+(HIGH-tier claims reproduced exactly on independent re-run; see the experiment's
+`results/comparison.md`).
+
+## Acceptance criteria
+
+| # | Criterion | Source |
+|---|---|---|
+| A1 | `run` writes one dated report containing the runtime's result body + a header with run params | SPEC Contract |
+| A2 | All 5 placeholders ({ROOT} {DAYS} {K} {PRICING} {PREV}) substituted; none leak into the prompt | SPEC Contract |
+| A3 | First run passes PREV="none provided for this run" | SPEC Contract |
+| A4 | Second run passes the first report's path as {PREV} (the metric-diff chain) | SPEC Contract |
+| A5 | Array-form runtime JSON parsed as well as object-form | observed CLI variance |
+| A6 | Failing runtime degrades to `_unavailable_`, exit 0, and writes NO report (never fabricates) | NEGATIVE CONTROL |
+| A7 | Garbage (non-JSON) runtime output also degrades to `_unavailable_` | NEGATIVE CONTROL |
+
+## Implementation
+
+| Piece | What | Where |
+|---|---|---|
+| Prompt template | forensic audit shape: schema-first, tiers, no dark buckets, owner tags, metric contracts, {PREV} diff | `prompt.md` |
+| Render + chain | placeholder substitution; newest `audit-*.md` in --out becomes {PREV} | `render_prompt()` / `latest_report()` |
+| Runtime | `claude -p --allowedTools Bash,Read,Grep,Glob --output-format json`, prompt on stdin, `SESSION_AUDIT_CMD` override | `run_agent()` |
+| Output parse | object-form and array-form `--output-format json` | `parse_runtime_json()` |
+| Report | `DIR/audit-YYYY-MM-DD.md`, header comment (date/root/days/model/cost/prev) | `main()` |
+| Tests | fixture runtime + capture helper, 12 assertions incl. 2 negative controls | `tests/smoke.sh` |
+
+## Confirmation run-table
+
+| Check | Command | Expected | Result |
+|---|---|---|---|
+| Smoke (all) | `bash lib/session/audit/tests/smoke.sh` | `smoke: 12 passed, 0 failed` | PASS |
+| Report write (A1) | items 1-3 | dated file, body + header params present | PASS |
+| Substitution (A2) | items 4-5 | ROOT present, no `{...}` placeholder remains | PASS |
+| PREV first run (A3) | item 6 | "none provided for this run" in rendered prompt | PASS |
+| PREV chained (A4) | item 7 | first report path in second rendered prompt | PASS |
+| Array-form (A5) | items 8-9 | status ok + body written | PASS |
+| Degrade fail (A6, NEGATIVE CONTROL) | items 10-11 | `_unavailable_`, exit 0, no report file | PASS |
+| Degrade garbage (A7, NEGATIVE CONTROL) | item 12 | `_unavailable_` | PASS |
+
+## Run detail
+
+```
+$ bash lib/session/audit/tests/smoke.sh
+  ok: report written
+  ok: body present
+  ok: header params
+  ok: ROOT substituted
+  ok: all placeholders resolved
+  ok: PREV=none on first run
+  ok: PREV chained
+  ok: array-form parsed
+  ok: array body written
+  ok: degrades on failure
+  ok: no report on failure
+  ok: degrades on garbage
+smoke: 12 passed, 0 failed
+Exit: 0
+```
+
+## Reproduce
+
+```bash
+cd <dwarves-kit> && bash lib/session/audit/tests/smoke.sh
+```

--- a/lib/session/audit/docs/proof-of-done.md
+++ b/lib/session/audit/docs/proof-of-done.md
@@ -19,6 +19,9 @@ smoke is the proof. Live-model quality was validated in the origin experiment
 | A5 | Array-form runtime JSON parsed as well as object-form | observed CLI variance |
 | A6 | Failing runtime degrades to `_unavailable_`, exit 0, and writes NO report (never fabricates) | NEGATIVE CONTROL |
 | A7 | Garbage (non-JSON) runtime output also degrades to `_unavailable_` | NEGATIVE CONTROL |
+| A8 | `triage` turns the report's machine-triage json footer into kanban proposal rows (propose-only banner, owner + metric in notes) | feedback-loop TRIAGE stage |
+| A9 | `triage` picks the LAST valid json block (decoy blocks in prose are ignored) | footer contract |
+| A10 | `triage` degrades to `_none_` on a report without the footer, and to "no audit report found" on an empty dir | NEGATIVE CONTROL |
 
 ## Implementation
 
@@ -29,13 +32,15 @@ smoke is the proof. Live-model quality was validated in the origin experiment
 | Runtime | `claude -p --allowedTools Bash,Read,Grep,Glob --output-format json`, prompt on stdin, `SESSION_AUDIT_CMD` override | `run_agent()` |
 | Output parse | object-form and array-form `--output-format json` | `parse_runtime_json()` |
 | Report | `DIR/audit-YYYY-MM-DD.md`, header comment (date/root/days/model/cost/prev) | `main()` |
-| Tests | fixture runtime + capture helper, 12 assertions incl. 2 negative controls | `tests/smoke.sh` |
+| Triage | last-valid fenced json footer -> `\| ?? \| change \| audit ref · owner · metric \| queued \|` rows, stdout only | `cmd_triage()` / `extract_recommendations()` |
+| Loop contract | COLLECT -> REPORT -> TRIAGE -> ENHANCE -> MEASURE stage contracts + invariants | `docs/feedback-loop.md` |
+| Tests | fixture runtime + capture helper, 18 assertions incl. 3 negative controls | `tests/smoke.sh` |
 
 ## Confirmation run-table
 
 | Check | Command | Expected | Result |
 |---|---|---|---|
-| Smoke (all) | `bash lib/session/audit/tests/smoke.sh` | `smoke: 12 passed, 0 failed` | PASS |
+| Smoke (all) | `bash lib/session/audit/tests/smoke.sh` | `smoke: 18 passed, 0 failed` | PASS |
 | Report write (A1) | items 1-3 | dated file, body + header params present | PASS |
 | Substitution (A2) | items 4-5 | ROOT present, no `{...}` placeholder remains | PASS |
 | PREV first run (A3) | item 6 | "none provided for this run" in rendered prompt | PASS |
@@ -43,6 +48,9 @@ smoke is the proof. Live-model quality was validated in the origin experiment
 | Array-form (A5) | items 8-9 | status ok + body written | PASS |
 | Degrade fail (A6, NEGATIVE CONTROL) | items 10-11 | `_unavailable_`, exit 0, no report file | PASS |
 | Degrade garbage (A7, NEGATIVE CONTROL) | item 12 | `_unavailable_` | PASS |
+| Triage rows (A8) | items 13-15 | 2 rows, owner+metric notes, propose-only banner | PASS |
+| Triage decoy (A9) | item 16 | decoy json block ignored | PASS |
+| Triage degrade (A10, NEGATIVE CONTROL) | items 17-18 | `_none_` / "no audit report found" | PASS |
 
 ## Run detail
 
@@ -60,7 +68,13 @@ $ bash lib/session/audit/tests/smoke.sh
   ok: degrades on failure
   ok: no report on failure
   ok: degrades on garbage
-smoke: 12 passed, 0 failed
+  ok: triage: 2 proposal rows
+  ok: triage: notes carry owner+metric
+  ok: triage: propose-only banner
+  ok: triage: decoy block ignored
+  ok: triage: no-block degrades
+  ok: triage: empty degrades
+smoke: 18 passed, 0 failed
 Exit: 0
 ```
 

--- a/lib/session/audit/prompt.md
+++ b/lib/session/audit/prompt.md
@@ -110,3 +110,11 @@ proxy rate, name the assumption everywhere it is load-bearing).
    causal chain to be visible in the logs, otherwise write "consistent with".
    Findings with zero occurrences are reported as zeros, not omitted: a clean
    corpus is a result.
+
+   Close the report with the Table B rows repeated once as a fenced ```json
+   code block (machine triage reads it; keep it the LAST fenced json block in
+   the report). A list of objects, same content as the table, no new rows:
+     [{"change": "...", "owner": "kit|user-habit|harness|instrumentation",
+       "finding": "...", "effect": "...", "confidence": "high|medium|low",
+       "falsifier": "...",
+       "metric": {"name": "...", "current": "...", "rerun": "<command>"}}]

--- a/lib/session/audit/prompt.md
+++ b/lib/session/audit/prompt.md
@@ -18,6 +18,9 @@ Pricing (for dollar attribution; per million tokens):
 {PRICING}
 The model name is in the logs; convert token findings to $ ranges per model. When
 a session mixes models, attribute by the per-message model field, never a blend.
+A model with no rate in the table: never price it silently; report its token
+share as its own finding and mark every $ total as a floor (or, if you assume a
+proxy rate, name the assumption everywhere it is load-bearing).
 
 1. LEARN THE SCHEMA FIRST. Do not grep for guessed event or field names, the
    schema drifts between client versions and a miss reads as a false negative.
@@ -29,6 +32,14 @@ a session mixes models, attribute by the per-message model field, never a blend.
    cache read, cache creation), the model field, timestamps, and the session/parent
    join keys. Note every schema variant you encounter; if a field is absent in
    some files, say which and treat those files as a separate stratum, not as zero.
+   Two known transcript traps you must rule out by observation before summing:
+   (a) one API response may span several JSONL lines (one per content block),
+   each repeating an identical usage block, pick a dedup key (response/message
+   id) and state it, or every token total inflates 2-3x; (b) not every
+   user-type event is a human prompt, harness injections (hook feedback, task
+   notifications, skill-dispatch templates, resume summaries) land as user
+   events too; separate them and report the injection share before any
+   prompt/rework analysis.
 
 2. CORPUS BASELINE. Before any judgment: session count, event count, date range,
    per-session size distribution (median / p90 / max), sidechain share. Every rate

--- a/lib/session/audit/prompt.md
+++ b/lib/session/audit/prompt.md
@@ -1,0 +1,101 @@
+Read-only usage-intelligence audit over Claude Code session transcripts: what does
+actual usage evidence say about where tokens, time, and attention are wasted, who
+owns each fix (the kit, the user's habits, the harness), and what specific changes
+would recover them?
+
+Rules: read-only, never modify, move, or delete a transcript. Transcripts contain
+secrets (env dumps, tokens, auth headers): never print one; quote any transcript
+text at most 150 chars, truncated. Work only under the given root. Every claim
+must cite its evidence (a command you ran + its counts, or session-id + line);
+an uncited claim is a hypothesis and must be labeled as one.
+
+Sources: JSONL transcripts under {ROOT} (one event per line), modified in the last
+{DAYS} days. Sibling directories may hold subagent transcripts of the same work.
+{PREV} (optional): path to the previous audit report; when present, open the
+report with a metric-by-metric diff against it before any new findings.
+
+Pricing (for dollar attribution; per million tokens):
+{PRICING}
+The model name is in the logs; convert token findings to $ ranges per model. When
+a session mixes models, attribute by the per-message model field, never a blend.
+
+1. LEARN THE SCHEMA FIRST. Do not grep for guessed event or field names, the
+   schema drifts between client versions and a miss reads as a false negative.
+   Start with distributions, then inspect one full example of each event kind you
+   will rely on:
+     jq -r '.type' <file> | sort | uniq -c | sort -rn
+   Locate from observation, not memory: user prompts vs assistant turns vs tool
+   results, the sidechain/subagent marker, the token-usage block (input, output,
+   cache read, cache creation), the model field, timestamps, and the session/parent
+   join keys. Note every schema variant you encounter; if a field is absent in
+   some files, say which and treat those files as a separate stratum, not as zero.
+
+2. CORPUS BASELINE. Before any judgment: session count, event count, date range,
+   per-session size distribution (median / p90 / max), sidechain share. Every rate
+   you report later is relative to this baseline. State how much of the corpus
+   each later measurement actually covered (all files vs a sample), and how the
+   sample was chosen.
+
+3. MEASUREMENTS. Prefer aggregate queries (jq/awk across files) over reading
+   transcripts; deep-read at most {K} sessions, chosen BY the aggregates (largest,
+   most-erroring, most-repetitive), and name them. For each signal report the
+   exact command, the counts, and the top offending sessions:
+
+   a. TOKEN ECONOMICS, per-session input / output / cache-read / cache-creation
+      from the observed usage fields; the cache-read:fresh-input ratio; sessions
+      whose cache reads dwarf their output (mega-context re-read); the largest
+      single tool results (paste/dump events) and what produced them. Convert the
+      top items to $ using the pricing table and the observed model field.
+   b. FRICTION LOOPS, runs of consecutive failed tool calls; the same command
+      retried 3+ times in one session; error text repeating across turns.
+      Distinguish "retried and recovered" from "abandoned".
+      NO DARK BUCKETS: decompose every error bucket that holds more than 10% of
+      total errors by the command/tool that produced it, recursively, until no
+      bucket over 10% remains unlabeled (a generic "Exit code 1" pile is a
+      finding-shaped hole, not a finding).
+      ATTRIBUTE HOOK BLOCKS: a "hook blocked this" error names the specific hook
+      or gate (they have different owners); report per-hook counts, and for the
+      top hook, whether the blocks look self-inflicted (the rule exists and was
+      ignored) or systemic (the rule fires where it should not).
+   c. REWORK, user prompts that correct or walk back the assistant. Detect by
+      pattern, then VERIFY by reading the matched prompts (quote up to 150 chars
+      each); report verified count / matched count / sample size separately.
+      Never report a rework number you did not read.
+   d. REPEATED WORK, near-identical command sequences or prompt intents recurring
+      across sessions (candidate automations/skills); recurring startup sequences
+      a session replays every time (candidate context or tooling fix).
+   e. DELEGATION SHAPE, sidechain share of events and tokens; heavy mechanical
+      stretches (bulk grep/read/transform) executed inline in the main context
+      where a subagent would have kept the parent small.
+
+4. EVIDENCE TIERS. Label every finding:
+     HIGH, deterministic count over an observed field; command shown; anyone
+              can re-run it and get the same number.
+     MEDIUM, pattern-matched with verified samples (you read a sample and report
+              the match-vs-verified rate).
+     LOW, model judgment over sampled text (topic labels, intent clusters);
+              report the sample size and give ranges, never precise counts.
+   Keep tiers separate: never average a LOW estimate into a HIGH total. Where the
+   data is ambiguous (an absent usage block: older client, or synthetic event?),
+   report the ambiguity and both readings, do not resolve it without evidence.
+
+5. REPORT.
+   Metric diff vs {PREV} first, when given: same metrics, old value, new value,
+   and whether each earlier recommendation's metric moved.
+   Table A, findings: finding, tier, sessions affected, magnitude (tokens, $ or
+             occurrences), evidence (the command or the quoted line).
+   Table B, recommendations ranked by expected recovery. Each row carries:
+             the change; OWNER (kit | user-habit | harness | instrumentation);
+             the finding it rests on; expected effect in $ or minutes where the
+             pricing/timestamps allow it; confidence; what would falsify it; and
+             a METRIC CONTRACT, the metric's name, its current value, and the
+             exact re-run command a follow-up audit uses to check movement.
+   Then: corpus totals; the {K} sessions deep-read and why; what these logs CANNOT
+   answer (and the one instrumentation change that would unblock the strongest
+   pending conclusion).
+
+   Claims must not exceed evidence: "N sessions matched pattern P, M of S sampled
+   matches verified" is supportable; "the user wastes X because of Y" requires the
+   causal chain to be visible in the logs, otherwise write "consistent with".
+   Findings with zero occurrences are reported as zeros, not omitted: a clean
+   corpus is a result.

--- a/lib/session/audit/tests/smoke.sh
+++ b/lib/session/audit/tests/smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# smoke: session-audit render + report-write + PREV chaining + degrade paths.
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SA="$DIR/bin/session-audit"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+ok() { PASS=$((PASS + 1)); echo "  ok: $1"; }
+no() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+# fixture: object-form runtime output
+cat > "$TMP/obj.json" <<'EOF'
+{"type":"result","subtype":"success","is_error":false,"result":"## Audit body OBJ","total_cost_usd":1.23,"duration_ms":4500}
+EOF
+# fixture: array-form runtime output (observed from some CLI versions)
+cat > "$TMP/arr.json" <<'EOF'
+[{"type":"system"},{"type":"result","subtype":"success","is_error":false,"result":"## Audit body ARR","total_cost_usd":2.5,"duration_ms":9000}]
+EOF
+# capture helper: saves the rendered prompt, then answers with the fixture
+cat > "$TMP/capture" <<EOF
+#!/usr/bin/env bash
+cat > "$TMP/prompt-seen.txt"
+cat "$TMP/obj.json"
+EOF
+chmod +x "$TMP/capture"
+
+# 1. run writes a dated report containing the result body
+out="$(SESSION_AUDIT_CMD="$TMP/capture" SESSION_AUDIT_DATE=2026-01-01 "$SA" run --out "$TMP/intel" --root /nonexistent --days 3)"
+[ -f "$TMP/intel/audit-2026-01-01.md" ] && ok "report written" || no "report missing: $out"
+grep -q "Audit body OBJ" "$TMP/intel/audit-2026-01-01.md" && ok "body present" || no "body missing"
+grep -q "days 3" "$TMP/intel/audit-2026-01-01.md" && ok "header params" || no "header params missing"
+
+# 2. prompt render: params substituted, no unresolved placeholders
+grep -q "/nonexistent" "$TMP/prompt-seen.txt" && ok "ROOT substituted" || no "ROOT not substituted"
+if grep -qE '\{(ROOT|DAYS|K|PRICING|PREV)\}' "$TMP/prompt-seen.txt"; then no "unresolved placeholder"; else ok "all placeholders resolved"; fi
+grep -q "none provided for this run" "$TMP/prompt-seen.txt" && ok "PREV=none on first run" || no "PREV wrong on first run"
+
+# 3. second run receives the first report as PREV
+SESSION_AUDIT_CMD="$TMP/capture" SESSION_AUDIT_DATE=2026-01-08 "$SA" run --out "$TMP/intel" --root /nonexistent >/dev/null
+grep -q "audit-2026-01-01.md" "$TMP/prompt-seen.txt" && ok "PREV chained" || no "PREV not chained"
+
+# 4. array-form output parsed
+out="$(SESSION_AUDIT_CMD="cat $TMP/arr.json" SESSION_AUDIT_DATE=2026-01-15 "$SA" run --out "$TMP/intel" --json)"
+echo "$out" | grep -q '"status": "ok"' && ok "array-form parsed" || no "array-form not parsed: $out"
+grep -q "Audit body ARR" "$TMP/intel/audit-2026-01-15.md" && ok "array body written" || no "array body missing"
+
+# 5. degrade: failing command -> _unavailable_, exit 0, no report
+out="$(SESSION_AUDIT_CMD="false" SESSION_AUDIT_DATE=2026-02-01 "$SA" run --out "$TMP/intel")"; rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "_unavailable_" && ok "degrades on failure" || no "degrade wrong: rc=$rc $out"
+[ ! -f "$TMP/intel/audit-2026-02-01.md" ] && ok "no report on failure" || no "report written on failure"
+
+# 6. degrade: garbage output -> _unavailable_
+out="$(SESSION_AUDIT_CMD="echo not-json" SESSION_AUDIT_DATE=2026-02-02 "$SA" run --out "$TMP/intel")"
+echo "$out" | grep -q "_unavailable_" && ok "degrades on garbage" || no "garbage not degraded: $out"
+
+echo "smoke: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/lib/session/audit/tests/smoke.sh
+++ b/lib/session/audit/tests/smoke.sh
@@ -72,13 +72,26 @@ More prose.
   "metric":{"name":"top10_cache_read_share","current":"76.3%","rerun":"jq group-sum"}}]
 ```
 EOF
-out="$("$SA" triage --out "$TMP/triage")"
-echo "$out" | grep -c "^| ?? |" | grep -q "^2$" && ok "triage: 2 proposal rows" || no "triage rows wrong: $out"
-echo "$out" | grep -q "owner:kit · metric subagent_opus_share=24.1%" && ok "triage: notes carry owner+metric" || no "triage notes wrong"
-echo "$out" | grep -q "PROPOSALS ONLY" && ok "triage: propose-only banner" || no "triage banner missing"
+# triage stages `## [staged]` blocks (the kit's ONE proposal currency), never a bespoke row
+STAGING="$TMP/staging.md"; BOARD="$TMP/BACKLOG.md"
+printf '# Board\n\n| ID | Item | Notes | Status |\n|---|---|---|---|\n| ID-1 | clear mega-sessions at boundaries | already on the board | queued |\n' > "$BOARD"
+out="$("$SA" triage --out "$TMP/triage" --staging "$STAGING" --backlog "$BOARD")"
+[ "$(grep -c '^## \[staged\]' "$STAGING")" = "1" ] && ok "triage: stages 1 new block (dedup dropped the board dup)" || no "triage staging wrong: $(cat "$STAGING")"
+grep -q '^## \[staged\] route Explore subagents to haiku' "$STAGING" && ok "triage: title from the change" || no "triage title wrong"
+grep -q 'metric subagent_opus_share now 24.1%; re-run: jq cross-tab' "$STAGING" && ok "triage: metric contract on Approach" || no "triage metric line missing"
+grep -q '^- Source: session audit .* owner=kit' "$STAGING" && ok "triage: owner + report cited on Source" || no "triage source wrong"
+echo "$out" | grep -q "skipped 1 duplicate" && ok "triage: reports the dedup" || no "triage dedup not reported: $out"
+echo "$out" | grep -q "board promote" && ok "triage: points at the human gate" || no "triage gate hint missing"
 
-# 8. triage: last-json-block wins (the decoy above is ignored)
-echo "$out" | grep -q "not.*the footer" && no "triage: decoy block leaked" || ok "triage: decoy block ignored"
+# 8. triage: idempotent (a second run re-stages nothing) + last-json-block wins
+"$SA" triage --out "$TMP/triage" --staging "$STAGING" --backlog "$BOARD" >/dev/null
+[ "$(grep -c '^## \[staged\]' "$STAGING")" = "1" ] && ok "triage: idempotent on re-run" || no "triage re-staged a duplicate"
+grep -q "the footer" "$STAGING" && no "triage: decoy block leaked" || ok "triage: decoy block ignored"
+
+# 8b. triage --dry-run writes nothing
+DRY="$TMP/dry.md"
+"$SA" triage --out "$TMP/triage" --staging "$DRY" --backlog "$BOARD" --dry-run | grep -q '^## \[staged\]' && ok "triage: dry-run prints blocks" || no "dry-run printed nothing"
+[ ! -f "$DRY" ] && ok "triage: dry-run writes nothing (NEGATIVE CONTROL)" || no "dry-run wrote a file"
 
 # 9. triage degrade: report without the footer -> _none_
 cat > "$TMP/triage/audit-2026-03-08.md" <<'EOF'

--- a/lib/session/audit/tests/smoke.sh
+++ b/lib/session/audit/tests/smoke.sh
@@ -54,5 +54,42 @@ out="$(SESSION_AUDIT_CMD="false" SESSION_AUDIT_DATE=2026-02-01 "$SA" run --out "
 out="$(SESSION_AUDIT_CMD="echo not-json" SESSION_AUDIT_DATE=2026-02-02 "$SA" run --out "$TMP/intel")"
 echo "$out" | grep -q "_unavailable_" && ok "degrades on garbage" || no "garbage not degraded: $out"
 
+# 7. triage: report with a machine-triage json footer -> kanban proposal rows
+mkdir -p "$TMP/triage"
+cat > "$TMP/triage/audit-2026-03-01.md" <<'EOF'
+## Report body
+Some findings prose with an unrelated fenced block:
+```json
+{"not": "the footer"}
+```
+More prose.
+```json
+[{"change":"route Explore subagents to haiku","owner":"kit","finding":"237/982 on opus",
+  "effect":"cuts subagent opus spend","confidence":"medium","falsifier":"still lands on opus",
+  "metric":{"name":"subagent_opus_share","current":"24.1%","rerun":"jq cross-tab"}},
+ {"change":"clear mega-sessions at boundaries","owner":"user-habit","finding":"694:1 ratio",
+  "effect":"cuts cache-read","confidence":"medium","falsifier":"share does not drop",
+  "metric":{"name":"top10_cache_read_share","current":"76.3%","rerun":"jq group-sum"}}]
+```
+EOF
+out="$("$SA" triage --out "$TMP/triage")"
+echo "$out" | grep -c "^| ?? |" | grep -q "^2$" && ok "triage: 2 proposal rows" || no "triage rows wrong: $out"
+echo "$out" | grep -q "owner:kit · metric subagent_opus_share=24.1%" && ok "triage: notes carry owner+metric" || no "triage notes wrong"
+echo "$out" | grep -q "PROPOSALS ONLY" && ok "triage: propose-only banner" || no "triage banner missing"
+
+# 8. triage: last-json-block wins (the decoy above is ignored)
+echo "$out" | grep -q "not.*the footer" && no "triage: decoy block leaked" || ok "triage: decoy block ignored"
+
+# 9. triage degrade: report without the footer -> _none_
+cat > "$TMP/triage/audit-2026-03-08.md" <<'EOF'
+## Older-format report, no machine block
+EOF
+out="$("$SA" triage --out "$TMP/triage")"
+echo "$out" | grep -q "_none_" && ok "triage: no-block degrades" || no "triage no-block wrong: $out"
+
+# 10. triage degrade: no reports at all -> empty
+out="$("$SA" triage --out "$TMP/empty-dir")"
+echo "$out" | grep -q "no audit report found" && ok "triage: empty degrades" || no "triage empty wrong: $out"
+
 echo "smoke: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/lib/session/audit/tool.toml
+++ b/lib/session/audit/tool.toml
@@ -1,0 +1,13 @@
+name        = "session-audit"
+description = "LLM deep-audit over CC session transcripts: renders a forensic-style prompt (schema-first, evidence tiers, no dark buckets, owner-tagged recommendations with metric contracts) and hands it to an agent runtime that explores the JSONL itself. Dated reports chain via {PREV} into an improve-measure-improve loop. Propose-don't-dispose; expensive by design (weekly/on-demand, ~$3.5/run Sonnet)."
+language    = "python"
+status      = "pilot"
+entry       = "bin/session-audit"
+created     = 2026-07-14
+
+# Born in ops-toolkit experiments/log-intel-prompt-v2 (2026-07-14): a gist-style
+# forensic rewrite of session-semantic's thin clustering prompt, validated
+# head-to-head on a 3-day corpus (HIGH-tier claims reproduced exactly on
+# independent re-run). The prompt template is generic (no tenant paths); the
+# corpus root, window, and pricing are all run-time parameters.
+consumers   = []

--- a/lib/session/session.sh
+++ b/lib/session/session.sh
@@ -14,6 +14,7 @@
 #   session.sh intel <args...>     -> lib/session/intel/bin/session-intel (own usage)
 #   session.sh report <args...>    -> lib/session/observe/bin/session-report (own usage)
 #   session.sh semantic <args...>  -> lib/session/observe/bin/session-semantic (own usage)
+#   session.sh audit <args...>     -> lib/session/audit/bin/session-audit (own usage)
 #   session.sh -h|--help|help      -> this usage
 set -euo pipefail
 
@@ -28,6 +29,7 @@ main() {
     intel)    exec "$SESSION_DIR/intel/bin/session-intel" "$@" ;;
     report)   exec "$SESSION_DIR/observe/bin/session-report" "$@" ;;
     semantic) exec "$SESSION_DIR/observe/bin/session-semantic" "$@" ;;
+    audit)    exec "$SESSION_DIR/audit/bin/session-audit" "$@" ;;
     -h|--help|help|"") usage ;;
     *) echo "session: unknown verb '$verb' (try: session --help)" >&2; exit 1 ;;
   esac


### PR DESCRIPTION
## What

`session-audit`: an LLM deep-audit verb over CC session transcripts, the agentic sibling of `session-intel`'s deterministic digest. Renders the co-located `prompt.md` (forensic-audit shape: schema-first exploration, evidence tiers, no dark buckets, per-hook block attribution, owner-tagged recommendations each carrying a metric contract) and pipes it to an agent runtime that explores the JSONL itself. Dated reports auto-chain via `{PREV}` so each run opens with a metric diff against the last: the collector-to-enhancement loop.

## Why

session-observe locates waste deterministically and session-semantic clusters topics cheaply, but neither produces evidence strong enough to drive changes: no verifiable citations, no owner, no dollar attribution, no fix-verification loop. Head-to-head vs the thin session-semantic prompt (same corpus, same model): the forensic prompt's HIGH-tier numbers reproduced exactly on independent re-run (587/7,939 tool errors; a 694:1 per-session cache ratio), while the thin prompt's headline number (21 self-corrections) turned out to be mostly false positives (read-verified: 13 of 31 matches genuine over a wider window).

## Validation

- `bash lib/session/audit/tests/smoke.sh` -> `smoke: 12 passed, 0 failed` (fixture runtime; covers report write, placeholder substitution, PREV chaining, array-form runtime JSON, and two negative controls: failing runtime and garbage output both degrade to `_unavailable_` with no report).
- Proof of done: `lib/session/audit/docs/proof-of-done.md`.
- Live-model validation + 3-way model-tier run (haiku/sonnet/opus): ops-toolkit `experiments/log-intel-prompt-v2/results/`. Key outcomes baked into this PR: Sonnet is the documented model floor (Haiku fails schema discovery outright, reporting existing fields as absent); the prompt now names the two observed transcript traps (per-content-block usage duplication; harness-injected pseudo-prompts, 22% of nominal user events) as must-rule-out checks; unpriced models are reported as a share + $ floor, never silently priced.

## Provenance

Prompt method modeled on the forensic log-audit style of https://gist.github.com/dedene/bfa88bb059d4946726cb1823ec1643ba (schema-first, evidence tiers, claims never exceed evidence, report ambiguity, fixed report contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
