### PR TITLE
feat(sync): wire sync.mode = cron to a per-repo scheduled LaunchAgent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to dwarves-kit are documented here.
   the ops-toolkit board on 2026-07-16.
 
 ### Added
+- **`sync.mode = cron`: scheduled `board sync` (kit ID-289).** Wires the
+  `[sync] mode` key (previously `[reserved]`) to a real per-repo macOS
+  LaunchAgent: `lib/sync/deploy/macos/install` refuses to render or load
+  anything unless the target repo's own `.kit.toml` sets `mode = "cron"`
+  (any other value is a clean, named refusal); the installed launcher also
+  re-checks `mode` live on every scheduled run and skips cleanly once a repo
+  un-opts-in. New `sync.interval_secs` key (default 3600) sets cadence. One
+  LaunchAgent per adopted repo (not a kit-weekly job -- sync is per-repo by
+  nature). Tests: `tests/test-sync-cron-install.sh` +
+  `tests/test-sync-cron-launcher.sh`.
 - **`sync` module: two-way board↔apps sync (SPEC-001/SPEC-002 P1).** The ops-toolkit
   backlog-sync engine graduates into the kit as registered module `sync` (leg Specify)
   at `lib/sync/`: `board sync` mirrors an adopted repo's BACKLOG.md to Apple Reminders /

--- a/docs/verification/sync-cron-mode.md
+++ b/docs/verification/sync-cron-mode.md
@@ -69,6 +69,15 @@ and absent).
 
 ## Confirmation run
 
+Command: `bash tests/test-sync-cron-install.sh`
+Exit: 0
+
+Command: `bash tests/test-sync-cron-launcher.sh`
+Exit: 0
+
+Command: `bash tests/test-meta.sh`
+Exit: 0
+
 | Check | Command | Exit | Verdict |
 |---|---|---|---|
 | Install-script suite (29 assertions) | `bash tests/test-sync-cron-install.sh` | 0 | PASS (29/29) |

