### PR TITLE
fix(gate): alias recorded phase 'execute' to matrix gate 'build'

### DIFF
--- a/lib/gate/gate-ledger.sh
+++ b/lib/gate/gate-ledger.sh
@@ -97,8 +97,15 @@ normalize_phase() {
   # collapse newlines first (security review, defense-in-depth): a phase arg with an embedded
   # newline would otherwise emit a second physical ledger line. Unreachable today (all callers
   # pass a hardcoded phase literal), but the guard is one tr and matches oneline()'s intent.
-  printf '%s' "$1" | tr '\n\r' '  ' | sed -E 's/\([^)]*\)//g' | tr 'A-Z' 'a-z' \
-    | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/-/g'
+  local p
+  p="$(printf '%s' "$1" | tr '\n\r' '  ' | sed -E 's/\([^)]*\)//g' | tr 'A-Z' 'a-z' \
+    | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/-/g')"
+  # Alias command-name drift: agents recording ad-hoc sometimes use the command name
+  # ("execute") instead of the matrix gate it owns ("build"), leaving check() blind to a
+  # build that ran (seen 2026-07-21, finance-warehouse run). "verify" is NOT aliased to
+  # "review": /kit:verify (right-arm re-run) and /kit:review (code review) are distinct gates.
+  case "$p" in execute) p=build ;; esac
+  printf '%s' "$p"
 }
 
 # print "<rawphase>\t<cell>" for each matrix row under the given lane column.

--- a/tests/test-gate-vocab-recording.sh
+++ b/tests/test-gate-vocab-recording.sh
@@ -155,5 +155,20 @@ case "$CHECK_OUT2" in *"MISSING-GATE: build"*) mg_ok=0 ;; *) mg_ok=1 ;; esac
 assert "the check names 'build' as the missing gate" "$mg_ok" "-- $CHECK_OUT2"
 
 echo ""
+echo "=== AC6: command-name drift alias -- recording 'execute' satisfies 'build'; 'verify' never satisfies 'review' ==="
+new_log
+RID3=demo-execute-alias
+gl record "$RID3" execute ran "6/6 tasks landed" >/dev/null
+grep -q "| GATE | build | ran |" "$LOGD/runs/$RID3.log"
+assert "record 'execute' lands in the ledger as phase 'build'" $?
+CHECK_OUT3="$(gl check full "$RID3" 2>&1)"
+case "$CHECK_OUT3" in *"MISSING-GATE: build"*) alias_ok=1 ;; *) alias_ok=0 ;; esac
+assert "check no longer reports build missing after an 'execute' record" "$alias_ok" "-- $CHECK_OUT3"
+gl record "$RID3" verify ran "task-verifiers PASS" >/dev/null
+CHECK_OUT4="$(gl check full "$RID3" 2>&1)"
+case "$CHECK_OUT4" in *"MISSING-GATE: review"*) noalias_ok=0 ;; *) noalias_ok=1 ;; esac
+assert "NEGATIVE CONTROL: 'verify' does NOT satisfy the 'review' gate" "$noalias_ok" "-- $CHECK_OUT4"
+
+echo ""
 echo "=== Summary: $PASS/$TOTAL passed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Why

During the finance-warehouse ship (2026-07-21, dfoundation PR #186) the ship-gate reported `MISSING-GATE: build` and `MISSING-GATE: review` even though `/kit:execute` and `/kit:verify` had run and logged: the session recorded the gates under the command names (`execute`, `verify`) instead of the matrix gate names, and the operator had to hand-backfill at ship time.

## What

- `normalize_phase()` in `lib/gate/gate-ledger.sh` now aliases `execute` -> `build`. Every path funnels through it (record / override / check / outcome-read), so ad-hoc recordings under the command name land as the matrix gate.
- `verify` is deliberately NOT aliased to `review`: the right-arm re-run and the code review are distinct gates; conflating them would let a verify pass silently satisfy the review requirement.
- New AC6 in `tests/test-gate-vocab-recording.sh`: `record execute ran` lands as `| GATE | build |` and clears the check, and the negative control proves `verify` still leaves `MISSING-GATE: review`.

## Proof

`bash tests/test-gate-vocab-recording.sh` -> 20/20 passed (AC6 = 3 new assertions). Related suites green: test-ledger-substrate, test-gate-outcome, test-ship-gate-fail-closed, test-ledger-durability. `test-ship-gate-profiles.sh` fails on master before this change (pre-existing, untouched by this diff).

Lane: tiny (one-line behavior alias + test). Rollback: revert the `case "$p" in execute)` line.
