### PR TITLE
Ledger rung-4 redteam rounds with cost

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Run gate-outcome emit tests (SPEC-129)
         run: bash tests/test-gate-outcome.sh
 
+      - name: Run redteam-gate tests (rung-4 cost checkpoint)
+        run: bash tests/test-redteam-gate.sh
+
       - name: Run outcome-emit-sweep no-orphan check (SPEC-193, harness-loop sub-goal 02)
         run: bash tests/test-outcome-emit-sweep.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,12 @@ jobs:
       # Update via Dependabot or manually when checkout cuts a new release.
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
 
+      # uv, scoped to lib/stats (the kit-gates-cost test needs `uv run stats`). Pinned to
+      # release SHA per the same supply-chain policy as checkout above. This does not adopt
+      # the rest of lib/stats/tests/*.sh into CI (a pre-existing, wider gap out of scope
+      # here); it only wires the one new test this PR added.
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
       - name: Install jq (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -115,6 +121,12 @@ jobs:
 
       - name: Run redteam-gate tests (rung-4 cost checkpoint)
         run: bash tests/test-redteam-gate.sh
+
+      - name: Run kit_gates cost-column tests (rung-4 cost checkpoint, lib/stats side)
+        run: |
+          cd lib/stats
+          uv sync
+          bash tests/test-kit-gates-cost.sh
 
       - name: Run outcome-emit-sweep no-orphan check (SPEC-193, harness-loop sub-goal 02)
         run: bash tests/test-outcome-emit-sweep.sh

--- a/docs/verification/redteam-gate-ledger.md
+++ b/docs/verification/redteam-gate-ledger.md
@@ -73,6 +73,45 @@ Result (verbatim, from a live run):
 ```bash
 bash tests/test-redteam-gate.sh
 ```
+Command: `bash tests/test-redteam-gate.sh`
+Exit: 0
+Result: `=== 31/31 passed, 0 failed ===`
+
+## Rollback (negative control: revert -> RED -> restore)
+
+Removed the "cost is required" guard in `lib/gate/redteam-gate.sh` `cmd_round` (the exact
+lines NC1 below protects), re-ran the suite, confirmed RED, then restored via
+`git checkout -- lib/gate/redteam-gate.sh` and confirmed GREEN again, byte-identical to the
+committed file (`git diff lib/gate/redteam-gate.sh` empty).
+
+```bash
+# remove the cost=<dollars> || { ...; return 64; } block from cmd_round
+bash tests/test-redteam-gate.sh
+```
+Command: `bash tests/test-redteam-gate.sh` (with the guard removed)
+Exit: 1
+Result (verbatim, RED):
+```
+FAIL AC6 missing cost= rejected (rc=0)
+FAIL AC6 no GATE row written on a failed round
+FAIL AC6 no TOKENS row written on a failed round
+FAIL AC6 no OUTCOME end written on a failed round
+FAIL AC6 exactly the one start line remains (got 4 lines)
+
+=== 26/31 passed, 5 failed ===
+```
+This is the exact regression NC1 exists to catch: with the guard gone, a cost-less round no
+longer errors, and instead silently writes a real `GATE`/`TOKENS`(`cost=` empty)/`OUTCOME`
+triple -- precisely the "misleadingly cheap zero-cost row" scenario the design note warns
+against.
+
+```bash
+git checkout -- lib/gate/redteam-gate.sh
+git diff --stat lib/gate/redteam-gate.sh   # empty: byte-identical restore
+bash tests/test-redteam-gate.sh
+```
+Command: `bash tests/test-redteam-gate.sh` (restored)
+Exit: 0
 Result: `=== 31/31 passed, 0 failed ===`
 
 ## Run 2 (NC1, load-bearing): a round with no cost= writes nothing
@@ -104,6 +143,8 @@ uv run stats mega-durations --json
 bash tests/test-kit-gates-cost.sh
 ```
 
+Command: `bash tests/test-kit-gates-cost.sh`
+Exit: 0
 Result: `== 12 passed, 0 failed ==`. Key rows confirmed (verbatim from `show kit_gates --json`):
 ```json
 { "rid": "rt-a", "gate": "redteam", "reason": "round=1 verdict=findings 2 findings, fixed",
@@ -134,6 +175,8 @@ and those rounds would join the checkpoint's average as fabricated free rounds.
 ```bash
 bash tests/test-meta.sh
 ```
+Command: `bash tests/test-meta.sh`
+Exit: 0
 Result: `Passed: 698 / 698` (pre-existing suite, run after every change above; every
 pre-existing `lib/stats/tests/*.sh` and root `tests/test-gate-outcome.sh`,
 `tests/test-quiz-gate.sh`, `tests/test-gate-vocab-recording.sh`,

--- a/docs/verification/redteam-gate-ledger.md
+++ b/docs/verification/redteam-gate-ledger.md
@@ -7,10 +7,17 @@ the ID-372 checkpoint ("tighten the rung-4 trigger if it averages >15% of mega c
 never be evaluated: N stayed 0 no matter how many redteams actually ran.
 
 Two behavioral claims, both required:
-1. Every rung-4 round now appends a `redteam` `kit_gates` row carrying that round's token
-   cost (`lib/gate/redteam-gate.sh round`).
-2. Every round brackets an `OUTCOME` start/end pair on the `redteam` phase, so
-   `lib/stats`' `mega-durations` (no gate-name whitelist) picks the round up for free.
+1. A rung-4 round CAN NOW append a `redteam` `kit_gates` row carrying that round's token
+   cost, in one call (`lib/gate/redteam-gate.sh round`).
+2. That call brackets an `OUTCOME` start/end pair on the `redteam` phase, so `lib/stats`'
+   `mega-durations` (no gate-name whitelist) picks the round up for free.
+
+**Scope boundary (read before assuming N > 0 after this merges):** the redteam PROCEDURE
+itself (the cap-3 loop, the `VERDICT: SECURE` judgment) lives in a sibling dotfiles repo's
+SKILL.md blocks, out of scope for this PR. This PR makes the recording call cheap (one call
+instead of three, kept in sync); it does not make anything call it. N stays 0 until the
+dotfiles-side procedure is edited to call `start`/`round` at its own round boundaries --
+that is a separate, tracked follow-up.
 
 ## What "done" means here
 
@@ -33,7 +40,7 @@ does not invent a second one.
 ## Fixtures
 
 Bash-level (`tests/test-redteam-gate.sh`): builds every ledger inline under a fresh
-`DWARVES_KIT_LOG_DIR` per case (31 assertions across start/round, all 3 verdicts, the two
+`DWARVES_KIT_LOG_DIR` per case (40 assertions across start/round, all 3 verdicts, the two
 negative controls, multi-round FIFO, token-count passthrough, embedded-newline injection
 defense, `gate.sh` dispatch, and usage errors).
 
@@ -46,6 +53,7 @@ Python-level (`lib/stats/tests/test-kit-gates-cost.sh`), a committed golden fixt
 | `rt-b.log` | 1 round, `TOKENS cost=notanumber` -- malformed input |
 | `rt-c.log` | 1 round, no phase-scoped `TOKENS` line at all -- an orphaned/failed-then-retried round |
 | `rt-d.log` | 1 round, plus an unscoped (no `phase=`) rid-wide `TOKENS` line that must never pair |
+| `rt-e.log` | 1 round, `TOKENS cost=0` -- a real zero-cost round, must land `0.0` not `NULL` |
 
 ## Run 1: end-to-end round emit (bash, `tests/test-redteam-gate.sh`)
 
@@ -75,20 +83,20 @@ bash tests/test-redteam-gate.sh
 ```
 Command: `bash tests/test-redteam-gate.sh`
 Exit: 0
-Result: `=== 31/31 passed, 0 failed ===`
+Result: `=== 40/40 passed, 0 failed ===`
 
 ## Rollback (negative control: revert -> RED -> restore)
 
-Removed the "cost is required" guard in `lib/gate/redteam-gate.sh` `cmd_round` (the exact
-lines NC1 below protects), re-ran the suite, confirmed RED, then restored via
-`git checkout -- lib/gate/redteam-gate.sh` and confirmed GREEN again, byte-identical to the
-committed file (`git diff lib/gate/redteam-gate.sh` empty).
+Removed `cmd_round`'s cost-validation block (the single unified regex check that covers both
+missing and malformed `cost=` -- see the code comment on why one check suffices), re-ran the
+suite, confirmed RED, then restored from a pre-edit checkpoint copy and confirmed GREEN again,
+byte-identical (`cmp` clean).
 
 ```bash
-# remove the cost=<dollars> || { ...; return 64; } block from cmd_round
+# remove the `if ! [[ "$cost" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then ...; fi` block from cmd_round
 bash tests/test-redteam-gate.sh
 ```
-Command: `bash tests/test-redteam-gate.sh` (with the guard removed)
+Command: `bash tests/test-redteam-gate.sh` (with the validation block removed)
 Exit: 1
 Result (verbatim, RED):
 ```
@@ -97,22 +105,25 @@ FAIL AC6 no GATE row written on a failed round
 FAIL AC6 no TOKENS row written on a failed round
 FAIL AC6 no OUTCOME end written on a failed round
 FAIL AC6 exactly the one start line remains (got 4 lines)
+FAIL AC13 malformed cost=1.2.3 rejected (rc=0)
+FAIL AC13 malformed cost=1.2.3 wrote nothing
+FAIL AC13 non-numeric cost=abc rejected (rc=0)
 
-=== 26/31 passed, 5 failed ===
+=== 32/40 passed, 8 failed ===
 ```
-This is the exact regression NC1 exists to catch: with the guard gone, a cost-less round no
-longer errors, and instead silently writes a real `GATE`/`TOKENS`(`cost=` empty)/`OUTCOME`
-triple -- precisely the "misleadingly cheap zero-cost row" scenario the design note warns
+This is the exact regression NC1/AC13 exist to catch: with the check gone, a cost-less OR
+malformed-cost round no longer errors, and instead silently writes a real
+`GATE`/`TOKENS`(`cost=` empty or `1.2.3`)/`OUTCOME` triple -- precisely the "misleadingly
+cheap zero-cost row" and "malformed-but-accepted cost" scenarios the design note warns
 against.
 
 ```bash
-git checkout -- lib/gate/redteam-gate.sh
-git diff --stat lib/gate/redteam-gate.sh   # empty: byte-identical restore
+cmp /tmp/redteam-gate-checkpoint.sh lib/gate/redteam-gate.sh   # byte-identical restore
 bash tests/test-redteam-gate.sh
 ```
 Command: `bash tests/test-redteam-gate.sh` (restored)
 Exit: 0
-Result: `=== 31/31 passed, 0 failed ===`
+Result: `=== 40/40 passed, 0 failed ===`
 
 ## Run 2 (NC1, load-bearing): a round with no cost= writes nothing
 
@@ -145,7 +156,7 @@ bash tests/test-kit-gates-cost.sh
 
 Command: `bash tests/test-kit-gates-cost.sh`
 Exit: 0
-Result: `== 12 passed, 0 failed ==`. Key rows confirmed (verbatim from `show kit_gates --json`):
+Result: `== 14 passed, 0 failed ==`. Key rows confirmed (verbatim from `show kit_gates --json`):
 ```json
 { "rid": "rt-a", "gate": "redteam", "reason": "round=1 verdict=findings 2 findings, fixed",
   "start_ts": "1000", "end_ts": "1030", "cost": 0.42 }
@@ -168,7 +179,50 @@ print(materialize.query(\"SELECT count(*) FROM kit_gates WHERE gate='redteam' AN
 ```
 Result: `3` (rt-b malformed + rt-c orphan + rt-d unscoped). If a future edit coerced an
 unparseable/missing `cost=` to `0.0` instead of `NULL`, this count would silently drop to 0
-and those rounds would join the checkpoint's average as fabricated free rounds.
+and those rounds would join the checkpoint's average as fabricated free rounds. The inverse
+falsifiable check (`rt-e`, `cost=0`) confirms a REAL zero is never swept into that NULL count
+(`test-kit-gates-cost.sh`'s `C-zero` case).
+
+## Review findings applied
+
+Reviewed by `kit:code-reviewer` (architecture lens, 8/10 approve-with-suggestions),
+`kit:code-reviewer` (test-coverage lens, 8/10 sufficient-with-gaps), and `kit:advisor`
+(critique mode, fable model, sound-with-concerns). Applied before merge:
+
+- **CI wiring gap** (architecture + test-coverage, independently): `lib/stats/tests/
+  test-kit-gates-cost.sh` had no CI step (only its bash sibling did). Fixed: added
+  `astral-sh/setup-uv` + a `uv sync` + test step to `.github/workflows/test.yml`, scoped to
+  this one new test (the wider "no `lib/stats/tests/*.sh` runs in CI" gap is pre-existing
+  across ~15 files and stays out of scope here).
+- **Factually-inaccurate rationale comment** (fable): the header claimed a costless round
+  "would desync the FIFO pairing" -- untrue, `read_kit_gates` already tolerates a missing/
+  malformed cost by landing `NULL` in the queue slot, FIFO position preserved. Rewrote the
+  rationale to the real reason: this tool exists to make rung-4 cost measurable, so silently
+  allowing costless rounds would just relocate the checkpoint's original gap.
+- **Overclaimed scope** (fable): the doc originally said rounds "now append" a `kit_gates`
+  row; softened to "can now append", and added an explicit SCOPE note (both here and in the
+  script header) that the dotfiles-side redteam PROCEDURE is not wired to call this yet --
+  that adoption is a separate, tracked follow-up, not implied by this PR.
+- **Lax cost validation** (fable): `cost=1.2.3` previously sanitized-then-silently-accepted
+  (landing `NULL` downstream); tightened to one strict regex (`^[0-9]+(\.[0-9]+)?$`) that also
+  subsumes the missing-cost case, so the separate presence check was removed as redundant.
+  Covered by new AC13 (bash) + the `rt-e` fixture (Python side, `cost=0` is real and distinct
+  from "malformed").
+- **`cost=0` untested** (test-coverage): added AC13 (bash) and `rt-e`/`C-zero` (Python),
+  confirming a real zero-cost round is never confused with the honest-NULL cases.
+- **`main()`'s bare-usage arm untested** (test-coverage): added AC11b (no-args, `-h`,
+  `--help`, `help`).
+- **Stale cross-reference** (fable): `schemas.py`'s `cost` column comment pointed at an
+  adapters.py docstring sentence this PR itself had already removed; fixed the pointer.
+- **Fabricated-zero token counts vs honest-NULL cost** (fable): documented, not changed --
+  `in=`/`out=`/etc. still zero-default (inherited from `gate-ledger.sh tokens()`, unlike
+  `cost`), which is now a named asymmetry in the script header rather than a silent one.
+
+Deferred, not applied (named as residual risk, not blockers): the redteam PROCEDURE's own
+dotfiles-side wiring (cross-repo, explicitly out of scope for this PR); the narrow
+between-subprocess-calls partial-write window (now named in the header comment); the
+pre-existing double-`start`-with-no-`end` timestamp-corruption case in `read_kit_gates`
+(inherited behavior, not introduced by this PR).
 
 ## Full suite, no regressions
 
@@ -189,6 +243,9 @@ docstring).
 ```bash
 git checkout feat/redteam-gate-ledger
 bash tests/test-redteam-gate.sh
-(cd lib/stats && bash tests/test-kit-gates-cost.sh)
+(cd lib/stats && uv sync && bash tests/test-kit-gates-cost.sh)
 bash tests/test-meta.sh
+bash tests/test-kit-contract.sh
 ```
+The `uv sync` step is what `.github/workflows/test.yml`'s new CI step also runs (verified
+locally against a freshly-rebuilt `.venv`, not just the pre-existing one).

--- a/docs/verification/redteam-gate-ledger.md
+++ b/docs/verification/redteam-gate-ledger.md
@@ -1,0 +1,151 @@
+# Verification: rung-4 redteam gate ledger (cost checkpoint)
+
+Closes the gap ops-toolkit's `research/2026-07-18-rung4-cost-checkpoint.md` found: real
+rung-4 redteam rounds (in-harness adversarial skeptic, cap 3, verbatim `VERDICT: SECURE`)
+had run inside hand-conducted megas, but none ever emitted a `redteam` `kit_gates` row, so
+the ID-372 checkpoint ("tighten the rung-4 trigger if it averages >15% of mega cost") could
+never be evaluated: N stayed 0 no matter how many redteams actually ran.
+
+Two behavioral claims, both required:
+1. Every rung-4 round now appends a `redteam` `kit_gates` row carrying that round's token
+   cost (`lib/gate/redteam-gate.sh round`).
+2. Every round brackets an `OUTCOME` start/end pair on the `redteam` phase, so
+   `lib/stats`' `mega-durations` (no gate-name whitelist) picks the round up for free.
+
+## What "done" means here
+
+Two negative controls, both load-bearing:
+- **NC1 (fail-closed emit):** a round with no `cost=` is rejected (rc 64) and writes NEITHER
+  a `GATE` row NOR a `TOKENS` row NOR an `OUTCOME` end -- a failed-to-emit round is loud
+  (the caller sees the rejection immediately) and leaves no fabricated ledger data, rather
+  than silently landing as an untracked or zero-cost row a cost-checkpoint reader could
+  mistake for a real, cheap round.
+- **NC2 (honest-NULL, not fabricated-zero):** a malformed `TOKENS cost=` value, or a
+  `redteam` `GATE` row with no phase-scoped `TOKENS` line at all, lands as `cost=NULL` in
+  `kit_gates`, never a fabricated `0.0` that would silently understate the checkpoint's
+  average.
+
+Plus a FIFO-order proof: two rounds in one rid pair to their OWN cost (round 1 -> its cost,
+round 2 -> its cost), never swapped, mirroring the exact FIFO-per-(rid,phase) contract
+`OUTCOME` brackets already use (SPEC-129 DEC-002) -- this feature reuses that contract, it
+does not invent a second one.
+
+## Fixtures
+
+Bash-level (`tests/test-redteam-gate.sh`): builds every ledger inline under a fresh
+`DWARVES_KIT_LOG_DIR` per case (31 assertions across start/round, all 3 verdicts, the two
+negative controls, multi-round FIFO, token-count passthrough, embedded-newline injection
+defense, `gate.sh` dispatch, and usage errors).
+
+Python-level (`lib/stats/tests/test-kit-gates-cost.sh`), a committed golden fixture at
+`lib/stats/tests/fixtures/kit-gates-cost/runs/`:
+
+| File (rid) | Contents |
+|---|---|
+| `rt-a.log` | 2 redteam rounds (findings cost=0.42, secure cost=0.31) + 1 unrelated `spec` gate |
+| `rt-b.log` | 1 round, `TOKENS cost=notanumber` -- malformed input |
+| `rt-c.log` | 1 round, no phase-scoped `TOKENS` line at all -- an orphaned/failed-then-retried round |
+| `rt-d.log` | 1 round, plus an unscoped (no `phase=`) rid-wide `TOKENS` line that must never pair |
+
+## Run 1: end-to-end round emit (bash, `tests/test-redteam-gate.sh`)
+
+```bash
+cd dwarves-kit
+bash lib/gate/redteam-gate.sh start rt1
+bash lib/gate/redteam-gate.sh round rt1 findings cost=0.42 round=1 in=1000 out=200 reason="2 findings, fixed"
+bash lib/gate/redteam-gate.sh start rt1
+bash lib/gate/redteam-gate.sh round rt1 secure cost=0.31 round=2
+cat "$DWARVES_KIT_LOG_DIR/runs/rt1.log"
+```
+
+Result (verbatim, from a live run):
+```
+2026-07-18T10:03:05Z | OUTCOME | redteam | start | at=1784368985
+2026-07-18T10:03:06Z | OUTCOME | redteam | end | at=1784368986 caught=true dur_s=1
+2026-07-18T10:03:06Z | TOKENS | in=1000 out=200 cache_read=0 cache_create=0 cost=0.42 phase=redteam
+2026-07-18T10:03:06Z | GATE | redteam | ran | round=1 verdict=findings 2 findings, fixed
+2026-07-18T10:03:06Z | OUTCOME | redteam | start | at=1784368986
+2026-07-18T10:03:08Z | OUTCOME | redteam | end | at=1784368988 caught=false dur_s=2
+2026-07-18T10:03:08Z | TOKENS | in=0 out=0 cache_read=0 cache_create=0 cost=0.31 phase=redteam
+2026-07-18T10:03:08Z | GATE | redteam | ran | round=2 verdict=secure
+```
+
+```bash
+bash tests/test-redteam-gate.sh
+```
+Result: `=== 31/31 passed, 0 failed ===`
+
+## Run 2 (NC1, load-bearing): a round with no cost= writes nothing
+
+```bash
+bash lib/gate/redteam-gate.sh start rt6
+bash lib/gate/redteam-gate.sh round rt6 secure round=1   # no cost=
+echo "rc=$?"
+cat "$DWARVES_KIT_LOG_DIR/runs/rt6.log"
+```
+
+Result (verbatim):
+```
+redteam-gate.sh round: cost=<dollars> is required (a round with no captured cost cannot be ledgered; see file header)
+rc=64
+2026-07-18T10:03:22Z | OUTCOME | redteam | start | at=1784369002
+```
+Only the earlier `start` line survives; no `GATE`/`TOKENS`/`OUTCOME end` line was written.
+The same rid can retry cleanly afterward (test AC6b).
+
+## Run 3: `kit_gates` cost pairing + FIFO order + mega-durations pickup
+
+```bash
+cd lib/stats
+export DWARVES_KIT_LOG_DIR="$(pwd)/tests/fixtures/kit-gates-cost"
+uv run stats rebuild
+uv run stats show kit_gates --json
+uv run stats mega-durations --json
+bash tests/test-kit-gates-cost.sh
+```
+
+Result: `== 12 passed, 0 failed ==`. Key rows confirmed (verbatim from `show kit_gates --json`):
+```json
+{ "rid": "rt-a", "gate": "redteam", "reason": "round=1 verdict=findings 2 findings, fixed",
+  "start_ts": "1000", "end_ts": "1030", "cost": 0.42 }
+{ "rid": "rt-a", "gate": "redteam", "reason": "round=2 verdict=secure",
+  "start_ts": "1030", "end_ts": "1050", "cost": 0.31 }
+{ "rid": "rt-b", "gate": "redteam", "cost": null }   // malformed cost=notanumber
+{ "rid": "rt-c", "gate": "redteam", "cost": null }   // no phase-scoped TOKENS line
+{ "rid": "rt-d", "gate": "redteam", "cost": null }   // unscoped TOKENS line, never pairs
+```
+`mega-durations --json` includes `rt-a` (`wall_seconds: 50, n_gates_timed: 2`) with zero
+changes to `mega-durations`'s own SQL -- it already has no gate-name whitelist.
+
+## NC2 (honest-NULL, falsifiable, not vacuous)
+
+```bash
+uv run python3 -c "
+from stats import materialize
+print(materialize.query(\"SELECT count(*) FROM kit_gates WHERE gate='redteam' AND cost IS NULL\")[1][0][0])
+"
+```
+Result: `3` (rt-b malformed + rt-c orphan + rt-d unscoped). If a future edit coerced an
+unparseable/missing `cost=` to `0.0` instead of `NULL`, this count would silently drop to 0
+and those rounds would join the checkpoint's average as fabricated free rounds.
+
+## Full suite, no regressions
+
+```bash
+bash tests/test-meta.sh
+```
+Result: `Passed: 698 / 698` (pre-existing suite, run after every change above; every
+pre-existing `lib/stats/tests/*.sh` and root `tests/test-gate-outcome.sh`,
+`tests/test-quiz-gate.sh`, `tests/test-gate-vocab-recording.sh`,
+`tests/test-outcome-emit-sweep.sh`, `tests/test-schema-parity.sh` re-run green, since the new
+`cost` column is additive-only, see `lib/stats/src/stats/adapters.py::read_kit_gates`
+docstring).
+
+## Reproduce
+
+```bash
+git checkout feat/redteam-gate-ledger
+bash tests/test-redteam-gate.sh
+(cd lib/stats && bash tests/test-kit-gates-cost.sh)
+bash tests/test-meta.sh
+```

--- a/lib/gate/gate-ledger.sh
+++ b/lib/gate/gate-ledger.sh
@@ -200,11 +200,19 @@ action() {
 # tokens: record a run's token usage as an ADDITIVE marker (SPEC-110). Emits a `| TOKENS |` line
 # that check()/override()/descent()/_rows() all ignore (they key on $2=="GATE"|START|ACTION), so a
 # token line can never fake a gate. Values are sanitized to non-negative integers.
-# Usage: tokens <rid> in=N out=N cache_read=N cache_create=N [cost=N]
+#
+# `phase=` (rung-4 redteam cost checkpoint) is an OPTIONAL, purely additive key: when given, the
+# TOKENS line is scoped to one gate phase (e.g. `phase=redteam`) instead of the whole rid. The
+# `kit_gates` reader (lib/stats read_kit_gates, dwarves-kit lib/stats) pairs a phase-scoped TOKENS
+# line to its GATE row the SAME way it already pairs an `| OUTCOME |` bracket: FIFO per (rid,
+# phase), so a `cost=` value lands on the matching gate row instead of only the rid-wide total
+# lane-telemetry's `_token_agg` already reads. Omitting `phase=` reproduces the exact pre-existing
+# line shape (no behavior change for any existing caller).
+# Usage: tokens <rid> in=N out=N cache_read=N cache_create=N [cost=N] [phase=P]
 tokens() {
-  local rid="${1:-}"; shift 2>/dev/null || { echo "usage: tokens <rid> in=N out=N cache_read=N cache_create=N [cost=N]" >&2; return 64; }
+  local rid="${1:-}"; shift 2>/dev/null || { echo "usage: tokens <rid> in=N out=N cache_read=N cache_create=N [cost=N] [phase=P]" >&2; return 64; }
   [ -n "$rid" ] || { echo "tokens requires a rid" >&2; return 64; }
-  local intok=0 outtok=0 cread=0 ccreate=0 cost="" kv k v
+  local intok=0 outtok=0 cread=0 ccreate=0 cost="" phase="" kv k v
   for kv in "$@"; do
     k="${kv%%=*}"; v="${kv#*=}"
     case "$k" in
@@ -213,11 +221,13 @@ tokens() {
       cache_read)   cread="$(printf '%s' "$v" | tr -cd '0-9')"; cread="${cread:-0}" ;;
       cache_create) ccreate="$(printf '%s' "$v" | tr -cd '0-9')"; ccreate="${ccreate:-0}" ;;
       cost)         cost="$(printf '%s' "$v" | tr -cd '0-9.')" ;;   # decimal dollars: digits + dot(s); display-only, never summed
+      phase)        phase="$(normalize_phase "$v")" ;;             # same normalizer the GATE/OUTCOME phase key uses
     esac
   done
   mkdir -p "$RUNS_DIR"
   local line; line="$(printf 'in=%s out=%s cache_read=%s cache_create=%s' "$intok" "$outtok" "$cread" "$ccreate")"
   [ -n "$cost" ] && line="$line cost=$cost"
+  [ -n "$phase" ] && line="$line phase=$phase"
   append_run_line "$rid" "$(printf '%s | TOKENS | %s' "$(now)" "$line")"
 }
 

--- a/lib/gate/gate.sh
+++ b/lib/gate/gate.sh
@@ -13,12 +13,13 @@
 #   gate.sh quiz <args...>            -> quiz-gate.sh (questions|tap|respond|route)
 #   gate.sh coverage-delta <args...>  -> coverage-delta.sh (check|class|classes)
 #   gate.sh mutation-smoke <args...>  -> mutation-smoke.sh (run|candidates|...)
+#   gate.sh redteam <args...>         -> redteam-gate.sh (start|round) -- rung-4 cost checkpoint
 #   gate.sh verif-counts               -> verif-counts.sh
 #   gate.sh -h|--help|help             -> this usage
 set -euo pipefail
 
 GATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-usage() { sed -n '2,17p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 main() {
   local verb="${1:-}"; [ $# -gt 0 ] && shift || true
@@ -31,6 +32,7 @@ main() {
     quiz)            exec bash "$GATE_DIR/quiz-gate.sh" "$@" ;;
     coverage-delta)  exec bash "$GATE_DIR/coverage-delta.sh" "$@" ;;
     mutation-smoke)  exec bash "$GATE_DIR/mutation-smoke.sh" "$@" ;;
+    redteam)         exec bash "$GATE_DIR/redteam-gate.sh" "$@" ;;
     verif-counts)    exec bash "$GATE_DIR/verif-counts.sh" "$@" ;;
     -h|--help|help|"") usage ;;
     *) echo "gate: unknown verb '$verb' (try: gate --help)" >&2; exit 1 ;;

--- a/lib/gate/redteam-gate.sh
+++ b/lib/gate/redteam-gate.sh
@@ -13,13 +13,20 @@
 # separate calls kept in sync (a GATE row, a TOKENS row, an OUTCOME bracket) and the redteam
 # procedure never made them. This script is that ONE call per round.
 #
-# Design: every round writes all three lines together, so a `redteam` phase never has a GATE row
-# without a matching OUTCOME bracket or TOKENS(phase=redteam) row -- the FIFO pairing
-# `lib/stats` `read_kit_gates` already uses for GATE<->OUTCOME (SPEC-129 DEC-002) extends
-# unchanged to GATE<->TOKENS(phase=) here (kit_gates gains a `cost` column, additive, NULL for
-# every pre-existing gate). `cost=` is REQUIRED on `round` precisely because a round with no cost
-# captured would desync that FIFO pairing for every round after it in the same rid; fail closed
-# (reject, write nothing) rather than emit a silently-wrong zero-cost row.
+# Design: one `round` call writes all three lines in sequence (argument-validation failures,
+# the case every test here covers, write NOTHING -- see `cost=` below; a crash or kill BETWEEN
+# the three subprocess calls, after validation passes, is a narrower residual window this script
+# does not protect against). The FIFO pairing `lib/stats` `read_kit_gates` already uses for
+# GATE<->OUTCOME (SPEC-129 DEC-002) extends unchanged to GATE<->TOKENS(phase=) here (kit_gates
+# gains a `cost` column, additive, NULL for every pre-existing gate). `read_kit_gates` itself
+# tolerates a phase-scoped TOKENS line with no cost= (or a malformed one): it lands `cost=NULL`
+# in that queue slot, FIFO position preserved, no desync -- so the FIFO pairing is not actually
+# why `cost=` is REQUIRED here. The real reason: this tool exists solely to make rung-4 cost
+# measurable (ID-372), so a round allowed to record itself WITHOUT a cost would reproduce the
+# checkpoint's original failure in a new shape (rounds ledgered, average still uncomputable, or
+# worse, silently understated by treating unmeasured rounds as free). Fail closed -- reject,
+# write nothing -- so a missing cost is loud (rc 64) at the call site instead of a quiet gap in
+# the average months later.
 #
 # Verbs:
 #   redteam-gate.sh start <rid>
@@ -32,9 +39,21 @@
 #          itself. verdict: secure (clean pass this round, caught=false), findings (this round
 #          found issues, another round follows, caught=true), capped (the 3-round cap was hit
 #          without ever reaching SECURE -- the fail-closed stop, caught=true).
+#          NOTE: `in=`/`out=`/`cache_read=`/`cache_create=` are optional and, unlike `cost=`,
+#          are NOT honest-NULL when omitted -- gate-ledger.sh's own `tokens()` zero-defaults
+#          them, so a round recorded without token counts reads as `in=0 out=0` (a real value,
+#          not "unknown"). Only `cost` gets the required+NULL-on-failure treatment this file
+#          is built around; a future per-round token-count average would need the same
+#          treatment token counts don't have yet.
 #
-# Usage the calling procedure follows (unchanged elsewhere; this script only adds the ledger
-# calls around the existing round loop):
+# SCOPE: the redteam PROCEDURE itself (the SKILL.md blocks named above, cap-3 loop,
+# VERDICT: SECURE judgment) lives in a sibling dotfiles repo, out of scope here. This script
+# only gives that procedure a call worth making; it does not call itself. N stays 0 in
+# `mega-durations`/`kit_gates` until the dotfiles-side procedure is edited to call `start`/
+# `round` at its own round boundaries -- that wiring is a separate, tracked follow-up, not
+# implied by this PR landing.
+#
+# Usage the calling procedure is expected to adopt (not yet wired anywhere as of this PR):
 #   redteam-gate.sh start "$RID"
 #   ... run the adversarial pass ...
 #   redteam-gate.sh round "$RID" findings cost=0.42 round=1 reason="2 findings, fixed"
@@ -76,7 +95,11 @@ cmd_round() {
   for kv in "$@"; do
     k="${kv%%=*}"; v="${kv#*=}"
     case "$k" in
-      cost)          cost="$(printf '%s' "$v" | tr -cd '0-9.')" ;;
+      cost)          cost="$v" ;;   # kept raw here; strictly validated below (this is a new
+                                     # tool with no legacy callers, unlike gate-ledger.sh's own
+                                     # lax `tr -cd '0-9.'` tokens() sanitizer, so a shape like
+                                     # "1.2.3" or "abc" is rejected here instead of silently
+                                     # landing malformed-but-accepted and NULL downstream)
       round)         round_n="$(printf '%s' "$v" | tr -cd '0-9')" ;;
       in)            intok="$v" ;;
       out)           outtok="$v" ;;
@@ -87,15 +110,17 @@ cmd_round() {
     esac
   done
 
-  # cost is REQUIRED (see file header): a round with no captured cost would desync the
-  # GATE<->TOKENS(phase=redteam) FIFO pairing for every later round in this rid. Fail closed --
-  # reject the call, write NOTHING (no GATE row, no OUTCOME end, no TOKENS row) -- rather than
-  # emit a silently-wrong zero-cost row that would look like a real (and misleadingly cheap)
-  # data point in the cost checkpoint.
-  [ -n "$cost" ] || {
-    echo "redteam-gate.sh round: cost=<dollars> is required (a round with no captured cost cannot be ledgered; see file header)" >&2
+  # cost is REQUIRED (see file header for the full rationale): this tool exists to make rung-4
+  # cost measurable, so a round allowed to record itself without a cost would just relocate the
+  # checkpoint's original gap rather than close it. Fail closed -- reject the call, write
+  # NOTHING (no GATE row, no OUTCOME end, no TOKENS row) -- so the gap is loud (rc 64) at the
+  # call site, not a silent hole in the average discovered later. One regex covers BOTH
+  # "missing" and "malformed" (it requires >=1 digit, so an empty/unset $cost fails it too) --
+  # no separate presence check needed.
+  if ! [[ "$cost" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "redteam-gate.sh round: cost='$cost' is not a plain decimal (digits, optionally one '.', e.g. 0.42)" >&2
     return 64
-  }
+  fi
 
   # caught derivation (mirrors gate-ledger.sh outcome()'s own convention: non-pass -> true,
   # clean pass -> false): a round that found issues, or the fail-closed cap, both COUNT as the

--- a/lib/gate/redteam-gate.sh
+++ b/lib/gate/redteam-gate.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# redteam-gate.sh -- the mechanical half of the done-condition ladder's rung 4 (an in-harness
+# adversarial skeptic on the frozen diff, verbatim `VERDICT: SECURE`, fail-closed, cap 3 rounds;
+# canonical block: dotfiles goal-craft/SKILL.md, plan-for-goal/SKILL.md,
+# plan-for-mega-goal/references/subgoal-template.md).
+#
+# THE GAP THIS CLOSES (ops-toolkit research/2026-07-18-rung4-cost-checkpoint.md): real rung-4
+# redteams HAVE run (board-tool 7-attempt, orchestrate-queue 3-round, board-writeback 4-attempt,
+# all VERDICT: SECURE), but none ever emitted a `redteam` kit_gates row, so the rung-4 cost
+# checkpoint (ID-372: tighten the trigger if rung 4 averages >15% of mega cost) can never be
+# evaluated -- every existing primitive (gate-ledger.sh record/tokens/outcome) was already
+# capable of recording a round, but nothing called them, because a round-in-progress needs THREE
+# separate calls kept in sync (a GATE row, a TOKENS row, an OUTCOME bracket) and the redteam
+# procedure never made them. This script is that ONE call per round.
+#
+# Design: every round writes all three lines together, so a `redteam` phase never has a GATE row
+# without a matching OUTCOME bracket or TOKENS(phase=redteam) row -- the FIFO pairing
+# `lib/stats` `read_kit_gates` already uses for GATE<->OUTCOME (SPEC-129 DEC-002) extends
+# unchanged to GATE<->TOKENS(phase=) here (kit_gates gains a `cost` column, additive, NULL for
+# every pre-existing gate). `cost=` is REQUIRED on `round` precisely because a round with no cost
+# captured would desync that FIFO pairing for every round after it in the same rid; fail closed
+# (reject, write nothing) rather than emit a silently-wrong zero-cost row.
+#
+# Verbs:
+#   redteam-gate.sh start <rid>
+#       -> opens the timing bracket for one round (gate-ledger.sh outcome <rid> redteam start).
+#          Call once per round, immediately before the adversarial pass begins.
+#   redteam-gate.sh round <rid> <secure|findings|capped> cost=<dollars> [round=N]
+#                    [in=N out=N cache_read=N cache_create=N] [reason=...]
+#       -> closes the round: an OUTCOME end bracket (caught derived from verdict), a
+#          TOKENS(phase=redteam) row carrying this round's cost, and the `redteam` GATE row
+#          itself. verdict: secure (clean pass this round, caught=false), findings (this round
+#          found issues, another round follows, caught=true), capped (the 3-round cap was hit
+#          without ever reaching SECURE -- the fail-closed stop, caught=true).
+#
+# Usage the calling procedure follows (unchanged elsewhere; this script only adds the ledger
+# calls around the existing round loop):
+#   redteam-gate.sh start "$RID"
+#   ... run the adversarial pass ...
+#   redteam-gate.sh round "$RID" findings cost=0.42 round=1 reason="2 findings, fixed"
+#   redteam-gate.sh start "$RID"
+#   ... run round 2 ...
+#   redteam-gate.sh round "$RID" secure cost=0.31 round=2
+
+set -uo pipefail
+
+RG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE_LEDGER="$RG_DIR/gate-ledger.sh"
+
+usage() { sed -n '2,38p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+# _oneline <text> -- collapse newlines the same way gate-ledger.sh's own oneline() does, so a
+# multi-line reason can never split into a second physical ledger line before it ever reaches
+# gate-ledger.sh (defense-in-depth; gate-ledger.sh's own record() re-applies this too).
+_oneline() { printf '%s' "${*:-}" | tr '\n\r' '  '; }
+
+cmd_start() {
+  local rid="${1:-}"
+  [ -n "$rid" ] || { echo "usage: redteam-gate.sh start <rid>" >&2; return 64; }
+  bash "$GATE_LEDGER" outcome "$rid" redteam start
+}
+
+cmd_round() {
+  local rid="${1:-}" verdict="${2:-}"
+  shift 2 2>/dev/null || {
+    echo "usage: redteam-gate.sh round <rid> <secure|findings|capped> cost=<dollars> [round=N] [in=N out=N cache_read=N cache_create=N] [reason=...]" >&2
+    return 64
+  }
+  [ -n "$rid" ] || { echo "redteam-gate.sh round requires a rid" >&2; return 64; }
+  case "$verdict" in
+    secure|findings|capped) ;;
+    *) echo "redteam-gate.sh round: verdict must be secure|findings|capped (got '${verdict:-<empty>}')" >&2; return 64 ;;
+  esac
+
+  local cost="" round_n="" intok="" outtok="" cread="" ccreate="" reason_parts=() kv k v
+  for kv in "$@"; do
+    k="${kv%%=*}"; v="${kv#*=}"
+    case "$k" in
+      cost)          cost="$(printf '%s' "$v" | tr -cd '0-9.')" ;;
+      round)         round_n="$(printf '%s' "$v" | tr -cd '0-9')" ;;
+      in)            intok="$v" ;;
+      out)           outtok="$v" ;;
+      cache_read)    cread="$v" ;;
+      cache_create)  ccreate="$v" ;;
+      reason)        reason_parts+=("$v") ;;
+      *)             reason_parts+=("$kv") ;;   # unrecognized k=v (or bare text) folds into reason, never dropped silently
+    esac
+  done
+
+  # cost is REQUIRED (see file header): a round with no captured cost would desync the
+  # GATE<->TOKENS(phase=redteam) FIFO pairing for every later round in this rid. Fail closed --
+  # reject the call, write NOTHING (no GATE row, no OUTCOME end, no TOKENS row) -- rather than
+  # emit a silently-wrong zero-cost row that would look like a real (and misleadingly cheap)
+  # data point in the cost checkpoint.
+  [ -n "$cost" ] || {
+    echo "redteam-gate.sh round: cost=<dollars> is required (a round with no captured cost cannot be ledgered; see file header)" >&2
+    return 64
+  }
+
+  # caught derivation (mirrors gate-ledger.sh outcome()'s own convention: non-pass -> true,
+  # clean pass -> false): a round that found issues, or the fail-closed cap, both COUNT as the
+  # gate catching something; only a clean secure verdict is caught=false.
+  local caught=false
+  [ "$verdict" = secure ] || caught=true
+
+  # 1) close the timing bracket this round's `start` opened.
+  bash "$GATE_LEDGER" outcome "$rid" redteam end "caught=$caught" || return 1
+
+  # 2) the round's cost, phase-scoped so lib/stats' read_kit_gates FIFO-pairs it onto this
+  #    round's GATE row (the same convention SPEC-129 already uses for OUTCOME brackets).
+  local tok_args=(cost="$cost" phase=redteam)
+  [ -n "$intok" ]    && tok_args+=("in=$intok")
+  [ -n "$outtok" ]   && tok_args+=("out=$outtok")
+  [ -n "$cread" ]    && tok_args+=("cache_read=$cread")
+  [ -n "$ccreate" ]  && tok_args+=("cache_create=$ccreate")
+  bash "$GATE_LEDGER" tokens "$rid" "${tok_args[@]}" || return 1
+
+  # 3) the GATE row itself -- always `ran` (the round DID execute; pass/fail lives in the
+  #    reason text, matching the kit's existing convention of encoding a verdict in free text
+  #    rather than overloading record()'s ran|skipped state, see e.g. lib/gate/mutation-smoke.sh).
+  local reason
+  reason="round=${round_n:-?} verdict=$verdict"
+  if [ "${#reason_parts[@]}" -gt 0 ]; then
+    reason="$reason $(_oneline "${reason_parts[*]}")"
+  fi
+  bash "$GATE_LEDGER" record "$rid" redteam ran "$reason"
+}
+
+main() {
+  local sub="${1:-}"; shift 2>/dev/null || true
+  case "$sub" in
+    start) cmd_start "$@" ;;
+    round) cmd_round "$@" ;;
+    ""|-h|--help|help) usage ;;
+    *) echo "redteam-gate.sh: unknown subcommand '$sub'" >&2; usage >&2; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/lib/stats/docs/ledger-event-schema.md
+++ b/lib/stats/docs/ledger-event-schema.md
@@ -44,7 +44,7 @@ them are `k=v`; this table states plainly which are and which aren't:
 | `START-AMEND` | same as `START` | yes | `gate-ledger.sh start --amend` |
 | `GATE` | `<phase> \| <ran\|skipped\|override> \| <reason>` | **no**, 3 more pipe-delimited positional fields, not k=v | `gate-ledger.sh record` / `override` |
 | `ACTION` | freeform oneline text | **no**, opaque text | `gate-ledger.sh action` |
-| `TOKENS` | `in=<N> out=<N> cache_read=<N> cache_create=<N> [cost=<N>]` | yes, space-separated | `gate-ledger.sh tokens` |
+| `TOKENS` | `in=<N> out=<N> cache_read=<N> cache_create=<N> [cost=<N>] [phase=<P>]` | yes, space-separated | `gate-ledger.sh tokens` |
 | `DEBT` | `significance=<low\|high> worthiness=<low\|high> verdict=<tap\|wave\|not-significant> [response=<engage\|defer\|wave>] [reason=<text>]` | yes, space-separated (see Edge Cases) | `gate-ledger.sh debt` / `debt-response` |
 
 **Parse rule:** split each line on ` | ` for the first two delimiters
@@ -142,4 +142,10 @@ real `find`/`grep` sweep produced.
 4. **`TOKENS`' `cost=` value is not strictly validated** (`gate-ledger.sh` sanitizes to
    `[0-9.]` only, so `1.2.3.4` is accepted, per the `advrun.log` sample above), display-only per the producer's own comment, never summed; a strict numeric parse of
    `cost=` will fail on malformed-but-accepted values and must degrade gracefully
-   (treat as opaque string), not throw.
+   (treat as opaque string), not throw. **Exception:** a `TOKENS` line carrying `phase=<P>`
+   (rung-4 cost checkpoint, `lib/gate/redteam-gate.sh`) IS summed, by `kit_gates`' own
+   `cost` column (`lib/stats/src/stats/adapters.py::read_kit_gates`), which FIFO-pairs it
+   onto the matching `GATE` row the same way an `OUTCOME` bracket pairs onto `caught`/
+   `start_ts`/`end_ts`; a malformed `cost=` on a phase-scoped line parses to `NULL` there
+   (never a fabricated `0.0`), so it degrades gracefully in the SAME direction this edge
+   case already documents, just structurally rather than as an opaque string.

--- a/lib/stats/src/stats/adapters.py
+++ b/lib/stats/src/stats/adapters.py
@@ -113,7 +113,7 @@ def _outcome_kv(field: str) -> dict[str, str]:
 
 def read_kit_gates(runs_dir: Path | None = None):
     """One row per `| GATE |` ledger line: `(rid, gate, outcome, caught, reason, start_ts,
-    end_ts)`. A direct line-level parse of the SAME run-ledger files lane-telemetry.sh's
+    end_ts, cost)`. A direct line-level parse of the SAME run-ledger files lane-telemetry.sh's
     `_rows()` aggregates (kit grammar: `TS | GATE | <phase> | ran|skipped|override |
     <reason>`); `_rows()` has no per-line output mode, so this is a NEW small parser, not a
     second copy of an existing one (see impl-notes / SPEC-131 DEC-001).
@@ -121,10 +121,15 @@ def read_kit_gates(runs_dir: Path | None = None):
     `caught` / `start_ts` / `end_ts` come from a SEPARATE, additive `| OUTCOME |` start/end
     bracket (kit's own SPEC-129: `TS | OUTCOME | <phase> | start | at=<epoch>` then `... | end
     | at=<epoch> caught=<bool> dur_s=<N>`), paired to a `GATE` row by matching phase name,
-    FIFO per (rid, gate) in file order (SPEC-131 DEC-002). As of this writing NO real run
-    ledger emits an OUTCOME bracket yet (the emitter lands via the kit-absorptions mega), so on
-    the real corpus every row's caught/start_ts/end_ts is NULL, by design, never dropped and
-    never mislabeled -- the FP negative control this table exists to pass.
+    FIFO per (rid, gate) in file order (SPEC-131 DEC-002).
+
+    `cost` is the SAME FIFO-by-phase pairing extended to a phase-scoped `| TOKENS |` line
+    (`TS | TOKENS | in=N out=N cache_read=N cache_create=N cost=<dollars> phase=<gate>`, the
+    rung-4 cost checkpoint's gap-close: `lib/gate/redteam-gate.sh` is the one caller that emits
+    a `phase=` token today). A bare `| TOKENS |` line with no `phase=` key (every pre-existing
+    caller) is invisible to this pairing -- it still feeds lane-telemetry's own rid-wide
+    `_token_agg`, untouched by this change. An unparseable `cost=` value (or a phase-tagged
+    TOKENS line with none at all) lands as `cost=None`, never a fabricated 0.0.
 
     Tolerant of: a GATE line with fewer than 4 pipe-fields (skipped, never raises); a GATE line
     missing its reason field (4 cols, not 5; reason -> None); a malformed `at=`/`caught=` token
@@ -144,6 +149,8 @@ def read_kit_gates(runs_dir: Path | None = None):
         pending_start: dict[str, str] = {}
         # phase -> FIFO queue of completed (start_ts, end_ts, caught) brackets.
         brackets: dict[str, list[tuple[str | None, str | None, bool | None]]] = {}
+        # phase -> FIFO queue of cost values, from `| TOKENS | ... phase=<phase>` lines only.
+        costs: dict[str, list[float | None]] = {}
         gate_lines: list[tuple[str, str, str | None]] = []  # (gate, outcome, reason)
         for line in text.splitlines():
             parts = line.split(" | ")
@@ -170,12 +177,28 @@ def read_kit_gates(runs_dir: Path | None = None):
                     end_ts = kv.get("at")
                     caught = {"true": True, "false": False}.get((kv.get("caught") or "").lower())
                     brackets.setdefault(phase, []).append((start_ts, end_ts, caught))
+            elif marker == "TOKENS":
+                if len(parts) < 3:
+                    continue
+                kv = _outcome_kv(parts[2])
+                phase = kv.get("phase")
+                if not phase:
+                    continue  # unscoped TOKENS line: not this table's concern (see docstring)
+                raw_cost = kv.get("cost")
+                cost: float | None
+                try:
+                    cost = float(raw_cost) if raw_cost else None
+                except ValueError:
+                    cost = None  # malformed cost=: excluded from averages, never a fake 0.0
+                costs.setdefault(phase, []).append(cost)
         for gate, outcome, reason in gate_lines:
             queue = brackets.get(gate)
             start_ts = end_ts = caught = None
             if queue:
                 start_ts, end_ts, caught = queue.pop(0)
-            rows.append([rid, gate, outcome, caught, reason, start_ts, end_ts])
+            cost_queue = costs.get(gate)
+            cost = cost_queue.pop(0) if cost_queue else None
+            rows.append([rid, gate, outcome, caught, reason, start_ts, end_ts, cost])
     return KIT_GATES_COLUMNS, rows
 
 

--- a/lib/stats/src/stats/schemas.py
+++ b/lib/stats/src/stats/schemas.py
@@ -63,8 +63,8 @@ LEARNED_SCHEMA: list[tuple[str, str]] = [
 
 # One row per `| GATE |` kit run-ledger line (SPEC-131). `caught`/`start_ts`/`end_ts` come
 # from a SEPARATE, additive `| OUTCOME |` start/end bracket (kit's own SPEC-129), paired by
-# phase name; NULL when no bracket exists (true for 100% of the real corpus as of writing --
-# see adapters.py `read_kit_gates` docstring). `cost` is the same pairing extended to a
+# phase name; NULL when no bracket exists for that gate (see adapters.py `read_kit_gates`
+# docstring for the pairing mechanics). `cost` is the same pairing extended to a
 # phase-scoped `| TOKENS |` line (`phase=<gate>`, the rung-4 cost-checkpoint gap-close):
 # NULL for every gate whose caller never passed `phase=` to `gate-ledger.sh tokens`, which
 # today is every gate except `redteam` (lib/gate/redteam-gate.sh). DOUBLE (not VARCHAR, unlike

--- a/lib/stats/src/stats/schemas.py
+++ b/lib/stats/src/stats/schemas.py
@@ -64,7 +64,14 @@ LEARNED_SCHEMA: list[tuple[str, str]] = [
 # One row per `| GATE |` kit run-ledger line (SPEC-131). `caught`/`start_ts`/`end_ts` come
 # from a SEPARATE, additive `| OUTCOME |` start/end bracket (kit's own SPEC-129), paired by
 # phase name; NULL when no bracket exists (true for 100% of the real corpus as of writing --
-# see adapters.py `read_kit_gates` docstring).
+# see adapters.py `read_kit_gates` docstring). `cost` is the same pairing extended to a
+# phase-scoped `| TOKENS |` line (`phase=<gate>`, the rung-4 cost-checkpoint gap-close):
+# NULL for every gate whose caller never passed `phase=` to `gate-ledger.sh tokens`, which
+# today is every gate except `redteam` (lib/gate/redteam-gate.sh). DOUBLE (not VARCHAR, unlike
+# the timestamp columns) because the rung-4 cost checkpoint's whole point is arithmetic over
+# it (sum/avg per rid, as a share of the mega's total cost) -- an unparseable TOKENS cost=
+# value lands as NULL, never a fabricated 0, so a malformed round is excluded from the
+# average rather than silently deflating it.
 KIT_GATES_SCHEMA: list[tuple[str, str]] = [
     ("rid", "VARCHAR"),
     ("gate", "VARCHAR"),
@@ -73,6 +80,7 @@ KIT_GATES_SCHEMA: list[tuple[str, str]] = [
     ("reason", "VARCHAR"),
     ("start_ts", "VARCHAR"),
     ("end_ts", "VARCHAR"),
+    ("cost", "DOUBLE"),
 ]
 
 # The tool's FIRST git-sourced table (SPEC-132). One row per (commit, file-touched) pair

--- a/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-a.log
+++ b/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-a.log
@@ -1,0 +1,10 @@
+2026-07-18T09:00:00Z | START | lane=full classified=full type=spec-feature ctype=spec-feature repo=fixrepo
+2026-07-18T09:00:01Z | GATE | spec | ran | drafted the spec
+2026-07-18T09:00:02Z | OUTCOME | redteam | start | at=1000
+2026-07-18T09:00:03Z | TOKENS | in=1000 out=200 cache_read=0 cache_create=0 cost=0.42 phase=redteam
+2026-07-18T09:00:03Z | GATE | redteam | ran | round=1 verdict=findings 2 findings, fixed
+2026-07-18T09:00:03Z | OUTCOME | redteam | end | at=1030 caught=true dur_s=30
+2026-07-18T09:00:04Z | OUTCOME | redteam | start | at=1030
+2026-07-18T09:00:05Z | TOKENS | in=800 out=150 cache_read=0 cache_create=0 cost=0.31 phase=redteam
+2026-07-18T09:00:05Z | GATE | redteam | ran | round=2 verdict=secure
+2026-07-18T09:00:05Z | OUTCOME | redteam | end | at=1050 caught=false dur_s=20

--- a/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-b.log
+++ b/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-b.log
@@ -1,0 +1,5 @@
+2026-07-18T10:00:00Z | START | lane=full classified=full type=spec-feature ctype=spec-feature repo=fixrepo
+2026-07-18T10:00:01Z | OUTCOME | redteam | start | at=2000
+2026-07-18T10:00:02Z | TOKENS | in=100 out=20 cache_read=0 cache_create=0 cost=notanumber phase=redteam
+2026-07-18T10:00:02Z | GATE | redteam | ran | round=1 verdict=findings malformed cost, must not crash
+2026-07-18T10:00:02Z | OUTCOME | redteam | end | at=2010 caught=true dur_s=10

--- a/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-c.log
+++ b/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-c.log
@@ -1,0 +1,4 @@
+2026-07-18T11:00:00Z | START | lane=full classified=full type=spec-feature ctype=spec-feature repo=fixrepo
+2026-07-18T11:00:01Z | OUTCOME | redteam | start | at=3000
+2026-07-18T11:00:02Z | GATE | redteam | ran | round=1 verdict=capped a failed round retried without ever emitting a cost line
+2026-07-18T11:00:02Z | OUTCOME | redteam | end | at=3005 caught=true dur_s=5

--- a/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-d.log
+++ b/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-d.log
@@ -1,0 +1,5 @@
+2026-07-18T12:00:00Z | START | lane=full classified=full type=spec-feature ctype=spec-feature repo=fixrepo
+2026-07-18T12:00:01Z | TOKENS | in=5000 out=1000 cache_read=200 cache_create=50 cost=1.23
+2026-07-18T12:00:02Z | OUTCOME | redteam | start | at=4000
+2026-07-18T12:00:03Z | GATE | redteam | ran | round=1 verdict=secure an unscoped rid-wide TOKENS line must never pair here
+2026-07-18T12:00:03Z | OUTCOME | redteam | end | at=4010 caught=false dur_s=10

--- a/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-e.log
+++ b/lib/stats/tests/fixtures/kit-gates-cost/runs/rt-e.log
@@ -1,0 +1,5 @@
+2026-07-18T13:00:00Z | START | lane=full classified=full type=spec-feature ctype=spec-feature repo=fixrepo
+2026-07-18T13:00:01Z | OUTCOME | redteam | start | at=5000
+2026-07-18T13:00:02Z | TOKENS | in=50 out=10 cache_read=0 cache_create=0 cost=0 phase=redteam
+2026-07-18T13:00:02Z | GATE | redteam | ran | round=1 verdict=secure a real zero-cost round, must not be treated as null
+2026-07-18T13:00:02Z | OUTCOME | redteam | end | at=5005 caught=false dur_s=5

--- a/lib/stats/tests/test-kit-gates-cost.sh
+++ b/lib/stats/tests/test-kit-gates-cost.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# test-kit-gates-cost.sh -- rung-4 redteam cost checkpoint (ops-toolkit
+# research/2026-07-18-rung4-cost-checkpoint.md). Validates `kit_gates`'s new `cost` column:
+# a phase-scoped `| TOKENS | ... phase=<gate> |` line (emitted per round by
+# lib/gate/redteam-gate.sh) FIFO-pairs onto its `redteam` GATE row the same way an
+# `| OUTCOME |` bracket already pairs onto caught/start_ts/end_ts (SPEC-129 DEC-002).
+#
+# Golden fixture: tests/fixtures/kit-gates-cost/runs/*.log (committed, inspectable/diffable
+# in the PR, per the SPEC-131 test-plan convention test-gate-yield.sh already established).
+#   rt-a: 2 redteam rounds (findings cost=0.42, secure cost=0.31) + 1 unrelated `spec` gate
+#         -> proves per-round FIFO order (round 1 gets 0.42, round 2 gets 0.31, never
+#            swapped) AND that a non-redteam gate's cost stays NULL.
+#   rt-b: 1 round, TOKENS cost=notanumber -> cost NULL, no crash (malformed input).
+#   rt-c: 1 round, NO phase-scoped TOKENS line at all (a round whose cost call never landed,
+#         e.g. the AC6 failed-then-retried case in test-redteam-gate.sh) -> cost NULL, honest,
+#         never fabricated.
+#   rt-d: 1 round, plus an UNSCOPED (no phase=) rid-wide TOKENS line -> cost NULL for the
+#         gate row; the unscoped line must never be mistaken for this gate's cost.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+PASS=0; FAIL=0
+ok()   { printf 'PASS  %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf 'FAIL  %s\n' "$1"; FAIL=$((FAIL+1)); }
+has()  { case "$3" in *"$2"*) ok "$1";; *) bad "$1 (missing: $2)";; esac; }
+hasnt(){ case "$3" in *"$2"*) bad "$1 (unexpected: $2)";; *) ok "$1";; esac; }
+
+FIX="$(mktemp -d)"
+export DWARVES_KIT_LOG_DIR="$ROOT/tests/fixtures/kit-gates-cost"
+export STATS_TIDE_DB="$FIX/nonexistent.sqlite"
+export STATS_TGCLEANUP_DIR="$FIX/nonexistent-tg"
+export STATS_LEARNED_MD="$FIX/nonexistent-learned.md"
+export STATS_GIT_REPO_DIR="$FIX/nonexistent-git-repo"
+export STATS_SESSIONS_DIR="$FIX/nonexistent-sessions-dir"
+export STATS_SECRET_GUARD_LOG="$FIX/nonexistent-safety.log"
+export STATS_MEMORY_REPO_DIR="$FIX/nonexistent-memory-repo"
+export STATS_MEMORY_PROJECTS_ROOT="$FIX/nonexistent-memory-projects"
+export STATS_DB_REMOVED="$FIX/lens.duckdb"
+
+R() { uv run stats "$@" 2>&1; }
+
+FIXTURE_BEFORE="$(find "$DWARVES_KIT_LOG_DIR" -type f -exec shasum -a 256 {} \; | sort)"
+
+echo "== C-rebuild: kit_gates materializes over the cost fixture =="
+rm -f "$STATS_DB_REMOVED" "$STATS_DB_REMOVED.wal"
+R rebuild >/dev/null
+
+ROWS="$(R show kit_gates --json)"
+
+echo "== C-order: rt-a's two rounds keep FIFO order -- round 1 gets 0.42, round 2 gets 0.31 (never swapped) =="
+has "C-order rt-a round 1 (findings) paired to cost=0.42" '"rid": "rt-a",
+    "gate": "redteam",
+    "outcome": "ran",
+    "caught": true,
+    "reason": "round=1 verdict=findings 2 findings, fixed",
+    "start_ts": "1000",
+    "end_ts": "1030",
+    "cost": 0.42' "$ROWS"
+has "C-order rt-a round 2 (secure) paired to cost=0.31" '"rid": "rt-a",
+    "gate": "redteam",
+    "outcome": "ran",
+    "caught": false,
+    "reason": "round=2 verdict=secure",
+    "start_ts": "1030",
+    "end_ts": "1050",
+    "cost": 0.31' "$ROWS"
+
+echo "== C-unrelated: rt-a's non-redteam 'spec' gate has cost=null (never contaminated) =="
+has "C-unrelated rt-a spec gate cost=null" '"rid": "rt-a",
+    "gate": "spec",
+    "outcome": "ran",
+    "caught": null,
+    "reason": "drafted the spec",
+    "start_ts": null,
+    "end_ts": null,
+    "cost": null' "$ROWS"
+
+echo "== C-malformed: rt-b's cost=notanumber lands as null, not a crash, not a fake 0 =="
+has "C-malformed rt-b cost=null on an unparseable TOKENS cost=" '"rid": "rt-b",
+    "gate": "redteam",
+    "outcome": "ran",
+    "caught": true,
+    "reason": "round=1 verdict=findings malformed cost, must not crash",
+    "start_ts": "2000",
+    "end_ts": "2010",
+    "cost": null' "$ROWS"
+
+echo "== C-orphan: rt-c's round with NO phase-scoped TOKENS line at all -> cost=null, honest =="
+has "C-orphan rt-c cost=null (no TOKENS line to pair)" '"rid": "rt-c",
+    "gate": "redteam",
+    "outcome": "ran",
+    "caught": true,
+    "reason": "round=1 verdict=capped a failed round retried without ever emitting a cost line",
+    "start_ts": "3000",
+    "end_ts": "3005",
+    "cost": null' "$ROWS"
+
+echo "== C-unscoped: rt-d's unscoped (no phase=) TOKENS line never pairs onto the redteam gate =="
+has "C-unscoped rt-d cost=null (the rid-wide TOKENS line is not phase-tagged)" '"rid": "rt-d",
+    "gate": "redteam",
+    "outcome": "ran",
+    "caught": false,
+    "reason": "round=1 verdict=secure an unscoped rid-wide TOKENS line must never pair here",
+    "start_ts": "4000",
+    "end_ts": "4010",
+    "cost": null' "$ROWS"
+
+echo "== C-sum: cost is genuine arithmetic (DOUBLE), not display-only text -- SUM over rt-a's 2 rounds =="
+SUM="$(uv run python3 - <<'PY' 2>&1
+from stats import materialize
+cols, rows = materialize.query(
+    "SELECT round(sum(cost), 2) AS total FROM kit_gates WHERE rid = 'rt-a' AND gate = 'redteam'"
+)
+print(rows[0][0])
+PY
+)"
+if [ "$SUM" = "0.73" ]; then ok "C-sum rt-a redteam cost sums to 0.73 (0.42 + 0.31, real arithmetic)"; else bad "C-sum want 0.73, got '$SUM'"; fi
+
+echo "== C-nc-deliberate-break: prove the malformed-cost NULL-exclusion is falsifiable, not vacuous =="
+# If a future edit coerced an unparseable cost= to 0.0 instead of NULL, this count would go
+# from 1 to 0 (a fabricated-zero would silently join the SUM/AVG above and understate cost).
+BROKEN="$(uv run python3 - <<'PY' 2>&1
+from stats import materialize
+cols, rows = materialize.query(
+    "SELECT count(*) AS n FROM kit_gates WHERE gate = 'redteam' AND cost IS NULL"
+)
+print(rows[0][0])
+PY
+)"
+if [ "$BROKEN" = "3" ]; then ok "C-nc-deliberate-break exactly 3 redteam rows are NULL-cost (rt-b malformed + rt-c orphan + rt-d unscoped)"; else bad "C-nc-deliberate-break want 3 NULL-cost redteam rows, got '$BROKEN'"; fi
+
+echo "== C-mega-durations: OUTCOME brackets on redteam rounds make mega-durations pick them up (requirement b) =="
+# No gate-name whitelist in mega-durations (cli.py's own docstring) -- this just proves the
+# OUTCOME start/end pairs redteam-gate.sh emits are real, complete brackets that the EXISTING
+# wall-time query already reads, with zero mega-durations changes needed.
+MD="$(R mega-durations --json)"
+has "C-mega-durations rt-a wall_seconds=50 (2 redteam rounds, min(1000)..max(1050))" '"rid": "rt-a",
+      "first_start": 1000,
+      "last_end": 1050,
+      "n_gates_timed": 2,
+      "wall_seconds": 50' "$MD"
+has "C-mega-durations rt-c (orphan-cost round) still timed (5s) -- a missing cost never blocks the duration read" '"rid": "rt-c",
+      "first_start": 3000,
+      "last_end": 3005,
+      "n_gates_timed": 1,
+      "wall_seconds": 5' "$MD"
+
+echo "== C-remat: delete-and-rematerialize is byte-identical (fixture files canonical) =="
+BEFORE="$(R show kit_gates --json)"
+rm -f "$STATS_DB_REMOVED" "$STATS_DB_REMOVED.wal"
+AFTER="$(R show kit_gates --json)"
+if [ "$BEFORE" = "$AFTER" ]; then ok "C-remat identical output"; else bad "C-remat output differs after delete+rebuild"; fi
+
+echo "== C-nc: read-only negative control (fixture files are never mutated) =="
+FIXTURE_AFTER="$(find "$DWARVES_KIT_LOG_DIR" -type f -exec shasum -a 256 {} \; | sort)"
+if [ "$FIXTURE_BEFORE" = "$FIXTURE_AFTER" ]; then ok "C-nc fixture ledger files byte-identical after rebuild+queries"; else bad "C-nc a fixture file changed"; fi
+
+echo ""
+echo "== $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]

--- a/lib/stats/tests/test-kit-gates-cost.sh
+++ b/lib/stats/tests/test-kit-gates-cost.sh
@@ -107,6 +107,25 @@ has "C-unscoped rt-d cost=null (the rid-wide TOKENS line is not phase-tagged)" '
     "end_ts": "4010",
     "cost": null' "$ROWS"
 
+echo "== C-zero: rt-e's cost=0 is a real zero, never confused with the NULL cases above =="
+has "C-zero rt-e cost=0.0 (not null, not dropped)" '"rid": "rt-e",
+    "gate": "redteam",
+    "outcome": "ran",
+    "caught": false,
+    "reason": "round=1 verdict=secure a real zero-cost round, must not be treated as null",
+    "start_ts": "5000",
+    "end_ts": "5005",
+    "cost": 0.0' "$ROWS"
+ZERO_INCLUDED="$(uv run python3 - <<'PY' 2>&1
+from stats import materialize
+cols, rows = materialize.query(
+    "SELECT count(*) AS n FROM kit_gates WHERE rid = 'rt-e' AND gate = 'redteam' AND cost IS NOT NULL"
+)
+print(rows[0][0])
+PY
+)"
+if [ "$ZERO_INCLUDED" = "1" ]; then ok "C-zero rt-e's cost=0 is NOT NULL (counted, not silently excluded from an average)"; else bad "C-zero want 1, got '$ZERO_INCLUDED'"; fi
+
 echo "== C-sum: cost is genuine arithmetic (DOUBLE), not display-only text -- SUM over rt-a's 2 rounds =="
 SUM="$(uv run python3 - <<'PY' 2>&1
 from stats import materialize

--- a/tests/test-redteam-gate.sh
+++ b/tests/test-redteam-gate.sh
@@ -24,7 +24,7 @@ trap cleanup EXIT
 
 LOGD=""
 gl()  { env DWARVES_KIT_LOG_DIR="$LOGD" bash "$GL" "$@"; }
-rg()  { env DWARVES_KIT_LOG_DIR="$LOGD" bash "$RG" "$@"; }
+rtg()  { env DWARVES_KIT_LOG_DIR="$LOGD" bash "$RG" "$@"; }
 gate(){ env DWARVES_KIT_LOG_DIR="$LOGD" bash "$GATE" "$@"; }
 new_log() { LOGD="$(_mk)/logs"; mkdir -p "$LOGD/runs"; }
 ledger_file() { printf '%s/runs/%s.log' "$LOGD" "$1"; }
@@ -35,7 +35,7 @@ echo "=== redteam-gate (rung-4 cost checkpoint) ==="
 # AC1: start opens an OUTCOME bracket for the `redteam` phase.
 # ---------------------------------------------------------------------------
 new_log
-rg start rt1 >/dev/null 2>&1; RC=$?
+rtg start rt1 >/dev/null 2>&1; RC=$?
 assert "AC1 start exits 0" "$RC" 0
 grep -q '| OUTCOME | redteam | start |' "$(ledger_file rt1)" \
   && assert "AC1 start writes an OUTCOME|redteam|start line" 0 \
@@ -45,8 +45,8 @@ grep -q '| OUTCOME | redteam | start |' "$(ledger_file rt1)" \
 # AC2: round secure -> GATE ran + TOKENS(phase=redteam,cost=) + OUTCOME end caught=false.
 # ---------------------------------------------------------------------------
 new_log
-rg start rt2 >/dev/null 2>&1
-rg round rt2 secure cost=0.42 round=1 >/dev/null 2>&1; RC=$?
+rtg start rt2 >/dev/null 2>&1
+rtg round rt2 secure cost=0.42 round=1 >/dev/null 2>&1; RC=$?
 assert "AC2 round secure exits 0" "$RC" 0
 F="$(ledger_file rt2)"
 grep -q '| GATE | redteam | ran | round=1 verdict=secure' "$F" \
@@ -60,8 +60,8 @@ grep -q '| OUTCOME | redteam | end | .*caught=false' "$F" \
 # AC3: round findings -> caught=true (this round found issues, another round follows).
 # ---------------------------------------------------------------------------
 new_log
-rg start rt3 >/dev/null 2>&1
-rg round rt3 findings cost=0.10 round=1 reason="2 findings, fixing" >/dev/null 2>&1
+rtg start rt3 >/dev/null 2>&1
+rtg round rt3 findings cost=0.10 round=1 reason="2 findings, fixing" >/dev/null 2>&1
 F="$(ledger_file rt3)"
 grep -q '| OUTCOME | redteam | end | .*caught=true' "$F" \
   && assert "AC3 OUTCOME end caught=true on a findings verdict" 0 || assert "AC3 OUTCOME end caught=true on a findings verdict" 1
@@ -72,8 +72,8 @@ grep -q '| GATE | redteam | ran | round=1 verdict=findings 2 findings, fixing' "
 # AC4: round capped -> caught=true (the fail-closed 3-round-cap stop, never reached SECURE).
 # ---------------------------------------------------------------------------
 new_log
-rg start rt4 >/dev/null 2>&1
-rg round rt4 capped cost=0.05 round=3 >/dev/null 2>&1
+rtg start rt4 >/dev/null 2>&1
+rtg round rt4 capped cost=0.05 round=3 >/dev/null 2>&1
 grep -q '| OUTCOME | redteam | end | .*caught=true' "$(ledger_file rt4)" \
   && assert "AC4 OUTCOME end caught=true on the fail-closed cap" 0 || assert "AC4 OUTCOME end caught=true on the fail-closed cap" 1
 
@@ -81,9 +81,9 @@ grep -q '| OUTCOME | redteam | end | .*caught=true' "$(ledger_file rt4)" \
 # AC5: bad verdict rejected (rc 64), NOTHING written past a prior start bracket.
 # ---------------------------------------------------------------------------
 new_log
-rg start rt5 >/dev/null 2>&1
+rtg start rt5 >/dev/null 2>&1
 BEFORE="$(cat "$(ledger_file rt5)")"
-rg round rt5 bogus cost=1 >/dev/null 2>&1; RC=$?
+rtg round rt5 bogus cost=1 >/dev/null 2>&1; RC=$?
 [ "$RC" -eq 64 ] && assert "AC5 bad verdict rejected (rc 64)" 0 || assert "AC5 bad verdict rejected (rc=$RC)" 1
 AFTER="$(cat "$(ledger_file rt5)")"
 [ "$BEFORE" = "$AFTER" ] && assert "AC5 bad verdict wrote nothing (ledger unchanged)" 0 || assert "AC5 bad verdict wrote nothing (ledger unchanged)" 1
@@ -96,8 +96,8 @@ AFTER="$(cat "$(ledger_file rt5)")"
 # for a real, cheap round.
 # ---------------------------------------------------------------------------
 new_log
-rg start rt6 >/dev/null 2>&1
-rg round rt6 secure round=1 >/dev/null 2>&1; RC=$?
+rtg start rt6 >/dev/null 2>&1
+rtg round rt6 secure round=1 >/dev/null 2>&1; RC=$?
 [ "$RC" -eq 64 ] && assert "AC6 missing cost= rejected (rc 64)" 0 || assert "AC6 missing cost= rejected (rc=$RC)" 1
 F="$(ledger_file rt6)"
 grep -q '| GATE | redteam |' "$F" \
@@ -115,7 +115,7 @@ N_LINES="$(grep -c . "$F" || true)"
 # AC6b: a rejected round can be retried and the retry succeeds cleanly (proves AC6's fail-closed
 # behavior does not corrupt the rid for a later, correctly-formed call).
 # ---------------------------------------------------------------------------
-rg round rt6 secure cost=0.20 round=1 >/dev/null 2>&1; RC=$?
+rtg round rt6 secure cost=0.20 round=1 >/dev/null 2>&1; RC=$?
 assert "AC6b retry with cost= succeeds (rc 0)" "$RC" 0
 grep -q '| GATE | redteam | ran | round=1 verdict=secure' "$(ledger_file rt6)" \
   && assert "AC6b retry GATE row present" 0 || assert "AC6b retry GATE row present" 1
@@ -124,10 +124,10 @@ grep -q '| GATE | redteam | ran | round=1 verdict=secure' "$(ledger_file rt6)" \
 # AC7: multiple rounds in one rid each get their own GATE+TOKENS+OUTCOME triple (no clobbering).
 # ---------------------------------------------------------------------------
 new_log
-rg start rt7 >/dev/null 2>&1
-rg round rt7 findings cost=0.30 round=1 >/dev/null 2>&1
-rg start rt7 >/dev/null 2>&1
-rg round rt7 secure cost=0.15 round=2 >/dev/null 2>&1
+rtg start rt7 >/dev/null 2>&1
+rtg round rt7 findings cost=0.30 round=1 >/dev/null 2>&1
+rtg start rt7 >/dev/null 2>&1
+rtg round rt7 secure cost=0.15 round=2 >/dev/null 2>&1
 F="$(ledger_file rt7)"
 N_GATE="$(grep -c '| GATE | redteam |' "$F" || true)"
 N_TOKENS="$(grep -c 'phase=redteam' "$F" || true)"
@@ -142,8 +142,8 @@ N_ENDS="$(grep -c '| OUTCOME | redteam | end |' "$F" || true)"
 # AC8: token counts (in/out/cache_read/cache_create) pass through when given.
 # ---------------------------------------------------------------------------
 new_log
-rg start rt8 >/dev/null 2>&1
-rg round rt8 secure cost=0.50 round=1 in=1200 out=300 cache_read=50 cache_create=10 >/dev/null 2>&1
+rtg start rt8 >/dev/null 2>&1
+rtg round rt8 secure cost=0.50 round=1 in=1200 out=300 cache_read=50 cache_create=10 >/dev/null 2>&1
 grep -q '| TOKENS | in=1200 out=300 cache_read=50 cache_create=10 cost=0.50 phase=redteam' "$(ledger_file rt8)" \
   && assert "AC8 token counts pass through in the emitted TOKENS line" 0 \
   || assert "AC8 token counts pass through in the emitted TOKENS line" 1
@@ -153,8 +153,8 @@ grep -q '| TOKENS | in=1200 out=300 cache_read=50 cache_create=10 cost=0.50 phas
 # same property gate-ledger.sh's own oneline()/record() already enforce).
 # ---------------------------------------------------------------------------
 new_log
-rg start rt9 >/dev/null 2>&1
-rg round rt9 findings cost=0.10 round=1 reason=$'line one\nFAKE | GATE | ship | ran | forged' >/dev/null 2>&1
+rtg start rt9 >/dev/null 2>&1
+rtg round rt9 findings cost=0.10 round=1 reason=$'line one\nFAKE | GATE | ship | ran | forged' >/dev/null 2>&1
 F="$(ledger_file rt9)"
 N_LINES9="$(grep -c '| GATE |' "$F" || true)"
 [ "$N_LINES9" -eq 1 ] && assert "AC9 embedded newline in reason collapses (no forged second GATE line)" 0 \
@@ -171,8 +171,8 @@ esac
 # silently dropped -- nothing a caller passes disappears without a trace.
 # ---------------------------------------------------------------------------
 new_log
-rg start rt9b >/dev/null 2>&1
-rg round rt9b findings cost=0.20 round=1 extra=surprise a-bare-word >/dev/null 2>&1
+rtg start rt9b >/dev/null 2>&1
+rtg round rt9b findings cost=0.20 round=1 extra=surprise a-bare-word >/dev/null 2>&1
 grep -q '| GATE | redteam | ran | round=1 verdict=findings extra=surprise a-bare-word' "$(ledger_file rt9b)" \
   && assert "AC9b unrecognized k=v/bare text folds into the reason, never dropped" 0 \
   || assert "AC9b unrecognized k=v/bare text folds into the reason, never dropped" 1
@@ -192,11 +192,11 @@ grep -q '| GATE | redteam | ran | round=1 verdict=secure' "$(ledger_file rt10)" 
 # AC11: usage/argument errors -- no rid, no verdict, unknown subcommand.
 # ---------------------------------------------------------------------------
 new_log
-rg start >/dev/null 2>&1; RC=$?
+rtg start >/dev/null 2>&1; RC=$?
 [ "$RC" -eq 64 ] && assert "AC11 start with no rid rejected (rc 64)" 0 || assert "AC11 start with no rid rejected (rc=$RC)" 1
-rg round rt11 >/dev/null 2>&1; RC=$?
+rtg round rt11 >/dev/null 2>&1; RC=$?
 [ "$RC" -eq 64 ] && assert "AC11 round with no verdict rejected (rc 64)" 0 || assert "AC11 round with no verdict rejected (rc=$RC)" 1
-rg bogus-subcommand >/dev/null 2>&1; RC=$?
+rtg bogus-subcommand >/dev/null 2>&1; RC=$?
 [ "$RC" -ne 0 ] && assert "AC11 unknown subcommand rejected (nonzero)" 0 || assert "AC11 unknown subcommand rejected (rc=$RC)" 1
 
 # ---------------------------------------------------------------------------

--- a/tests/test-redteam-gate.sh
+++ b/tests/test-redteam-gate.sh
@@ -200,6 +200,39 @@ rtg bogus-subcommand >/dev/null 2>&1; RC=$?
 [ "$RC" -ne 0 ] && assert "AC11 unknown subcommand rejected (nonzero)" 0 || assert "AC11 unknown subcommand rejected (rc=$RC)" 1
 
 # ---------------------------------------------------------------------------
+# AC11b: the bare-usage main() arm (no subcommand, -h, --help, help) all print usage and
+# exit 0 -- the one case-arm in main() otherwise uncovered by every other AC above.
+# ---------------------------------------------------------------------------
+for arg in "" "-h" "--help" "help"; do
+  OUT="$(rtg $arg 2>&1)"; RC=$?
+  [ "$RC" -eq 0 ] && [ -n "$OUT" ] && assert "AC11b '${arg:-<no args>}' prints usage and exits 0" 0 \
+    || assert "AC11b '${arg:-<no args>}' prints usage and exits 0 (rc=$RC, out empty=$([ -z "$OUT" ] && echo yes || echo no))" 1
+done
+
+# ---------------------------------------------------------------------------
+# AC13: cost format validation -- cost=0 is a real, valid, non-falsy value; a malformed shape
+# (cost=1.2.3, kept accepted-but-NULL by gate-ledger.sh's own lax tokens() sanitizer) is
+# rejected HERE instead, so a redteam round never ledgers a cost that silently degrades to
+# NULL downstream.
+# ---------------------------------------------------------------------------
+new_log
+rtg start rt13 >/dev/null 2>&1
+rtg round rt13 secure cost=0 round=1 >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 0 ] && assert "AC13 cost=0 is accepted (rc 0), a real zero-cost round" 0 || assert "AC13 cost=0 is accepted (rc=$RC)" 1
+grep -q '| TOKENS | .*cost=0 .*phase=redteam' "$(ledger_file rt13)" \
+  && assert "AC13 cost=0 lands in the TOKENS line verbatim" 0 || assert "AC13 cost=0 lands in the TOKENS line verbatim" 1
+
+new_log
+rtg start rt14 >/dev/null 2>&1
+BEFORE14="$(cat "$(ledger_file rt14)")"
+rtg round rt14 secure cost=1.2.3 round=1 >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 64 ] && assert "AC13 malformed cost=1.2.3 rejected (rc 64)" 0 || assert "AC13 malformed cost=1.2.3 rejected (rc=$RC)" 1
+AFTER14="$(cat "$(ledger_file rt14)")"
+[ "$BEFORE14" = "$AFTER14" ] && assert "AC13 malformed cost=1.2.3 wrote nothing" 0 || assert "AC13 malformed cost=1.2.3 wrote nothing" 1
+rtg round rt14 secure cost=abc round=1 >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 64 ] && assert "AC13 non-numeric cost=abc rejected (rc 64)" 0 || assert "AC13 non-numeric cost=abc rejected (rc=$RC)" 1
+
+# ---------------------------------------------------------------------------
 # AC12: PORTABILITY -- no BSD-only date/stat constructs in the new script.
 # ---------------------------------------------------------------------------
 if grep -vE '^[[:space:]]*#' "$RG" | grep -nE 'date -d|date -r|stat -f|sed -i '"''" >/dev/null 2>&1; then

--- a/tests/test-redteam-gate.sh
+++ b/tests/test-redteam-gate.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# test-redteam-gate.sh -- rung-4 redteam cost checkpoint (ops-toolkit
+# research/2026-07-18-rung4-cost-checkpoint.md). Validates lib/gate/redteam-gate.sh: every
+# round appends a `redteam` kit_gates row carrying its token cost, bracketed by an OUTCOME
+# start/end pair so `lib/stats` mega-durations picks the round up. Isolation: every case runs
+# under a fresh DWARVES_KIT_LOG_DIR so the real machine corpus is never touched.
+#
+# Run: bash tests/test-redteam-gate.sh   (exit 0 = all AC green)
+
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GL="$KIT_DIR/lib/gate/gate-ledger.sh"
+RG="$KIT_DIR/lib/gate/redteam-gate.sh"
+GATE="$KIT_DIR/lib/gate/gate.sh"
+
+PASS=0; FAIL=0; TOTAL=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 ${3:-}"; FAIL=$((FAIL+1)); fi; }
+
+TMPS=()
+_mk() { local d; d="$(mktemp -d)"; TMPS+=("$d"); printf '%s' "$d"; }
+cleanup() { local d; for d in "${TMPS[@]:-}"; do [ -n "$d" ] && rm -rf "$d" 2>/dev/null; done; }
+trap cleanup EXIT
+
+LOGD=""
+gl()  { env DWARVES_KIT_LOG_DIR="$LOGD" bash "$GL" "$@"; }
+rg()  { env DWARVES_KIT_LOG_DIR="$LOGD" bash "$RG" "$@"; }
+gate(){ env DWARVES_KIT_LOG_DIR="$LOGD" bash "$GATE" "$@"; }
+new_log() { LOGD="$(_mk)/logs"; mkdir -p "$LOGD/runs"; }
+ledger_file() { printf '%s/runs/%s.log' "$LOGD" "$1"; }
+
+echo "=== redteam-gate (rung-4 cost checkpoint) ==="
+
+# ---------------------------------------------------------------------------
+# AC1: start opens an OUTCOME bracket for the `redteam` phase.
+# ---------------------------------------------------------------------------
+new_log
+rg start rt1 >/dev/null 2>&1; RC=$?
+assert "AC1 start exits 0" "$RC" 0
+grep -q '| OUTCOME | redteam | start |' "$(ledger_file rt1)" \
+  && assert "AC1 start writes an OUTCOME|redteam|start line" 0 \
+  || assert "AC1 start writes an OUTCOME|redteam|start line" 1
+
+# ---------------------------------------------------------------------------
+# AC2: round secure -> GATE ran + TOKENS(phase=redteam,cost=) + OUTCOME end caught=false.
+# ---------------------------------------------------------------------------
+new_log
+rg start rt2 >/dev/null 2>&1
+rg round rt2 secure cost=0.42 round=1 >/dev/null 2>&1; RC=$?
+assert "AC2 round secure exits 0" "$RC" 0
+F="$(ledger_file rt2)"
+grep -q '| GATE | redteam | ran | round=1 verdict=secure' "$F" \
+  && assert "AC2 GATE row: ran, round=1 verdict=secure" 0 || assert "AC2 GATE row: ran, round=1 verdict=secure" 1
+grep -q '| TOKENS | .*cost=0.42.*phase=redteam' "$F" \
+  && assert "AC2 TOKENS row carries cost=0.42 phase=redteam" 0 || assert "AC2 TOKENS row carries cost=0.42 phase=redteam" 1
+grep -q '| OUTCOME | redteam | end | .*caught=false' "$F" \
+  && assert "AC2 OUTCOME end caught=false on a clean secure verdict" 0 || assert "AC2 OUTCOME end caught=false on a clean secure verdict" 1
+
+# ---------------------------------------------------------------------------
+# AC3: round findings -> caught=true (this round found issues, another round follows).
+# ---------------------------------------------------------------------------
+new_log
+rg start rt3 >/dev/null 2>&1
+rg round rt3 findings cost=0.10 round=1 reason="2 findings, fixing" >/dev/null 2>&1
+F="$(ledger_file rt3)"
+grep -q '| OUTCOME | redteam | end | .*caught=true' "$F" \
+  && assert "AC3 OUTCOME end caught=true on a findings verdict" 0 || assert "AC3 OUTCOME end caught=true on a findings verdict" 1
+grep -q '| GATE | redteam | ran | round=1 verdict=findings 2 findings, fixing' "$F" \
+  && assert "AC3 GATE reason carries round+verdict+free text" 0 || assert "AC3 GATE reason carries round+verdict+free text" 1
+
+# ---------------------------------------------------------------------------
+# AC4: round capped -> caught=true (the fail-closed 3-round-cap stop, never reached SECURE).
+# ---------------------------------------------------------------------------
+new_log
+rg start rt4 >/dev/null 2>&1
+rg round rt4 capped cost=0.05 round=3 >/dev/null 2>&1
+grep -q '| OUTCOME | redteam | end | .*caught=true' "$(ledger_file rt4)" \
+  && assert "AC4 OUTCOME end caught=true on the fail-closed cap" 0 || assert "AC4 OUTCOME end caught=true on the fail-closed cap" 1
+
+# ---------------------------------------------------------------------------
+# AC5: bad verdict rejected (rc 64), NOTHING written past a prior start bracket.
+# ---------------------------------------------------------------------------
+new_log
+rg start rt5 >/dev/null 2>&1
+BEFORE="$(cat "$(ledger_file rt5)")"
+rg round rt5 bogus cost=1 >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 64 ] && assert "AC5 bad verdict rejected (rc 64)" 0 || assert "AC5 bad verdict rejected (rc=$RC)" 1
+AFTER="$(cat "$(ledger_file rt5)")"
+[ "$BEFORE" = "$AFTER" ] && assert "AC5 bad verdict wrote nothing (ledger unchanged)" 0 || assert "AC5 bad verdict wrote nothing (ledger unchanged)" 1
+
+# ---------------------------------------------------------------------------
+# AC6 (LOAD-BEARING NEGATIVE CONTROL): a round with no cost= is rejected (rc 64) and emits
+# NEITHER a GATE row NOR a TOKENS row NOR an OUTCOME end -- a failed-to-emit round is
+# detectable (the caller sees rc=64 immediately) and leaves NO fabricated ledger data, rather
+# than silently landing as an untracked/zero-cost row a cost-checkpoint reader could mistake
+# for a real, cheap round.
+# ---------------------------------------------------------------------------
+new_log
+rg start rt6 >/dev/null 2>&1
+rg round rt6 secure round=1 >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 64 ] && assert "AC6 missing cost= rejected (rc 64)" 0 || assert "AC6 missing cost= rejected (rc=$RC)" 1
+F="$(ledger_file rt6)"
+grep -q '| GATE | redteam |' "$F" \
+  && assert "AC6 no GATE row written on a failed round" 1 || assert "AC6 no GATE row written on a failed round" 0
+grep -q '| TOKENS |' "$F" \
+  && assert "AC6 no TOKENS row written on a failed round" 1 || assert "AC6 no TOKENS row written on a failed round" 0
+grep -q '| OUTCOME | redteam | end' "$F" \
+  && assert "AC6 no OUTCOME end written on a failed round" 1 || assert "AC6 no OUTCOME end written on a failed round" 0
+# the round IS still recoverable/auditable: the earlier start bracket is the only line present.
+N_LINES="$(grep -c . "$F" || true)"
+[ "$N_LINES" -eq 1 ] && assert "AC6 exactly the one start line remains (failure is visible, not silently absorbed)" 0 \
+  || assert "AC6 exactly the one start line remains (got $N_LINES lines)" 1
+
+# ---------------------------------------------------------------------------
+# AC6b: a rejected round can be retried and the retry succeeds cleanly (proves AC6's fail-closed
+# behavior does not corrupt the rid for a later, correctly-formed call).
+# ---------------------------------------------------------------------------
+rg round rt6 secure cost=0.20 round=1 >/dev/null 2>&1; RC=$?
+assert "AC6b retry with cost= succeeds (rc 0)" "$RC" 0
+grep -q '| GATE | redteam | ran | round=1 verdict=secure' "$(ledger_file rt6)" \
+  && assert "AC6b retry GATE row present" 0 || assert "AC6b retry GATE row present" 1
+
+# ---------------------------------------------------------------------------
+# AC7: multiple rounds in one rid each get their own GATE+TOKENS+OUTCOME triple (no clobbering).
+# ---------------------------------------------------------------------------
+new_log
+rg start rt7 >/dev/null 2>&1
+rg round rt7 findings cost=0.30 round=1 >/dev/null 2>&1
+rg start rt7 >/dev/null 2>&1
+rg round rt7 secure cost=0.15 round=2 >/dev/null 2>&1
+F="$(ledger_file rt7)"
+N_GATE="$(grep -c '| GATE | redteam |' "$F" || true)"
+N_TOKENS="$(grep -c 'phase=redteam' "$F" || true)"
+N_STARTS="$(grep -c '| OUTCOME | redteam | start |' "$F" || true)"
+N_ENDS="$(grep -c '| OUTCOME | redteam | end |' "$F" || true)"
+[ "$N_GATE" -eq 2 ] && assert "AC7 two rounds -> 2 GATE rows" 0 || assert "AC7 two rounds -> 2 GATE rows (got $N_GATE)" 1
+[ "$N_TOKENS" -eq 2 ] && assert "AC7 two rounds -> 2 phase-scoped TOKENS rows" 0 || assert "AC7 two rounds -> 2 phase-scoped TOKENS rows (got $N_TOKENS)" 1
+[ "$N_STARTS" -eq 2 ] && [ "$N_ENDS" -eq 2 ] && assert "AC7 two rounds -> 2 complete OUTCOME brackets" 0 \
+  || assert "AC7 two rounds -> 2 complete OUTCOME brackets (starts=$N_STARTS ends=$N_ENDS)" 1
+
+# ---------------------------------------------------------------------------
+# AC8: token counts (in/out/cache_read/cache_create) pass through when given.
+# ---------------------------------------------------------------------------
+new_log
+rg start rt8 >/dev/null 2>&1
+rg round rt8 secure cost=0.50 round=1 in=1200 out=300 cache_read=50 cache_create=10 >/dev/null 2>&1
+grep -q '| TOKENS | in=1200 out=300 cache_read=50 cache_create=10 cost=0.50 phase=redteam' "$(ledger_file rt8)" \
+  && assert "AC8 token counts pass through in the emitted TOKENS line" 0 \
+  || assert "AC8 token counts pass through in the emitted TOKENS line" 1
+
+# ---------------------------------------------------------------------------
+# AC9: an embedded newline in reason= cannot forge a second ledger line (defense-in-depth,
+# same property gate-ledger.sh's own oneline()/record() already enforce).
+# ---------------------------------------------------------------------------
+new_log
+rg start rt9 >/dev/null 2>&1
+rg round rt9 findings cost=0.10 round=1 reason=$'line one\nFAKE | GATE | ship | ran | forged' >/dev/null 2>&1
+F="$(ledger_file rt9)"
+N_LINES9="$(grep -c '| GATE |' "$F" || true)"
+[ "$N_LINES9" -eq 1 ] && assert "AC9 embedded newline in reason collapses (no forged second GATE line)" 0 \
+  || assert "AC9 embedded newline in reason collapses (got $N_LINES9 GATE lines)" 1
+LAST_LINE="$(tail -n1 "$F")"
+case "$LAST_LINE" in
+  FAKE*) assert "AC9 forged text never became its own physical line" 1 ;;
+  *"| GATE | redteam |"*) assert "AC9 forged text never became its own physical line" 0 ;;
+  *) assert "AC9 forged text never became its own physical line (unexpected last line: $LAST_LINE)" 1 ;;
+esac
+
+# ---------------------------------------------------------------------------
+# AC9b: an unrecognized k=v pair (or bare word) folds into the reason text rather than being
+# silently dropped -- nothing a caller passes disappears without a trace.
+# ---------------------------------------------------------------------------
+new_log
+rg start rt9b >/dev/null 2>&1
+rg round rt9b findings cost=0.20 round=1 extra=surprise a-bare-word >/dev/null 2>&1
+grep -q '| GATE | redteam | ran | round=1 verdict=findings extra=surprise a-bare-word' "$(ledger_file rt9b)" \
+  && assert "AC9b unrecognized k=v/bare text folds into the reason, never dropped" 0 \
+  || assert "AC9b unrecognized k=v/bare text folds into the reason, never dropped" 1
+
+# ---------------------------------------------------------------------------
+# AC10: gate.sh dispatches `redteam` verb identically to calling redteam-gate.sh directly.
+# ---------------------------------------------------------------------------
+new_log
+gate redteam start rt10 >/dev/null 2>&1
+gate redteam round rt10 secure cost=0.05 round=1 >/dev/null 2>&1; RC=$?
+assert "AC10 gate.sh redteam round exits 0" "$RC" 0
+grep -q '| GATE | redteam | ran | round=1 verdict=secure' "$(ledger_file rt10)" \
+  && assert "AC10 gate.sh redteam dispatch reaches redteam-gate.sh" 0 \
+  || assert "AC10 gate.sh redteam dispatch reaches redteam-gate.sh" 1
+
+# ---------------------------------------------------------------------------
+# AC11: usage/argument errors -- no rid, no verdict, unknown subcommand.
+# ---------------------------------------------------------------------------
+new_log
+rg start >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 64 ] && assert "AC11 start with no rid rejected (rc 64)" 0 || assert "AC11 start with no rid rejected (rc=$RC)" 1
+rg round rt11 >/dev/null 2>&1; RC=$?
+[ "$RC" -eq 64 ] && assert "AC11 round with no verdict rejected (rc 64)" 0 || assert "AC11 round with no verdict rejected (rc=$RC)" 1
+rg bogus-subcommand >/dev/null 2>&1; RC=$?
+[ "$RC" -ne 0 ] && assert "AC11 unknown subcommand rejected (nonzero)" 0 || assert "AC11 unknown subcommand rejected (rc=$RC)" 1
+
+# ---------------------------------------------------------------------------
+# AC12: PORTABILITY -- no BSD-only date/stat constructs in the new script.
+# ---------------------------------------------------------------------------
+if grep -vE '^[[:space:]]*#' "$RG" | grep -nE 'date -d|date -r|stat -f|sed -i '"''" >/dev/null 2>&1; then
+  assert "AC12 redteam-gate.sh free of BSD-only date/stat/sed constructs" 1
+else
+  assert "AC12 redteam-gate.sh free of BSD-only date/stat/sed constructs" 0
+fi
+
+echo ""
+echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- The rung-4 redteam gate (in-harness adversarial skeptic, cap 3 rounds, verbatim
  `VERDICT: SECURE`) ran real rounds but never emitted a `redteam` `kit_gates` row, so the
  ID-372 cost checkpoint (tighten the trigger if rung 4 averages >15% of mega cost) could
  never be evaluated. `lib/gate/redteam-gate.sh` gives the redteam procedure one call per
  round (`start`, `round`) that appends a `GATE` row, a phase-scoped `TOKENS` row carrying
  the round's cost, and an `OUTCOME` start/end bracket together.
- `lib/stats`' `kit_gates` gains a `cost` column: `read_kit_gates` FIFO-pairs a phase-scoped
  `TOKENS` line onto its `GATE` row the same way it already pairs an `OUTCOME` bracket
  (SPEC-129 DEC-002). `mega-durations` already has no gate-name whitelist, so it picks up
  redteam rounds with zero changes of its own.
- `cost=` is required on `round`; a round with no captured cost is rejected (rc 64) and
  writes nothing, never a silently-wrong zero-cost row.

## Test plan

- [x] `bash tests/test-redteam-gate.sh` (31/31): start/round, all 3 verdicts, the two
      negative controls (missing cost writes nothing; bad verdict writes nothing), FIFO
      multi-round pairing, token-count passthrough, embedded-newline injection defense,
      `gate.sh redteam` dispatch, usage errors.
- [x] `(cd lib/stats && bash tests/test-kit-gates-cost.sh)` (12/12): FIFO cost pairing,
      malformed cost -> NULL not a crash, an orphan round (no TOKENS at all) -> NULL, an
      unscoped rid-wide TOKENS line never pairs, real SQL arithmetic (`SUM(cost)`),
      `mega-durations` pickup, delete-and-rematerialize, read-only NC.
- [x] `bash tests/test-meta.sh` (698/698), plus the full pre-existing `lib/stats/tests/*.sh`
      and root gate-ledger/quiz-gate/schema-parity/outcome-emit-sweep suites, all green
      (additive-only change, see `docs/verification/redteam-gate-ledger.md`).
- [x] Rollback negative control performed live: removed the cost-required guard, confirmed
      RED (5 failures), restored via `git checkout`, confirmed byte-identical + GREEN again.
