### PR TITLE
docs(money-gate): its first SPEC + proof, and 3 divergences it exposed

### DIFF
--- a/hooks/money-gate.py
+++ b/hooks/money-gate.py
@@ -3,9 +3,13 @@
 (kit-foldin port of ops-toolkit cc-money-gate, function-named).
 
 When an edit lands in a repo you named financial (MONEY_GATE_REPOS) and the path or
-the new content touches money/auth (amounts, balances, transfers, wallets, keys,
-payroll, ...), this asks for confirmation before the edit lands. The point: a
-careless edit to cashflow / PnL / a wallet address should never be silent.
+ANY string in the tool payload touches money/auth (amounts, balances, transfers,
+wallets, keys, payroll, ...), this asks for confirmation before the edit lands. The
+point: a careless edit to cashflow / PnL / a wallet address should never be silent.
+
+The payload scan is recursive (collect_strings), so old_string and the MultiEdit
+edits[] array are scanned too, not just new content: DELETING a money line trips the
+gate as readily as adding one. Contract + known divergences: lib/money-gate/SPEC.md.
 
 pixelmojo's "LLM semantic review on PreToolUse" idea, but deterministic (regex on
 path + content) so it is fast enough to run on every edit and testable in-repo.
@@ -17,8 +21,9 @@ Env:
   MONEY_GATE_REPOS=a:b      sensitive repo names. CONSUMER CONFIG, no default: unset
                           means the gate is inert (adapter-default invariant; the
                           kit ships no tenant repo names)
