### PR TITLE
ci: supersede stale PR runs and cut macOS from PR feedback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,14 @@ on:
     branches: [master]
   pull_request:
 
+# Continuous pushes to one PR branch would otherwise start a full run per push and
+# let every one of them race to completion. Supersede instead: only the newest run
+# on a ref survives. Master pushes are exempt (cancel only on pull_request) because
+# a master run is the record of what actually shipped, not throwaway feedback.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Least-privilege token: workflow only reads code and runs tests; no writes,
 # no PR comments, no release operations.
 permissions:
@@ -17,7 +25,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # PRs run ubuntu only (~2m45s); master pushes additionally run macOS (~4m25s,
+        # the long pole). macOS is not redundant coverage: its /bin/bash is 3.2, so it
+        # is what catches `declare -A` / `mapfile` regressions in launcher scripts. This
+        # moves that signal from pre-merge to post-merge, it does not delete it.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
     steps:
       # Pinned to release SHA to defend against tag-replay supply-chain attack.
       # Update via Dependabot or manually when checkout cuts a new release.


### PR DESCRIPTION
ci: supersede stale PR runs and cut macOS from PR feedback

Continuous pushing to a PR branch started a fresh full run per push, with every
run racing to completion, so feedback latency was a queue of superseded runs
rather than one run's duration.

Two changes:

- concurrency group per workflow+ref with cancel-in-progress on pull_request
  only. Superseded PR runs die; master runs still all complete, since a master
  run is the record of what shipped.
- matrix is ubuntu-only on pull_request, both OSes on push to master. macOS was
  the long pole (~4m25s vs ubuntu's ~2m45s) and it always ran because
  fail-fast is false.

macOS coverage is not deleted, only moved post-merge. Its /bin/bash is 3.2, so
it remains the signal that catches declare -A / mapfile regressions in launcher
scripts.

Branch protection updated to match: required contexts are now
test (ubuntu-latest) alone. Leaving test (macos-latest) required would have hung
every PR at "Expected, waiting for status" once it stopped running on PRs.
