### PR TITLE
docs(telemetry): durable-root ADR, its proof, and a latent split-brain

### DIFF
--- a/docs/decisions/0035-durable-ledger-root.md
+++ b/docs/decisions/0035-durable-ledger-root.md
@@ -1,0 +1,72 @@
+# 0035. The durable ledger root: one resolver, one precedence chain
+
+Date: 2026-07-15
+Status: Accepted. Records a decision already implemented and shipped (SPEC-097, 2026-07-02; extended by SPEC-182 and the `[ledger]` config wiring proved at `docs/verification/wire-ledger.md`). This ADR is the retroactive record the telemetry module never had: the machinery was built, the reasoning lived only in code comments and two specs, and the 2026-07-14 doc sweep listed `telemetry` as having "an origin SPEC but zero ADR / proof / implementation notes of its own" (`tests/kit-contract-known-gaps.txt`). Nothing here changes behavior; it names the invariant so a future change cannot quietly break it.
+Relates-to: SPEC-097 (ledger durability, the origin), SPEC-182 (stats plane; D2 `KIT_LEDGER_DIR` as the one root), SPEC-061 (lane-telemetry, the module's other half), SPEC-200 C6 (the contract lint that enforces this), ADR-0024 (gate-ledger + ship enforcement, the biggest consumer), ADR-0034 decision 10 (append-only retention stands), `docs/verification/wire-ledger.md` (the `[ledger]` config layer; its SPEC-186 ID has no spec file in `docs/specs/`)
+
+## Decision (one line)
+
+Every durable ledger the kit writes resolves its root through exactly ONE function, `kit_resolve_log_dir` in `lib/telemetry/kit-log-dir.sh`, whose default lives OUTSIDE `~/.claude/` (the plugin reinstall blast zone), whose precedence is `KIT_LEDGER_DIR` -> `DWARVES_KIT_LOG_DIR` -> `kit.toml [ledger].location` -> XDG state, and which FAILS LOUD rather than resolve a root it cannot trust.
+
+## Context
+
+**The incident.** Until SPEC-097 the run corpus defaulted to `~/.claude/dwarves-kit/logs`, inside the plugin's own state directory. That directory holds the real `logs/` beside symlinks (`lib`, `AGENTS.md`, `WORKFLOW.md`) that a plugin reinstall regenerates. On **2026-07-01 a plugin reinstall recreated the directory and wiped the entire run corpus.** Telemetry that cannot survive a reinstall cannot feed `/kit:retro` or the SPEC-073 effectiveness eval, which is the only reason the corpus exists. This was not a near-miss; the history was gone.
+
+**Why a resolver and not just a better default.** The corpus is written by many hands: the gate ledger, the proof ledger, the lane classifier's downgrade log, the precedent index, mega-merge, and (since 2026-07-14) the overnight queue's journal. A path constant copied into six libs is six places for the next default to drift, and drift here is silent: nothing errors, the writes just land somewhere the readers do not look. The property that matters is not "the default is good" but "there is exactly one place the default lives."
+
+**Three failure modes the root can have, all silent.** Each is why a corresponding rule exists below.
+
+| Failure mode | What it looks like | Why it is silent |
+|---|---|---|
+| Root inside the blast zone | reinstall wipes the corpus | nothing errors; the ledgers are simply gone next read |
+| Root resolves to empty | every writer appends to a RELATIVE `runs/...` path in the caller's cwd | the writes succeed, scattered across whatever directory each tool ran in |
+| Legacy dir is a symlink | `cp -R legacy/.` dereferences it and fans the link target into the corpus | the migration "succeeds"; the corpus that `/kit:retro` reads is now attacker-seeded |
+
+## Decision
+
+**1. One resolver.** `lib/telemetry/kit-log-dir.sh` exposes `kit_resolve_log_dir` (the root), `kit_legacy_log_dir` (the pre-SPEC-097 path), and `kit_migrate_log_dir` (one-time additive migration). Corpus-bearing libs SOURCE it instead of hard-coding a path. It is a lib-layer file with no output on load, safe under `set -euo pipefail`, and guarded against double-sourcing.
+
+**2. The precedence chain.** Four levels, in order. The first three exist so a consumer can relocate the root without editing the kit; the fourth is the durable default.
+
+| # | Source | Resolves to | Why it is at this level |
+|---|---|---|---|
+| 1 | `$KIT_LEDGER_DIR` | the literal value | the canonical knob (SPEC-182 D2). Essential-tier config, one root per consumer. Wins over everything. |
+| 2 | `$DWARVES_KIT_LOG_DIR` | the literal value | back-compat alias, the pre-SPEC-182 name. Kept because every existing test pin and the live corpus resolve through it; retiring it would be churn with no gain. |
+| 3 | `kit.toml` / `.kit.toml` `[ledger].location` | `isolated` -> `$PWD/.kit/logs`; `shared` or unset -> level 4; any other value -> that explicit path | the config layer, read via `lib/config/kit-config.sh` (project `.kit.toml` overrides kit-root `kit.toml`). Sits BELOW the env vars so a test or a one-off run can always override a project's committed config. |
+| 4 | `${XDG_STATE_HOME:-$HOME/.local/state}/dwarves-kit/logs` | the hardcoded default | the whole point: XDG state is the canonical home for persistent state, and it is **entirely outside `~/.claude`**, so no `~/.claude/dwarves-kit*` reinstall can reach it. |
+
+**3. Set-but-empty is FATAL, never a fall-through.** A `KIT_LEDGER_DIR` that is SET but EMPTY makes `kit_resolve_log_dir` print a diagnostic to stderr and `return 1`. It does not fall through to the next level. The distinction is deliberate: a genuinely UNSET variable means "I have no opinion, use the chain" (erroring there would break every existing consumer), while a set-but-empty one means a caller computed a root and got nothing, and continuing would append to a relative path. Callers use the `LOG_DIR="$(kit_resolve_log_dir)" || exit 1` form so the failure is clean. `lib/queue/queue.sh` adds a second belt for the same footgun: it refuses a journal path of `/queue-journal.tsv` or `queue-journal.tsv` outright, because it is the one launcher that runs unattended overnight and a silently-misplaced journal there means the whole night's history lands in the filesystem root.
+
+**4. Migration is additive, one-time, and refuses a symlink.** `kit_migrate_log_dir` copies the legacy corpus into the durable root with `cp -Rn` (recursive, no-clobber, never deletes the legacy dir), then drops a `.migrated` sentinel. It no-ops when either env knob is set (an explicit root means the caller owns the path, which is what stops a test pointing at a mktemp dir from ingesting the real machine corpus). Two hardening rules, both from the SPEC-097 security review:
+- **Symlink refusal.** If the legacy dir is a symlink, migration refuses to copy THROUGH it, warns, and sentinels. `cp` dereferences a `/.`-suffixed symlink, so `-P` does not help; the guard is an explicit `[ ! -L ]` test. Without it, an attacker-planted link fans its target's contents into the corpus that `/kit:retro` and the eval read.
+- **Sentinel only on success.** The `.migrated` sentinel is written only inside the `cp`-success branch, so a partial or failed copy (permissions, disk) leaves no sentinel and the next access retries. This is what preserves the additive guarantee.
+- Migration always returns 0 (every fallible op is guarded), because a migration hiccup must never abort a lib load under `set -e`: that would make `gate-ledger check` exit nonzero and fail-CLOSE the ship gate on unrelated work.
+
+**5. The consumer list is closed and enforced.** Every module that persists state resolves through the resolver; SPEC-200's C6 lint fails the build on any `lib/` code line hardcoding the pre-SPEC-097 path.
+
+| Consumer | What it persists | Source discipline |
+|---|---|---|
+| `lib/gate/gate-ledger.sh` | the run ledgers (`runs/<rid>.log`), the ship gate's evidence | FATAL on missing resolver |
+| `lib/gate/proof-ledger.sh` | proof-of-done records, overrides | FATAL |
+| `lib/gate/proof-table-gen.sh` | generated proof run-tables | FATAL |
+| `lib/telemetry/lane-telemetry.sh` | reads the corpus (SPEC-061 aggregator) | FATAL |
+| `lib/classify/lane-classify.sh` | `completeness.log` LANE-CHECK downgrades | FATAL. In the set because it WRITES what lane-telemetry READS; leaving it behind would split-brain the downgrades. |
+| `lib/precedent.sh` | the precedent index | FATAL |
+| `lib/goal/mega-merge.sh` | mega-merge records | FATAL |
+| `lib/ledger/ledger.sh` | the SPEC-182 append substrate (row-append + root in ONE place) | FATAL |
+| `lib/learn/weekend-batch.sh` | the debt ledger | FATAL |
+| `lib/mega.sh` | sources the resolver and EXPORTS `KIT_LOG_DIR` for child tools | FATAL |
+| `lib/queue/queue.sh` | the overnight queue journal (`queue-journal.tsv`); **joined 2026-07-14**, commit `8475ace` | soft-source + a `declare -f` check, because queue runs without `set -e`: an unguarded call would substitute empty and put the journal at `/queue-journal.tsv` |
+| `lib/spec/spec-next.sh` | (optional) | best-effort source; degrades if the resolver is absent |
+
+Hook **diagnostic** logs (`ship-gate.log`, `slop-cleaner.log`, `citation-guard.log`) are deliberately OUT of this set and stay on the legacy default: they are ephemeral breadcrumbs that regenerate, not corpus. This is not a leak in the enforcement path, and that is worth stating precisely because it looks like one: `hooks/ship-gate.sh` uses its `LOG_DIR` ONLY to append its own `ship-gate.log` line, and delegates the actual ledger read to `bash "$LEDGER" check ...` (gate-ledger.sh), which resolves through the resolver like everything else.
+
+**6. Retention: append-only stands.** Restated from ADR-0034 decision 10 so it is visible from the root's own record: ledgers are never rewritten, and rotation is revisited only at a measured threshold (shared root over 100 MB, or `stats digest` wall-time over 10 s), never as silent TTL deletion.
+
+## Consequences
+
+- **The corpus survives a reinstall.** The default root is outside `~/.claude` entirely, so the 2026-07-01 failure cannot recur through that path. Verified by `lib/telemetry/tests/smoke.sh` case P4c, which asserts the default never resolves inside the blast zone whatever `$HOME` is.
+- **A new persistent store must source the resolver.** Not a convention, a lint: SPEC-200 C6 greps `lib/` for the hardcoded legacy path (code lines only, comments exempt) and fails the contract test. Adding a store that opens its own path is a red build, not a review comment.
+- **Consumers can relocate the root without forking the kit**, via the env knob (per-run) or `[ledger].location` (committed per-project). `isolated` gives a project its own `./.kit/logs`.
+- **The failure is loud, so a misconfigured root costs one error message, not a scattered corpus.** The cost is that a caller MUST handle the nonzero return; the `|| exit 1` form is the contract.
+- **KNOWN DIVERGENCE: the read plane does not implement level 3.** `lib/stats/src/stats/config.py::kit_log_dir` is a second, Python implementation of this precedence, and it implements only levels 1, 2 and 4. It never reads `kit.toml [ledger].location`, though its docstring claims it "mirrors the shell resolver exactly (SPEC-182)". The shell resolver gained the config layer later (the `[ledger]` wiring at `docs/verification/wire-ledger.md`) and the Python copy was never updated. Consequence: with `[ledger].location` set to `isolated` or an explicit path and no env var set, the WRITE plane writes to the toml location while the `stats` READ plane reads the XDG default. That is precisely the split-brain SPEC-182 D2 exists to forbid ("the writer writes and `stats` reads the SAME root"). It is latent, not currently firing: the shipped `kit.toml` default is `location = "shared"`, which both planes resolve to XDG. It bites the moment a consumer uses the `isolated` mode the config surface openly offers. Reproduced 2026-07-15 (evidence in `lib/telemetry/docs/proof-of-done.md`). Two exits exist: have `stats` shell out to the one resolver, or teach it the toml layer and lint the two implementations against each other. Choosing between them is a behavior change and belongs in its own spec, not in this record.

--- a/lib/telemetry/docs/proof-of-done.md
+++ b/lib/telemetry/docs/proof-of-done.md
@@ -1,0 +1,142 @@
+# Proof of Done: telemetry
+
+**Feature:** the durable ledger root (`kit-log-dir.sh`, the ONE resolver every kit ledger routes through) and the lane/gate misroute aggregator (`lane-telemetry.sh`).
+**Date:** 2026-07-15 · **Lane:** full (lib/ enforcement-adjacent storage; data-loss class) · **Host:** Hans-Air-M4 (macOS 26.5)
+**Specs:** `docs/specs/SPEC-097-ledger-durability.md` (origin), `docs/specs/SPEC-182-stats-plane.md` D2 (one root, two planes), `docs/specs/SPEC-061-lane-telemetry.md` (the aggregator) · **ADR:** `docs/decisions/0035-durable-ledger-root.md`
+
+Written to close a gap the module's own records named: `telemetry` shipped the resolver that decides where EVERY durable ledger in the kit is written, and carried no ADR, no proof, and no tests of its own (`tests/kit-contract-known-gaps.txt`, 2026-07-14 doc sweep). The machinery was real and the evidence was not. This proof and the 17-assertion suite it records are new; the behavior they pin is not.
+
+## Acceptance criteria
+
+| # | Criterion | Source |
+|---|---|---|
+| A1 | `KIT_LEDGER_DIR` wins over the `DWARVES_KIT_LOG_DIR` alias AND over `kit.toml [ledger].location` | SPEC-182 D2 |
+| A2 | With `KIT_LEDGER_DIR` unset, the `DWARVES_KIT_LOG_DIR` alias still resolves (back-compat: the live corpus and every pre-SPEC-182 test pin ride this) | SPEC-182 D2 |
+| A3 | With neither env var set, `kit.toml [ledger].location` decides: `isolated` -> `$PWD/.kit/logs`, an explicit path -> that path | `docs/verification/wire-ledger.md` |
+| A4 | The bare default is `${XDG_STATE_HOME:-$HOME/.local/state}/dwarves-kit/logs`, and it is never inside `~/.claude` (the reinstall blast zone that wiped the corpus on 2026-07-01) | SPEC-097 AC1 |
+| A5 | A set-but-EMPTY `KIT_LEDGER_DIR` FAILS LOUD (nonzero, diagnostic on stderr, no path on stdout) instead of silently resolving a relative root | NEGATIVE CONTROL / SPEC-182 D2 |
+| A6 | Migration REFUSES to copy through a symlinked legacy dir (no arbitrary-file exfiltration into the corpus `/kit:retro` reads), and still sentinels so a hostile link is not re-scanned | NEGATIVE CONTROL / SPEC-097 SEC2 |
+| A7 | The consumers actually resolve through the resolver: `lane-telemetry report` reads the root it returns, and aggregates a seeded lane misroute | SPEC-061 |
+| A8 | No regression in the existing suites that pin this machinery | SPEC-097 AC9 |
+
+## Implementation
+
+| Piece | What | Where |
+|---|---|---|
+| The resolver | `kit_resolve_log_dir` (4-level precedence + the set-but-empty fatal), `kit_legacy_log_dir`, `kit_migrate_log_dir` (additive, sentinel-guarded, symlink-refusing) | `lib/telemetry/kit-log-dir.sh` |
+| The aggregator | `report` / `misfires` / `render` / `trace` over the pipe-delimited run ledgers; pure bash+awk, no new store | `lib/telemetry/lane-telemetry.sh` |
+| Config layer (level 3) | `[ledger].location` read via the one TOML reader | `lib/config/kit-config.sh` |
+| The lint that keeps it single | C6: no `lib/` code line may hardcode the pre-SPEC-097 path | `tests/test-kit-contract.sh` |
+| Tests (new) | 17 assertions: 4 precedence levels, the empty-root fatal + falsifier, the symlink refusal + positive control, consumer wiring | `lib/telemetry/tests/smoke.sh` |
+| Records (new) | the decision record this module never had | `docs/decisions/0035-durable-ledger-root.md` |
+
+## Confirmation run-table
+
+| Check | Command | Expected | Result |
+|---|---|---|---|
+| A1-A4, A7 (precedence + wiring) | `bash lib/telemetry/tests/smoke.sh` | `smoke: all 17 passed` | PASS |
+| A5 NEGATIVE CONTROL (empty root fails loud) | `env KIT_LEDGER_DIR= bash lib/queue/queue.sh --help` | refuses, exit 1, names the cause | PASS |
+| A5 falsifier (a sane root still works) | `env KIT_LEDGER_DIR=/tmp/kit-nc-root bash lib/queue/queue.sh --help` | usage banner, `Exit: 0` | PASS |
+| A6 NEGATIVE CONTROL (symlink refusal) | smoke cases 6a-6d | target contents NOT copied; refusal on stderr; sentinel dropped | PASS |
+| A8 no regression | `bash tests/test-lane-telemetry.sh` | `25/25 passed` | PASS |
+| A8 no regression | `bash tests/test-ledger-durability.sh` | `35/35 passed` | PASS |
+| Contract lint stays green | `bash tests/test-kit-contract.sh` | `22 passed, 0 failed` | PASS |
+
+Run on a clean clone of `master` (`8475ace`) with only this branch's changes applied, because the shared working copy was being written concurrently by a sibling agent (see Notes).
+
+## Run detail
+
+```
+$ bash lib/telemetry/tests/smoke.sh
+== precedence: KIT_LEDGER_DIR > DWARVES_KIT_LOG_DIR > kit.toml [ledger].location > XDG ==
+  ok: P1 KIT_LEDGER_DIR wins over the alias and the toml
+  ok: P2 DWARVES_KIT_LOG_DIR (alias) wins over the toml when KIT_LEDGER_DIR is unset
+  ok: P3a kit.toml [ledger].location = <explicit path>
+  ok: P3b kit.toml location = isolated -> $PWD/.kit/logs
+  ok: P4a location = shared -> XDG state default
+  ok: P4b no [ledger] key at all -> XDG state default
+  ok: P4c the default is outside ~/.claude (the SPEC-097 invariant)
+== NEGATIVE CONTROL: a set-but-empty root must FAIL LOUD, not resolve ==
+  ok: NC1 empty KIT_LEDGER_DIR exits nonzero (rc=1)
+  ok: NC2 empty KIT_LEDGER_DIR prints NO path on stdout
+  ok: NC3 the failure names the cause on stderr
+  ok: NC4 (falsifier) a non-empty KIT_LEDGER_DIR still resolves
+== NEGATIVE CONTROL: migration must refuse a symlinked legacy dir ==
+  ok: 6a POSITIVE CONTROL: a real legacy dir IS migrated (so 6b's refusal is falsifiable)
+  ok: 6b the symlink target's contents are NOT copied into the corpus
+  ok: 6c the refusal is announced on stderr
+  ok: 6d the sentinel is dropped, so a hostile link is not re-scanned every command
+== wiring: the module's own consumer resolves through the resolver ==
+  ok: 7a lane-telemetry report reads the root the resolver returns
+  ok: 7b the seeded lane misroute is aggregated (chosen != classified)
+
+smoke: all 17 passed
+Exit: 0
+```
+
+The A5 NEGATIVE CONTROL, driven organically (an empty root propagating into the one launcher that runs unattended overnight). Both guards fire in sequence: the resolver refuses to return a root, and queue.sh refuses the `/queue-journal.tsv` path it would otherwise have written a whole night's history to.
+
+```
+$ env KIT_LEDGER_DIR= bash lib/queue/queue.sh --help
+kit-log-dir: KIT_LEDGER_DIR is set but empty; refusing to resolve a ledger root (would write to a relative path)
+queue: refusing a filesystem-root journal path (/queue-journal.tsv)
+Exit: 1
+
+$ env KIT_LEDGER_DIR=/tmp/kit-nc-root bash lib/queue/queue.sh --help
+usage: queue.sh run <src.tsv> [--dry-run] [--max-megas N] [--from-boards] [--journal <path>]
+Exit: 0
+```
+
+No regression, and the contract lint stays green:
+
+```
+$ bash tests/test-lane-telemetry.sh | tail -1
+=== 25/25 passed, 0 failed ===
+Exit: 0
+
+$ bash tests/test-ledger-durability.sh | tail -1
+=== 35/35 passed, 0 failed ===
+Exit: 0
+
+$ bash tests/test-kit-contract.sh | tail -1
+=== kit-contract: 22 passed, 0 failed ===
+Exit: 0
+```
+
+## Defect found while writing this proof (NOT fixed here)
+
+The write plane and the read plane disagree about the root whenever `[ledger].location` is not the default. `lib/stats/src/stats/config.py::kit_log_dir` is a SECOND, Python implementation of this precedence and it implements only levels 1, 2 and 4: it never reads `kit.toml [ledger].location`, although its docstring claims it "mirrors the shell resolver exactly (SPEC-182)". The shell resolver gained the config layer later; the Python copy was never updated. SPEC-182 D2 requires precisely the opposite ("the writer writes and `stats` reads the SAME root").
+
+```
+kit.toml: [ledger].location = /var/folders/.../tmp.L1Rmg8vmsm/explicit
+
+shell write plane : /var/folders/.../tmp.L1Rmg8vmsm/explicit
+python read plane : /var/folders/.../tmp.L1Rmg8vmsm/xdg/dwarves-kit/logs
+Exit: 0
+```
+
+Latent, not currently firing: the shipped `kit.toml` default is `location = "shared"`, which both planes resolve to XDG. It bites the moment a consumer selects the `isolated` mode the config surface openly offers, and it fails SILENTLY (stats reads an empty root and reports no runs). Recorded in ADR-0035's Consequences with the two exits (shell out to the one resolver, or teach the Python copy the toml layer and lint the two against each other). Choosing between them is a behavior change and needs its own spec, so this branch documents it rather than smuggling a fix into a records PR.
+
+## Reproduce
+
+```bash
+cd <dwarves-kit>
+bash lib/telemetry/tests/smoke.sh              # 17 assertions: precedence, empty-root fatal, symlink refusal
+env KIT_LEDGER_DIR= bash lib/queue/queue.sh --help   # NEGATIVE CONTROL: must refuse, exit 1
+bash tests/test-lane-telemetry.sh              # 25/25
+bash tests/test-ledger-durability.sh           # 35/35
+bash tests/test-kit-contract.sh                # 22 passed, 0 failed
+
+# the write-plane / read-plane divergence (defect above)
+W=$(mktemp -d); mkdir -p "$W/root" "$W/proj"
+printf '[ledger]\nlocation = "%s/explicit"\n' "$W" > "$W/root/kit.toml"
+env HOME="$W/h" XDG_STATE_HOME="$W/xdg" KIT_CONFIG_ROOT="$W/root" KIT_PROJECT_ROOT="$W/proj" \
+  bash -c 'source lib/telemetry/kit-log-dir.sh && kit_resolve_log_dir; echo'
+env HOME="$W/h" XDG_STATE_HOME="$W/xdg" KIT_CONFIG_ROOT="$W/root" KIT_PROJECT_ROOT="$W/proj" \
+  python3 -c "import sys; sys.path.insert(0,'lib/stats/src')
+from stats.config import kit_log_dir; print(kit_log_dir())"
+```
+
+## Notes
+
+Every command above was run on a clean clone of `master` (`8475ace`) carrying only this branch's changes. The shared working copy could not be trusted as a test bed: a sibling agent was concurrently scaffolding `lib/cosmetic/` and `lib/money-gate/` in the same checkout (and switching its branch), which made `tests/test-kit-contract.sh` report different offenders run to run. That flapping is theirs, not this branch's; on an isolated tree the contract lint is `22 passed, 0 failed`.

--- a/lib/telemetry/tests/smoke.sh
+++ b/lib/telemetry/tests/smoke.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# telemetry smoke test -- the durable-ledger-root resolver (lib/telemetry/kit-log-dir.sh).
+#
+# The resolver decides WHERE every ledger in the kit is written (gate-ledger, proof-ledger,
+# lane-telemetry, precedent, mega-merge, queue). Getting it wrong is not a cosmetic bug: it is
+# the 2026-07-01 class of incident (corpus written inside the plugin state dir, wiped by a
+# reinstall) or the silent-wrong-path class (an empty root turning every append into a relative
+# `runs/...` write in whatever cwd the caller happened to be in). So the four precedence levels,
+# the set-but-empty FATAL, and the symlink refusal each get an assertion here.
+#
+# FULLY HERMETIC: every case runs in a fresh `bash -c` with $HOME, $KIT_CONFIG_ROOT,
+# $KIT_PROJECT_ROOT and $XDG_STATE_HOME pointed at mktemp dirs, so no case can read or write the
+# real machine corpus. KIT_LEDGER_DIR / DWARVES_KIT_LOG_DIR are NEVER exported by this script;
+# they are passed per-case as command prefixes, which is what makes "genuinely unset" testable.
+#
+# Run: bash lib/telemetry/tests/smoke.sh   Pass: "smoke: all N passed", exit 0.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"          # lib/telemetry
+RESOLVER="$DIR/kit-log-dir.sh"
+LANE_TELEMETRY="$DIR/lane-telemetry.sh"
+
+pass=0; fail=0
+ok() { echo "  ok: $*"; pass=$((pass+1)); }
+no() { echo "  FAIL: $*" >&2; fail=$((fail+1)); }
+eq() {  # eq <label> <got> <want>
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1 (got [$2] want [$3])"; fi
+}
+
+# `cd`+`pwd` normalizes the path: macOS $TMPDIR carries a trailing slash, so a raw mktemp path
+# holds a `//` that $PWD later collapses -- which would make the isolated-mode compare (P3b,
+# built from $PWD) fail on a string artifact rather than on resolver behavior.
+WORK="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/telemetry-smoke.XXXXXX")" && pwd)"
+trap 'rm -rf "$WORK"' EXIT
+
+HOME_FX="$WORK/home";      mkdir -p "$HOME_FX"
+XDG_FX="$WORK/xdg-state";  mkdir -p "$XDG_FX"
+CFG_FX="$WORK/kit-root";   mkdir -p "$CFG_FX"     # holds kit.toml (the kit-root config layer)
+PROJ_FX="$WORK/project";   mkdir -p "$PROJ_FX"    # holds .kit.toml (the project config layer)
+
+# The config layer the resolver consults at level 3. Default: no [ledger].location at all, so
+# level 4 (XDG) is what a bare install resolves to. Individual cases rewrite kit.toml.
+: > "$CFG_FX/kit.toml"
+
+# Every case inherits this hermetic env; the two ledger-root env vars are deliberately absent.
+env_base=(
+  "HOME=$HOME_FX"
+  "XDG_STATE_HOME=$XDG_FX"
+  "KIT_CONFIG_ROOT=$CFG_FX"
+  "KIT_PROJECT_ROOT=$PROJ_FX"
+)
+
+# resolve [extra env...] -- print kit_resolve_log_dir's stdout from a FRESH shell.
+resolve() {
+  env "${env_base[@]}" "$@" bash -c 'source "$0" && kit_resolve_log_dir' "$RESOLVER" 2>/dev/null
+}
+
+echo "== precedence: KIT_LEDGER_DIR > DWARVES_KIT_LOG_DIR > kit.toml [ledger].location > XDG =="
+
+# P1: the canonical knob wins over BOTH the alias and the toml (all three set at once, so this
+# asserts the ORDER, not merely that the var is read).
+printf '[ledger]\nlocation = "%s"\n' "$WORK/from-toml" > "$CFG_FX/kit.toml"
+eq "P1 KIT_LEDGER_DIR wins over the alias and the toml" \
+   "$(resolve "KIT_LEDGER_DIR=$WORK/from-canonical" "DWARVES_KIT_LOG_DIR=$WORK/from-alias")" \
+   "$WORK/from-canonical"
+
+# P2: with the canonical knob genuinely unset, the back-compat alias wins over the toml. This is
+# the level every pre-SPEC-182 test pin and the live corpus still resolve through.
+eq "P2 DWARVES_KIT_LOG_DIR (alias) wins over the toml when KIT_LEDGER_DIR is unset" \
+   "$(resolve "DWARVES_KIT_LOG_DIR=$WORK/from-alias")" \
+   "$WORK/from-alias"
+
+# P3: with neither env var set, [ledger].location decides. Three values, three meanings.
+eq "P3a kit.toml [ledger].location = <explicit path>" \
+   "$(resolve)" \
+   "$WORK/from-toml"
+
+printf '[ledger]\nlocation = "isolated"\n' > "$CFG_FX/kit.toml"
+eq "P3b kit.toml location = isolated -> \$PWD/.kit/logs" \
+   "$(cd "$PROJ_FX" && resolve)" \
+   "$PROJ_FX/.kit/logs"
+
+# P4: location = shared (and, below, absent entirely) falls to the XDG default -- the whole point
+# of SPEC-097: a path OUTSIDE ~/.claude, where no plugin reinstall can reach it.
+printf '[ledger]\nlocation = "shared"\n' > "$CFG_FX/kit.toml"
+eq "P4a location = shared -> XDG state default" \
+   "$(resolve)" \
+   "$XDG_FX/dwarves-kit/logs"
+
+: > "$CFG_FX/kit.toml"
+eq "P4b no [ledger] key at all -> XDG state default" \
+   "$(resolve)" \
+   "$XDG_FX/dwarves-kit/logs"
+
+# And the default is never inside the reinstall blast zone, whatever HOME is.
+case "$(resolve)" in
+  *".claude/dwarves-kit"*) no "P4c default resolves INSIDE the ~/.claude reinstall blast zone" ;;
+  *) ok "P4c the default is outside ~/.claude (the SPEC-097 invariant)" ;;
+esac
+
+echo "== NEGATIVE CONTROL: a set-but-empty root must FAIL LOUD, not resolve =="
+
+# The footgun this guards: an empty root makes every writer append to a RELATIVE `runs/...` path
+# in the caller's cwd. Silent, and the corpus scatters. The contract is a clean nonzero exit.
+out="$(env "${env_base[@]}" "KIT_LEDGER_DIR=" bash -c 'source "$0" && kit_resolve_log_dir' "$RESOLVER" 2>"$WORK/err.txt")"
+rc=$?
+[ "$rc" -ne 0 ] && ok "NC1 empty KIT_LEDGER_DIR exits nonzero (rc=$rc)" || no "NC1 empty KIT_LEDGER_DIR exited 0 -- silent fall-through"
+[ -z "$out" ] && ok "NC2 empty KIT_LEDGER_DIR prints NO path on stdout" || no "NC2 empty KIT_LEDGER_DIR still printed a path [$out]"
+grep -q 'set but empty' "$WORK/err.txt" && ok "NC3 the failure names the cause on stderr" || no "NC3 no diagnostic on stderr"
+
+# Falsifier for NC1-NC3: the same call with a NON-empty value must succeed. Without this row the
+# three assertions above would also pass if the resolver were simply broken for every input.
+eq "NC4 (falsifier) a non-empty KIT_LEDGER_DIR still resolves" \
+   "$(resolve "KIT_LEDGER_DIR=$WORK/nonempty")" \
+   "$WORK/nonempty"
+
+echo "== NEGATIVE CONTROL: migration must refuse a symlinked legacy dir =="
+
+# Threat: the legacy dir (~/.claude/dwarves-kit/logs) is attacker-replaceable with a symlink, and
+# `cp -R legacy/.` DEREFERENCES it -- fanning the link target's contents into the corpus that
+# /kit:retro and the effectiveness eval read. The resolver refuses to migrate THROUGH a symlink.
+# Migration only runs when neither env knob is set (an explicit root means the caller owns the
+# path), so both cases below steer the durable root via the toml instead.
+
+# 6a POSITIVE CONTROL: a real legacy DIRECTORY does migrate. Without this, "nothing was copied"
+# in 6b would prove nothing -- migration might simply be dead.
+LEGACY_REAL="$HOME_FX/.claude/dwarves-kit/logs"
+mkdir -p "$LEGACY_REAL/runs"
+printf 'ts | START | lane=normal classified=normal type=feature repo=fixture\n' > "$LEGACY_REAL/runs/real-run.log"
+printf '[ledger]\nlocation = "%s"\n' "$WORK/durable-a" > "$CFG_FX/kit.toml"
+env "${env_base[@]}" bash -c 'source "$0" && kit_migrate_log_dir' "$RESOLVER" >/dev/null 2>&1
+[ -f "$WORK/durable-a/runs/real-run.log" ] \
+  && ok "6a POSITIVE CONTROL: a real legacy dir IS migrated (so 6b's refusal is falsifiable)" \
+  || no "6a a real legacy dir was NOT migrated -- migration is dead, 6b proves nothing"
+
+# 6b the refusal itself: same shape, but the legacy dir is a symlink to an attacker-owned tree.
+rm -rf "$HOME_FX/.claude"
+mkdir -p "$WORK/evil" "$HOME_FX/.claude/dwarves-kit"
+printf 'exfiltrate-me\n' > "$WORK/evil/secret.txt"
+ln -s "$WORK/evil" "$LEGACY_REAL"
+printf '[ledger]\nlocation = "%s"\n' "$WORK/durable-b" > "$CFG_FX/kit.toml"
+env "${env_base[@]}" bash -c 'source "$0" && kit_migrate_log_dir' "$RESOLVER" >/dev/null 2>"$WORK/mig-err.txt"
+
+[ ! -e "$WORK/durable-b/secret.txt" ] \
+  && ok "6b the symlink target's contents are NOT copied into the corpus" \
+  || no "6b migration followed the symlink and exfiltrated the target into the corpus"
+grep -q 'symlink' "$WORK/mig-err.txt" \
+  && ok "6c the refusal is announced on stderr" \
+  || no "6c the symlink refusal was silent"
+[ -f "$WORK/durable-b/.migrated" ] \
+  && ok "6d the sentinel is dropped, so a hostile link is not re-scanned every command" \
+  || no "6d no sentinel -- the hostile link would be re-scanned on every kit command"
+
+echo "== wiring: the module's own consumer resolves through the resolver =="
+
+# The precedence chain above is only worth anything if the libs that WRITE and READ the corpus
+# actually go through it. lane-telemetry.sh is telemetry's own reader: point the canonical knob at
+# a seeded fixture root and its `report` must see the run.
+FIXROOT="$WORK/fixture-root"
+mkdir -p "$FIXROOT/runs"
+cat > "$FIXROOT/runs/smoke-rid-001.log" <<'LEDGER'
+2026-07-15T00:00:00Z | START | lane=normal classified=full type=feature ctype=feature repo=fixture
+2026-07-15T00:01:00Z | GATE | review | ran | verdict=clean findings=0
+LEDGER
+rep="$(env "${env_base[@]}" "KIT_LEDGER_DIR=$FIXROOT" bash "$LANE_TELEMETRY" report 2>/dev/null)"
+printf '%s' "$rep" | grep -q 'smoke-rid-001' \
+  && ok "7a lane-telemetry report reads the root the resolver returns" \
+  || no "7a lane-telemetry did not read the resolved root"
+# The seeded run has lane=normal but classified=full: the aggregator must count it as a misroute.
+printf '%s' "$rep" | grep -q 'lane-misrouted: 1' \
+  && ok "7b the seeded lane misroute is aggregated (chosen != classified)" \
+  || no "7b the lane misroute was not aggregated"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "smoke: all $pass passed"
+  exit 0
+fi
+echo "smoke: $pass passed, $fail FAILED" >&2
+exit 1