--- a/docs/verification/sync-cron-mode.md
+++ b/docs/verification/sync-cron-mode.md
@@ -1,0 +1,179 @@
+# Proof of done: sync.mode = cron, scheduled `board sync` (kit ID-289)
+
+**Change class:** behavioral (`lib/sync/deploy/macos/install`,
+`lib/sync/deploy/macos/board-sync-cron`, `board-sync-cron.plist.tmpl`; config
+surface: `kit.toml` + `lib/config/module-registry.md`).
+
+**Claim:** `sync.mode` (previously `[reserved]`, `manual` | `cron`) is now a
+real gate. `lib/sync/deploy/macos/install` renders and (with `--apply`) loads
+a per-repo macOS LaunchAgent that runs `board sync` on a schedule, but ONLY
+for a repo whose own `.kit.toml [sync]` sets `mode = "cron"`; `manual`
+(default), unset, or any other value is refused cleanly (exit 2, naming the
+bad value), never a silent fallthrough. The installed launcher
+(`board-sync-cron`) re-checks the same key live on every scheduled run, so
+flipping `mode` back to `manual` after install makes the job go inert
+without needing a re-install. `install` defaults to `--dry-run` (prints the
+rendered plist + exact `launchctl` commands, never touches the host); no
+host was mutated by this build, per the task's repo-side-only constraint.
+
+## Review disposition (kit:code-reviewer architecture lens + kit:advisor/fable critique)
+
+| Finding | Lens | Applied? |
+|---|---|---|
+| Architecture: per-repo LaunchAgent vs kit-weekly's single scheduler is the right call, but ADR-0034 decision 9's literal "rejects plist-per-job" needs explicit disambiguation | architecture (should-fix) | Applied, README now states the rejection targeted fragmentation WITHIN one shared jobs list, not N self-owned per-repo agents |
+| Docs: `mode` is read once at install time; nothing said so | architecture (should-fix) | Superseded by a real fix (see next row), then documented anyway |
+| `sync.mode` gate is install-time only; a repo that later flips `mode` back to `manual` keeps syncing forever on the still-loaded job | advisor (finding 1) | Applied: launcher re-reads `sync.mode` live every run and skips cleanly (exit 0) once it's no longer `cron` |
+| Cadence lives only in a CLI flag, no config key, contradicts the "different cadence per repo" framing | advisor (finding 2) | Applied: new `sync.interval_secs` kit.toml key (default 3600), `--interval-secs` overrides it for one run |
+| Log has no run boundaries; can't tell which run failed from the file alone | advisor (finding 3) | Applied: launcher prints timestamped start/end (with rc) lines per run |
+| No consumer-bridge hook symmetry with kit-weekly; a future vps-mon wiring would have to touch the launcher again | advisor (finding 4) | Applied: `~/.config/board-sync-cron/bridge` best-effort hook, same shape as kit-weekly's |
+| Slug uses logical (`cd && pwd`) path, diverges from `backlog_sync.py`'s physical-path slug under a symlinked checkout | advisor (finding 5) | Applied: `install` resolves the repo with `pwd -P` |
+| Label collision: two differently-laid-out repos can slug to the same LaunchAgent label; `--apply` would silently take over | advisor (finding 6) | Applied: `install` refuses (exit 2, names both paths) when an existing plist's baked-in backlog differs |
+| `launchctl print \| grep && echo ok` under `set -e` has no `else`; a confirmation-only failure masks a real successful bootstrap | advisor (finding 7a) | Applied: restructured to an explicit `if/else`, bootstrap success is never gated on the confirmation grep |
+| `mktemp -t NAME` is BSD-only, breaks on GNU/Linux | advisor (finding 7b) | Applied: portable `mktemp "$TMPDIR/....XXXXXX"` template form |
+| BTM: multiple per-repo installs share one Login Items row name | architecture (nit) | Documented (README caveat + `launchctl print` disambiguation command); accepted as a known cosmetic limitation |
+| `cmd_sync` (manual `board sync`) should stay unaffected by `sync.mode` | architecture (passed) | Confirmed correct by design; `board.sh cmd_sync` untouched, module-registry row states this explicitly |
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | `sync.mode` unset/`manual` refuses install, exit 2, names the fix | PASS |
+| 2 | `sync.mode` = any value other than `manual`/`cron` (negative control) rejected cleanly, exit 2, names the bad value | PASS |
+| 3 | `sync.mode = cron` + `apps` unset still refuses (exit 2) | PASS |
+| 4 | `sync.mode = cron` + `apps` set: dry-run prints the rendered plist + exact `launchctl` commands, mutates nothing (stubbed `launchctl`, empty log) | PASS |
+| 5 | `--apply` actually writes the plist and calls `launchctl bootout` then `bootstrap` | PASS |
+| 6 | Both `BACKLOG.md` conventions (`_meta/` and root-level) resolve | PASS |
+| 7 | `--interval-secs` flag and `sync.interval_secs` config both set cadence, flag wins | PASS |
+| 8 | Non-numeric interval rejected cleanly | PASS |
+| 9 | Two differently-named repos get two different labels | PASS |
+| 10 | Two repos whose slugs COLLIDE are refused (not silently merged), under both dry-run and `--apply` | PASS |
+| 11 | Re-running install for the SAME repo over its own existing plist is not flagged as a collision | PASS |
+| 12 | Installed launcher: missing `argv[1]` fails cleanly (no unbound-var crash) | PASS |
+| 13 | Installed launcher: `mode = cron` forwards to `bin/board sync --backlog-file <path>`, widens `PATH`, logs timestamped start/end+rc | PASS |
+| 14 | Installed launcher: `mode = manual` (or unset) skips cleanly, exit 0, does NOT invoke `bin/board` | PASS |
+| 15 | Installed launcher: optional consumer env + optional consumer bridge hook both sourced/invoked when present, silent no-op when absent | PASS |
+| 16 | No regression to existing `sync` module tests (engine, dispatch, config registry) or the kit-wide structural suite | PASS |
+
+## Coverage
+
+Test lines added: 174 (`tests/test-sync-cron-install.sh`) + 125
+(`tests/test-sync-cron-launcher.sh`) = 299. Behavioral code lines added:
+72 (`board-sync-cron`) + 179 (`install`) = 251. Ratio 299/251 ≈ 119%, above
+the 80% target. Every branch in both scripts is exercised: the `sync.mode`
+case (`cron`/`manual`/other), the `apps` guard, both `BACKLOG.md`
+conventions, `--interval-secs` flag vs config vs default vs invalid, the
+label-collision guard (both the collision path and the non-collision
+same-repo re-run), dry-run vs `--apply`, and in the launcher: missing argv,
+live mode skip, PATH widening, consumer env, and the bridge hook (present
+and absent).
+
+## Confirmation run
+
+| Check | Command | Exit | Verdict |
+|---|---|---|---|
+| Install-script suite (29 assertions) | `bash tests/test-sync-cron-install.sh` | 0 | PASS (29/29) |
+| Launcher suite (14 assertions) | `bash tests/test-sync-cron-launcher.sh` | 0 | PASS (14/14) |
+| sync engine suite (unchanged) | `bash tests/test-sync.sh` | 0 | PASS (60/60) |
+| sync dispatch suite (unchanged) | `bash tests/test-sync-dispatch.sh` | 0 | PASS (5/5) |
+| config registry drift lint (new `sync.interval_secs` + `sync.mode` status flip both clean) | `bash tests/test-config-registry.sh` | 0 | PASS (19/19) |
+| kit-wide structural suite (no regression) | `bash tests/test-meta.sh` | 0 | PASS (698/698) |
+| shellcheck (warning level) on both new scripts + both new test files | `shellcheck -S warning lib/sync/deploy/macos/install lib/sync/deploy/macos/board-sync-cron tests/test-sync-cron-install.sh tests/test-sync-cron-launcher.sh` | 0 | clean |
+
+## Run detail
+
+```
+$ bash tests/test-sync-cron-install.sh
+  PASS unset mode (default manual) refuses, exit 2
+  PASS unset mode: message points at mode = "cron"
+  PASS unset mode: no launchctl.log written (nothing attempted)
+  PASS explicit mode=manual refuses, exit 2
+  PASS bad mode value ('biweekly') rejected, exit 2 (not a crash)
+  PASS bad mode value: message names the offending value
+  PASS bad mode value: no launchctl invocation
+  PASS mode=cron with no apps refuses, exit 2
+  PASS mode=cron/no-apps: message names the missing apps key
+  PASS mode=cron + apps, dry-run exits 0
+  PASS dry-run: prints the rendered ProgramArguments (backlog path)
+  PASS dry-run: prints the label
+  PASS dry-run: prints the exact launchctl bootstrap command to run
+  PASS dry-run NEVER calls the real launchctl (no mutation)
+  PASS dry-run: no plist written to $HOME/Library/LaunchAgents
+  PASS root-level BACKLOG.md convention resolves
+  PASS custom --interval-secs is rendered into the plist
+  PASS non-numeric --interval-secs rejected cleanly, exit 2
+  PASS mode=cron + apps, --apply exits 0
+  PASS --apply writes a plist under $HOME/Library/LaunchAgents
+  PASS written plist references the repo's own board-sync-cron launcher + backlog path
+  PASS --apply invoked launchctl bootout then bootstrap
+  PASS two different repos render two different LaunchAgent labels
+  PASS sync.interval_secs from .kit.toml is used when --interval-secs is omitted
+  PASS --interval-secs flag overrides sync.interval_secs
+  PASS colliding slug from a DIFFERENT repo's backlog is refused, exit 2
+  PASS collision message names both the existing and the new backlog path
+  PASS colliding slug also refused under --apply (never silently takes over)
+  PASS re-installing the SAME repo over its own existing plist is fine (not a collision)
+=== 29/29 passed ===
+
+$ bash tests/test-sync-cron-launcher.sh
+  PASS missing backlog argv[1] fails cleanly (not an unbound-var crash trace)
+  PASS mode=cron: resolves KIT via BASH_SOURCE (4 dirs up) and execs the fake bin/board
+  PASS mode=cron: forwards argv as: sync --backlog-file <path>
+  PASS mode=cron: widens PATH with ~/.local/bin and /opt/homebrew/bin
+  PASS mode=cron: prints a timestamped start line
+  PASS mode=cron: prints a timestamped end line with rc
+  PASS mode=manual: skips cleanly, exit 0
+  PASS mode=manual: does NOT invoke bin/board
+  PASS mode=manual: says why it skipped
+  PASS no .kit.toml (default manual): skips cleanly, exit 0, no board call
+  PASS sources ~/.config/board-sync-cron/env when present
+  PASS absent consumer env file is a silent no-op (exit 0, no error text)
+  PASS executable bridge hook is invoked with rc + backlog path
+  PASS absent bridge hook is a silent no-op (exit 0)
+=== 14/14 passed ===
+```
+
+## NEGATIVE CONTROL (revert -> RED -> restore)
+
+Performed live on this branch, not merely asserted:
+
+1. **Revert**: `lib/sync/deploy/macos/install`'s `sync.mode` case statement
+   was mutated from `cron) : ;;` to `cron|biweekly) : ;;`, i.e. the exact
+   defect the gate exists to catch: a typo'd/unrecognized mode value
+   silently accepted instead of refused.
+2. **RED**: `bash tests/test-sync-cron-install.sh` immediately dropped to
+   **27/29**, with the two negative-control assertions failing exactly as
+   expected:
+   ```
+   FAIL bad mode value ('biweekly') rejected, exit 2 (not a crash) -- got: rc=0
+   FAIL bad mode value: message names the offending value -- got: dry-run: sync.mode=cron confirmed for .../repoC (apps=reminders)
+   === 27/29 passed ===
+   ```
+   This proves the test is load-bearing: it is not a tautology that passes
+   regardless of the implementation.
+3. **Restore**: `git checkout -- lib/sync/deploy/macos/install` reverted the
+   mutation; `bash tests/test-sync-cron-install.sh` returned to **29/29**
+   (confirmed above in Run detail). Working tree confirmed clean
+   (`git status --short` empty) before this proof was written.
+
+**Verdict: PASS.**
+
+## Reproduce
+
+```
+bash tests/test-sync-cron-install.sh    # 29/29
+bash tests/test-sync-cron-launcher.sh   # 14/14
+bash tests/test-sync.sh                 # 60/60 (unchanged sync engine)
+bash tests/test-sync-dispatch.sh        # 5/5 (unchanged cmd_sync dispatch)
+bash tests/test-config-registry.sh      # 19/19 (config drift lint)
+bash tests/test-meta.sh                 # 698/698 (kit-wide structural suite)
+```
+
+**Rollback:** `git revert` this commit removes `lib/sync/deploy/macos/`
+entirely and reverts the two doc-only config edits (`kit.toml`,
+`lib/config/module-registry.md`, both single-line status/key changes). No
+host state is involved: this build never ran `--apply` against a real
+`launchctl`, so there is nothing installed on any host to roll back. A repo
+that already ran `install --apply` on a real Mac before a future revert
+would still need a manual `launchctl bootout gui/$(id -u)/board-sync-<slug>`
+(documented in `lib/sync/deploy/macos/README.md`'s Uninstall section) since
+git revert cannot reach into launchd state.

--- a/kit.toml
+++ b/kit.toml
@@ -107,7 +107,8 @@ pilot            = false        # [design] end-to-end UAT (held)
 
 [sync]
 apps           = ""             # [impl] comma list of apps to sync to: reminders,notion,hermes,multica; empty = sync off. Legacy aliases: `surfaces`, `sources`
-mode           = "manual"       # [reserved] manual | cron (scheduled runs not built yet)
+mode           = "manual"       # [impl] manual | cron; cron gates lib/sync/deploy/macos/install (kit ID-289)
+interval_secs  = 3600           # [impl] cron LaunchAgent StartInterval seconds; --interval-secs overrides at install
 reminders_list = "Backlog"      # [impl] Reminders list name
 notion_db      = ""             # [impl] bind an existing Notion database id
 notion_parent  = ""             # [impl] Notion page id to create the board under (bootstrap)

--- a/lib/config/module-registry.md
+++ b/lib/config/module-registry.md
@@ -154,7 +154,8 @@ single-reader fence). No env vars; per-repo values live in `.kit.toml [sync]`.
 | Env var | kit.toml key | Default | Status | Module | Doc |
 |---|---|---|---|---|---|
 | - | sync.apps | `""` (sync off) | [impl] | sync | Comma list of apps to sync to (`reminders,notion,hermes,multica`); the plugin mechanism. Legacy aliases `surfaces` and `sources` still read as fallbacks (renamed 2026-07-16 for plain vocabulary; `sources` also collided with SPEC-002's board-side inputs). |
-| - | sync.mode | `"manual"` | [reserved] | sync | `manual` today; `cron` reserved for scheduled runs. |
+| - | sync.mode | `"manual"` | [impl] | sync | `manual` (default) or `cron`. Read by `lib/sync/deploy/macos/install` (kit ID-289): a repo must set `mode = "cron"` before that installer will render or load a per-repo scheduled-sync LaunchAgent; any other value is a clean refusal, not a silent fallthrough. Not read by `board.sh cmd_sync` itself -- manual `board sync` runs are unaffected by this key. ALSO re-read live by the installed `board-sync-cron` launcher on every scheduled run: flipping `mode` back to `"manual"` after install makes the next scheduled run skip cleanly (exit 0, logged) rather than silently keep syncing against a config that says it shouldn't. |
+| - | sync.interval_secs | `3600` | [impl] | sync | Cron LaunchAgent `StartInterval` seconds, read by `lib/sync/deploy/macos/install` as the default cadence for `mode = "cron"`; `--interval-secs N` overrides it for one install run. |
 | - | sync.reminders_list | `"Backlog"` | [impl] | sync | Apple Reminders list name. |
 | - | sync.notion_db | `""` | [impl] | sync | Bind an existing Notion database id. |
 | - | sync.notion_parent | `""` | [impl] | sync | Notion page id to create the board under (bootstrap). |

--- a/lib/sync/README.md
+++ b/lib/sync/README.md
@@ -76,6 +76,31 @@ reader); the python engine takes flags only and reads no config file. Flags:
 `--hermes-home`. State snapshots live per board at
 `~/.cache/backlog-sync/<board-slug>/<source>.state.json`.
 
