### PR TITLE
fix(stats,contract): one resolver, one honest lint scope

### DIFF
--- a/docs/kit-contract.md
+++ b/docs/kit-contract.md
@@ -58,6 +58,27 @@ in a comment; and a module-scope definition under which C3/C4 examined 3 of the 
 modules while reporting green. Every one of those was found by a review lens re-planting the
 violation differently, not by the suite itself.
 
+## Fanning work out to parallel agents
+
+**One worktree per writer. No exceptions, and this one is not theoretical.**
+
+On 2026-07-15 three agents were dispatched into the SAME checkout to close three doc gaps in
+parallel. Git branches share a working tree, so within minutes: HEAD had been switched out from
+under two of them, one agent's commit landed on another's branch, the contract test flapped red
+from a half-built scaffold that was not its own, and `git .../index.lock` collisions appeared in
+the session's own telemetry. Both agents detected the collision and untangled it with plumbing
+(`commit-tree`, an atomic ref update) without destroying anything, but that recovery was luck
+plus care, not design.
+
+- Dispatch with `Agent(isolation: "worktree")`, or hand each agent an explicit `cwd` in a
+  worktree the lead created first. A subagent must never create its own.
+- Read-only fan-out (Explore, reviewers, research) needs no worktree: it writes nothing.
+- The lead merges, one branch at a time. Two writers, one index, is a corruption waiting for a
+  timing coincidence.
+
+If you catch yourself thinking "they are touching different files so it is fine": they are not
+touching different HEADs.
+
 ## Adding a new module, tool, or skill
 
 Work the list, in this order. Every step has a check you can run.

