### PR TITLE
fix(money-gate): close the snake_case hole and the silent strict knob

### DIFF
--- a/docs/verification/money-gate-identifiers.md
+++ b/docs/verification/money-gate-identifiers.md
@@ -1,0 +1,82 @@
+# Proof of Done: money-gate matches identifier-shaped money code
+
+**Feature:** close the money gate's two safety holes (snake_case blindness; a strict knob that silently did nothing).
+**Date:** 2026-07-15 · **Lane:** normal · **Host:** Hans-Air-M4 (macOS 26.5) · **Spec:** `lib/money-gate/SPEC.md` divergences 3 and 4
+
+## What was wrong
+
+The gate is supposed to ask before a money-touching edit lands. It was matching with `\b`
+anchors, and `_` is a word character, so **it never matched inside a snake_case identifier**:
+`payroll_total = 5000` sailed through while `payroll = 5000` fired. Identifier-shaped money
+code is exactly what an agent edits, so the gate was blind to its own main case.
+
+Separately, `MONEY_GATE_STRICT` was compared against the literal string `"1"`. An operator who
+armed it with `MONEY_GATE_STRICT=true` got log-only mode while believing they were being
+prompted: a safety knob that silently does nothing is worse than no knob.
+
+## Acceptance criteria
+
+| # | Criterion | Source |
+|---|---|---|
+| A1 | `payroll_total`, `invoice_id`, `amounts` trip the gate | divergence 3 |
+| A2 | `total_payroll`, `_balance_` (leading/trailing underscore) trip it | divergence 3 |
+| A3 | `mypayroll`, `payrolling`, `tokenizer`, `balanced` do NOT trip it | NEGATIVE CONTROL (no over-match) |
+| A4 | `MONEY_GATE_STRICT=true` / `on` arm the gate | divergence 4 |
+| A5 | `0`, `false`, `no`, `off`, empty stay log-only | NEGATIVE CONTROL (no false ask) |
+| A6 | Every pre-existing assertion still passes (no regression in the gate's other behavior) | regression |
+
+## Implementation
+
+| Piece | What | Where |
+|---|---|---|
+| Boundaries | `\b` -> `(?<![A-Za-z0-9])` ... `s?(?![A-Za-z0-9])`: `_` reads as a separator, plural caught, alphanumeric neighbour still blocks | `hooks/money-gate.py` `MONEY_RE` |
+| Strict knob | literal `"1"` -> any truthy spelling (`1`/`true`/`yes`/`on`, case-insensitive) | `hooks/money-gate.py` `main()` |
+| Tests | `[12]` flipped from characterization-of-the-hole to assertion-it-is-shut; `[12b]`, `[12c]`, `[10]`, `[10b]` added | `tests/test-money-gate.sh` |
+
+## Confirmation run-table
+
+| Check | Command | Expected | Result |
+|---|---|---|---|
+| Full suite (A1-A6) | `bash tests/test-money-gate.sh` | `test-money-gate: all 16 passed` | PASS |
+| snake_case fires (A1) | item 12 | `ask` + `payroll` reported | PASS |
+| underscore forms (A2) | item 12b | `ask` | PASS |
+| NEGATIVE CONTROL no over-match (A3) | item 12c | no output, empty log | PASS |
+| truthy strict (A4) | item 10 | `ask` for `true` and `on` | PASS |
+| NEGATIVE CONTROL falsy strict (A5) | item 10b | log-only for 0/false/no/off/empty | PASS |
+| Contract | `bash tests/test-kit-contract.sh` | green | PASS |
+
+## Run detail
+
+```
+$ bash tests/test-money-gate.sh
+...
+[10] MONEY_GATE_STRICT accepts any truthy spelling ('true' now ARMS the gate)
+  ok: STRICT=true arms the gate
+  ok: STRICT=on arms the gate
+[10b] NEGATIVE CONTROL: a FALSY strict value stays log-only (no false ask)
+  ok: 0/false/no/off/empty all stay log-only
+[11] exit 0 ALWAYS, even when emitting an ask (decision travels in JSON, not rc)
+  ok: asked and still exit 0
+[12] snake_case identifiers and plurals DO trip the gate (the hole is closed)
+  ok: payroll_total / invoice_id / amounts now fire
+[12b] the leading-underscore and trailing-underscore forms fire too
+  ok: total_payroll / _balance_ fire
+[12c] NEGATIVE CONTROL: widening did NOT make the gate match inside a longer word
+  ok: no false fire inside longer words
+
+test-money-gate: all 16 passed
+Exit: 0
+Verdict: PASS
+```
+
+NEGATIVE CONTROL, at the source level: restore the `\b` anchors and item 12 fails
+(`still blind to snake_case`), proving the assertion is not vacuous. The over-match control
+(12c) fails if the boundaries are widened to plain `.`, proving the fix is not a blunt one.
+
+## Reproduce
+
+```bash
+cd <dwarves-kit>
+bash tests/test-money-gate.sh
+bash tests/test-kit-contract.sh
+```

--- a/hooks/money-gate.py
+++ b/hooks/money-gate.py
@@ -21,8 +21,9 @@ Env:
   MONEY_GATE_REPOS=a:b      sensitive repo names. CONSUMER CONFIG, no default: unset
                           means the gate is inert (adapter-default invariant; the
                           kit ships no tenant repo names)
-  MONEY_GATE_STRICT=1       ask-to-confirm instead of log-only (the LITERAL "1"; any
-                          other value, including "true", stays log-only)
+  MONEY_GATE_STRICT=1       ask-to-confirm instead of log-only. Any truthy spelling arms
+                          it (1/true/yes/on, case-insensitive); 0/false/no/off/empty
+                          stay log-only.
   MONEY_GATE_LOG=FILE       log destination (default ~/.claude/logs/money-gate.log)
 Stdlib only. Exit 0 always (decision is carried in the JSON, not the exit code).
 """
@@ -33,10 +34,20 @@ import sys
 import time
 
 DEFAULT_LOG = os.path.expanduser("~/.claude/logs/money-gate.log")
+# Boundaries are underscore-AWARE, not \b. `_` is a word character, so a \b-anchored pattern
+# never matches inside a snake_case identifier: `payroll_total = 5000` did NOT trip this gate
+# while `payroll = 5000` did. Identifier-shaped money code is exactly what an agent edits, so
+# that was the gate's largest hole (found writing its first SPEC, 2026-07-15). These lookarounds
+# treat `_` as a separator: payroll_total, total_payroll and invoice_id all match; mypayroll and
+# payrolling still do not. `s?` catches the bare plural (`amounts`) the old pattern also missed.
+_LB = r"(?<![A-Za-z0-9])"   # left boundary: not preceded by an alphanumeric (so `_` is fine)
+_RB = r"s?(?![A-Za-z0-9])"  # right boundary: optional plural, not followed by an alphanumeric
 MONEY_RE = re.compile(
-    r"\b(amount|balance|transfer|payout|payment|payroll|invoice|wallet|private[_-]?key|"
+    _LB +
+    r"(amount|balance|transfer|payout|payment|payroll|invoice|wallet|private[_-]?key|"
     r"secret|password|api[_-]?key|token|iban|account[_-]?number|routing|"
-    r"ledger|cashflow|pnl|net[_-]?worth|deposit|withdraw|usd|vnd)\b",
+    r"ledger|cashflow|pnl|net[_-]?worth|deposit|withdraw|usd|vnd)" +
+    _RB,
     re.IGNORECASE,
 )
 
@@ -83,7 +94,10 @@ def main():
     except OSError:
         pass
 
-    if os.environ.get("MONEY_GATE_STRICT") == "1":
+    # Any truthy spelling arms it. The old check compared to the LITERAL "1", so an operator who
+    # armed the gate with `MONEY_GATE_STRICT=true` got log-only mode and believed they were being
+    # prompted: a safety knob that silently does nothing is worse than no knob (found 2026-07-15).
+    if os.environ.get("MONEY_GATE_STRICT", "").strip().lower() in ("1", "true", "yes", "on"):
         print(json.dumps({"hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "ask",

--- a/lib/money-gate/SPEC.md
+++ b/lib/money-gate/SPEC.md
@@ -154,21 +154,29 @@ this SPEC documents reality; neither is changed by it.
    Whether that breadth is the point (auth edits in a money repo *are* worth a prompt) or
    an accepted false-positive tax was never stated. It overlaps the `secrets-guard` spine
    hook, which owns credential-leak detection proper.
-3. **The `\b` anchors make the gate blind to snake_case identifiers and plurals.** `_` is
-   a word character, so `\bpayroll\b` does not match `payroll_total`, and `\bamount\b`
-   does not match `amounts`. Verified against the live regex:
+3. **FIXED 2026-07-15: the `\b` anchors made the gate blind to snake_case and plurals.**
+   `_` is a word character, so `\bpayroll\b` did not match `payroll_total`, and `\bamount\b`
+   did not match `amounts`. A Python file whose only money signal was `payroll_total = 5000`
+   **did not trip the gate**, while the same line written `payroll = 5000` did. That was the
+   gate's largest real hole: identifier-shaped money code is exactly what an agent edits.
 
-   | Input | Hits |
+   The boundaries are now underscore-aware lookarounds (`(?<![A-Za-z0-9])` / `s?(?![A-Za-z0-9])`),
+   so `_` reads as a separator and the bare plural is caught:
+
+   | Input | Fires? |
    |---|---|
-   | `payroll_total`, `invoice_id`, `total_payroll`, `amounts` | *(none)* |
-   | `payroll`, `amount`, `payroll-total` (hyphen is not a word char) | matched |
+   | `payroll_total`, `total_payroll`, `invoice_id`, `_balance_`, `amounts` | yes (was: no) |
+   | `payroll`, `amount`, `payroll-total` | yes (unchanged) |
+   | `mypayroll`, `payrolling`, `tokenizer`, `balanced` | no (an alphanumeric neighbour still blocks the match) |
 
-   So a Python file whose only money signal is `payroll_total = 5000` **does not trip the
-   gate**, while the same line written `payroll = 5000` does. This is the gate's largest
-   real hole: identifier-shaped money code is exactly what an agent edits. It is pinned by
-   test `[12]` as a characterization test, so widening the regex will fail that test
-   loudly rather than drift silently. Not fixed here: this SPEC records the code, and
-   changing the match set is a behavior change that deserves its own diff.
+   Test `[12]` was a characterization test pinning the hole; it is now the assertion proving
+   it shut, with `[12c]` as the negative control against over-matching.
+
+4. **FIXED 2026-07-15: `MONEY_GATE_STRICT` compared against the literal `"1"`.** An operator
+   who armed the gate with `MONEY_GATE_STRICT=true` silently got log-only mode while believing
+   they were being prompted. A safety knob that silently does nothing is worse than no knob.
+   Any truthy spelling (`1`/`true`/`yes`/`on`, case-insensitive) now arms it; `0`/`false`/`no`/
+   `off`/empty stay log-only (test `[10]`, negative control `[10b]`).
 
 ## Non-goals
 

--- a/tests/test-money-gate.sh
+++ b/tests/test-money-gate.sh
@@ -65,24 +65,48 @@ echo "[9] recursive scan reaches old_string (DELETING money content trips the ga
 out="$(printf '%s' "$del_money" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l6" bash "$SHIM")"
 if grep -q '"permissionDecision": "ask"' <<<"$out" && grep -q 'balance' <<<"$out"; then ok "old_string scanned"; else no "got: $out"; fi
 
-echo "[10] NC: MONEY_GATE_STRICT must be the literal '1' -- 'true' logs but does NOT ask"
+echo "[10] MONEY_GATE_STRICT accepts any truthy spelling ('true' now ARMS the gate)"
+# Was: only the literal "1" armed it, so `MONEY_GATE_STRICT=true` left the operator in
+# log-only mode believing they were being prompted. A safety knob that silently does
+# nothing is worse than no knob (fixed 2026-07-15).
 out="$(printf '%s' "$fin_money" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=true MONEY_GATE_LOG="$TMP/l7" bash "$SHIM")"
-if [[ -z "$out" ]] && grep -q 'transactions.csv' "$TMP/l7"; then ok "non-'1' strict is log-only"; else no "false ask: $out"; fi
+if grep -q '"permissionDecision": "ask"' <<<"$out"; then ok "STRICT=true arms the gate"; else no "true did not arm: $out"; fi
+out="$(printf '%s' "$fin_money" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=on MONEY_GATE_LOG="$TMP/l7b" bash "$SHIM")"
+if grep -q '"permissionDecision": "ask"' <<<"$out"; then ok "STRICT=on arms the gate"; else no "on did not arm: $out"; fi
+
+echo "[10b] NEGATIVE CONTROL: a FALSY strict value stays log-only (no false ask)"
+for v in 0 false no off ""; do
+  out="$(printf '%s' "$fin_money" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT="$v" MONEY_GATE_LOG="$TMP/l7c" bash "$SHIM")"
+  [[ -n "$out" ]] && { no "STRICT='$v' wrongly armed the gate: $out"; break; }
+done
+[[ -z "$out" ]] && ok "0/false/no/off/empty all stay log-only"
 
 echo "[11] exit 0 ALWAYS, even when emitting an ask (decision travels in JSON, not rc)"
 set +e; out="$(printf '%s' "$fin_money" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l8" bash "$SHIM")"; rc=$?; set -e
 if [[ $rc -eq 0 ]] && grep -q '"permissionDecision": "ask"' <<<"$out"; then ok "asked and still exit 0"; else no "rc=$rc out=$out"; fi
 
-# CHARACTERIZATION, not a desired property. MONEY_RE is \b-anchored and `_` is a word
-# char, so a snake_case identifier never matches its own money token: `payroll_total`,
-# `invoice_id`, `net_worth_usd` and the bare plural `amounts` all sail through. A .py
-# file whose ONLY money signal is `payroll_total = 5000` does not trip the gate. This
-# pins the blind spot so it cannot be forgotten (SPEC.md "Known divergences" 3); if a
-# later change widens the regex, this test fails loudly and the SPEC gets updated with it.
-echo "[12] CHARACTERIZATION (known gap): snake_case + plurals do NOT match -> no fire"
+# The gate's largest hole, closed. It WAS \b-anchored, and `_` is a word character, so a
+# snake_case identifier never matched its own money token: `payroll_total = 5000` sailed
+# through while `payroll = 5000` fired. Identifier-shaped money code is exactly what an agent
+# edits. The characterization test that pinned the gap is now the assertion that proves it shut.
+echo "[12] snake_case identifiers and plurals DO trip the gate (the hole is closed)"
 snake='{"tool_input":{"file_path":"/home/u/work/acme-books/pay.py","new_string":"payroll_total = 5000; invoice_id = 7; amounts = []"},"cwd":"/home/u/work/acme-books"}'
 out="$(printf '%s' "$snake" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l9" bash "$SHIM")"
-if [[ -z "$out" && ! -s "$TMP/l9" ]]; then ok "gap confirmed: \\b-anchored regex misses snake_case/plurals"; else no "regex widened? update SPEC.md: $out"; fi
+if grep -q '"permissionDecision": "ask"' <<<"$out" && grep -q 'payroll' <<<"$out"; then
+  ok "payroll_total / invoice_id / amounts now fire"; else no "still blind to snake_case: $out"; fi
+
+echo "[12b] the leading-underscore and trailing-underscore forms fire too"
+under='{"tool_input":{"file_path":"/home/u/work/acme-books/pay.py","new_string":"total_payroll = 1; _balance_ = 2"},"cwd":"/home/u/work/acme-books"}'
+out="$(printf '%s' "$under" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l9b" bash "$SHIM")"
+grep -q '"permissionDecision": "ask"' <<<"$out" && ok "total_payroll / _balance_ fire" || no "missed: $out"
+
+echo "[12c] NEGATIVE CONTROL: widening did NOT make the gate match inside a longer word"
+# `mypayroll`, `payrolling`, `tokenizer` must NOT fire: the boundary treats `_` as a
+# separator but still refuses an alphanumeric neighbour. A gate that fires on everything
+# is a gate people disable.
+nofire='{"tool_input":{"file_path":"/home/u/work/acme-books/x.py","new_string":"mypayroll = 1; payrolling = 2; tokenizer = 3; balanced = 4"},"cwd":"/home/u/work/acme-books"}'
+out="$(printf '%s' "$nofire" | MONEY_GATE_REPOS=acme-books MONEY_GATE_STRICT=1 MONEY_GATE_LOG="$TMP/l9c" bash "$SHIM")"
+if [[ -z "$out" && ! -s "$TMP/l9c" ]]; then ok "no false fire inside longer words"; else no "FALSE POSITIVE: $out"; fi
 
 echo
 if [[ $fail -gt 0 ]]; then echo "test-money-gate: $pass passed, $fail FAILED" >&2; exit 1; fi


### PR DESCRIPTION
(Re-opened: #253 was auto-closed when its base #249 merged with --delete-branch. Rebased onto master.)

**The money gate never matched a snake_case identifier.** The regex was `\b`-anchored and `_` is a word character, so `payroll_total = 5000` sailed through while `payroll = 5000` fired. Identifier-shaped money code is exactly what an agent edits: the gate was blind to its own main case. Boundaries are now underscore-aware lookarounds, and the bare plural (`amounts`) is caught too. `mypayroll`, `payrolling`, `tokenizer` and `balanced` still do NOT fire (negative control 12c: a gate that fires on everything is a gate people disable).

**`MONEY_GATE_STRICT` compared against the literal `"1"`.** An operator who armed it with `MONEY_GATE_STRICT=true` got log-only mode while believing they were being prompted. A safety knob that silently does nothing is worse than no knob. Any truthy spelling arms it now; falsy spellings stay log-only (negative control 10b).

The characterization test that pinned hole 1 is now the assertion that proves it shut.

tests/test-money-gate.sh 12 -> 16. Proof: `docs/verification/money-gate-identifiers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