+### Scheduled runs (cron)
+
+`board sync` is manual by default. Set `mode = "cron"` in a repo's own
+`.kit.toml [sync]` section and install a per-repo LaunchAgent via
+`lib/sync/deploy/macos/install` (macOS; kit board ID-289) so it runs
+unattended:
+
+```toml
+[sync]
+apps = "reminders,notion"
+mode = "cron"
+interval_secs = 3600   # optional; default 3600 (hourly)
+```
+
+```
+bash lib/sync/deploy/macos/install --repo <this repo>            # dry-run
+bash lib/sync/deploy/macos/install --repo <this repo> --apply     # loads it
+```
+
+The installed job re-checks `mode` on every scheduled run, so flipping it
+back to `"manual"` makes the next run skip cleanly rather than keep syncing.
+See `lib/sync/deploy/macos/README.md` for the gate (`mode` must be exactly
+`cron`, refused otherwise), the service graph, log shape, and BTM/TCC
+details.
+
 ### Bootstrap per app
 
 - **Reminders**: list auto-created on first run.

--- a/lib/sync/deploy/macos/README.md
+++ b/lib/sync/deploy/macos/README.md
@@ -1,0 +1,142 @@
+# board-sync-cron: scheduled `board sync` (macOS LaunchAgent)
+
+Kit board ID-289: `sync.mode` was declared `[reserved]` (`manual` | `cron`,
+scheduled runs not built yet). This wires the `cron` value to a real,
+per-repo unattended run so hub-and-spoke sync doesn't depend on someone
+remembering to run `board sync` by hand.
+
+```
+bash lib/sync/deploy/macos/install --repo <path>              # dry-run: prints the plan
+bash lib/sync/deploy/macos/install --repo <path> --apply       # renders + loads the LaunchAgent
+launchctl kickstart -k gui/$(id -u)/board-sync-<slug>          # run now
+tail -f ~/Library/Logs/dwarves-kit/board-sync-<slug>.log       # watch a run
+```
+
+`<slug>` is the target repo's `BACKLOG.md` PHYSICAL absolute path (`pwd -P`,
+symlinks resolved) with every non-alphanumeric run collapsed to a single `-`
+(the same slugging `backlog_sync.py`'s `board_state_dir()` uses for its
+state-cache dir, so the label and the state dir are recognizably the same
+identity). `install` refuses to overwrite an existing plist whose baked-in
+backlog path differs from the one it's about to render -- a same-label
+collision from two differently-laid-out repos is refused, not silently taken
+over. Login Items caveat: every per-repo install shares the same
+`board-sync-cron` script name, so with 2+ repos on `mode = "cron"`, System
+Settings -> Login Items shows multiple identically-named rows; use
+`launchctl print gui/$(id -u)/board-sync-<slug>` to tell them apart.
+
+## Why per-repo, not a kit-weekly job
+
+`deploy/macos/` (kit root) is ADR-0034 decision 9's ONE weekly scheduler,
+which explicitly REJECTED a plist-per-job scheme ("N daemons, N runbooks, the
+fragmentation Han flagged") in favor of one LaunchAgent walking a declarative
+`jobs.txt`. That rejection targeted fragmentation WITHIN one shared,
+kit-owned jobs list, N housekeeping tasks (session-intel, kit-retro,
+prose-rag-index) all resolved relative to the kit repo itself, competing for
+one dispatcher. This is a different shape: one self-contained, self-owned
+LaunchAgent PER OPTED-IN CONSUMER REPO, not N jobs fragmenting one shared
+list. `board sync` is inherently per-CONSUMER-REPO (a different `BACKLOG.md`,
+a different set of `[sync]` apps, potentially a different cadence per repo),
+and the kit repo's own `jobs.txt` is shared across every adopter of this
+kit, so it cannot carry one operator's repo paths without breaking
+genericity for everyone else who installs the kit. Each adopted repo
+therefore gets its own LaunchAgent, installed from within that repo, exactly
+the "consumer instantiates the template" split SPEC-126 already established
+for kit-weekly.
+
+## Gate: `sync.mode` must be `cron`
+
+`install` reads `.kit.toml [sync] mode` for the target repo via the one TOML
+resolver (`kit_config_get`, same as `board.sh cmd_sync`) and refuses to
+render or load anything unless it is exactly `cron`:
+
+| `sync.mode` value | Result |
+|---|---|
+| unset / `manual` (default) | refuses, tells you to set `mode = "cron"` |
+| `cron` | proceeds (also requires `[sync] apps` to be non-empty) |
+| anything else (typo, stray value) | refuses, names the bad value |
+
+This is deliberate: a launchd job silently never getting installed because
+`mode` was misspelled would be a much worse failure than a loud, immediate
+refusal at install time.
+
+**`mode` is read live in TWO different places, for two different questions:**
+`install` reads it ONCE, at install time, to decide whether to LOAD the
+LaunchAgent at all -- editing `.kit.toml` afterward does not retroactively
+unload an already-installed job (`launchctl bootout`, below, is the only
+off-switch for that). The installed **launcher** (`board-sync-cron`) also
+re-reads the same key on EVERY scheduled run, so a repo that later flips
+`mode` back to `"manual"` gets its next scheduled run skip cleanly (exit 0,
+logged) instead of silently syncing forever against a config that says it
+shouldn't. Net effect: to stop scheduled syncing, either flip `mode` back to
+`manual` (job stays loaded but goes inert) or fully `launchctl bootout` it
+(job stops existing); both are documented, self-service, no re-install
+needed for the former.
+
+## Service graph
+
+```
+board-sync-<slug>.plist -> lib/sync/deploy/macos/board-sync-cron <backlog-path>
+                            -> bin/board sync --backlog-file <backlog-path>
+                               -> lib/board/board.sh cmd_sync
+                                  -> lib/sync/backlog_sync.py (per-app three-way merge)
+```
+
+`board-sync-cron` is generic and kit-owned (git-tracked, never templated);
+only the plist itself carries per-repo values (`__KIT__`, `__BACKLOG__`,
+`__LABEL__`, `__INTERVAL__`, `__HOME__`), rendered once at install time and
+never hand-edited afterward (anti-drift: edit the `.tmpl`, re-run
+`install --apply`; a custom `--interval-secs` given at a previous install is
+NOT remembered by the template -- put it in `[sync] interval_secs` in the
+repo's own `.kit.toml` if it should survive a re-render, see Cadence below).
+
+**Log shape.** Every run writes two timestamped lines to
+`~/Library/Logs/dwarves-kit/board-sync-<slug>.log` (start with the backlog
+path, end with the exit code), so a failed scheduled run is identifiable by
+run even though the file accumulates across every run (no rotation is
+shipped; `newsyslog`/`logrotate` it yourself if it grows too large for your
+taste).
+
+**Cadence.** `install` computes `StartInterval` (seconds) from, in order:
+the `--interval-secs N` flag, else `[sync] interval_secs` in the repo's
+`.kit.toml`, else `3600` (hourly). `StartInterval` (not
+`StartCalendarInterval`, which kit-weekly uses for its fixed Monday-09:00
+slot) is the right launchd key for a fixed-cadence, drift-tolerant job like
+this one.
+
+**Consumer env (optional).** launchd gives jobs a bare env. If
+`~/.config/board-sync-cron/env` exists, the launcher sources it before
+running (e.g. a per-machine `MULTICA_TOKEN` override), never committed to
+the kit repo.
+
+**Consumer bridge (optional).** If an executable exists at
+`~/.config/board-sync-cron/bridge`, the launcher runs it best-effort AFTER
+every sync attempt (success or failure), passing `<exit-code> <backlog-path>`
+as argv -- a liveness heartbeat, notification, or anything tenant-side. A
+bridge failure never fails the run. The kit ships NO bridge (no monitoring
+endpoint, no secret): symmetric with kit-weekly's own
+`~/.config/kit-weekly/bridge`.
+
+BTM rules honored: `ProgramArguments[0]` is `board-sync-cron`'s own absolute
+path (never `/bin/sh`), the launcher has no `.sh` extension, and its shebang
+is `#!/bin/bash` (Apple-signed) rather than `env bash` -- the reminders spoke
+drives Automation/Reminders via `osascript`, and TCC keys that grant to the
+resolved interpreter binary, so a brew-upgraded `env bash` would silently
+lose the grant on the next `brew upgrade bash`.
+
+## Monitoring (follow-up, out of this repo)
+
+This ships the schedule PLUS the seam a monitor needs: the per-run log
+lines (start/end/rc) for a log-mtime-freshness check, and the consumer
+bridge hook above for a real success-keyed heartbeat -- the same seam
+kit-weekly exposes via its own bridge. Per the job-monitoring-onboarding
+convention (a scheduled job isn't "done" until it's monitored), actually
+WIRING that up (an ops-toolkit `vps-mon` probe or bridge script for
+`board-sync-<slug>`) is a separate follow-up in
+`ops-toolkit/tools/vps-mon/`, not part of this kit repo.
+
+## Uninstall
+
+```
+launchctl bootout gui/$(id -u)/board-sync-<slug>
+rm ~/Library/LaunchAgents/board-sync-<slug>.plist
+```

--- a/lib/sync/deploy/macos/board-sync-cron
+++ b/lib/sync/deploy/macos/board-sync-cron
@@ -1,0 +1,72 @@
+#!/bin/bash
+# board-sync-cron: launchd-safe `board sync` runner for ONE repo (kit board
+# ID-289, sync.mode = cron). Generic + kit-owned: the per-repo LaunchAgent
+# plist (rendered by lib/sync/deploy/macos/install) passes the target repo's
+# BACKLOG.md path as argv[1], so this script never needs per-repo templating
+# and stays byte-identical across every consumer repo's installed job.
+#
+# BTM/TCC note: shebang is #!/bin/bash (Apple-signed), not `env bash` -- the
+# reminders spoke drives Automation/Reminders via osascript, and TCC keys that
+# grant to the resolved interpreter binary. A brew-upgraded `env bash` would
+# silently lose the grant on the next `brew upgrade bash` (the fleet-wide
+# precedent this mirrors: ops-toolkit CLAUDE.md's plist-authoring rule 3).
+# Deliberately NOT `set -e`: a failed sync should log and exit nonzero for
+# launchd to see, not blow up mid-cleanup.
+set -uo pipefail
+
+BACKLOG="${1:?board-sync-cron: missing backlog path argv[1]}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT="$(cd "$HERE/../../../.." && pwd)"
+
+# launchd gives a bare PATH (/usr/bin:/bin:...); board sync shells out to
+# consumer CLIs (op, ntn, ssh), so widen it the same way kit-weekly does.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+# Optional consumer env (launchd gives a bare env; settings.json env only
+# exists inside Claude Code sessions). Per-machine secrets/paths (e.g. a
+# MULTICA_TOKEN override) live here, never in the kit repo.
+CONSUMER_ENV="$HOME/.config/board-sync-cron/env"
+# shellcheck disable=SC1090
+[ -f "$CONSUMER_ENV" ] && . "$CONSUMER_ENV"
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+
+# Live re-check of sync.mode (advisor review finding, 2026-07-18): the
+# install-time gate only decides whether this LaunchAgent gets LOADED;
+# without a re-check here, a repo that later flips `mode` back to "manual"
+# in .kit.toml would keep syncing forever on the still-loaded job -- the
+# same silent config/host-state contradiction the install-time gate exists
+# to prevent, just in the reverse direction. The fix is cheap: re-resolve
+# the SAME key the SAME way on every run and skip (exit 0, not a failure)
+# the moment the repo no longer opts in.
+# mirrors board.sh's own _repo_root_for exactly (git toplevel of the
+# backlog's dir, else that dir itself), so this agrees with cmd_sync's own
+# KIT_PROJECT_ROOT resolution bit-for-bit.
+_backlog_dir="$(cd "$(dirname "$BACKLOG")" && pwd)"
+REPO_ROOT="$(git -C "$_backlog_dir" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$_backlog_dir")"
+# shellcheck disable=SC1091
+. "$KIT/lib/config/kit-config.sh"
+mode="$(KIT_PROJECT_ROOT="$REPO_ROOT" kit_config_get sync.mode "manual")"
+if [ "$mode" != "cron" ]; then
+  echo "[$(ts)] board-sync-cron: sync.mode='$mode' (no longer cron) for" \
+       "$REPO_ROOT, skipping this run. To stop this job for good:" \
+       "launchctl bootout gui/\$(id -u)/<label> (see lib/sync/deploy/macos/README.md)"
+  exit 0
+fi
+
+echo "[$(ts)] board-sync-cron: start backlog=$BACKLOG"
+bash "$KIT/bin/board" sync --backlog-file "$BACKLOG"
+rc=$?
+echo "[$(ts)] board-sync-cron: end rc=$rc"
+
+# Optional consumer bridge (liveness ping, notification, anything
+# tenant-side), run best-effort after the sync attempt regardless of rc so a
+# monitoring hook always sees a heartbeat. The kit ships NO bridge: secrets
+# and monitoring endpoints (e.g. ops-toolkit's vps-mon) are consumer config,
+# symmetric with kit-weekly's own `~/.config/kit-weekly/bridge`.
+BRIDGE="$HOME/.config/board-sync-cron/bridge"
+if [ -x "$BRIDGE" ]; then
+  "$BRIDGE" "$rc" "$BACKLOG" || echo "[$(ts)] board-sync-cron: bridge failed (non-fatal)"
+fi
+
+exit "$rc"

--- a/lib/sync/deploy/macos/board-sync-cron.plist.tmpl
+++ b/lib/sync/deploy/macos/board-sync-cron.plist.tmpl
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  board-sync-cron: per-repo scheduled `board sync` (kit board ID-289,
+  sync.mode = cron). One LaunchAgent per adopted repo that has explicitly
+  opted in via `.kit.toml [sync] mode = "cron"`; rendered by
+  lib/sync/deploy/macos/install, never hand-edited.
+
+  TEMPLATE: __HOME__, __KIT__, __BACKLOG__, __LABEL__, __INTERVAL__ are
+  rendered by lib/sync/deploy/macos/install (launchd does not expand env vars
+  in ProgramArguments). BTM rule: ProgramArguments[0] is the bare-name
+  board-sync-cron launcher itself (no .sh, no /bin/sh wrapper).
+
+  Install:  bash lib/sync/deploy/macos/install --repo <this repo> --apply
+  Status:   launchctl print gui/$(id -u)/__LABEL__
+  Run now:  launchctl kickstart -k gui/$(id -u)/__LABEL__
+  Unload:   launchctl bootout gui/$(id -u)/__LABEL__
+  Anti-drift: edit this template in the kit then re-run install --apply;
+  never hand-edit the installed copy.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>__LABEL__</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__KIT__/lib/sync/deploy/macos/board-sync-cron</string>
+    <string>__BACKLOG__</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>__INTERVAL__</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/dwarves-kit/__LABEL__.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/dwarves-kit/__LABEL__.log</string>
+</dict>
+</plist>

--- a/lib/sync/deploy/macos/install
+++ b/lib/sync/deploy/macos/install
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# lib/sync/deploy/macos/install -- per-repo scheduled `board sync` LaunchAgent
+# (kit board ID-289: sync.mode = cron). Gated on the target repo's own
+# `.kit.toml [sync] mode = "cron"` (default "manual" refuses cleanly, so a
+# launchd job is never installed for a repo that hasn't explicitly opted in).
+#
+# Consumer-instantiated (SPEC-126 split, same shape as deploy/macos/install
+# for kit-weekly): the kit owns the template + launcher + this installer, the
+# CONSUMER runs it FROM their own adopted repo to render + load their own
+# LaunchAgent. One repo, one plist -- unlike kit-weekly's single kit-wide
+# scheduler (ADR-0034 decision 9's rejection of "plist-per-job" targeted
+# fragmentation WITHIN one shared, kit-owned jobs list), sync jobs are
+# inherently per-CONSUMER-REPO (a different BACKLOG.md, a different `[sync]`
+# config, possibly a different cadence), and the kit repo's own jobs.txt is
+# shared across every adopter of this kit, so it cannot carry one operator's
+# repo paths without breaking genericity for everyone else who installs the
+# kit. Each opted-in repo therefore gets its own self-contained, self-owned
+# LaunchAgent.
+#
+# Repo-side by design: this script only RENDERS + (with --apply) LOADS a
+# LaunchAgent on THIS host. It never runs unattended itself and never phones
+# home. Default is --dry-run (prints the rendered plist + the exact
+# `launchctl` command); pass --apply to actually write the plist and
+# bootstrap it.
+#
+# `sync.mode` is read ONCE, here, at install time, to decide whether to load
+# the LaunchAgent at all. It does NOT stay a live switch for install itself:
+# re-running install after flipping `mode` back to "manual" will (correctly)
+# refuse to re-install, but does not retroactively unload an already-running
+# job -- use `launchctl bootout` for that (see README). The installed
+# LAUNCHER, however, re-checks `sync.mode` itself on every scheduled run and
+# skips cleanly the moment a repo un-opts-in, so an already-loaded job never
+# silently keeps syncing against a config that says it shouldn't.
+#
+# Usage:
+#   bash lib/sync/deploy/macos/install [--repo <path>] [--interval-secs N] [--apply]
+#
+#   --repo <path>       repo to install for (default: git toplevel of $PWD)
+#   --interval-secs N   StartInterval seconds between runs (default: the
+#                        repo's `[sync] interval_secs`, else 3600)
+#   --apply             actually render + launchctl bootstrap (default: dry-run)
+#
+# Status:   launchctl print gui/$(id -u)/board-sync-<slug>
+# Run now:  launchctl kickstart -k gui/$(id -u)/board-sync-<slug>
+# Unload:   launchctl bootout gui/$(id -u)/board-sync-<slug> && rm ~/Library/LaunchAgents/board-sync-<slug>.plist
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT="$(cd "$HERE/../../../.." && pwd)"
+
+REPO="" INTERVAL="" APPLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="${2:?--repo needs a path}"; shift 2 ;;
+    --interval-secs) INTERVAL="${2:?--interval-secs needs a value}"; shift 2 ;;
+    --apply) APPLY=1; shift ;;
+    --dry-run) APPLY=0; shift ;;
+    -h|--help) sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "install: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO="${REPO:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+[ -d "$REPO" ] || { echo "install: no such repo dir: $REPO" >&2; exit 2; }
+# -P (physical path, symlinks resolved) so the slug below agrees bit-for-bit
+# with backlog_sync.py's board_state_dir(), which slugs Python's resolve()
+# (also physical) -- a symlinked checkout (e.g. macOS /tmp -> /private/tmp)
+# would otherwise silently slug a DIFFERENT identity than the sync state dir.
+REPO="$(cd "$REPO" && pwd -P)"
+
+# shellcheck source=../../../config/kit-config.sh
+. "$KIT/lib/config/kit-config.sh"
+export KIT_PROJECT_ROOT="$REPO"
+
+# The whole point of sync.mode: a launchd job must never get installed for a
+# repo that hasn't explicitly opted in. Any value other than the two declared
+# ones is a clean, closed error, never a silent fallthrough to either
+# behavior (this is the negative control: a typo'd mode fails loudly here,
+# not three hops downstream in a scheduled log nobody reads).
+mode="$(kit_config_get sync.mode "manual")"
+case "$mode" in
+  cron) : ;;
+  manual)
+    echo "install: sync.mode is 'manual' in $REPO/.kit.toml (default); set:" >&2
+    printf '  [sync]\n  mode = "cron"\n' >&2
+    exit 2
+    ;;
+  *)
+    echo "install: sync.mode='$mode' in $REPO/.kit.toml is not a recognized value (expected manual|cron)" >&2
+    exit 2
+    ;;
+esac
+
+apps="$(kit_config_get sync.apps "")"
+[ -n "$apps" ] || apps="$(kit_config_get sync.surfaces "")"
+[ -n "$apps" ] || apps="$(kit_config_get sync.sources "")"
+if [ -z "$apps" ]; then
+  echo "install: sync.mode=cron but no [sync] apps configured in $REPO/.kit.toml" >&2
+  printf '  add e.g.:\n  [sync]\n  apps = "reminders"\n' >&2
+  exit 2
+fi
+
+backlog="$REPO/_meta/BACKLOG.md"
+[ -f "$backlog" ] || backlog="$REPO/BACKLOG.md"
+[ -f "$backlog" ] || {
+  echo "install: no BACKLOG.md found under $REPO (checked _meta/ and root)" >&2
+  exit 2
+}
+
+INTERVAL="${INTERVAL:-$(kit_config_get sync.interval_secs "3600")}"
+case "$INTERVAL" in
+  ''|*[!0-9]*)
+    echo "install: --interval-secs (or sync.interval_secs) must be a positive integer, got '$INTERVAL'" >&2
+    exit 2
+    ;;
+esac
+
+# Slug mirrors backlog_sync.py's board_state_dir() slugging (same identity
+# rule, now over the same physical-path convention -- see the -P note above),
+# so the LaunchAgent label is stable and recognizably the same identity as
+# the sync state dir.
+slug="$(printf '%s' "$backlog" | sed -E 's/[^a-zA-Z0-9]+/-/g; s/^-+//; s/-+$//')"
+label="board-sync-$slug"
+plist="$HOME/Library/LaunchAgents/$label.plist"
+
+# Label-collision guard: the slug collapses every non-alphanumeric run to a
+# single '-', so two differently-laid-out repos CAN produce the same label.
+# Without this check, a second repo's --apply would silently launchctl-bootout
+# and replace the first repo's job (review finding, 2026-07-18). Detect it by
+# reading back the backlog path already baked into any existing plist for
+# this label (the ProgramArguments' one '<string>...BACKLOG.md</string>').
+if [ -f "$plist" ]; then
+  existing_backlog="$(grep -oE '<string>[^<]+\.md</string>' "$plist" 2>/dev/null \
+    | head -1 | sed -E 's#</?string>##g')"
+  if [ -n "$existing_backlog" ] && [ "$existing_backlog" != "$backlog" ]; then
+    echo "install: label '$label' is already installed for a DIFFERENT repo's backlog:" >&2
+    echo "  existing: $existing_backlog" >&2
+    echo "  this run: $backlog" >&2
+    echo "  refusing to silently take over; uninstall the existing job first if this is intended." >&2
+    exit 2
+  fi
+fi
+
+# Portable mktemp: BSD's "-t NAME" form (no dir needed) is not accepted by
+# GNU mktemp ("too few X's"), so the explicit-template form works on both.
+rendered="$(mktemp "${TMPDIR:-/tmp}/board-sync-cron-plist.XXXXXX")"
+trap 'rm -f "$rendered"' EXIT
+
+sed -e "s#__HOME__#$HOME#g" -e "s#__KIT__#$KIT#g" -e "s#__BACKLOG__#$backlog#g" \
+    -e "s#__LABEL__#$label#g" -e "s#__INTERVAL__#$INTERVAL#g" \
+    "$HERE/board-sync-cron.plist.tmpl" > "$rendered"
+
+if [ "$APPLY" -eq 0 ]; then
+  echo "dry-run: sync.mode=cron confirmed for $REPO (apps=$apps)"
+  echo "dry-run: would write $plist:"
+  echo "---"
+  cat "$rendered"
+  echo "---"
+  echo "dry-run: would then run:"
+  echo "  mkdir -p \"$HOME/Library/LaunchAgents\" \"$HOME/Library/Logs/dwarves-kit\""
+  echo "  launchctl bootout \"gui/\$(id -u)/$label\" 2>/dev/null || true"
+  echo "  launchctl bootstrap \"gui/\$(id -u)\" \"$plist\""
+  echo "re-run with --apply on the target host to actually install."
+  exit 0
+fi
+
+mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs/dwarves-kit"
+cp "$rendered" "$plist"
+launchctl bootout "gui/$(id -u)/$label" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$plist"
+# Best-effort confirmation only: bootstrap above already succeeded (or `set
+# -e` would have stopped the script), so a failed confirmation is a WARNING,
+# never a reason to report install failure after the job is actually loaded.
+if launchctl print "gui/$(id -u)/$label" 2>/dev/null | grep -q "$label"; then
+  echo "[ok] $label installed (every ${INTERVAL}s; kickstart to run now)"
+else
+  echo "[warn] $label bootstrapped but could not be confirmed via launchctl print; check:" >&2
+  echo "       launchctl print gui/\$(id -u)/$label" >&2
+fi