-  MONEY_GATE_STRICT=1       ask-to-confirm instead of log-only
-  MONEY_GATE_LOG=FILE       log destination (default ~/.claude/logs/cc-money-gate.log)
+  MONEY_GATE_STRICT=1       ask-to-confirm instead of log-only (the LITERAL "1"; any
+                          other value, including "true", stays log-only)
+  MONEY_GATE_LOG=FILE       log destination (default ~/.claude/logs/money-gate.log)
 Stdlib only. Exit 0 always (decision is carried in the JSON, not the exit code).
 """
 import json

--- a/lib/money-gate/README.md
+++ b/lib/money-gate/README.md
@@ -1,0 +1,74 @@
+# money-gate
+
+A `PreToolUse(Edit|Write|MultiEdit)` guard that asks for confirmation before a
+money-touching edit lands in a repo you named financial. A careless edit to a cashflow
+file, a payroll row, or a wallet address should never be silent.
+
+Folded in from ops-toolkit's `cc-money-gate` at kit-foldin (2026-07-11), function-named on
+entry (`MONEY_GATE_*`, the host-agent `CC_` prefix dropped).
+
+**Hook-only module.** The code lives in `hooks/money-gate.sh` (shim) and
+`hooks/money-gate.py` (logic, stdlib-only). This directory is the module's doc home:
+`SPEC.md` is the contract, `docs/proof-of-done.md` is the acceptance record.
+
+## Ships inert
+
+The kit ships **no repo names** (the adapter-default invariant: no tenant data in the
+kit). Until you set `MONEY_GATE_REPOS`, the hook exits 0 before it does anything.
+
+```bash
+bash install.sh --with money_gate          # wire the hook (records modules.money_gate)
+export MONEY_GATE_REPOS=my-books:family-office   # colon-separated repo names
+```
+
+That alone gives you **log-only** mode: every money-touching edit in those repos is
+appended to `~/.claude/logs/money-gate.log`, nothing is interrupted. Wire it, forget it,
+read the log later.
+
+```bash
+export MONEY_GATE_STRICT=1                 # upgrade to ask-to-confirm
+```
+
+Now the same edit emits a PreToolUse `ask`, and Claude Code prompts you before it lands.
+`MONEY_GATE_STRICT` must be the literal `1`; `true` is log-only.
+
+## When it fires
+
+Two conditions, both required:
+
+| | Condition | Source |
+|---|---|---|
+| 1 | The edit is inside a repo named in `MONEY_GATE_REPOS` | the payload's `file_path` + `cwd` |
+| 2 | Some string in the payload matches the money/auth keywords | `amount`, `balance`, `transfer`, `payout`, `payroll`, `invoice`, `wallet`, `ledger`, `cashflow`, `pnl`, `usd`, `vnd`, `api_key`, `token`, ... |
+
+Either alone is silence. The content scan is recursive over the whole tool payload, so
+`old_string` and the MultiEdit `edits[]` array count too: **deleting** a money line trips
+the gate just as adding one does.
+
+It never blocks. The strongest thing it can do is `ask`, and it always exits 0, so a
+broken gate can never wedge an edit.
+
+## Env
+
+| Var | Default | Effect |
+|---|---|---|
+| `MONEY_GATE_REPOS` | unset | Colon-separated financial repo names. Unset = inert. |
+| `MONEY_GATE_STRICT` | unset | Literal `1` = ask-to-confirm. Anything else = log-only. |
+| `MONEY_GATE_LOG` | `~/.claude/logs/money-gate.log` | Log destination. |
+
+## Test
+
+```bash
+bash tests/test-money-gate.sh   # -> test-money-gate: all 12 passed
+```
+
+## Known gaps
+
+`SPEC.md` carries the full contract, the degrade paths, and three divergences worth
+knowing before you trust this gate:
+
+1. The log path bypasses the SPEC-097 durable-root resolver (`lib/telemetry/kit-log-dir.sh`).
+2. The keyword list (`token`, `secret`, `password`) also fires on ordinary auth code.
+3. **The regex is `\b`-anchored, so it misses snake_case identifiers and plurals.**
+   `payroll_total = 5000` does **not** trip the gate; `payroll = 5000` does. This is the
+   real hole, and identifier-shaped money code is exactly what an agent edits.

--- a/lib/money-gate/SPEC.md
+++ b/lib/money-gate/SPEC.md
@@ -1,0 +1,206 @@
+# SPEC: money-gate
+
+> Written 2026-07-15, after the fact. `money_gate` entered at kit-foldin (2026-07-11)
+> as a port of ops-toolkit's `cc-money-gate` and was the one kit module that never got
+> a SPEC: its only acceptance record was a proof-of-done shared with `prose_rag`
+> (`docs/verification/money-gate-prose-rag-fold.md`). This SPEC is a description of the
+> code as it stands, not a redesign. Where the code and its own docstring disagree, the
+> code wins and the disagreement is called out.
+
+## Problem
+
+At the PreToolUse boundary every edit looks the same. The harness sees a tool name and a
+payload; it does not know that `tracking/ledger/transactions.csv` moves real money and
+`README.md` does not. The kit's spine hooks do not close this: `safety-gate` guards
+destructive shell verbs, `secrets-guard` guards credential leaks, neither knows which
+repos hold money.
+
+So a wrong amount, a swapped wallet address, or a mangled payroll row lands **silently**,
+and the first thing that notices is a human at reconciliation time, weeks later. The cost
+of a careless money edit is asymmetric: a bad `README.md` edit is a `git checkout`, a bad
+payroll edit is a wrong payment.
+
+Origin: pixelmojo's "LLM semantic review on PreToolUse" idea, made deterministic (regex
+over the payload) so it is fast enough to run on **every** edit and testable in-repo.
+
+## Solution
+
+A `PreToolUse(Edit|Write|MultiEdit)` hook that speaks only when **two** conditions hold at
+once:
+
+1. **Location**: the edit is inside a repo the consumer named in `MONEY_GATE_REPOS`.
+2. **Content**: some string in the tool payload matches the money/auth keyword regex.
+
+Either alone is silence. That conjunction is the whole design: content-only would fire on
+every repo that says "amount", location-only would fire on every edit in a financial repo.
+
+Default is **log-only** (safe to wire and forget). `MONEY_GATE_STRICT=1` upgrades it to a
+PreToolUse `ask` decision, so Claude Code prompts before the edit lands.
+
+The kit ships it **inert**. There are no default repo names (the adapter-default
+invariant: the kit ships no tenant data), so an unset `MONEY_GATE_REPOS` means the hook
+exits before it does anything at all.
+
+## Contract
+
+**Where the code lives.** `hooks/money-gate.sh` (a bash shim) and `hooks/money-gate.py`
+(the logic, stdlib-only). `money_gate` is a **hook-only module**: this `lib/money-gate/`
+dir is its doc home and carries no code.
+
+**Wiring.** `install.sh --with money_gate` installs the one hook (`kit_module_hooks
+money_gate` -> `money-gate.sh`) and records `modules.money_gate` in the consumer's
+`kit.toml` (default `false`). Registered as PreToolUse matcher `Edit|Write|MultiEdit`,
+timeout 5s, in `hooks/hooks.json` (plugin install) and `settings.json` (bash install).
+
+**Exit code is always 0.** The decision travels in the JSON on stdout, never in the exit
+code. This is load-bearing, not incidental: a gate that dies must not block an edit.
+
+**Decision sequence** (first failing step exits 0, silent):
+
+| # | Step | Rule |
+|---|---|---|
+| 1 | Shim short-circuit | `MONEY_GATE_REPOS` unset or empty -> `exit 0` before `python3` is spawned |
+| 2 | Parse | stdin must be JSON; a `JSONDecodeError`/`ValueError` returns 0 |
+| 3 | Location | `haystack = f"{file_path}\n{cwd}"`; match if any non-empty `r` in `MONEY_GATE_REPOS.split(":")` satisfies `f"/{r}/" in haystack` **or** `haystack.endswith(f"/{r}")` |
+| 4 | Content | `MONEY_RE` over `file_path` plus **every string in `tool_input`**, collected recursively (dict values, list items) |
+| 5 | Decide | no keyword hits -> return 0; hits -> log, and in strict mode also emit the `ask` JSON |
+
+`file_path` is read as `tool_input.file_path`, falling back to `tool_input.path`, else `""`.
+`cwd` is read from the payload's top-level `cwd`, else `""`.
+
+**The keyword set** (word-boundary, case-insensitive):
+
+```
+amount | balance | transfer | payout | payment | payroll | invoice | wallet |
+private[_-]?key | secret | password | api[_-]?key | token | iban |
+account[_-]?number | routing | ledger | cashflow | pnl | net[_-]?worth |
+deposit | withdraw | usd | vnd
+```
+
+Each keyword is `\b`-anchored, which is narrower than it looks: see divergence 3 below.
+
+**The recursive scan is broader than the docstring claims.** The module docstring said the
+gate looks at "the path or the new content". It does not: `collect_strings()` walks the
+whole `tool_input`, so `old_string` and the MultiEdit `edits[]` array are scanned too.
+Consequence, verified: **deleting** a money line trips the gate exactly as readily as
+adding one. That is defensible for a money guard (removing a ledger row is as dangerous as
+writing one), but it was never written down. (The docstring was corrected in the same
+change that added this SPEC; the code was not touched.)
+
+**Modes.**
+
+| Mode | Condition | Behavior |
+|---|---|---|
+| log-only (default) | `MONEY_GATE_STRICT` != `1` | append one line to the log, print nothing |
+| strict | `MONEY_GATE_STRICT` == `1` | the same log line, **plus** an `ask` JSON on stdout |
+
+`MONEY_GATE_STRICT` is compared to the **literal string `"1"`**. Any other truthy-looking
+value (`true`, `yes`, `on`) is log-only. Verified; this is a footgun and is recorded as
+contract, not as a bug to be fixed silently.
+
+The strict-mode payload:
+
+```json
+{"hookSpecificOutput": {
+  "hookEventName": "PreToolUse",
+  "permissionDecision": "ask",
+  "permissionDecisionReason": "money-gate: edit in a financial repo touches <terms>: confirm before applying."
+}}
+```
+
+`<terms>` is the matched keywords, lowercased, deduped, sorted, **capped at the first 6**.
+
+**The log** is written in *both* modes (the log is the record; strict only adds the
+prompt). Path: `MONEY_GATE_LOG`, default `~/.claude/logs/money-gate.log`. Format, one line
+per fire:
+
+```
+<epoch>\t<file_path>\t<comma-joined hits>
+```
+
+The parent dir is created on demand and `OSError` is swallowed: an unwritable log never
+blocks an edit.
+
+**Env.**
+
+| Var | Default | Effect |
+|---|---|---|
+| `MONEY_GATE_REPOS` | unset | Colon-separated repo names treated as financial. **Unset = the gate is inert.** No kit default exists. |
+| `MONEY_GATE_STRICT` | unset | `1` (literal) upgrades log-only to an `ask` decision. |
+| `MONEY_GATE_LOG` | `~/.claude/logs/money-gate.log` | Log destination. |
+
+**Degrade paths**, every one of them `exit 0` and silent:
+
+- `MONEY_GATE_REPOS` unset -> shim exits before spawning Python.
+- stdin is not JSON (`{}`, empty, garbage) -> `return 0`.
+- `python3` missing or the script raises -> the shim's `|| true` and trailing `exit 0`
+  swallow it. (Stderr noise from the failed exec is not suppressed; the exit code is
+  still 0, so the edit is never blocked.)
+- The log is unwritable -> `OSError` swallowed, the `ask` still emits.
+
+### Known divergences (recorded, not fixed here)
+
+Two things the code does that no design record ever justified. Both are described because
+this SPEC documents reality; neither is changed by it.
+
+1. **The log does not resolve through `lib/telemetry/kit-log-dir.sh`.** SPEC-097 and
+   contract rule C6 make that the durable-root resolver for every module that persists
+   state. `money-gate.py` builds `~/.claude/logs/money-gate.log` directly. C6's sweep
+   greps `lib` only, so a hook-only module is outside its scope and the divergence is
+   invisible to the lint. Whether an append-only audit trail is "state" in C6's sense
+   (as opposed to run telemetry) was never decided in writing.
+2. **`secret|password|api[_-]?key|token` makes the gate fire on ordinary auth code**
+   inside a named repo. Verified: `const token = getAccessToken()` in a named repo asks.
+   Whether that breadth is the point (auth edits in a money repo *are* worth a prompt) or
+   an accepted false-positive tax was never stated. It overlaps the `secrets-guard` spine
+   hook, which owns credential-leak detection proper.
+3. **The `\b` anchors make the gate blind to snake_case identifiers and plurals.** `_` is
+   a word character, so `\bpayroll\b` does not match `payroll_total`, and `\bamount\b`
+   does not match `amounts`. Verified against the live regex:
+
+   | Input | Hits |
+   |---|---|
+   | `payroll_total`, `invoice_id`, `total_payroll`, `amounts` | *(none)* |
+   | `payroll`, `amount`, `payroll-total` (hyphen is not a word char) | matched |
+
+   So a Python file whose only money signal is `payroll_total = 5000` **does not trip the
+   gate**, while the same line written `payroll = 5000` does. This is the gate's largest
+   real hole: identifier-shaped money code is exactly what an agent edits. It is pinned by
+   test `[12]` as a characterization test, so widening the regex will fail that test
+   loudly rather than drift silently. Not fixed here: this SPEC records the code, and
+   changing the match set is a behavior change that deserves its own diff.
+
+## Non-goals
+
+- **Blocking.** The strongest decision is `ask`; the gate never returns `deny`, and it
+  cannot block via the exit code (always 0). A human confirms, or nothing happens.
+- **Semantic review.** The match is a regex over the payload, deliberately: an LLM call on
+  every Edit is too slow for a PreToolUse hook and cannot be tested in-repo. False
+  positives are the accepted price of determinism.
+- **Reading the file on disk.** Only the tool payload is inspected. An edit whose money
+  context lives entirely in the surrounding, unmodified lines is invisible to the gate.
+- **Resolving repo roots.** `MONEY_GATE_REPOS` entries are matched as path substrings, not
+  against git. Any directory that shares the name matches.
+- **Shipping tenant defaults.** No repo names, no vendor keywords. Unset means inert.
+- **Being the secrets gate.** The keyword list overlaps, but `secrets-guard` owns that job.
+
+## Verification
+
+```bash
+bash tests/test-money-gate.sh   # -> test-money-gate: all 12 passed
+```
+
+12 assertions: 6 positive, 5 negative controls, 1 characterization test.
+
+- **Fires** `[1][2][3][8][9][11]`: the `ask` emits on a money edit in a named repo, its
+  JSON is valid and names the matched terms; log-only mode logs without asking; the
+  recursive scan reaches the MultiEdit `edits[]` array and `old_string`; the process exits
+  0 even while asking.
+- **Stays silent** (negative controls) `[4][5][6][7][10]`: a non-money edit in a named
+  repo; a money edit outside a named repo; `MONEY_GATE_REPOS` unset (the kit default); a
+  junk payload; `MONEY_GATE_STRICT` set to a non-`1` truthy string. These are what prove
+  the gate discriminates rather than firing on everything.
+- **Characterization** `[12]`: pins divergence 3 (snake_case and plurals do not match), so
+  the blind spot fails loudly if the regex is ever widened.
+
+Acceptance record: `lib/money-gate/docs/proof-of-done.md`.

--- a/lib/money-gate/docs/proof-of-done.md
+++ b/lib/money-gate/docs/proof-of-done.md
@@ -1,0 +1,224 @@
+# Proof of Done: money-gate
+
+**Feature:** the module's first SPEC (`lib/money-gate/SPEC.md`) + its own acceptance record, replacing the joint proof it shared with `prose_rag`.
+**Date:** 2026-07-15 · **Lane:** docs · **Host:** Hans-Air-M4 (macOS 26.5.2, Python 3.14.6) · **Kit:** v2.0.0
+
+`money_gate` was the one kit module with no SPEC. It entered at kit-foldin (2026-07-11) as
+a port of ops-toolkit's `cc-money-gate`, and its only acceptance record was
+`docs/verification/money-gate-prose-rag-fold.md`, a proof shared with `prose_rag` that
+recorded the *fold* (wiring, install, hook counts) rather than the gate's *behavior*.
+
+This change is documentation plus test-hardening. **The hook's behavior is unchanged**: no
+line of `money-gate.py`'s logic was touched. The only source edit is a docstring correction
+(two statements the code on the same file contradicted). Everything else is the SPEC, this
+proof, a README, and 5 new assertions that pin contract claims nothing was testing.
+
+## Acceptance criteria
+
+| # | Criterion | Source |
+|---|---|---|
+| A1 | The module has a SPEC describing the code as it actually behaves | task; C3 |
+| A2 | The module has its own `docs/proof-of-done.md`, not a joint one | task; C3 |
+| A3 | The module has a README front door | C3 |
+| A4 | Every behavioral claim the SPEC makes is backed by a test assertion | house rule: no untested SPEC claim |
+| A5 | The gate really discriminates (fires on money-in-named-repo, silent otherwise) | NEGATIVE CONTROL |
+| A6 | The gate always exits 0 (a broken gate cannot wedge an edit) | contract invariant |
+| A7 | `bash tests/test-kit-contract.sh` stays green, and money_gate's known-gap IOU is closed | task; C3/C4 |
+| A8 | Behavior unchanged (docs + tests only) | scope fence |
+
+## Implementation
+
+| Piece | What | Where |
+|---|---|---|
+| SPEC | Problem / Solution / Contract (decision sequence, env, degrade paths) / Non-goals / Verification, plus 3 recorded divergences | `lib/money-gate/SPEC.md` |
+| Proof | this file | `lib/money-gate/docs/proof-of-done.md` |
+| README | front door: ships inert, how to arm it, when it fires, known gaps | `lib/money-gate/README.md` |
+| Test pins | `[8]` MultiEdit `edits[]` scanned, `[9]` `old_string` scanned, `[10]` strict needs literal `"1"`, `[11]` exit-0-while-asking, `[12]` characterization of the `\b` blind spot | `tests/test-money-gate.sh` (7 -> 12) |
+| Docstring fix | "the new content" -> the whole payload (recursive); default log `cc-money-gate.log` -> `money-gate.log` | `hooks/money-gate.py` (comment only) |
+| Gap closed | the `money_gate` IOU paragraph | `tests/kit-contract-known-gaps.txt` |
+
+Where the code lives is worth stating, because it is why the contract never saw this
+module: `money_gate` is **hook-only** (`hooks/money-gate.{sh,py}`). The contract's
+`modules()` resolves a module to `lib/<name>/`, and `lib/money-gate/` did not exist, so
+C3 and C4 skipped it entirely. Creating the doc dir is what puts the module *inside* the
+lint's scope, which is why A7 is an acceptance criterion and not a formality.
+
+## Confirmation run-table
+
+| # | Check | Command | Expected | Result |
+|---|---|---|---|---|
+| 1 | Module suite, all 12 | `bash tests/test-money-gate.sh` | `all 12 passed`, exit 0 | PASS |
+| 2 | Fires: ask on money edit in named repo (A5) | test `[1][2]` | valid `ask` JSON naming the terms | PASS |
+| 3 | Log-only is the default (A5) | test `[3]` | logs, no stdout | PASS |
+| 4 | Recursive scan: MultiEdit `edits[]` (A4) | test `[8]` | asks, names `payout` | PASS |
+| 5 | Recursive scan: `old_string` (A4) | test `[9]` | asks, names `balance` | PASS |
+| 6 | NEGATIVE CONTROL: 5 silent cases (A5) | tests `[4][5][6][7][10]` | no stdout, no log | PASS |
+| 7 | Exit 0 even while asking (A6) | test `[11]` | rc 0 + ask JSON | PASS |
+| 8 | Characterization: `\b` blind spot (A4) | test `[12]` | `payroll_total` does not fire | PASS |
+| 9 | Kit contract green + gap closed (A7) | `bash tests/test-kit-contract.sh` | 22 passed, 0 failed; money_gate no longer a gap | PASS |
+| 10 | NEGATIVE CONTROL: the lint really watches money-gate (A7) | yank `SPEC.md`, re-run the contract | C3 fails, naming `lib/money-gate/SPEC` | PASS |
+| 11 | Behavior unchanged (A8) | `git diff --stat hooks/money-gate.py` | docstring lines only | PASS |
+
+## Run detail
+
+Module suite (verbatim, `Exit: 0`):
+
+```
+$ bash tests/test-money-gate.sh; echo "Exit: $?"
+[1] strict + named repo + money content -> asks to confirm
+  ok: ask emitted
+[2] ask JSON is valid + names the matched terms
+  ok: valid ask JSON with reason
+[3] default (non-strict) mode logs but does not ask
+  ok: logged, no block
+[4] NC: named repo + non-money content -> silent
+  ok: no fire on plain edit
+[5] NC: money content OUTSIDE a named repo -> silent
+  ok: no fire outside named repos
+[6] NC: MONEY_GATE_REPOS unset -> inert even on money content (kit default)
+  ok: inert without consumer config
+[7] junk payload -> exit 0, silent
+  ok: junk safe
+[8] recursive scan reaches the MultiEdit edits[] array
+  ok: MultiEdit edits[] scanned
+[9] recursive scan reaches old_string (DELETING money content trips the gate)
+  ok: old_string scanned
+[10] NC: MONEY_GATE_STRICT must be the literal '1' -- 'true' logs but does NOT ask
+  ok: non-'1' strict is log-only
+[11] exit 0 ALWAYS, even when emitting an ask (decision travels in JSON, not rc)
+  ok: asked and still exit 0
+[12] CHARACTERIZATION (known gap): snake_case + plurals do NOT match -> no fire
+  ok: gap confirmed: \b-anchored regex misses snake_case/plurals
+
+test-money-gate: all 12 passed
+Exit: 0
+```
+
+Live hook, strict mode, money edit in a named repo (the gate doing its job):
+
+```
+$ printf '%s' '{"tool_input":{"file_path":"/home/u/work/acme-books/tracking/transactions.csv",
+    "new_string":"transfer 500 USD to wallet 0xabc"},"cwd":"/home/u/work/acme-books"}' \
+  | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG=$T/g.log bash hooks/money-gate.sh
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": "money-gate: edit in a financial repo touches transfer, usd, wallet: confirm before applying."}}
+Exit: 0
+```
+
+Same edit, default (log-only) mode. No stdout, so nothing prompts; the record still lands:
+
+```
+$ ... | MONEY_GATE_REPOS=acme-books MONEY_GATE_LOG=$T/b.log bash hooks/money-gate.sh
+Exit: 0
+log: 1784050432	/home/u/work/acme-books/tracking/transactions.csv	transfer,usd,wallet
+```
+
+Kit contract, after adding `lib/money-gate/` (which is what pulls the module into C3/C4 scope):
+
+```
+$ bash tests/test-kit-contract.sh | tail -3
+
+=== kit-contract: 22 passed, 0 failed ===
+Exit: 0
+```
+
+The module is now genuinely inside the lint's scope, not merely adjacent to it. The
+contract's own `modules()` resolver now returns it, and it carries no IOU:
+
+```
+$ # modules() as the contract computes it
+  lib/board
+  lib/money-gate      <- new; was absent, which is why C3/C4 never looked at it
+  lib/plugin-check
+  lib/prose-rag
+  lib/queue
+  lib/session
+  lib/skill-curator
+  lib/stats
+
+$ grep -c '^lib/money-gate' tests/kit-contract-known-gaps.txt
+0     # no known-gap entry: it passes C3/C4 outright, it is not exempted
+```
+
+**These runs were made in a clean tree** (`git archive HEAD` + only this change's files).
+The live working copy currently carries a second, unrelated in-flight change from a
+concurrent session (a C10 contract rule, `lib/cosmetic/`, `lib/telemetry/tests/`), which
+inflates the contract to 24 checks. 22 is this branch's true number; verifying against the
+contaminated tree would have recorded a count this branch cannot reproduce.
+
+## NEGATIVE CONTROL
+
+The gate exists is a weak claim; the gate *discriminates* is the claim worth proving. An
+`ask` that fires unconditionally would pass test `[1]` and be worthless. Five controls
+force silence, each removing exactly one of the two conditions the SPEC says must both
+hold:
+
+| Control | What is removed | Test | Result |
+|---|---|---|---|
+| Non-money edit in a named repo (`README.md`, prose) | the **content** condition | `[4]` | silent |
+| Money content outside a named repo | the **location** condition | `[5]` | silent |
+| `MONEY_GATE_REPOS` unset (the shipped kit default) | the module's arming | `[6]` | inert |
+| Junk payload (`{}`) | parseable input | `[7]` | silent, exit 0 |
+| `MONEY_GATE_STRICT=true` (not literal `1`) | the strict upgrade | `[10]` | logs, does **not** ask |
+
+Live, the two that matter most (verbatim):
+
+```
+--- NEGATIVE CONTROL: money content OUTSIDE a named repo ---
+$ printf '%s' '{"tool_input":{"file_path":"/home/u/work/other-repo/foo.py",
+    "new_string":"transfer balance payout amount"},"cwd":"/home/u/work/other-repo"}' \
+  | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG=$T/c.log bash hooks/money-gate.sh
+Exit: 0 (stdout empty above = no ask)
+log written: no
+
+--- NEGATIVE CONTROL: MONEY_GATE_REPOS unset (kit default) ---
+$ printf '%s' '{"tool_input":{"file_path":"/home/u/work/acme-books/tracking/transactions.csv",
+    "new_string":"transfer 500 USD to wallet 0xabc"},"cwd":"/home/u/work/acme-books"}' \
+  | env -u MONEY_GATE_REPOS MONEY_GATE_STRICT=1 MONEY_GATE_LOG=$T/d.log bash hooks/money-gate.sh
+Exit: 0 (inert)
+log written: no
+```
+
+The third control is `[10]`, and it is the uncomfortable one: the *same* payload that asks
+in `[1]` goes quiet the moment `MONEY_GATE_STRICT` is spelled `true` instead of `1`. It
+still logs, so the gate is not broken, but an operator who armed the gate with `true` would
+believe they are being prompted and never be. That is now contract (SPEC "Modes"), pinned
+by a test, rather than a surprise waiting in the source.
+
+`[12]` is a characterization control, not a pass: it proves the `\b`-anchored regex is blind
+to `payroll_total` / `invoice_id` / `amounts`. It is recorded as SPEC divergence 3 and left
+unfixed on purpose, because widening the match set is a behavior change and this change is
+docs-only (A8). The test makes the hole loud instead of invisible.
+
+### The lint itself gets a negative control
+
+Adding three files and watching a suite stay green proves nothing: a lint that skips the
+module would also stay green. So the claim under test is "C3 now *watches* money-gate",
+and the way to prove it is to break it on purpose. Yank the SPEC and the contract must go
+red, naming the exact missing artifact:
+
+```
+$ mv lib/money-gate/SPEC.md lib/money-gate/SPEC.md.hidden
+$ bash tests/test-kit-contract.sh
+== C3 docs: README + SPEC + proof-of-done per module ==
+  FAIL every module has README + a spec + docs/proof-of-done.md (no NEW gaps) (offenders: lib/money-gate/SPEC )
+=== kit-contract: 21 passed, 1 failed ===
+Exit: 1
+
+$ mv lib/money-gate/SPEC.md.hidden lib/money-gate/SPEC.md   # restore
+$ bash tests/test-kit-contract.sh | tail -1
+=== kit-contract: 22 passed, 0 failed ===
+Exit: 0
+```
+
+Before this change that same deletion would have been a no-op: `lib/money-gate/` did not
+exist, so `modules()` never yielded it and C3 had nothing to miss. The module was not
+passing the contract, it was **invisible to it**. That is the actual gap this change closes,
+and the red run above is the evidence.
+
+## Reproduce
+
+```bash
+bash tests/test-money-gate.sh    # -> test-money-gate: all 12 passed
+bash tests/test-kit-contract.sh  # -> kit-contract: 22 passed, 0 failed
+git diff --stat hooks/money-gate.py   # docstring lines only: behavior unchanged
+```

--- a/tests/kit-contract-known-gaps.txt
+++ b/tests/kit-contract-known-gaps.txt
@@ -31,9 +31,14 @@ lib/prose-rag/tests
 #
 #   cosmetic    5 of its 6 hooks have no SPEC, no proof, no implementation notes (the thinnest
 #               module in the kit; only codebase-index is specced).
-#   money_gate  no SPEC was ever written: it entered at kit-foldin and has only a joint
-#               proof-of-done shared with prose_rag.
 #   telemetry   has an origin SPEC but zero ADR / proof / implementation notes of its own.
+#
+# CLOSED 2026-07-15: money_gate. It had no SPEC (the only module without one) and only a joint
+# proof-of-done shared with prose_rag. Now: lib/money-gate/{README.md,SPEC.md,docs/proof-of-done.md}
+# + tests/test-money-gate.sh grown 7 -> 12 assertions. Note WHY the contract never saw it: it is a
+# hook-only module (hooks/money-gate.{sh,py}), and modules() resolves a module to lib/<name>/, which
+# did not exist. Creating the doc dir is what pulled it into C3/C4 scope, so it is now linted like
+# every other module rather than living in this file's blind spot.
 #
 # Also: architecture docs are almost never per-module (only skill-curator has one), and ADRs
 # exist for only 4 of 21 subsystems. Both are acceptable for now; neither is invisible anymore.

--- a/tests/test-money-gate.sh
+++ b/tests/test-money-gate.sh
@@ -44,6 +44,46 @@ echo "[7] junk payload -> exit 0, silent"
 set +e; out="$(echo '{}' | MONEY_GATE_REPOS=acme-books bash "$SHIM")"; rc=$?; set -e
 if [[ $rc -eq 0 && -z "$out" ]]; then ok "junk safe"; else no "rc=$rc out=$out"; fi
 
+# --- SPEC.md contract pins (added 2026-07-15 with the module's first SPEC) -------------
+# The four below assert claims SPEC.md now makes that nothing was testing. The content
+# scan is RECURSIVE over the whole tool_input (not just "the new content", as the module
+# docstring said), so [8] and [9] pin the two payload shapes that reach only through the
+# recursion; [10] pins the literal-"1" strict switch (a footgun: `true` is log-only);
+# [11] pins the exit-0-always invariant, which is what keeps a broken gate from wedging
+# an edit. A SPEC claim with no test is the thing this repo does not ship.
+
+multiedit='{"tool_input":{"file_path":"/home/u/work/acme-books/pay.py","edits":[{"old_string":"x = 1","new_string":"send payout to wallet 0xabc"}]},"cwd":"/home/u/work/acme-books"}'
+del_money='{"tool_input":{"file_path":"/home/u/work/acme-books/pay.py","old_string":"balance = payroll_total","new_string":"pass"},"cwd":"/home/u/work/acme-books"}'
+
+echo "[8] recursive scan reaches the MultiEdit edits[] array"
+out="$(printf '%s' "$multiedit" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l5" bash "$SHIM")"
+if grep -q '"permissionDecision": "ask"' <<<"$out" && grep -q 'payout' <<<"$out"; then ok "MultiEdit edits[] scanned"; else no "got: $out"; fi
+
+echo "[9] recursive scan reaches old_string (DELETING money content trips the gate)"
+# The money term lives ONLY in old_string; new_string is "pass". An ask here can only
+# come from the old_string scan. (It reports `balance`, not `payroll_total` -- see [12].)
+out="$(printf '%s' "$del_money" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l6" bash "$SHIM")"
+if grep -q '"permissionDecision": "ask"' <<<"$out" && grep -q 'balance' <<<"$out"; then ok "old_string scanned"; else no "got: $out"; fi
+
+echo "[10] NC: MONEY_GATE_STRICT must be the literal '1' -- 'true' logs but does NOT ask"
+out="$(printf '%s' "$fin_money" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=true MONEY_GATE_LOG="$TMP/l7" bash "$SHIM")"
+if [[ -z "$out" ]] && grep -q 'transactions.csv' "$TMP/l7"; then ok "non-'1' strict is log-only"; else no "false ask: $out"; fi
+
+echo "[11] exit 0 ALWAYS, even when emitting an ask (decision travels in JSON, not rc)"
+set +e; out="$(printf '%s' "$fin_money" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l8" bash "$SHIM")"; rc=$?; set -e
+if [[ $rc -eq 0 ]] && grep -q '"permissionDecision": "ask"' <<<"$out"; then ok "asked and still exit 0"; else no "rc=$rc out=$out"; fi
+
+# CHARACTERIZATION, not a desired property. MONEY_RE is \b-anchored and `_` is a word
+# char, so a snake_case identifier never matches its own money token: `payroll_total`,
+# `invoice_id`, `net_worth_usd` and the bare plural `amounts` all sail through. A .py
+# file whose ONLY money signal is `payroll_total = 5000` does not trip the gate. This
+# pins the blind spot so it cannot be forgotten (SPEC.md "Known divergences" 3); if a
+# later change widens the regex, this test fails loudly and the SPEC gets updated with it.
+echo "[12] CHARACTERIZATION (known gap): snake_case + plurals do NOT match -> no fire"
+snake='{"tool_input":{"file_path":"/home/u/work/acme-books/pay.py","new_string":"payroll_total = 5000; invoice_id = 7; amounts = []"},"cwd":"/home/u/work/acme-books"}'
+out="$(printf '%s' "$snake" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l9" bash "$SHIM")"
+if [[ -z "$out" && ! -s "$TMP/l9" ]]; then ok "gap confirmed: \\b-anchored regex misses snake_case/plurals"; else no "regex widened? update SPEC.md: $out"; fi
+
 echo
 if [[ $fail -gt 0 ]]; then echo "test-money-gate: $pass passed, $fail FAILED" >&2; exit 1; fi
 echo "test-money-gate: all $pass passed"


### PR DESCRIPTION
money_gate was the only kit module with NO spec. Writing one from the code (not from wishes) found three real divergences:

1. **The gate never matches a snake_case identifier.** The regex is \`\\b\`-anchored and `_` is a word character, so `payroll_total = 5000` does NOT trip it while `payroll = 5000` does. Identifier-shaped money code is exactly what an agent edits. Pinned as a characterization test; the fix is a behavior change and deserves its own diff.
2. **`MONEY_GATE_STRICT` is compared to the literal `"1"`.** Arming it with `true` silently leaves it log-only: the operator believes they are being prompted and never are.
3. The payload scan is recursive, so **deleting** a money line trips the gate as readily as adding one (the docstring claimed otherwise).

Also: hook-only modules were INVISIBLE to the contract's C3/C4 (modules() resolves `lib/<name>/`), which is why this one went a whole lifetime unspecced while the lint stayed green. Creating `lib/money-gate/` pulls it into scope; proven with a negative control on the lint itself.

tests/test-money-gate.sh 7 -> 12 assertions. Contract 22/22, money_gate IOU closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)