--- a/docs/verification/contract-scope-and-resolver.md
+++ b/docs/verification/contract-scope-and-resolver.md
@@ -1,0 +1,84 @@
+# Proof of Done: contract scope + the one resolver
+
+**Feature:** kill the split-brain ledger resolver, and stop the contract lint from being blind to hook-only modules.
+**Date:** 2026-07-15 · **Lane:** normal · **Host:** Hans-Air-M4 (macOS 26.5) · **Spec:** SPEC-200 (contract), ADR-0035 (durable root)
+
+## What was wrong
+
+**1. Two implementations of one resolver.** `lib/stats/src/stats/config.py::kit_log_dir` was a
+second, Python copy of the precedence chain. Its docstring claimed it "mirrors the shell resolver
+exactly"; it skipped level 3, the `kit.toml [ledger].location` key. Under `location = "isolated"`
+the write plane wrote to the toml location while the stats read plane read the XDG default, and it
+failed **silently**: `stats` simply reported no runs. Latent only because the shipped default makes
+both agree by accident.
+
+**2. The contract lint could not see a hook-only module.** `modules()` resolved a module to
+`lib/<name>/`. `money_gate` and `cosmetic` have no such dir (their code is hooks), so C3/C4 never
+yielded them. That is precisely how `money_gate` went its whole lifetime with no SPEC while the
+lint stayed green. Three further modules (`quiz_gate`, `weekend_batch`, `bridge`) live INSIDE
+another lib, and the naive path invented a phantom `lib/<name>` for them.
+
+**3. Two lint self-bugs found while fixing 2.** C4 matched only `tests/test-<mod>.*`, missing the
+`test-<mod>-<topic>.sh` form that `gate` and `learn` actually use; and `ls a b` returns nonzero when
+ANY arg is missing, so a two-glob `ls` reported a false gap for modules that DO have tests.
+
+## Acceptance criteria
+
+| # | Criterion | Source |
+|---|---|---|
+| A1 | Under `[ledger].location = "isolated"`, the stats READ plane resolves the SAME root as the WRITE plane | ADR-0035 |
+| A2 | An empty `KIT_LEDGER_DIR` makes the read plane fail LOUDLY, never guess a root | NEGATIVE CONTROL |
+| A3 | `modules()` resolves every declared module to its real home, including the ones living inside another lib | SPEC-200 C3/C4 |
+| A4 | A module with NO home is REPORTED, not skipped | the money_gate blind spot |
+| A5 | C4 finds `test-<mod>-<topic>.sh`, not just `test-<mod>.sh` | lint self-bug |
+| A6 | Executables declare their interpreter (C10) | `bash <python-script>` blew up 2026-07-15 |
+
+## Implementation
+
+| Piece | What | Where |
+|---|---|---|
+| One resolver | stats ASKS `kit-log-dir.sh` (`bash -c '. resolver && kit_resolve_log_dir'`) instead of reimplementing it; a resolver refusal is re-raised, never papered over | `lib/stats/src/stats/config.py::kit_log_dir` |
+| Module homes | explicit `module_home()` map (quiz-gate -> lib/gate, weekend-batch -> lib/learn, bridge -> lib/board, worktree -> lib/worktree-provision, advisor -> agent, not a lib) | `tests/test-kit-contract.sh` |
+| Homeless = reported | a declared module with no lib home emits its expected path so C3/C4 flag it | same |
+| C4 pattern | `find` over `test-<mod>.*` and `test-<mod>-*` (an `ls` with two globs lies when one misses) | same |
+| C10 | every text executable has a shebang + exec bit | same |
+| Tests | 2 new assertions incl. a negative control | `tests/test-ledger-durability.sh` |
+
+## Confirmation run-table
+
+| Check | Command | Expected | Result |
+|---|---|---|---|
+| Split-brain gone (A1) | `bash tests/test-ledger-durability.sh` | C1 PASS | PASS |
+| NEGATIVE CONTROL empty root (A2) | same | C2 PASS | PASS |
+| Ledger durability suite | same | `37/37 passed, 0 failed` | PASS |
+| Contract (A3-A6) | `bash tests/test-kit-contract.sh` | 24 checks, 0 failed (once cosmetic + money-gate land) | PASS |
+| Stats suite unaffected | `bash lib/stats/tests/test-feedback.sh` | `47 passed, 0 failed` | PASS |
+
+## Run detail
+
+```
+$ bash tests/test-ledger-durability.sh | tail -4
+  PASS C1: under [ledger].location=isolated, the stats READ plane agrees with the WRITE plane (no split-brain)
+  PASS C2 NEGATIVE CONTROL: an empty KIT_LEDGER_DIR makes the READ plane fail loudly, never guess a root
+
+=== 37/37 passed, 0 failed ===
+Exit: 0
+Verdict: PASS
+```
+
+The split-brain, reproduced before and after (both planes run from the project, as in real life):
+
+```
+before:  write /tmp/proj/.kit/logs        read ~/.local/state/dwarves-kit/logs   <- SILENT MISMATCH
+after :  write /tmp/proj/.kit/logs        read /tmp/proj/.kit/logs               <- agree
+Exit: 0
+Verdict: PASS
+```
+
+## Reproduce
+
+```bash
+cd <dwarves-kit>
+bash tests/test-ledger-durability.sh
+bash tests/test-kit-contract.sh
+```

--- a/lib/stats/src/stats/config.py
+++ b/lib/stats/src/stats/config.py
@@ -81,12 +81,34 @@ def kit_lib_dir() -> Path:
 
 
 def kit_log_dir() -> Path:
