### PR TITLE
docs: register the two hook-entry pipelines in the signal inventory

### DIFF
--- a/docs/specs/SPEC-200-signal-pipelines.md
+++ b/docs/specs/SPEC-200-signal-pipelines.md
@@ -4,7 +4,7 @@ Status: Draft · 2026-07-14 · Owner: Han
 
 ## Problem
 
-The kit has **19 pipelines shaped like collect -> analyze -> report -> propose**
+The kit has **21 pipelines shaped like collect -> analyze -> report -> propose**
 (full inventory in the Appendix). They read different sources (run ledger, CC
 transcripts, boards, git, the filesystem) at different depths (awk, DuckDB,
 heuristics, LLM), and that variety is legitimate. What is not legitimate is that
@@ -147,11 +147,16 @@ env-prefix lint (T2), a verb-vocabulary lint over `lib/*/bin/*` help text (T4),
 and a proposal-currency test asserting every proposer writes staging blocks and
 nothing else (I1).
 
-## Appendix: the 19 pipelines
+## Appendix: the pipelines
 
 lane-telemetry · learn propose · learn drain · learn debt · stats · mega report
 · mega review · skill-curator reviewer · cc-improve curate · board mirror /
 writeback · session observe · session report · session semantic · session intel
 · session audit · proof-table-gen · verif-counts · /kit:retro · /kit:kit-health
+· backlog-stage · intake-sweep
+
+The last two are hook-entry pipelines feeding the same staging file as `learn
+propose`; both were added by the 2026-07-20 re-sweep (see the inventory's header
+note on why the original CLI-oriented sweep missed them).
 
 Full source/transform/output/proposal/cadence table: `docs/verification/signal-pipeline-inventory.md`.

--- a/docs/verification/signal-pipeline-inventory.md
+++ b/docs/verification/signal-pipeline-inventory.md
@@ -1,8 +1,13 @@
 # Signal-pipeline inventory (evidence for SPEC-200)
 
-Swept 2026-07-14 over the whole repo. 19 pipelines match the shape
-collect -> analyze -> report -> propose. This is the evidence base for SPEC-200's
-claim that the kit has one ETL class with five vocabularies.
+Swept 2026-07-14 over the whole repo; re-swept 2026-07-20. The pipelines below match
+the shape collect -> analyze -> report -> propose. This is the evidence base for
+SPEC-200's claim that the kit has one ETL class with five vocabularies.
+
+The 2026-07-20 re-sweep added rows 20-21: the two hook-entry pipelines that feed the
+same staging file the `learn` verbs do. Row 20 (`backlog-stage`) was a pre-existing
+omission from the original sweep, found while registering row 21; the original sweep
+enumerated CLI entries and missed the hook-entry ones.
 
 | # | Pipeline | Entry | Source | Transform | Output | Proposal shape | Cadence | Chains? |
 |---|---|---|---|---|---|---|---|---|
@@ -25,10 +30,12 @@ claim that the kit has one ETL class with five vocabularies.
 | 17 | verif-counts | `lib/gate/verif-counts.sh` | test output | grep/sed | `COUNTS.md` block | none | on-demand | overwrite |
 | 18 | /kit:retro | `commands/retro.md` | git + specs + completeness.log + lane-telemetry | LLM-facilitated Q&A | `RETRO-[date].md` | **checkbox action items** | on-demand | loose |
 | 19 | /kit:kit-health | `commands/kit-health.md` | kit's own fs/hooks/logs | bash checklist | stdout report | advisory prose | on-demand | no |
+| 20 | backlog-stage | `hooks/backlog-stage.sh` | CC session transcript | prefilter + LLM (haiku) extract | `## [staged]` blocks | **staging block** | hook (SessionEnd), 1h throttle | yes (dedup vs board + staging) |
+| 21 | intake-sweep | `hooks/intake-sweep.py` (via `backlog-stage.sh --surface`) | consumer-declared sources (`_meta/intake-sources.json`: jsonl / command adapters) | filter + field-map, no LLM | `## [staged]` blocks | **staging block** | hook (SessionStart), daily throttle | yes (board + staging + durable swept-keys) |
 
 ## What the sweep proves
 
-- **Three proposal shapes, one gate.** Staging blocks (2, 5, 15) are the currency
+- **Three proposal shapes, one gate.** Staging blocks (2, 5, 15, 20, 21) are the currency
   `board promote` reads. Bullet prose (14) and checkbox items (18) never reach it:
   they are leads a human must retype, which is why nobody does. SPEC-200 I1.
 - **One resource, three env families.** `_meta/BACKLOG.md` is addressed by


### PR DESCRIPTION
## What

Registers `intake-sweep` (merged in #279) and `backlog-stage` in `docs/verification/signal-pipeline-inventory.md` as rows 20-21, and updates SPEC-200's count + appendix to match.

## Why

SPEC-200 cites that inventory as its evidence base for "the kit has one ETL class with five vocabularies". `intake-sweep` is a pipeline of exactly that shape (collect -> propose a `## [staged]` block) and was missing. Registering it surfaced that `backlog-stage`, its older sibling and the other hook-entry pipeline feeding the same staging file, was never listed either: the original 2026-07-14 sweep enumerated CLI entries and had a blind spot for hook entries. The header now records that so the next sweep does not repeat it.

## Test

`tests/test-meta.sh` 0 FAIL, `tests/test-intake-sweep.sh` 19/19. Docs-only change; no count is pinned by any test (checked), so the 19 -> 21 update is prose-consistent rather than gate-enforced.
