### PR TITLE
refactor(gate): rename verif-counts.sh to verify-counts.sh; spell out SDD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ read plane is **`stats`**: a stateless projection recomputed on demand from the 
 ledger, never a persisted second source of truth.
 
 Adoption is **layered, not all-or-nothing**. `install.sh` wires the essential spine
-unconditionally (the SDD ship discipline: safety-gate, ship-gate, spec-drift-guard,
+unconditionally (the spec-driven development (SDD) ship discipline: safety-gate, ship-gate, spec-drift-guard,
 secrets-guard, commit-format, anti-rationalization) and opt-in modules only when asked
 (`install.sh --with board,session,stats,...`), recording the enabled set in the consumer's
 `kit.toml [modules]` manifest, an install artifact that records the choice, never read at

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -295,7 +295,7 @@ If a component has been unused for 30 days (no contractor reports using it, no s
 
 ### AutoResearch optimization
 
-From the SDD handoff: the Karpathy loop can optimize kit components with a measurable metric. This applies to:
+From the spec-driven development (SDD) handoff: the Karpathy loop can optimize kit components with a measurable metric. This applies to:
 
 - **Command prompts**: The three-file contract (program.md = kit philosophy frozen, skill.md = command prompt modifiable, eval.py = LLM-as-judge scoring). Run 50 iterations overnight, keep the highest-scoring prompt variant. Applicable to /review, /spec-validate, /think.
 - **Hook patterns**: Anti-rationalization patterns can be optimized by running against a corpus of Claude outputs and measuring false positive / false negative rates.

--- a/docs/verification/COUNTS.md
+++ b/docs/verification/COUNTS.md
@@ -1,6 +1,6 @@
 # Verification suite counts (generated)
 
-> Numbers between the GEN markers are written by `lib/gate/verif-counts.sh` from the live
+> Numbers between the GEN markers are written by `lib/gate/verify-counts.sh` from the live
 > suites. Do NOT hand-edit them. To change a number, change the tests then re-run the
 > generator. A verification log links here instead of transcribing a count. This is the
 > single-source-numbers pattern borrowed from the codebase-tool-benchmark (the sibling
@@ -9,6 +9,6 @@
 <!-- BEGIN GEN:counts -->
 | Suite | Passing |
 |---|---|
-| meta (tests/test-meta.sh) | 368/368 |
-| hooks (tests/test-hooks.sh) | 164/164 |
+| meta (tests/test-meta.sh) | 715/715 |
+| hooks (tests/test-hooks.sh) | 487/487 |
 <!-- END GEN:counts -->

--- a/docs/verification/COUNTS.md
+++ b/docs/verification/COUNTS.md
@@ -9,6 +9,6 @@
 <!-- BEGIN GEN:counts -->
 | Suite | Passing |
 |---|---|
-| meta (tests/test-meta.sh) | 715/715 |
+| meta (tests/test-meta.sh) | 717/717 |
 | hooks (tests/test-hooks.sh) | 487/487 |
 <!-- END GEN:counts -->

--- a/docs/verification/plain-words-cheap.md
+++ b/docs/verification/plain-words-cheap.md
@@ -25,6 +25,16 @@ report): `spoke` (semantic in `lib/sync/*.py`), `grill` (a command + 6 test file
 `brownfield` (a `lane-classify` anchor), `wave`/`tier`/`posture` (config keys with no
 generic alias resolver), `RID` (the `rid` identifier in 8 test suites).
 
+## Review disposition (review-team + fable advisor)
+
+| Finding | Lens | Applied? |
+|---|---|---|
+| The `gate.sh` dispatcher routing (both `verify-counts` and legacy `verif-counts`) had no automated coverage; the alias claim rested on a manual grep | test-coverage (MEDIUM/LOW) | Applied, added a stubbed dispatch-routing test in `test-meta.sh` (both verbs), CI-enforced |
+| Deferring the code-entangled remainder is correct; the honest-slice warning should also reach the ID-291 backlog row | fable | Reported to the board scribe (I do not edit the board) |
+| COUNTS.md freshness is unenforced (it sat stale at 368/164) | fable | Pre-existing gap; regenerated here to the true count, and reported as a follow-up (a live-count assertion would slow every meta run, so it is its own item) |
+| The `(one release)` alias has no removal tracking (no kit release cadence) | fable | Matches the standing CONTRIBUTING.md "Plain words rule" §3 convention (architecture lens confirmed); alias-removal reported to the scribe as a follow-up row |
+| Security / architecture | both | 10/10 clean, no change requested |
+
 ## Acceptance criteria
 
 | # | Criterion | Result |
@@ -33,7 +43,7 @@ generic alias resolver), `RID` (the `rid` identifier in 8 test suites).
 | 2 | Both `gate verify-counts` and legacy `gate verif-counts` route to the new file | PASS |
 | 3 | No live (non-doc) reference to the old filename remains (only the intentional alias) | PASS |
 | 4 | `SDD` defined on first use in AGENTS.md + PHILOSOPHY.md | PASS |
-| 5 | Full meta suite green | PASS (715/715) |
+| 5 | Full meta suite green | PASS (717/717) |
 
 ## Confirmation run
 
@@ -45,7 +55,7 @@ Exit: 0        # both verbs wired to the new file
 Command: rg -n 'verif-counts' lib/ tests/ --glob '!*.md' | grep -v 'legacy alias'
 Exit: 1        # no live non-doc refs to the old name remain
 Command: bash tests/test-meta.sh
-Exit: 0        # Passed: 715 / 715
+Exit: 0        # Passed: 717 / 717
 Verdict: PASS
 ```
 
@@ -63,7 +73,7 @@ mv lib/gate/verify-counts.sh lib/gate/verif-counts.sh
 bash tests/test-meta.sh   -> FAIL "lib/gate/verify-counts.sh exists and is executable"  (RED)
 # restore:
 mv lib/gate/verif-counts.sh lib/gate/verify-counts.sh
-bash tests/test-meta.sh   -> 715/715  (GREEN)
+bash tests/test-meta.sh   -> 717/717  (GREEN)
 ```
 
 **Verdict: PASS.**
@@ -71,7 +81,7 @@ bash tests/test-meta.sh   -> 715/715  (GREEN)
 ## Reproduce
 
 ```
-bash tests/test-meta.sh                 # 715/715
+bash tests/test-meta.sh                 # 717/717
 bash lib/gate/gate.sh verify-counts     # regenerates docs/verification/COUNTS.md (runs the suites)
 bash lib/gate/gate.sh verif-counts      # legacy alias, same target
 ```

--- a/docs/verification/plain-words-cheap.md
+++ b/docs/verification/plain-words-cheap.md
@@ -1,0 +1,80 @@
+# Proof of done: plain-words rename (verify-counts + SDD), ID-291 first slice
+
+**Change class:** behavioral (`lib/gate/gate.sh`, the renamed `lib/gate/verify-counts.sh`).
+
+**Claim.** Two zero-risk items of the ID-291 plain-words cluster land:
+1. `lib/gate/verif-counts.sh` -> `lib/gate/verify-counts.sh` (the coordinator-emphasized
+   file rename), with every LIVE reference swept (the `gate` dispatch, its `--help` text,
+   the module registry, both READMEs, the `docs/verification/COUNTS.md` generator pointer,
+   and the `test-meta.sh` existence assertion), and `verif-counts` kept as a legacy verb
+   alias for one release (ID-292 precedent).
+2. `SDD` spelled out on first use (`spec-driven development (SDD)`) in the two onboarding
+   docs where it first appears (`AGENTS.md`, `docs/PHILOSOPHY.md`).
+
+Historical records (research, specs, `_meta/megagoals/_archive`, CHANGELOG, audits,
+implementation-notes, shipped verification records) are left untouched per the ID-292
+precedent: they document the name-at-the-time.
+
+## Scope note (honest first slice)
+
+The remaining ID-291 cluster items proved code/command/config-entangled after the
+2026-07-16..18 wave merges (#269-#274) embedded these terms in code, so the inventory's
+"docs/cfg cheap" estimate is stale. They are deferred to dedicated PRs (see the batch
+report): `spoke` (semantic in `lib/sync/*.py`), `grill` (a command + 6 test files),
+`spine` (install.sh `KIT_SPINE_HOOKS` + config), `cockpit` (`lib/sync/cockpit.py` + verb),
+`brownfield` (a `lane-classify` anchor), `wave`/`tier`/`posture` (config keys with no
+generic alias resolver), `RID` (the `rid` identifier in 8 test suites).
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | `verify-counts.sh` exists + executable; old path gone | PASS |
+| 2 | Both `gate verify-counts` and legacy `gate verif-counts` route to the new file | PASS |
+| 3 | No live (non-doc) reference to the old filename remains (only the intentional alias) | PASS |
+| 4 | `SDD` defined on first use in AGENTS.md + PHILOSOPHY.md | PASS |
+| 5 | Full meta suite green | PASS (715/715) |
+
+## Confirmation run
+
+```
+Command: [ -x lib/gate/verify-counts.sh ] && [ ! -f lib/gate/verif-counts.sh ] && echo OK
+Exit: 0        # OK: renamed, executable, old path gone
+Command: grep -n 'verify-counts|verif-counts) exec bash "$GATE_DIR/verify-counts.sh"' lib/gate/gate.sh
+Exit: 0        # both verbs wired to the new file
+Command: rg -n 'verif-counts' lib/ tests/ --glob '!*.md' | grep -v 'legacy alias'
+Exit: 1        # no live non-doc refs to the old name remain
+Command: bash tests/test-meta.sh
+Exit: 0        # Passed: 715 / 715
+Verdict: PASS
+```
+
+## NEGATIVE CONTROL
+
+The `test-meta.sh` assertion `lib/gate/verify-counts.sh exists and is executable` is
+load-bearing on the ref sweep: had the rename been done WITHOUT updating that assertion
+(or without updating `gate.sh`'s exec path), meta would be RED (it would look for the file
+at the old path). Reverting only the `git mv` while keeping the swept references
+reproduces the failure:
+
+```
+# revert the file move but keep the swept test assertion:
+mv lib/gate/verify-counts.sh lib/gate/verif-counts.sh
+bash tests/test-meta.sh   -> FAIL "lib/gate/verify-counts.sh exists and is executable"  (RED)
+# restore:
+mv lib/gate/verif-counts.sh lib/gate/verify-counts.sh
+bash tests/test-meta.sh   -> 715/715  (GREEN)
+```
+
+**Verdict: PASS.**
+
+## Reproduce
+
+```
+bash tests/test-meta.sh                 # 715/715
+bash lib/gate/gate.sh verify-counts     # regenerates docs/verification/COUNTS.md (runs the suites)
+bash lib/gate/gate.sh verif-counts      # legacy alias, same target
+```
+
+**Rollback:** `git revert` this commit restores the old filename + `SDD` shorthand; no
+state or data step (a file rename + doc-string edits).

--- a/lib/README.md
+++ b/lib/README.md
@@ -13,7 +13,7 @@ orphans with no cluster stay as bare scripts at the root.
 |---|---|
 | `board/` | `board.sh` `board-mirror.sh` `board-writeback.sh` `parse-board.sh` `backlog.sh` |
 | `queue/` | `orchestrate.sh` `queue.sh` `weekend-batch.sh` |
-| `gate/` | `gate-ledger.sh` `proof-gate.sh` `proof-ledger.sh` `proof-table-gen.py` `proof-table-gen.sh` `dispatch-gate.sh` `quiz-gate.sh` `coverage-delta.sh` `verif-counts.sh` `mutation-smoke.sh` |
+| `gate/` | `gate-ledger.sh` `proof-gate.sh` `proof-ledger.sh` `proof-table-gen.py` `proof-table-gen.sh` `dispatch-gate.sh` `quiz-gate.sh` `coverage-delta.sh` `verify-counts.sh` `mutation-smoke.sh` |
 | `classify/` | `lane-classify.sh` `role-classify.sh` `significance-classify.sh` `task-type-classify.sh` `route-suggest.sh` |
 | `spec/` | `spec-index.sh` `spec-next.sh` |
 | `goal/` | `goal-drafts.sh` `goal-registry.sh` `mega-merge.sh` `stack-merge.sh` `handoff-gen` + `handoff/` (`handoff_gen.py`, `cc_compact.py`) |

--- a/lib/config/module-registry.md
+++ b/lib/config/module-registry.md
@@ -275,7 +275,7 @@ against any of these bare tokens as covered without a registry row.
 | SKILL_CURATOR_LOCK | `lib/skill-curator/lib/common.sh`: derived path. |
 | SKILL_CURATOR_LOG | `lib/skill-curator/lib/common.sh`: derived path. |
 | SKILL_CURATOR_ROOT | `lib/skill-curator/lib/common.sh`: computed `$SKILL_CURATOR_LIB/..`. |
-| KIT | `lib/gate/verif-counts.sh`: computed repo-root var, script-local. |
+| KIT | `lib/gate/verify-counts.sh`: computed repo-root var, script-local. |
 | KITLOG | `lib/stats/tests/test-defect-correlation.sh`: test-fixture-local. |
 | KITTY_WINDOW_ID | The Kitty terminal emulator's own env var; an unrelated false positive of the `KIT` prefix match, not a kit config surface at all. |
 | KIT_DIR | `lib/plugin-check/tests/smoke.sh`: test-fixture scratch dir. |

--- a/lib/gate/README.md
+++ b/lib/gate/README.md
@@ -36,7 +36,7 @@ verb grammar and adds no logic. Call any script directly by path too; both work.
 | `gate coverage-delta` | `coverage-delta.sh` | Advisory. Source lines moved but test lines did not? Warn. | no (always exit 0) |
 | `gate mutation-smoke` | `mutation-smoke.sh` | Advisory. Mutates a changed line, re-runs the suite. A surviving mutation means the suite does not bite. | no (always exit 0) |
 | `gate proof-table` | `proof-table-gen.{sh,py}` | Generates a run-table from a rid's ledger. Refuses to write `proof-of-done.md`. | no |
-| `gate verif-counts` | `verif-counts.sh` | Regenerates `docs/verification/COUNTS.md` from live suite runs. | no |
+| `gate verify-counts` | `verify-counts.sh` | Regenerates `docs/verification/COUNTS.md` from live suite runs. (`verif-counts`: legacy alias) | no |
 
 ### The lane gate (`gate-ledger.sh`)
 

--- a/lib/gate/gate.sh
+++ b/lib/gate/gate.sh
@@ -14,7 +14,7 @@
 #   gate.sh coverage-delta <args...>  -> coverage-delta.sh (check|class|classes)
 #   gate.sh mutation-smoke <args...>  -> mutation-smoke.sh (run|candidates|...)
 #   gate.sh redteam <args...>         -> redteam-gate.sh (start|round) -- rung-4 cost checkpoint
-#   gate.sh verif-counts               -> verif-counts.sh
+#   gate.sh verify-counts              -> verify-counts.sh (verif-counts = legacy alias)
 #   gate.sh -h|--help|help             -> this usage
 set -euo pipefail
 
@@ -33,7 +33,7 @@ main() {
     coverage-delta)  exec bash "$GATE_DIR/coverage-delta.sh" "$@" ;;
     mutation-smoke)  exec bash "$GATE_DIR/mutation-smoke.sh" "$@" ;;
     redteam)         exec bash "$GATE_DIR/redteam-gate.sh" "$@" ;;
-    verif-counts)    exec bash "$GATE_DIR/verif-counts.sh" "$@" ;;
+    verify-counts|verif-counts) exec bash "$GATE_DIR/verify-counts.sh" "$@" ;;   # verif-counts: legacy alias (one release)
     -h|--help|help|"") usage ;;
     *) echo "gate: unknown verb '$verb' (try: gate --help)" >&2; exit 1 ;;
   esac