--- a/tests/test-sync-cron-install.sh
+++ b/tests/test-sync-cron-install.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# lib/sync/deploy/macos/install tests (kit board ID-289: sync.mode = cron).
+# Covers the sync.mode gate (manual refuses, cron proceeds, a bad value is
+# rejected cleanly -- the negative control), the apps-not-configured guard,
+# both board conventions, --interval-secs validation, dry-run vs --apply (a
+# stubbed launchctl proves dry-run never mutates and --apply calls it with
+# the right verbs/args), and label/slug uniqueness across two repos.
+set -uo pipefail
+KIT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL="$KIT_ROOT/lib/sync/deploy/macos/install"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  PASS %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+check(){ if eval "$2"; then ok "$1"; else bad "$1 -- got: $3"; fi; }
+
+d="$(mktemp -d)"; trap 'rm -rf "$d"' EXIT
+
+# fake $HOME so the script never touches the real ~/Library, and a fake
+# kit-root kit.toml so kit_config_get's second precedence level is inert.
+export HOME="$d/home"; mkdir -p "$HOME"
+export KIT_CONFIG_ROOT="$d/kitroot"; mkdir -p "$KIT_CONFIG_ROOT"
+printf '[sync]\nmode = "manual"\n' > "$KIT_CONFIG_ROOT/kit.toml"
+
+# a stub launchctl that logs every invocation, so dry-run-never-mutates and
+# apply-calls-it-correctly are both directly provable (not inferred).
+mkdir -p "$d/bin"
+LAUNCHCTL_LOG="$d/launchctl.log"
+cat > "$d/bin/launchctl" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$LAUNCHCTL_LOG"
+# mimic real launchctl print: echo something containing the label so the
+# install script's own best-effort confirmation grep has something to match.
+[ "\$1" = "print" ] && printf 'service = %s\n' "\${2##*/}"
+exit 0
+STUB
+chmod +x "$d/bin/launchctl"
+export PATH="$d/bin:$PATH"
+
+mk_repo() {
+  local dir="$1" convention="$2"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  if [ "$convention" = "meta" ]; then
+    mkdir -p "$dir/_meta"; touch "$dir/_meta/BACKLOG.md"
+  else
+    touch "$dir/BACKLOG.md"
+  fi
+}
+
+# --- repo A: no [sync] section at all (mode defaults to manual) -----------
+mk_repo "$d/repoA" meta
+out="$(bash "$INSTALL" --repo "$d/repoA" 2>&1)"; rc=$?
+check "unset mode (default manual) refuses, exit 2" '[ "$rc" -eq 2 ]' "rc=$rc"
+check "unset mode: message points at mode = \"cron\"" \
+  '[[ "$out" == *'"'"'mode = "cron"'"'"'* ]]' "$out"
+check "unset mode: no launchctl.log written (nothing attempted)" \
+  '[ ! -f "$LAUNCHCTL_LOG" ]' "$(cat "$LAUNCHCTL_LOG" 2>/dev/null)"
+
+# --- repo B: mode explicitly "manual" ---------------------------------------
+mk_repo "$d/repoB" meta
+printf '[sync]\napps = "reminders"\nmode = "manual"\n' > "$d/repoB/.kit.toml"
+out="$(bash "$INSTALL" --repo "$d/repoB" 2>&1)"; rc=$?
+check "explicit mode=manual refuses, exit 2" '[ "$rc" -eq 2 ]' "rc=$rc"
+
+# --- repo C: NEGATIVE CONTROL -- a bad mode value is rejected cleanly ------
+mk_repo "$d/repoC" meta
+printf '[sync]\napps = "reminders"\nmode = "biweekly"\n' > "$d/repoC/.kit.toml"
+out="$(bash "$INSTALL" --repo "$d/repoC" 2>&1)"; rc=$?
+check "bad mode value ('biweekly') rejected, exit 2 (not a crash)" '[ "$rc" -eq 2 ]' "rc=$rc"
+check "bad mode value: message names the offending value" \
+  '[[ "$out" == *"mode='"'"'biweekly'"'"'"* ]]' "$out"
+check "bad mode value: no launchctl invocation" \
+  '[ ! -s "$LAUNCHCTL_LOG" ]' "$(cat "$LAUNCHCTL_LOG" 2>/dev/null)"
+
+# --- repo D: mode=cron but no apps configured ------------------------------
+mk_repo "$d/repoD" meta
+printf '[sync]\nmode = "cron"\n' > "$d/repoD/.kit.toml"
+out="$(bash "$INSTALL" --repo "$d/repoD" 2>&1)"; rc=$?
+check "mode=cron with no apps refuses, exit 2" '[ "$rc" -eq 2 ]' "rc=$rc"
+check "mode=cron/no-apps: message names the missing apps key" \
+  '[[ "$out" == *"apps"* ]]' "$out"
+
+# --- repo E: mode=cron + apps, DRY-RUN (default) ---------------------------
+mk_repo "$d/repoE" meta
+printf '[sync]\napps = "reminders,notion"\nmode = "cron"\n' > "$d/repoE/.kit.toml"
+out="$(bash "$INSTALL" --repo "$d/repoE" 2>&1)"; rc=$?
+check "mode=cron + apps, dry-run exits 0" '[ "$rc" -eq 0 ]' "rc=$rc"
+check "dry-run: prints the rendered ProgramArguments (backlog path)" \
+  '[[ "$out" == *"$d/repoE/_meta/BACKLOG.md"* ]]' "$out"
+check "dry-run: prints the label" \
+  '[[ "$out" == *"board-sync-"* ]]' "$out"
+check "dry-run: prints the exact launchctl bootstrap command to run" \
+  '[[ "$out" == *"launchctl bootstrap"* ]]' "$out"
+check "dry-run NEVER calls the real launchctl (no mutation)" \
+  '[ ! -s "$LAUNCHCTL_LOG" ]' "$(cat "$LAUNCHCTL_LOG" 2>/dev/null)"
+check "dry-run: no plist written to \$HOME/Library/LaunchAgents" \
+  '[ ! -d "$HOME/Library/LaunchAgents" ] || [ -z "$(ls -A "$HOME/Library/LaunchAgents" 2>/dev/null)" ]' \
+  "$(ls "$HOME/Library/LaunchAgents" 2>/dev/null)"
+
+# --- repo E again, root-level BACKLOG.md convention, --interval-secs -------
+mk_repo "$d/repoF" root
+printf '[sync]\napps = "hermes"\nmode = "cron"\n' > "$d/repoF/.kit.toml"
+out="$(bash "$INSTALL" --repo "$d/repoF" --interval-secs 900 2>&1)"; rc=$?
+check "root-level BACKLOG.md convention resolves" \
+  '[[ "$rc" -eq 0 && "$out" == *"$d/repoF/BACKLOG.md"* ]]' "rc=$rc $out"
+check "custom --interval-secs is rendered into the plist" \
+  '[[ "$out" == *"<integer>900</integer>"* ]]' "$out"
+
+# --- --interval-secs validation --------------------------------------------
+out="$(bash "$INSTALL" --repo "$d/repoE" --interval-secs abc 2>&1)"; rc=$?
+check "non-numeric --interval-secs rejected cleanly, exit 2" '[ "$rc" -eq 2 ]' "rc=$rc"
+
+# --- repo E, APPLY: stubbed launchctl proves the real mutation path --------
+out="$(bash "$INSTALL" --repo "$d/repoE" --apply 2>&1)"; rc=$?
+check "mode=cron + apps, --apply exits 0" '[ "$rc" -eq 0 ]' "rc=$rc"
+check "--apply writes a plist under \$HOME/Library/LaunchAgents" \
+  '[ -n "$(ls "$HOME/Library/LaunchAgents"/board-sync-*.plist 2>/dev/null)" ]' \
+  "$(ls "$HOME/Library/LaunchAgents" 2>/dev/null)"
+plist_written="$(ls "$HOME/Library/LaunchAgents"/board-sync-*.plist 2>/dev/null | head -1)"
+check "written plist references the repo's own board-sync-cron launcher + backlog path" \
+  '[[ -f "$plist_written" && "$(cat "$plist_written")" == *"lib/sync/deploy/macos/board-sync-cron"* && "$(cat "$plist_written")" == *"$d/repoE/_meta/BACKLOG.md"* ]]' \
+  "$plist_written"
+check "--apply invoked launchctl bootout then bootstrap" \
+  '[ "$(grep -c "^bootout\|^bootstrap" "$LAUNCHCTL_LOG")" -ge 2 ]' "$(cat "$LAUNCHCTL_LOG")"
+
+# --- label uniqueness across two differently-named repos ------------------
+mk_repo "$d/repoG" meta
+printf '[sync]\napps = "reminders"\nmode = "cron"\n' > "$d/repoG/.kit.toml"
+out_e="$(bash "$INSTALL" --repo "$d/repoE" 2>&1)"
+out_g="$(bash "$INSTALL" --repo "$d/repoG" 2>&1)"
+label_e="$(printf '%s\n' "$out_e" | grep -oE 'board-sync-[a-zA-Z0-9-]+' | head -1)"
+label_g="$(printf '%s\n' "$out_g" | grep -oE 'board-sync-[a-zA-Z0-9-]+' | head -1)"
+check "two different repos render two different LaunchAgent labels" \
+  '[ -n "$label_e" ] && [ -n "$label_g" ] && [ "$label_e" != "$label_g" ]' \
+  "e=$label_e g=$label_g"
+
+# --- sync.interval_secs config default (no --interval-secs flag) ----------
+mk_repo "$d/repoH" meta
+printf '[sync]\napps = "reminders"\nmode = "cron"\ninterval_secs = 1800\n' > "$d/repoH/.kit.toml"
+out="$(bash "$INSTALL" --repo "$d/repoH" 2>&1)"; rc=$?
+check "sync.interval_secs from .kit.toml is used when --interval-secs is omitted" \
+  '[ "$rc" -eq 0 ] && [[ "$out" == *"<integer>1800</integer>"* ]]' "$out"
+out="$(bash "$INSTALL" --repo "$d/repoH" --interval-secs 60 2>&1)"; rc=$?
+check "--interval-secs flag overrides sync.interval_secs" \
+  '[ "$rc" -eq 0 ] && [[ "$out" == *"<integer>60</integer>"* ]]' "$out"
+
+# --- label-collision guard: two repos whose slugs collapse to the SAME
+# label (mktemp -d, . and - both collapse to one '-') must not silently
+# clobber each other's installed job. ---------------------------------------
+mk_repo "$d/collide-one" meta
+mk_repo "$d/collide.one" meta
+printf '[sync]\napps = "reminders"\nmode = "cron"\n' > "$d/collide-one/.kit.toml"
+printf '[sync]\napps = "reminders"\nmode = "cron"\n' > "$d/collide.one/.kit.toml"
+slug_a="$(printf '%s' "$d/collide-one/_meta/BACKLOG.md" | sed -E 's/[^a-zA-Z0-9]+/-/g; s/^-+//; s/-+$//')"
+slug_b="$(printf '%s' "$d/collide.one/_meta/BACKLOG.md" | sed -E 's/[^a-zA-Z0-9]+/-/g; s/^-+//; s/-+$//')"
+if [ "$slug_a" = "$slug_b" ]; then
+  bash "$INSTALL" --repo "$d/collide-one" --apply >/dev/null 2>&1
+  out="$(bash "$INSTALL" --repo "$d/collide.one" 2>&1)"; rc=$?
+  check "colliding slug from a DIFFERENT repo's backlog is refused, exit 2" \
+    '[ "$rc" -eq 2 ]' "rc=$rc $out"
+  check "collision message names both the existing and the new backlog path" \
+    '[[ "$out" == *"$d/collide-one/_meta/BACKLOG.md"* && "$out" == *"$d/collide.one/_meta/BACKLOG.md"* ]]' "$out"
+  out="$(bash "$INSTALL" --repo "$d/collide.one" --apply 2>&1)"; rc=$?
+  check "colliding slug also refused under --apply (never silently takes over)" \
+    '[ "$rc" -eq 2 ]' "rc=$rc $out"
+  out="$(bash "$INSTALL" --repo "$d/collide-one" 2>&1)"; rc=$?
+  check "re-installing the SAME repo over its own existing plist is fine (not a collision)" \
+    '[ "$rc" -eq 0 ]' "rc=$rc $out"
+else
+  bad "label-collision fixture assumption ('.' and '-' collapse identically) -- got: slug_a=$slug_a slug_b=$slug_b"
+fi
+
+printf '=== %d/%d passed ===\n' "$PASS" "$((PASS+FAIL))"
+[ "$FAIL" -eq 0 ]

