### PR TITLE
feat(prose-rag): ride the weekly scheduler, with a corpus-config guard

### DIFF
--- a/bin/prose-rag
+++ b/bin/prose-rag
@@ -14,5 +14,12 @@ elif [ -x "$PR/rust/target/release/prose-rag" ]; then
   exec "$PR/rust/target/release/prose-rag" "$@"
 fi
 [ "${1:-}" = "hook" ] && exit 0
+# `index` with no corpus configured = an unconfigured consumer (the shipped
+# kit-weekly job): skip clean, same contract as the engine's own guard. An
+# explicit --corpus means someone is driving interactively -> honest error.
+if [ "${1:-}" = "index" ] && [ -z "${PROSE_RAG_CORPUS:-}" ] && [[ "$*" != *"--corpus"* ]]; then
+  echo "prose-rag: no corpus configured (set PROSE_RAG_CORPUS or pass --corpus); nothing indexed"
+  exit 0
+fi
 echo "prose-rag: engine not built. Run: (cd $PR/rust && cargo build --release && cp target/release/prose-rag ../bin/prose-rag-rs)" >&2
 exit 1

--- a/deploy/macos/README.md
+++ b/deploy/macos/README.md
@@ -19,6 +19,12 @@ three weeks once) -> each `jobs.txt` line in order:
 |---|---|---|
 | `session-intel` | `bin/session intel run` | `~/.claude/intel/intel-YYYY-MM-DD.md`, the weekly digest: harness scorecard (`stats digest`), usage, repo health, merge + extract-workflow proposals |
 | `kit-retro` | `bin/learn propose` | cited, deduped, adversarially-checked proposals into the staging file (review with `learn drain`, promote with `board promote`) |
+| `prose-rag-index` | `bin/prose-rag index` | incremental recall-index refresh (`~/.claude/prose-rag/index.bin`). Opt-in by config: with no `PROSE_RAG_CORPUS` (and no built engine) it skips clean, exit 0, db untouched |
+
+**Consumer env (optional).** launchd gives jobs a bare env (Claude Code's
+`settings.json` env exists only inside sessions). If `~/.config/kit-weekly/env`
+exists, the dispatcher sources it before running jobs; per-machine config like
+`PROSE_RAG_CORPUS` lives there, never in the kit repo.
 
 **Jobs-list contract.** `<job-name> <command relative to the kit root, or
 absolute>`, one per line; `#` comments and blank lines skipped. A malformed line

--- a/deploy/macos/jobs.txt
+++ b/deploy/macos/jobs.txt
@@ -5,3 +5,4 @@
 # here, never a new plist.
 session-intel bin/session intel run
 kit-retro bin/learn propose
+prose-rag-index bin/prose-rag index

--- a/deploy/macos/kit-weekly
+++ b/deploy/macos/kit-weekly
@@ -17,6 +17,13 @@ JOBS="${KIT_WEEKLY_JOBS:-$HERE/jobs.txt}"
 # (repo-sweep, uv, gh), so widen it the same way the retired per-job launcher did.
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
+# Optional consumer env (launchd gives a bare env; settings.json env only exists
+# inside Claude Code sessions). Corpus paths and similar per-machine config live
+# here, never in the kit repo: e.g. PROSE_RAG_CORPUS for the prose-rag-index job.
+CONSUMER_ENV="$HOME/.config/kit-weekly/env"
+# shellcheck disable=SC1090
+[ -f "$CONSUMER_ENV" ] && . "$CONSUMER_ENV"
+
 if [ ! -f "$JOBS" ]; then
   echo "kit-weekly: jobs list not found: $JOBS" >&2
   exit 1