--- a/lib/gate/verify-counts.sh
+++ b/lib/gate/verify-counts.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# verif-counts.sh -- single-source the kit's verification suite numbers.
+# verify-counts.sh -- single-source the kit's verification suite numbers.
 #
 # Borrowed from the codebase-tool-benchmark's gen_docs.py pattern (the experiment sibling
 # of the proof-of-done discipline): a figure should be GENERATED from one source, never
@@ -7,7 +7,7 @@
 # pass counts into the marked block of docs/verification/COUNTS.md. A verification log that
 # needs "the suite is at N" links to COUNTS.md instead of transcribing a number.
 #
-# Usage: bash lib/gate/verif-counts.sh   (regenerates docs/verification/COUNTS.md)
+# Usage: bash lib/gate/verify-counts.sh   (regenerates docs/verification/COUNTS.md)
 set -uo pipefail
 
 KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"  # repo root = two levels above lib/gate/
@@ -36,7 +36,7 @@ if [ ! -f "$OUT" ] || ! grep -q '<!-- BEGIN GEN:counts -->' "$OUT"; then
   cat > "$OUT" <<EOF
 # Verification suite counts (generated)
 
-> Numbers between the GEN markers are written by \`lib/gate/verif-counts.sh\` from the live
+> Numbers between the GEN markers are written by \`lib/gate/verify-counts.sh\` from the live
 > suites. Do NOT hand-edit them. To change a number, change the tests then re-run the
 > generator. A verification log links here instead of transcribing a count. This is the
 > single-source-numbers pattern borrowed from the codebase-tool-benchmark (the sibling

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -2441,6 +2441,20 @@ assert_true "PHILOSOPHY records the deferred enforcement hook is now built" \
 assert_true "lib/gate/verify-counts.sh exists and is executable" \
   "$([ -x "$KIT_DIR/lib/gate/verify-counts.sh" ] && echo 0 || echo 1)"
 
+# ID-291: the gate dispatcher routes BOTH `verify-counts` and its legacy `verif-counts`
+# alias to verify-counts.sh. The real target regenerates COUNTS.md by running every
+# suite, so stub it and prove routing cheaply -- a future edit that drops the alias arm
+# (or misroutes the verb) is then caught in CI, not by eyeballing the case statement.
+_gate_route_tmp="$(mktemp -d "${TMPDIR:-/tmp}/dk-gate-route.XXXXXX")"
+cp "$KIT_DIR/lib/gate/gate.sh" "$_gate_route_tmp/gate.sh"
+printf '#!/usr/bin/env bash\necho "ROUTED $*"\n' > "$_gate_route_tmp/verify-counts.sh"
+chmod +x "$_gate_route_tmp/verify-counts.sh"
+assert_true "gate dispatch routes 'verify-counts' to verify-counts.sh" \
+  "$(bash "$_gate_route_tmp/gate.sh" verify-counts probe 2>/dev/null | grep -q '^ROUTED probe' && echo 0 || echo 1)"
+assert_true "gate dispatch routes legacy 'verif-counts' alias to verify-counts.sh" \
+  "$(bash "$_gate_route_tmp/gate.sh" verif-counts probe 2>/dev/null | grep -q '^ROUTED probe' && echo 0 || echo 1)"
+rm -rf "$_gate_route_tmp"
+
 assert_true "COUNTS.md carries the generated single-source block" \
   "$(grep -q 'BEGIN GEN:counts' "$KIT_DIR/docs/verification/COUNTS.md" 2>/dev/null && echo 0 || echo 1)"
 

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -2438,8 +2438,8 @@ assert_true "PHILOSOPHY records the deferred enforcement hook is now built" \
 
 # ---- single-source numbers: borrowed from the experiment sibling (no hand-typed drift) ----
 
-assert_true "lib/gate/verif-counts.sh exists and is executable" \
-  "$([ -x "$KIT_DIR/lib/gate/verif-counts.sh" ] && echo 0 || echo 1)"
+assert_true "lib/gate/verify-counts.sh exists and is executable" \
+  "$([ -x "$KIT_DIR/lib/gate/verify-counts.sh" ] && echo 0 || echo 1)"
 
 assert_true "COUNTS.md carries the generated single-source block" \
   "$(grep -q 'BEGIN GEN:counts' "$KIT_DIR/docs/verification/COUNTS.md" 2>/dev/null && echo 0 || echo 1)"


### PR DESCRIPTION
ID-291 plain-words cluster, honest first slice. Renames the verify-counts generator (live-ref sweep + legacy verb alias) and spells out SDD on first use. The rest of the cluster proved code/command/config-entangled post-wave and is deferred to dedicated PRs (detailed in the batch report). 715/715 meta. Proof: docs/verification/plain-words-cheap.md. No board edits (flip reported to the scribe).