--- a/tests/kit-contract-known-gaps.txt
+++ b/tests/kit-contract-known-gaps.txt
@@ -31,7 +31,17 @@ lib/prose-rag/tests
 #
 #   cosmetic    5 of its 6 hooks have no SPEC, no proof, no implementation notes (the thinnest
 #               module in the kit; only codebase-index is specced).
-#   telemetry   has an origin SPEC but zero ADR / proof / implementation notes of its own.
+#   money_gate  no SPEC was ever written: it entered at kit-foldin and has only a joint
+#               proof-of-done shared with prose_rag.
+#
+# CLOSED 2026-07-15: telemetry. It had SPEC-061 (lane-telemetry, its read side) and nothing for
+# the half that matters most: kit-log-dir.sh, the SINGLE resolver every durable ledger in the kit
+# routes through. Now: ADR-0035 (durable-ledger-root: the precedence chain, the set-but-empty
+# FATAL, the symlink refusal, the consumer list) + lib/telemetry/docs/proof-of-done.md +
+# lib/telemetry/tests/smoke.sh (17 assertions). Writing the proof surfaced a real divergence the
+# records had been hiding: lib/stats' Python copy of the resolver never learned the kit.toml
+# [ledger] layer, so a non-default `location` splits the write plane from the read plane. It is in
+# the ADR's Consequences with a repro, unfixed (a behavior change needs its own spec).
 #
 # CLOSED 2026-07-15: money_gate. It had no SPEC (the only module without one) and only a joint
 # proof-of-done shared with prose_rag. Now: lib/money-gate/{README.md,SPEC.md,docs/proof-of-done.md}


### PR DESCRIPTION
`lib/telemetry` owns the single resolver for the durable ledger root and had ZERO ADR, proof, or notes of its own. ADR-0035 records why one resolver exists (a plugin reinstall wipes `~/.claude/dwarves-kit/`; the 2026-07-01 incident), the four-level precedence chain, the set-but-empty FATAL rule, and the symlink refusal.

**It also found a latent split-brain, the exact thing the spec forbids.** `lib/stats/src/stats/config.py::kit_log_dir` is a SECOND, Python implementation of the precedence chain. Its docstring claims it mirrors the shell resolver exactly; it does not: it never reads `kit.toml [ledger].location`. Under `location = "isolated"`, the write plane writes to the toml location while the stats read plane reads the XDG default, and it fails SILENTLY (stats just reports no runs). Latent only because the shipped default makes both agree. Reproduced in the proof; NOT fixed here (a behavior change deserves its own diff, not a smuggled one in a records PR).

New: `lib/telemetry/tests/smoke.sh`, 17 assertions, hermetic. The negative controls are real: the empty-root NC is driven organically and both guards fire in sequence; the symlink NC is paired with a POSITIVE control so "nothing was copied" cannot pass vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