--- a/docs/verification/weekly-prose-rag-index.md
+++ b/docs/verification/weekly-prose-rag-index.md
@@ -1,0 +1,68 @@
+# Proof of done: weekly prose-rag index (kit-weekly job + corpus-config guard)
+
+Branch: `feat/weekly-prose-rag-index`. Stateful change: a new `jobs.txt` job, a
+consumer-env source in the `kit-weekly` dispatcher, and an unconfigured-corpus
+guard in the engine + `bin/prose-rag` wrapper.
+
+## Acceptance criteria
+
+1. `prose-rag index` with no `PROSE_RAG_CORPUS` and no `--corpus` skips clean:
+   exit 0, message, index db byte-identical (never clobbered to empty).
+2. Configured-but-empty corpus stays a real error (exit 1).
+3. `kit-weekly` sources `~/.config/kit-weekly/env` when present; the shipped
+   `prose-rag-index` jobs line is silent-green for unconfigured consumers and
+   indexes for configured ones.
+
+## Confirmation runs
+
+### Engine suites (green run)
+
+```
+Command: cd lib/prose-rag/rust && cargo build --release && bash tests/smoke.sh
+Exit: 0
+ok 14 - unconfigured corpus skips clean (exit 0, db untouched)
+ok 15 - configured-but-empty corpus errors (exit 1)
+smoke: all 15 passed
+
+Command: cargo test --release
+Exit: 0
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+Check 14 is the negative control for the clobber risk: it `cmp`s the db before
+and after the unconfigured run (byte-identical required). Check 15 is the
+negative control for over-silencing: a configured-but-empty corpus must still
+fail loudly.
+
+### Dispatcher end-to-end (isolated `$HOME`, jobs file with only the new line)
+
+```
+Command: HOME="$T" KIT_WEEKLY_JOBS="$T/jobs.txt" deploy/macos/kit-weekly   # no consumer env
+Exit: 0
+prose-rag: no corpus configured (set PROSE_RAG_CORPUS or pass --corpus); nothing indexed
+kit-weekly: 'prose-rag-index' ok
+kit-weekly: done (ran=1 skipped=0 failed=0)
+
+Command: HOME="$T" KIT_WEEKLY_JOBS="$T/jobs.txt" deploy/macos/kit-weekly   # $T/.config/kit-weekly/env sets PROSE_RAG_CORPUS + PROSE_RAG_DB
+Exit: 0
+prose-rag: embedding 1 chunks from 1 changed files (0 removed, 1 total files)...
+prose-rag: indexed 1 chunks (1 files) -> $T/index.bin
+kit-weekly: 'prose-rag-index' ok
+kit-weekly: done (ran=1 skipped=0 failed=0)
+```
+
+## Reproduce
+
+```
+cd lib/prose-rag/rust && cargo build --release && bash tests/smoke.sh && cargo test --release
+T=$(mktemp -d); printf 'prose-rag-index bin/prose-rag index\n' > "$T/jobs.txt"
+HOME="$T" KIT_WEEKLY_JOBS="$T/jobs.txt" deploy/macos/kit-weekly
+```
+
+## Rollback
+
+Revert the commit (single commit on the branch). Runtime rollback without a
+revert: delete the `prose-rag-index` line from `deploy/macos/jobs.txt` (the
+dispatcher takes effect next weekly run; no daemon reload needed, the plist is
+untouched). The consumer file `~/.config/kit-weekly/env` is machine-side and
+inert once the jobs line is gone.

--- a/lib/config/module-registry.md
+++ b/lib/config/module-registry.md
@@ -174,6 +174,7 @@ real reader consumes it today (all rows below are, except where noted).
 | Env var | kit.toml key | Default | Status | Module | Doc |
 |---|---|---|---|---|---|
 | PROSE_RAG_INJECT | env-only | unset (hook inert) | [impl] | prose_rag | The engine's own opt-in master switch for the recall-inject hook , deliberately NOT `modules.prose_rag` (that toggle only gates hook *install*, this gates whether the installed hook actually fires). |
+| PROSE_RAG_CORPUS | env-only | unset (index skips clean) | [impl] | prose_rag | Colon-separated corpus dirs/files for `prose-rag index` (adapter-default invariant: no personal path in the kit). Unset with no `--corpus` = unconfigured consumer -> `index` exits 0, db untouched (the shipped kit-weekly `prose-rag-index` job stays silent-green). Under launchd, supplied via `~/.config/kit-weekly/env`. |
 | MONEY_GATE_REPOS | env-only | (unset) | [impl] | money_gate | Colon-separated list of repo names the guard treats as financial; hook is inert (exits 0) without it. |
 
 ### modules (install-time manifest, `install.sh:170` `KIT_KNOWN_MODULES`, 12 of 12)

--- a/lib/prose-rag/README.md
+++ b/lib/prose-rag/README.md
@@ -66,7 +66,7 @@ The index is bincode with a per-file FNV-1a content hash, so `index` re-embeds o
 ```bash
 cd tools/prose-rag/rust
 cargo test --release        # 9 unit tests: chunker (+boundaries/windowing), fnv, gate, search, index roundtrip/corruption guard, gather parity/symlink guard, f16+f32 row decode