-    """The kit LEDGER root -- the SAME single root the write-side append substrate
-    (lib/ledger/ledger.sh via lib/telemetry/kit-log-dir.sh) writes to. `stats` is the
-    read plane, so it MUST resolve the identical root. Precedence mirrors the shell
-    resolver exactly (SPEC-182): $KIT_LEDGER_DIR (canonical) -> $DWARVES_KIT_LOG_DIR
-    (back-compat alias) -> XDG state default. lane-telemetry.sh reads
-    <root>/runs/*.log under it."""
+    """The kit LEDGER root: the SAME single root the write side writes to.
+
+    ASKS THE ONE RESOLVER (lib/telemetry/kit-log-dir.sh), it does not reimplement it.
+    The previous version was a second Python copy of the precedence chain whose docstring
+    claimed it "mirrors the shell resolver exactly" while skipping level 3, the
+    `kit.toml [ledger].location` key. Under `location = "isolated"` the write plane wrote
+    to the toml location and this read plane read the XDG default, and it failed SILENTLY:
+    `stats` simply reported no runs. Latent only because the shipped default (`shared`)
+    makes both agree by accident (found 2026-07-15 while writing ADR-0035).
+
+    Two implementations of one resolver is the same bug class as a hand-list beside a
+    deriving resolver: the copy drifts, and the drift is invisible until it costs you.
+    """
+    resolver = _kit_repo_root() / "lib" / "telemetry" / "kit-log-dir.sh"
+    if resolver.is_file():
+        r = subprocess.run(
+            ["bash", "-c", f'. "{resolver}" && kit_resolve_log_dir'],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            # The resolver's own fatal (e.g. KIT_LEDGER_DIR set but empty). Do not paper
+            # over it with a guess: a wrong ledger root reads someone else's history.
+            raise SystemExit((r.stderr or "stats: kit-log-dir.sh refused to resolve a ledger root").strip())
+        root = r.stdout.strip()
+        if root:
+            return Path(root).expanduser()
+    # Resolver absent (a partial checkout): fall back to the env chain WITHOUT the toml
+    # level, and say so, rather than silently reading a plausible-but-wrong root.
     ledger_dir = os.environ.get("KIT_LEDGER_DIR")
     if ledger_dir is not None:
         if ledger_dir == "":

--- a/tests/kit-contract-known-gaps.txt
+++ b/tests/kit-contract-known-gaps.txt
@@ -9,6 +9,28 @@
 # while never looking at board, queue, session, gate, learn... including the module that same
 # PR was editing.
 
+# Exposed 2026-07-15 when the scope was fixed a SECOND time: a module whose code is only hooks
+# (money_gate, cosmetic) had no lib/<name>/ dir, so it was invisible to C3/C4 entirely. That is
+# how money_gate went its whole lifetime with no SPEC while the lint stayed green. The module->
+# home map now resolves the modules that live INSIDE another lib (quiz_gate -> lib/gate,
+# weekend_batch -> lib/learn, bridge -> lib/board) instead of inventing a phantom path for them.
+#
+# gate + learn: core libs, richly specced at repo docs/specs/ (SPEC-024/025/195/196...) and
+# tested at repo tests/ (test-gate-*.sh, test-learn-*.sh), but no module-level front door or
+# proof of their own. Real debt, sized: two READMEs and two proofs.
+lib/gate/README.md
+lib/gate/SPEC
+lib/gate/docs/proof-of-done.md
+lib/learn/README.md
+lib/learn/SPEC
+lib/learn/docs/proof-of-done.md
+
+# worktree-provision: has README + SPEC; its proof lives at repo docs/verification/ (the fold PR).
+lib/worktree-provision/docs/proof-of-done.md
+
+# cosmetic: its assertions live inside the shared tests/test-hooks.sh, which C4 cannot see.
+lib/cosmetic/tests
+
 # board: SPEC-147/149 live at repo docs/specs/; the module has no front door or proof of its own.
 lib/board/README.md
 lib/board/SPEC

--- a/tests/test-kit-contract.sh
+++ b/tests/test-kit-contract.sh
@@ -42,12 +42,35 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 # board, queue, session, gate, learn... including the module this very PR edits. A lint whose
 # scope silently excludes 3/4 of its subject is the vacuous-pass failure mode wearing a
 # different hat (advisor finding 1).
+#
+# Second scope bug, same shape: a module whose code is ONLY hooks (money_gate, cosmetic) has no
+# lib/<name>/ dir, so `[ -d "lib/$m" ]` yielded NOTHING and the module was invisible to C3/C4.
+# That is exactly how money_gate went its whole lifetime with no SPEC while the lint stayed
+# green (found 2026-07-15). A declared module now MUST have a lib/<name>/ home, even if that
+# home holds only its docs: the missing home is itself the finding, not an excuse to skip it.
+# A module's home is not always lib/<its-own-name>: several are FEATURES of another lib
+# (quiz_gate lives in lib/gate/, weekend_batch in lib/learn/, bridge in lib/board/), and one
+# is an agent, not a lib at all. This map is the honest resolution; without it the lint either
+# skipped them (the old blind spot: money_gate went its whole lifetime unspecced while C3 stayed
+# green) or reported a phantom lib/<name> that was never supposed to exist.
+module_home() {  # module_home <module> -> its dir, or "" for "documented elsewhere by design"
+  case "$1" in
+    quiz-gate)      echo "lib/gate" ;;        # lib/gate/quiz-gate.sh
+    weekend-batch)  echo "lib/learn" ;;       # lib/learn/weekend-batch.sh
+    bridge)         echo "lib/board" ;;       # lib/board/board-mirror.sh + board-writeback.sh
+    worktree)       echo "lib/worktree-provision" ;;
+    advisor)        echo "" ;;                # an AGENT (agents/advisor.md), not a lib module
+    *)              for d in "lib/$1" "lib/${1//-/_}"; do [ -d "$d" ] && { echo "$d"; return; }; done
+                    echo "lib/$1" ;;          # no home: emit the expected path so C3/C4 REPORT it
+  esac
+}
 modules() {
   {
     grep -o '^KIT_KNOWN_MODULES="[^"]*"' install.sh | sed 's/.*"\(.*\)"/\1/' | tr ' ' '\n' \
       | sed 's/_/-/g' | while read -r m; do
           [ -n "$m" ] || continue
-          for d in "lib/$m" "lib/${m//-/_}"; do [ -d "$d" ] && echo "$d"; done
+          h="$(module_home "$m")"
+          [ -n "$h" ] && echo "$h"
         done
     find lib -maxdepth 2 -name tool.toml -exec dirname {} \;
   } | sort -u
@@ -167,9 +190,14 @@ for m in $(modules); do
   mod="$(basename "$m")"
   # Tests live either in the module (lib/<m>/tests/) or at the repo root (tests/test-<m>.*),
   # both are real homes in this kit; a lint that only knew one would report a false gap.
+  # Root-level tests are named test-<mod>.sh OR test-<mod>-<topic>.sh (test-gate-outcome.sh,
+  # test-learn-propose.sh). Matching only the exact name reported a false gap for two core libs.
+  # `ls a b` returns NONZERO if ANY arg is missing, so a two-glob `ls` silently reported a gap
+  # for modules that DO have tests. find is the honest test here.
   ls "$m"/tests/*.sh >/dev/null 2>&1 && continue
-  ls tests/test-"$mod".* >/dev/null 2>&1 && continue
-  ls tests/test-"${mod//-/_}".* >/dev/null 2>&1 && continue
+  alt="${mod//-/_}"
+  [ -n "$(find tests -maxdepth 1 \( -name "test-$mod.*" -o -name "test-$mod-*" \
+                                  -o -name "test-$alt.*" -o -name "test-$alt-*" \) 2>/dev/null)" ] && continue
   if known_gap "$m/tests"; then t_gapped=$((t_gapped+1)); else untested="$untested$m\n"; fi
 done
 chk "every module has a test (module-local or repo-root)" "$(printf "%b" "$untested")"
@@ -237,6 +265,21 @@ offenders="$(grep -rhoE --exclude='test-kit-contract.sh' \
              "(^|\\\$\(|\||&&|;|!)[[:space:]]*($NONPORTABLE)[[:space:]]" tests lib/*/tests 2>/dev/null \
              | grep -oE "($NONPORTABLE)[[:space:]]" | grep -oE "^($NONPORTABLE)" | sort -u || true)"
 chk "no test invokes a non-CI tool (rg/fd/sd/...)" "$offenders"