--- a/tests/test-sync-cron-launcher.sh
+++ b/tests/test-sync-cron-launcher.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# lib/sync/deploy/macos/board-sync-cron tests (kit board ID-289). The
+# install-script tests (test-sync-cron-install.sh) cover the install-time
+# gate + render path; this covers the LAUNCHER itself: argv[1] required,
+# the LIVE sync.mode re-check (skips cleanly once a repo un-opts-in),
+# forwards to `bin/board sync --backlog-file <path>` unchanged, widens PATH,
+# timestamped start/end log lines, the optional consumer env file, and the
+# optional consumer bridge hook.
+set -uo pipefail
+KIT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LAUNCHER="$KIT_ROOT/lib/sync/deploy/macos/board-sync-cron"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  PASS %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+check(){ if eval "$2"; then ok "$1"; else bad "$1 -- got: $3"; fi; }
+
+d="$(mktemp -d)"; trap 'rm -rf "$d"' EXIT
+
+# stub bin/board (the launcher execs "$KIT/bin/board", resolved 4 dirs up
+# from its own location -- exercise that path resolution for real by copying
+# the launcher + the REAL kit-config.sh it now sources (for the live
+# sync.mode re-check) into a throwaway kit-shaped tree with a fake bin/board).
+FAKE_KIT="$d/fake-kit"
+mkdir -p "$FAKE_KIT/lib/sync/deploy/macos" "$FAKE_KIT/lib/config" "$FAKE_KIT/bin"
+cp "$LAUNCHER" "$FAKE_KIT/lib/sync/deploy/macos/board-sync-cron"
+chmod +x "$FAKE_KIT/lib/sync/deploy/macos/board-sync-cron"
+cp "$KIT_ROOT/lib/config/kit-config.sh" "$FAKE_KIT/lib/config/kit-config.sh"
+BOARD_LOG="$d/board.log"
+cat > "$FAKE_KIT/bin/board" <<STUB
+#!/usr/bin/env bash
+printf 'ARGV:%s\n' "\$*" > "$BOARD_LOG"
+printf 'PATH:%s\n' "\$PATH" >> "$BOARD_LOG"
+[ -n "\${CONSUMER_MARKER:-}" ] && printf 'CONSUMER_MARKER:%s\n' "\$CONSUMER_MARKER" >> "$BOARD_LOG"
+exit 0
+STUB
+chmod +x "$FAKE_KIT/bin/board"
+
+export HOME="$d/home"; mkdir -p "$HOME"
+export KIT_CONFIG_ROOT="$d/kitroot"; mkdir -p "$KIT_CONFIG_ROOT"
+printf '[sync]\nmode = "manual"\n' > "$KIT_CONFIG_ROOT/kit.toml"
+
+mk_repo() {
+  local dir="$1" mode="$2"
+  mkdir -p "$dir/_meta"
+  git -C "$dir" init -q
+  touch "$dir/_meta/BACKLOG.md"
+  if [ -n "$mode" ]; then
+    printf '[sync]\napps = "reminders"\nmode = "%s"\n' "$mode" > "$dir/.kit.toml"
+  fi
+}
+
+run() { bash "$FAKE_KIT/lib/sync/deploy/macos/board-sync-cron" "$1"; }
+
+# --- missing argv[1] ---------------------------------------------------
+out="$(bash "$FAKE_KIT/lib/sync/deploy/macos/board-sync-cron" 2>&1)"; rc=$?
+check "missing backlog argv[1] fails cleanly (not an unbound-var crash trace)" \
+  '[ "$rc" -ne 0 ] && [[ "$out" == *"missing backlog path"* ]]' "rc=$rc $out"
+
+# --- live sync.mode re-check: mode=cron proceeds to bin/board -------------
+mk_repo "$d/repoCron" cron
+rm -f "$BOARD_LOG"
+out="$(run "$d/repoCron/_meta/BACKLOG.md" 2>&1)"; rc=$?
+check "mode=cron: resolves KIT via BASH_SOURCE (4 dirs up) and execs the fake bin/board" \
+  '[ "$rc" -eq 0 ] && [ -f "$BOARD_LOG" ]' "rc=$rc"
+check "mode=cron: forwards argv as: sync --backlog-file <path>" \
+  '[[ "$(cat "$BOARD_LOG")" == *"ARGV:sync --backlog-file $d/repoCron/_meta/BACKLOG.md"* ]]' \
+  "$(cat "$BOARD_LOG" 2>/dev/null)"
+check "mode=cron: widens PATH with ~/.local/bin and /opt/homebrew/bin" \
+  '[[ "$(cat "$BOARD_LOG")" == *"$HOME/.local/bin"* && "$(cat "$BOARD_LOG")" == *"/opt/homebrew/bin"* ]]' \
+  "$(cat "$BOARD_LOG" 2>/dev/null)"
+check "mode=cron: prints a timestamped start line" \
+  '[[ "$out" == *"board-sync-cron: start backlog=$d/repoCron/_meta/BACKLOG.md"* ]]' "$out"
+check "mode=cron: prints a timestamped end line with rc" \
+  '[[ "$out" == *"board-sync-cron: end rc=0"* ]]' "$out"
+
+# --- live sync.mode re-check: mode=manual (or unset) skips cleanly --------
+mk_repo "$d/repoManual" manual
+rm -f "$BOARD_LOG"
+out="$(run "$d/repoManual/_meta/BACKLOG.md" 2>&1)"; rc=$?
+check "mode=manual: skips cleanly, exit 0" '[ "$rc" -eq 0 ]' "rc=$rc"
+check "mode=manual: does NOT invoke bin/board" '[ ! -f "$BOARD_LOG" ]' "$(cat "$BOARD_LOG" 2>/dev/null)"
+check "mode=manual: says why it skipped" '[[ "$out" == *"no longer cron"* ]]' "$out"
+
+mk_repo "$d/repoUnset" ""
+rm -f "$BOARD_LOG"
+out="$(run "$d/repoUnset/_meta/BACKLOG.md" 2>&1)"; rc=$?
+check "no .kit.toml (default manual): skips cleanly, exit 0, no board call" \
+  '[ "$rc" -eq 0 ] && [ ! -f "$BOARD_LOG" ]' "rc=$rc $(cat "$BOARD_LOG" 2>/dev/null)"
+
+# --- sources the optional consumer env file -----------------------------
+mkdir -p "$HOME/.config/board-sync-cron"
+printf 'export CONSUMER_MARKER=from-consumer-env\n' > "$HOME/.config/board-sync-cron/env"
+rm -f "$BOARD_LOG"
+run "$d/repoCron/_meta/BACKLOG.md" >/dev/null 2>&1
+check "sources ~/.config/board-sync-cron/env when present" \
+  '[[ "$(cat "$BOARD_LOG" 2>/dev/null)" == *"CONSUMER_MARKER:from-consumer-env"* ]]' \
+  "$(cat "$BOARD_LOG" 2>/dev/null)"
+rm -f "$HOME/.config/board-sync-cron/env"
+
+# --- no consumer env file: silent no-op, not an error ---------------------
+rm -f "$BOARD_LOG"
+out="$(run "$d/repoCron/_meta/BACKLOG.md" 2>&1)"; rc=$?
+check "absent consumer env file is a silent no-op (exit 0, no error text)" \
+  '[ "$rc" -eq 0 ] && [[ "$out" != *"No such file"* ]]' "rc=$rc $out"
+
+# --- optional consumer bridge hook: called with rc + backlog path ---------
+mkdir -p "$HOME/.config/board-sync-cron"
+BRIDGE_LOG="$d/bridge.log"
+cat > "$HOME/.config/board-sync-cron/bridge" <<STUB
+#!/usr/bin/env bash
+printf 'BRIDGE_ARGV:%s\n' "\$*" > "$BRIDGE_LOG"
+STUB
+chmod +x "$HOME/.config/board-sync-cron/bridge"
+run "$d/repoCron/_meta/BACKLOG.md" >/dev/null 2>&1
+check "executable bridge hook is invoked with rc + backlog path" \
+  '[[ "$(cat "$BRIDGE_LOG" 2>/dev/null)" == "BRIDGE_ARGV:0 $d/repoCron/_meta/BACKLOG.md" ]]' \
+  "$(cat "$BRIDGE_LOG" 2>/dev/null)"
+rm -f "$HOME/.config/board-sync-cron/bridge" "$BRIDGE_LOG"
+
+# --- no bridge hook: silent no-op ------------------------------------------
+out="$(run "$d/repoCron/_meta/BACKLOG.md" 2>&1)"; rc=$?
+check "absent bridge hook is a silent no-op (exit 0)" '[ "$rc" -eq 0 ]' "rc=$rc $out"
+
+printf '=== %d/%d passed ===\n' "$PASS" "$((PASS+FAIL))"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Wires kit board row ID-289: `[sync] mode` (previously `[reserved]`) now gates a real per-repo macOS LaunchAgent (`lib/sync/deploy/macos/install`) that runs `board sync` unattended. Only a repo whose own `.kit.toml` sets `mode = "cron"` gets a LaunchAgent installed; `manual`/unset/any other value refuses cleanly (exit 2, naming the bad value).
- The installed launcher (`board-sync-cron`) re-checks `sync.mode` live on every scheduled run, so flipping it back to `manual` makes the job go inert without a re-install; it also logs timestamped start/end lines and supports an optional consumer bridge hook, symmetric with the kit's existing `kit-weekly` scheduler.
- New `sync.interval_secs` config key sets cadence (default 3600s, `--interval-secs` overrides). `install` guards against LaunchAgent label collisions between differently-laid-out repos and resolves paths physically (`pwd -P`) so the label agrees with `backlog_sync.py`'s own state-dir slug under symlinked checkouts.
- Repo-side only, per the task constraint: no host was mutated by this build. `install` defaults to `--dry-run` (prints the exact plist + `launchctl` commands); `--apply` is the real activation path, left for the operator to run on their own Mac.
- Deliberately NOT folded into `deploy/macos/kit-weekly` (ADR-0034 decision 9's single shared scheduler): that scheduler is shared across every adopter of this kit and can't carry one operator's repo paths, whereas `board sync` is inherently per-consumer-repo. Reasoning is documented in `lib/sync/deploy/macos/README.md`.
- Both `kit:code-reviewer` (architecture lens, verdict: ship) and `kit:advisor` (fable, critique mode, 7 findings) reviewed the branch; all confirmed findings were applied (see `docs/verification/sync-cron-mode.md` for the disposition table).

## Test plan

- [x] `bash tests/test-sync-cron-install.sh` — 29/29 (mode gate incl. negative control for a bad `mode` value, apps-missing guard, both `BACKLOG.md` conventions, `--interval-secs` flag/config/default/invalid, dry-run-never-mutates via stubbed `launchctl`, `--apply` mutation path, label-collision guard, label uniqueness)
- [x] `bash tests/test-sync-cron-launcher.sh` — 14/14 (missing argv, live mode re-check skip/proceed, PATH widening, argv forwarding, timestamped log lines, consumer env, bridge hook)
- [x] `bash tests/test-sync.sh` — 60/60 (unchanged sync engine, no regression)
- [x] `bash tests/test-sync-dispatch.sh` — 5/5 (unchanged `cmd_sync` dispatch, no regression)
- [x] `bash tests/test-config-registry.sh` — 19/19 (no drift orphans from the new `sync.interval_secs` key or the `sync.mode` status flip)
- [x] `bash tests/test-meta.sh` — 698/698 (kit-wide structural suite, no regression)
- [x] `shellcheck -S warning` clean on both new scripts + both new test files
- [x] Live negative control performed on this branch: mutated the `sync.mode` case statement to accept a bad value, confirmed `tests/test-sync-cron-install.sh` dropped to 27/29 with exactly the two mode-gate assertions failing, then restored via `git checkout --` and confirmed back to 29/29. Recorded in `docs/verification/sync-cron-mode.md`.