-bash tests/smoke.sh         # 13 CLI checks: index/query/hook end-to-end, incremental rerun, deletion prune, clobber guard, windowed-tail retrieval
+bash tests/smoke.sh         # CLI checks: index/query/hook end-to-end, incremental rerun, deletion prune, clobber guard, corpus-config guard, windowed-tail retrieval
 ```
 
 The legacy Python suite is `tests/smoke.sh` at the tool root (11 checks, Python engine only).

--- a/lib/prose-rag/rust/src/main.rs
+++ b/lib/prose-rag/rust/src/main.rs
@@ -391,6 +391,12 @@ fn cmd_index(corpus: Vec<PathBuf>, db: &Path, full: bool) -> Result<i32> {
     } else {
         corpus
     };
+    if corpus.is_empty() {
+        // No --corpus and PROSE_RAG_CORPUS unset: an unconfigured consumer (the
+        // shipped kit-weekly job hits this) -> clean opt-in skip, db untouched.
+        println!("prose-rag: no corpus configured (set PROSE_RAG_CORPUS or pass --corpus); nothing indexed");
+        return Ok(0);
+    }
     let files = gather_files(&corpus);
     if files.is_empty() {
         eprintln!("prose-rag: no markdown files found in corpus");

--- a/lib/prose-rag/rust/tests/smoke.sh
+++ b/lib/prose-rag/rust/tests/smoke.sh
@@ -107,4 +107,18 @@ out="$("$BIN" query "xylophone amortization anomaly" --db "$DB" --floor 0 --k 2)
 echo "$out" | grep -q "long.md" || fail "windowed tail not retrievable: $out"
 ok "windowed tail content retrievable end-to-end"
 
+# 14. unconfigured corpus (no --corpus, no PROSE_RAG_CORPUS) skips clean: exit 0, db untouched
+cp "$DB" "$T/before.bin"
+out="$(env -u PROSE_RAG_CORPUS "$BIN" index --db "$DB" 2>&1)" || fail "unconfigured index exited nonzero: $out"
+echo "$out" | grep -q "no corpus configured" || fail "unconfigured skip message missing: $out"
+cmp -s "$DB" "$T/before.bin" || fail "unconfigured index touched the db"
+ok "unconfigured corpus skips clean (exit 0, db untouched)"
+
+# 15. configured corpus with no markdown files is a real error (exit 1)
+mkdir -p "$T/empty"
+if env PROSE_RAG_CORPUS="$T/empty" "$BIN" index --db "$DB" 2>/dev/null; then
+  fail "empty configured corpus exited 0"
+fi
+ok "configured-but-empty corpus errors (exit 1)"
+
 echo "smoke: all $pass passed"


### PR DESCRIPTION
## What

Wires the prose-rag recall index into the one weekly scheduler (ADR-0034 decision 9): `prose-rag-index` becomes a `jobs.txt` line riding `kit-weekly` alongside `session-intel` and `kit-retro`. No new plist, no new daemon.

## Why

The index was manual-only: the UserPromptSubmit hook reads it every prompt, but nothing ever refreshed it. On the operator machine it sat 5 days stale while the hook kept serving old vectors (and the module's history includes a 26-day undetected dead spell, kit board ID-100).

## How

- **`deploy/macos/jobs.txt`**: one new line, `prose-rag-index bin/prose-rag index`.
- **`deploy/macos/kit-weekly`**: sources `~/.config/kit-weekly/env` (optional) before running jobs. launchd gives a bare env and Claude Code's `settings.json` env exists only inside sessions, so per-machine config like `PROSE_RAG_CORPUS` needs a consumer channel; corpus paths stay out of the kit repo (adapter-default invariant).
- **Engine (`cmd_index`) + `bin/prose-rag` wrapper**: split the empty-corpus case in two. Unconfigured (no `PROSE_RAG_CORPUS`, no `--corpus`) is a clean opt-in skip: exit 0, message, db untouched, so the shipped jobs line stays silent-green for consumers who never opted into prose-rag, including engine-not-built. Configured-but-empty stays a real error (exit 1).
- **Docs**: jobs table + consumer-env section in `deploy/macos/README.md`; smoke-count phrasing in `lib/prose-rag/README.md`.

## Verification

- `tests/smoke.sh` 15/15 (two new checks: unconfigured skip leaves the db byte-identical; configured-but-empty exits 1).
- `cargo test --release` 10/10.
- Dispatcher e2e with an isolated `$HOME`: run without consumer env → `'prose-rag-index' ok`, "no corpus configured", db untouched; run with env file → real incremental index, `failed=0` both runs.

## Notes

- Consumer side on the operator machine is already staged: `~/.config/kit-weekly/env` exporting `PROSE_RAG_CORPUS` (per-machine file, not in any repo).
- No overlap with the in-flight bridge→sync work on master (checked: disjoint file sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