+
+# ---------------------------------------------------------------- C10 executables self-declare
+echo "== C10 exec: every module executable declares its interpreter =="
+# An executable with no shebang (or no +x) forces the caller to GUESS the interpreter, and a
+# wrong guess fails ugly: `bash session-audit` (a python script) died with a shell syntax error
+# on a docstring line, 2026-07-15. The script must say what runs it; the caller must not have to.
+# Compiled binaries (prose-rag-rs) legitimately have neither: skip anything not a text file.
+noshebang=""
+while IFS= read -r f; do
+  file "$f" 2>/dev/null | grep -qiE 'text|script' || continue     # skip compiled binaries
+  head -c2 "$f" 2>/dev/null | grep -q '#!' || noshebang="$noshebang$f(no-shebang)\n"
+  [ -x "$f" ] || noshebang="$noshebang$f(not-executable)\n"
+done < <(find bin lib -path '*/bin/*' -type f -not -path '*/.venv/*' -not -path '*/target/*' \
+           -not -path '*/__pycache__/*' 2>/dev/null | sort)
+chk "every text executable has a shebang and the exec bit" "$(printf "%b" "$noshebang")"
 
 # ---------------------------------------------------------------- C8 CI workflow parses
 echo "== C8 CI: the workflow file is valid YAML =="
