### PR TITLE
fix(release): refuse in-repo stream/, paid sources via STREAM_SRC

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -33,6 +33,15 @@ CUR="$(cat VERSION)"
   || { echo "version must move forward: current $CUR, asked $VER" >&2; exit 1; }
 [ "$DRY" = 1 ] || [ -z "$(git status --porcelain)" ] || { echo "tree not clean" >&2; exit 1; }
 
+# Paid sources NEVER live in this repo (it is public; the private
+# dwarves-kit-stream repo is created when the first paid module ships).
+# An in-repo stream/ dir is a foot-gun: refuse it, point at --stream-src.
+if [ -d stream ]; then
+  echo "REFUSED: stream/ exists inside this (public) repo. Paid sources live in the" >&2
+  echo "private dwarves-kit-stream checkout; pass it via STREAM_SRC=<path>." >&2
+  exit 1
+fi
+
 echo "== channel 1 · public (free core) =="
 python3 - "$VER" <<'PY'
 import json, sys
@@ -67,7 +76,11 @@ STAGE="$(mktemp -d)"
 mkdir -p "$STAGE/forge-stream"
 cp CHANGELOG.md "$STAGE/forge-stream/"
 [ -f docs/tiers.md ] && cp docs/tiers.md "$STAGE/forge-stream/"
-[ -d stream ] && cp -R stream "$STAGE/forge-stream/stream"
+if [ -n "${STREAM_SRC:-}" ]; then
+  [ -d "$STREAM_SRC" ] || { echo "STREAM_SRC=$STREAM_SRC not found" >&2; exit 1; }
+  cp -R "$STREAM_SRC" "$STAGE/forge-stream/stream"
+  echo "  paid sources from $STREAM_SRC"
+fi
 printf '{"version":"%s","channel":"paid-stream"}\n' "$VER" > "$STAGE/forge-stream/manifest.json"
 TAR="$STAGE/forge-stream-$VER.tar.gz"
 tar -czf "$TAR" -C "$STAGE" forge-stream

--- a/docs/verification/release-channels.md
+++ b/docs/verification/release-channels.md
@@ -38,3 +38,21 @@ Verdict: PASS
 `bin/release <ver> --dry-run`; the staging proof script shape lives in the session
 scratchpad (stream-proof.py: token via env, prints statuses only). Human release
 steps (git push --tags, gh release) intentionally excluded per ID-295.
+
+## Addendum (2026-07-25): public-repo guard + STREAM_SRC
+
+The repo is PUBLIC; paid sources must never enter it (private dwarves-kit-stream repo
+is created when the first paid module ships).
+
+Command: `mkdir stream && bin/release 9.9.9 --dry-run`
+Exit: 1, BEFORE any file mutation (guard moved above channel 1; tree stays clean)
+Output: "REFUSED: stream/ exists inside this (public) repo..."
+Verdict: PASS
+
+NEGATIVE CONTROL is the guard itself (revert = create stream/ -> RED refuse -> restore
+= remove it); the accept path:
+
+Command: `STREAM_SRC=<private checkout> bin/release 2.0.2 --dry-run`
+Exit: 0
+Output: "paid sources from <path>", 4361-byte bundle with sha256.
+Verdict: PASS


### PR DESCRIPTION
The repo is public: an in-repo stream/ dir would publish the paid channel to GitHub. bin/release now refuses it before any mutation and takes the private checkout via STREAM_SRC=<dir> (the dwarves-kit-stream repo, created when the first paid module ships). Proof addendum in docs/verification/release-channels.md.