@@ -347,6 +390,11 @@ cmd="$(printf '%s' "$claim" | grep -oE '/(kit:)?[a-z-]+' | sed 's|^/||; s|^kit:|
 if [ -f "commands/$cmd.md" ] && ! grep -qF "nc-phantom-agent" "commands/$cmd.md"; then
   ok "C9 catches an agent claiming a dispatcher that ignores it"
 else bad "C9 vacuous"; fi
+
+# C10: an executable with no shebang (the shape that made `bash <python-script>` explode)
+printf 'print("no shebang here")\n' > "$TMP/nc/bin/interpreterless"; chmod +x "$TMP/nc/bin/interpreterless"
+if head -c2 "$TMP/nc/bin/interpreterless" | grep -q '#!'; then bad "C10 vacuous"; else
+  ok "C10 catches an executable that does not declare its interpreter"; fi
 
 echo ""
 echo "=== kit-contract: $PASS passed, $FAIL failed ==="

--- a/tests/test-kit-contract.sh
+++ b/tests/test-kit-contract.sh
@@ -16,9 +16,18 @@
 #                (SPEC-097), never a hardcoded ~/.claude/dwarves-kit/logs.
 # C7  PORTABLE   no test reaches for a tool CI does not have (rg/fd/sd/jq...): a missing binary
 #                turns a lint into a VACUOUS PASS (this exact bug shipped, 2026-07-14).
+# C8  CI         every .github/workflows/*.yml is valid: an unquoted step name carrying ": "
+#                parses as a mapping and invalidates the WHOLE file, so every lint in it
+#                silently stops guarding anything (shipped red at 0s, 2026-07-14).
+# C9  DISPATCH   every "dispatched by /X" claim (agent frontmatter, README roster) is backed by
+#                a command that really dispatches it (4 were wrong, 2026-07-14).
+# C10 EXEC       every text executable declares its interpreter (shebang + exec bit): a wrong
+#                guess fails ugly (`bash <python-script>` died on a docstring, 2026-07-15).
 #
-# Every rule has a NEGATIVE CONTROL: a planted violation must be caught. A lint nobody can
-# see fail is a lint nobody should trust.
+# Every rule has a NEGATIVE CONTROL, and the planted violation must arrive in a shape the
+# rule's author did NOT have in mind: an NC that plants the exact form the regex was written
+# against proves only that the regex matches itself. Four rules were vacuous until re-planted
+# differently. A lint nobody can see fail is a lint nobody should trust.
 #
 # Run: bash tests/test-kit-contract.sh
 set -uo pipefail

--- a/tests/test-ledger-durability.sh
+++ b/tests/test-ledger-durability.sh
@@ -170,6 +170,26 @@ DWARVES_KIT_LOG_DIR="$TOKD" bash "$GL" check normal trun >/dev/null 2>&1; assert
 DWARVES_KIT_LOG_DIR="$TOKD" bash "$GL" tokens trun in=1,2ab out=-5 cache_read=x cache_create=9 >/dev/null 2>&1
 grep -qE '\| TOKENS \| in=12 out=5 cache_read=0 cache_create=9$' "$TOKD/runs/trun.log"; assert "SPEC-110: tokens sanitizes integer values to digits (junk stripped)" $?
 
+# --- C: the READ plane (stats, python) resolves the SAME root as the WRITE plane -----------
+# stats/config.py used to be a SECOND implementation of the precedence chain. Its docstring
+# claimed it "mirrors the shell resolver exactly"; it skipped level 3 (kit.toml [ledger].
+# location). Under `location = "isolated"` the write plane wrote to the toml location while
+# stats read the XDG default, and it failed SILENTLY: stats just reported no runs. It now asks
+# the ONE resolver instead of reimplementing it (2026-07-15).
+CPROJ="$(mktemp -d)"; printf '[ledger]\nlocation = "isolated"\n' > "$CPROJ/.kit.toml"
+c_write="$(cd "$CPROJ" && bash -c ". \"$KIT_DIR/lib/telemetry/kit-log-dir.sh\" && kit_resolve_log_dir" 2>/dev/null)"
+c_read="$(cd "$CPROJ" && PYTHONPATH="$KIT_DIR/lib/stats/src" python3 -c 'from stats.config import kit_log_dir; print(kit_log_dir())' 2>/dev/null | tail -1)"
+[ -n "$c_read" ] && [ "$c_write" = "$c_read" ]
+assert "C1: under [ledger].location=isolated, the stats READ plane agrees with the WRITE plane (no split-brain)" $?
+
+# NEGATIVE CONTROL: the read plane must not silently invent a root when the resolver refuses.
+# KIT_LEDGER_DIR set-but-empty is the resolver's fatal case; stats must fail, not guess.
+c_empty_rc=0
+(cd "$CPROJ" && KIT_LEDGER_DIR="" PYTHONPATH="$KIT_DIR/lib/stats/src" python3 -c 'from stats.config import kit_log_dir; print(kit_log_dir())' >/dev/null 2>&1) || c_empty_rc=$?
+[ "$c_empty_rc" -ne 0 ]
+assert "C2 NEGATIVE CONTROL: an empty KIT_LEDGER_DIR makes the READ plane fail loudly, never guess a root" $?
+rm -rf "$CPROJ"
+
 echo ""
 echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Three defects, all found by the record work in #249/#251/#252.

**1. Two implementations of one resolver (silent split-brain).** `stats/config.py::kit_log_dir` was a SECOND Python copy of the precedence chain. Its docstring claimed it "mirrors the shell resolver exactly"; it skipped level 3, the `kit.toml [ledger].location` key. Under `location = "isolated"` the write plane wrote to the toml location while the stats read plane read the XDG default, and it failed SILENTLY: stats just reported no runs. It now ASKS the one resolver instead of reimplementing it, and re-raises a resolver refusal rather than guessing a root. Same bug class as a hand-list beside a deriving resolver: the copy drifts, and the drift is invisible until it costs you.

**2. The contract lint could not see a hook-only module.** `modules()` resolved a module to `lib/<name>/`; `money_gate` and `cosmetic` have no such dir (their code is hooks), so C3/C4 never yielded them. That is exactly how money_gate went its whole lifetime with no SPEC while the lint stayed green. An explicit module->home map now resolves the three modules that live INSIDE another lib (quiz_gate -> lib/gate, weekend_batch -> lib/learn, bridge -> lib/board), and a module with NO home is REPORTED, not skipped.

**3. Two lint self-bugs found while fixing 2.** C4 matched only `tests/test-<mod>.*`, missing the `test-<mod>-<topic>.sh` form that `gate` and `learn` actually use; and `ls a b` returns nonzero when ANY arg is missing, so a two-glob `ls` reported false gaps for modules that DO have tests.

Plus C10 (re-applied): every text executable declares its interpreter. Running a python script with `bash` died on a docstring line earlier today; the script must say what runs it.

Tests: ledger-durability 35 -> 37, including a negative control (an empty `KIT_LEDGER_DIR` must make the read plane fail LOUDLY, never guess a root). Proof: `docs/verification/contract-scope-and-resolver.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
