### PR TITLE
feat(sync): GitHub Issues spoke, and the mesh learns per-board prefixes

### DIFF
--- a/commands/onboard.md
+++ b/commands/onboard.md
@@ -140,6 +140,27 @@ If the chosen modules genuinely have no `[impl]` knob rows at all, say so in one
 Recommended default at each knob: leave it at its current value (skip), since the kit-root defaults
 already give a working baseline.
 
+## D2. Register the board (offer, never assume)
+
+Adoption wires modules; it does not create the board. If `<repo>/_meta/BACKLOG.md` is missing, offer
+this sequence, calling the real surfaces (`bin/board`, the sync installer), never reimplementing them:
+
+1. `board init` -- scaffolds `_meta/BACKLOG.md` + the `_meta/board` shim, idempotently.
+2. **Team surface, one question**: does this repo's team work in GitHub Issues (or Notion / Hermes /
+   Reminders)? If yes, preview the `.kit.toml` addition (`[sync]` + `apps = "github"`, plus
+   `github_repo` only when origin is not the right target) and confirm before writing, same contract
+   as the knob writes in D.
+3. First `board sync --dry-run`, then live: on a repo that already lived in its tracker, intake
+   creates a queued `#inbox` row per open item -- history arrives on the board with no manual
+   backfill. Tell the user the `#inbox` tag marks rows awaiting first human triage.
+4. **Cadence**: manual `board sync` is the default. If they want it ambient, set
+   `[sync] mode = "cron"` and run `bash "$KIT/lib/sync/deploy/macos/install" <backlog-path>`
+   (the per-repo LaunchAgent; the launcher re-checks `mode` every run, so flipping back to
+   "manual" in `.kit.toml` stops it without an uninstall). Mention `board capture "<title>"`
+   as the from-a-session filing verb while you are here.
+
+A repo that declines any step stays fully functional; the board is additive.
+
 ## E. Disclose the plugin-path gaps (only for mode `plugin` or `both`)
 
 Be honest about what the plugin path cannot do (ADR-0009), in four short bullets:

--- a/docs/verification/board-github-adapter.md
+++ b/docs/verification/board-github-adapter.md
@@ -1,0 +1,48 @@
+# Verification: GitHub Issues spoke + per-prefix boards in the sync mesh
+
+Scope: `lib/sync/sources/github.py` (new spoke), prefix threading in
+`sync_core.py` / `backlog_sync.py`, `[sync]` wiring in `lib/board/board.sh`.
+Pilot board: `dwarvesf/whetstone` `_meta/BACKLOG.md` (WS- prefix), live issues.
+
+## Run table
+
+| Check | Command | Verdict |
+|---|---|---|
+| Unit suite (all spokes + core) | `uv run --with pytest python -m pytest lib/sync/tests/ -q` | PASS, 170 passed (163 pre-existing + 7 new: 5 github, 2 core-merge; also 5 prefix tests in test_prefix.py) |
+| Cold link, no dupes | `board sync --dry-run` on whetstone (4 rows WS-1..4, 4 issues retitled `WS-N ·`) | PASS: "4 spoke items, 4 board rows, (nothing to do)" |
+| Board row -> issue | add `WS-5` row, `board sync` | PASS: issue #12 created, title `WS-5 · ...`, body carries `bls: WS-5` idempotency marker |
+| Row dropped -> issue closed | flip WS-5 to dropped, `board sync` | PASS: `~ spoke 12 -> dropped`, #12 CLOSED |
+| Stability (the oscillation NC) | two further `board sync` runs | PASS: both "(nothing to do)"; row stays `dropped`, #12 stays CLOSED |
+| Board wins after board edit | sed row status, one sync, one more | PASS: one `~ spoke` push, then quiet |
+
+## Negative controls (defects this work FOUND live; each now pinned by a test)
+
+1. **ID-hardwired mesh (parse leg).** Before the prefix threading, `board sync`
+   on whetstone read "4 spoke items, **0 board rows**" and planned duplicate
+   intake for every already-rowed issue. Every cockpit repo has a non-`ID`
+   prefix by design, so the two-way mesh was ID-repos-only. Pinned by
+   `test_strict_parse_sees_prefixed_rows` (asserts the 0-rows failure on the
+   old default AND the fix).
+2. **ID-hardwired `TITLE_RE` (link leg).** With parsing fixed, linking still
+   failed: 4 rows + 4 matching issues planned 8 duplicates. `TITLE_RE` only
+   matched `ID-` titles. Fixed with the generic token; a bid still only links
+   when it exists in that board's rows, so boards cannot cross-link.
+3. **Binary-spoke status oscillation (engine).** A dropped row with a closed
+   issue flipped to `shipped` on EVERY sync: the engine re-derived `shipped`
+   from `done=True` and compared keywords against the snapshot. Affects any
+   open/done-only spoke (Reminders too), not just GitHub. Fix: when a spoke
+   reports `status: None`, compare DONENESS against the snapshot's
+   terminal-ness; a reopen flows back as `queued`. Pinned by
+   `test_binary_spoke_dropped_row_closed_item_is_stable` and
+   `test_binary_spoke_reopen_flows_to_board_as_queued`.
+
+## Reproduce
+
+```
+cd <repo>            # gh remote + _meta/BACKLOG.md kanban, any prefix
+printf '[sync]\napps = "github"\n' > .kit.toml
+board sync --dry-run # inspect, then run without --dry-run
+```
+
+Adapter capability envelope is documented in `lib/sync/sources/github.py`'s
+header (open/closed only; reopen supported; `sync_fields=False`).

--- a/docs/verification/board-github-adapter.md
+++ b/docs/verification/board-github-adapter.md
@@ -46,3 +46,16 @@ board sync --dry-run # inspect, then run without --dry-run
 
 Adapter capability envelope is documented in `lib/sync/sources/github.py`'s
 header (open/closed only; reopen supported; `sync_fields=False`).
+
+## Second pass: `board init` + `board capture` (2026-07-27)
+
+| Check | Command | Verdict |
+|---|---|---|
+| init idempotent | `board init` on whetstone (files exist) | PASS: "kept existing" both files, nothing touched |
+| init scaffold | `board init` in a fresh scratch repo | PASS: BACKLOG.md header + executable shim created, [sync] hint printed |
+| capture e2e | `board capture "<title>" -b "<notes>"` on whetstone | PASS: row WS-6 minted (prefix-aware, via sync_core), sync created issue #14, URL printed AND verified on the clipboard via pbpaste |
+| capture без github | (code path) state snapshot missing rid | prints "row is on the board", never fails the filing |
+
+`capture` composes what exists: sync_core mints the row, `cmd_sync` (in a
+subshell, since it ends in exec) does the push, the state snapshot yields the
+issue number. No second sync implementation.

--- a/docs/verification/board-github-adapter.md
+++ b/docs/verification/board-github-adapter.md
@@ -54,7 +54,7 @@ header (open/closed only; reopen supported; `sync_fields=False`).
 | init idempotent | `board init` on whetstone (files exist) | PASS: "kept existing" both files, nothing touched |
 | init scaffold | `board init` in a fresh scratch repo | PASS: BACKLOG.md header + executable shim created, [sync] hint printed |
 | capture e2e | `board capture "<title>" -b "<notes>"` on whetstone | PASS: row WS-6 minted (prefix-aware, via sync_core), sync created issue #14, URL printed AND verified on the clipboard via pbpaste |
-| capture без github | (code path) state snapshot missing rid | prints "row is on the board", never fails the filing |
+| capture without github | (code path) state snapshot missing rid | prints "row is on the board", never fails the filing |
 
 `capture` composes what exists: sync_core mints the row, `cmd_sync` (in a
 subshell, since it ends in exec) does the push, the state snapshot yields the

--- a/lib/board/board.sh
+++ b/lib/board/board.sh
@@ -764,7 +764,7 @@ cmd_sync() {
   fi
   args+=(--apps "$v")
   local app fk
-  for app in reminders notion hermes multica; do
+  for app in reminders notion hermes multica github; do
     for fk in only_tags skip_tags intake; do
       v="$(kit_config_get "sync.${app}_${fk}" "")"
       [ -n "$v" ] && args+=(--filter "${app}:${fk}=${v}")
@@ -798,6 +798,7 @@ cmd_sync() {
   [ -n "$v" ] && args+=(--notion-taskboard-props "$v")
   v="$(kit_config_get sync.notion_taskboard_types "")"
   [ -n "$v" ] && args+=(--notion-taskboard-types "$v")
+  v="$(kit_config_get sync.github_repo "")";     [ -n "$v" ] && args+=(--github-repo "$v")
   v="$(kit_config_get sync.hermes_target "")";   [ -n "$v" ] && args+=(--hermes-target "$v")
   v="$(kit_config_get sync.hermes_home "")";     [ -n "$v" ] && args+=(--hermes-home "$v")
   v="$(kit_config_get sync.multica_url "")";       [ -n "$v" ] && args+=(--multica-url "$v")

--- a/lib/board/board.sh
+++ b/lib/board/board.sh
@@ -736,6 +736,113 @@ cmd_writeback() {
 # module, lib/sync/). Consumer shims append --backlog-file; translate it to the
 # engine's --backlog. Config resolution happens HERE per ADR-0034: a command
 # reads [sync] keys via the ONE resolver at invocation and hands the python
+# init: scaffold the board files adopt does not cover. `kit adopt` seeds
+# .kit.toml and wires modules; the board itself (_meta/BACKLOG.md + the _meta/
+# board shim) was a copy-by-hand step, which is exactly how a new repo ends up
+# half-registered. Idempotent: existing files are never touched.
+cmd_init() {
+  local root; root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  local meta="$root/_meta"
+  mkdir -p "$meta"
+  if [ ! -f "$meta/BACKLOG.md" ]; then
+    printf '# BACKLOG\n\n| ID | Item | Notes & source | Status |\n|---|---|---|---|\n' \
+      > "$meta/BACKLOG.md"
+    echo "created _meta/BACKLOG.md (empty board; \`board sync\` intakes open issues as rows)"
+  else
+    echo "kept existing _meta/BACKLOG.md"
+  fi
+  if [ ! -f "$meta/board" ]; then
+    cat > "$meta/board" <<'SHIM'
+#!/usr/bin/env bash
+# _meta/board -- one-line shim exec'ing the dwarves-kit `board` command against
+# THIS repo's own BACKLOG.md. Scaffolded by `board init`; logic lives in the kit.
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+exec bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/bin/board" "${@:-board}" --backlog-file "$here/BACKLOG.md"
+SHIM
+    chmod +x "$meta/board"
+    echo "created _meta/board shim"
+  else
+    echo "kept existing _meta/board"
+  fi
+  [ -f "$root/.kit.toml" ] && grep -q '^\[sync\]' "$root/.kit.toml" 2>/dev/null || {
+    echo "next: add a [sync] section to .kit.toml, e.g."
+    printf '  [sync]\n  apps = "github"\n'
+  }
+}
+
+# capture: file ONE item from a working session -- a queued row on the board,
+# pushed to the configured spokes immediately, and (when the github app is on)
+# the new issue's URL printed and put on the clipboard. This is the
+# harness-agnostic "file this" verb: Claude Code, Codex, pi and Hermes all just
+# run `board capture "<title>" [-b <notes>]`.
+cmd_capture() {
+  local backlog="" title="" notes="" a
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --backlog-file) backlog="${2:-}"; shift 2 ;;
+      -b|--notes) notes="${2:-}"; shift 2 ;;
+      *) if [ -z "$title" ]; then title="$1"; else title="$title $1"; fi; shift ;;
+    esac
+  done
+  [ -n "$title" ] || { echo "usage: board capture \"<title>\" [-b <notes>]" >&2; exit 2; }
+  backlog="${backlog:-$PWD/_meta/BACKLOG.md}"
+  [ -f "$backlog" ] || { echo "board capture: no board at $backlog (run \`board init\`)" >&2; exit 2; }
+  local bid
+  bid="$(BOARD_SYNC_LIB="$BOARD_DIR/../sync" python3 - "$backlog" "$title" "$notes" <<'PY'
+import os, sys
+from pathlib import Path
+sys.path.insert(0, os.environ["BOARD_SYNC_LIB"])
+from sync_core import detect_prefix, next_id, escape
+path = Path(sys.argv[1])
+text = path.read_text()
+prefix = detect_prefix(text)
+bid = f"{prefix}-{next_id(text, prefix)}"
+title, notes = sys.argv[2], sys.argv[3] or "filed via board capture"
+row = f"| {bid} | {escape(' '.join(title.split()))} | {escape(notes)} | queued |\n"
+lines = text.splitlines(keepends=True)
+for i, ln in enumerate(lines):
+    if ln.startswith("|---"):
+        lines.insert(i + 1, row)
+        break
+else:
+    sys.exit(f"no table header found in {path}")
+path.write_text("".join(lines))
+print(bid)
+PY
+)"
+  # sync in a subshell: cmd_sync ends in exec and must not replace this shell.
+  ( cmd_sync --backlog-file "$backlog" ) || true
+  local rid=""
+  rid="$(python3 - "$backlog" "$bid" <<'PY'
+import json, re, sys
+from pathlib import Path
+slug = re.sub(r"[^a-zA-Z0-9]+", "-", str(Path(sys.argv[1]).resolve())).strip("-")
+p = Path.home() / ".cache" / "backlog-sync" / slug / "github.state.json"
+try:
+    print(json.loads(p.read_text())["map"][sys.argv[2]]["rid"])
+except Exception:
+    pass
+PY
+)"
+  echo "filed: $bid"
+  if [ -n "$rid" ]; then
+    local url
+    url="$(cd "$(dirname "$backlog")/.." && gh issue view "$rid" --json url --jq .url 2>/dev/null || true)"
+    if [ -n "$url" ]; then
+      printf '%s' "$url" | pbcopy 2>/dev/null || true
+      echo "issue: $url  (link on clipboard)"
+      # enrich: what already exists nearby, so duplicates get merged early
+      (cd "$(dirname "$backlog")/.." && gh issue list --state all --search "$title" \
+        --limit 4 --json number,title \
+        --jq '.[] | "  #\(.number) \(.title)"' 2>/dev/null | grep -v "^  #$rid " || true) \
+        | sed '1s/^/related existing issues:\n/' | head -5
+    fi
+  else
+    echo "note: no github spoke configured (or sync skipped); row is on the board"
+  fi
+}
+
 # engine plain flags (the engine never reads TOML). User-passed flags land
 # after the config-derived ones, so argparse lets them win.
 cmd_sync() {
@@ -836,6 +943,8 @@ main() {
     status) shift; cmd_status "$@" ;;
     writeback) shift; cmd_writeback "$@" ;;
     sync) shift; cmd_sync "$@" ;;
+    init) shift; cmd_init "$@" ;;
+    capture) shift; cmd_capture "$@" ;;
     promote) shift; exec "$BOARD_DIR/bin/add-backlog" "$@" ;;
     -h|--help|help) usage ;;
     *) cmd_board_single "$@" ;;

--- a/lib/sync/backlog_sync.py
+++ b/lib/sync/backlog_sync.py
@@ -27,10 +27,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from sync_core import (ID_TOKEN, apply_board, build_state, describe,  # noqa: E402
-                       parse_board, plan_create_only, plan_sync)
+                       detect_prefix, parse_board, plan_create_only, plan_sync)
 
 # apps that push one-way and read boards with any repo prefix (not just ID-)
 CREATE_ONLY_APPS = {"notion-taskboard"}
+from sources.github import GitHubSource  # noqa: E402
 from sources.hermes import HermesSource  # noqa: E402
 from sources.multica import MulticaSource  # noqa: E402
 from sources.notion import NotionSource  # noqa: E402
@@ -54,13 +55,15 @@ def atomic_write(path: Path, text: str) -> None:
 
 
 def warn_duplicate_ids(text: str, strict_id: bool = True) -> None:
-    token = r"ID-\d+" if strict_id else ID_TOKEN
+    token = (re.escape(detect_prefix(text)) + r"-\d+") if strict_id \
+        else ID_TOKEN
     ids = re.findall(r"^\| (" + token + r") \|", text, flags=re.M)
     dups = sorted({i for i in ids if ids.count(i) > 1})
     if dups:
         print(f"WARNING: duplicate board rows for {', '.join(dups)}; "
               "first occurrence wins, fix the board")
-    parsed = set(parse_board(text, strict_id=strict_id))
+    parsed = set(parse_board(text, strict_id=strict_id,
+                             prefix=detect_prefix(text)))
     broken = sorted(set(ids) - parsed - set(dups))
     if broken:
         print(f"WARNING: malformed board rows (not 4 cells, invisible to "
@@ -112,7 +115,8 @@ def sync_source(src, backlog: Path, state_path: Path, dry_run: bool,
     if getattr(src, "create_only", False):
         return sync_create_only(src, backlog, state_path, dry_run, filt)
     text = backlog.read_text()
-    rows = parse_board(text)
+    prefix = detect_prefix(text)
+    rows = parse_board(text, prefix=prefix)
     state = json.loads(state_path.read_text()) if state_path.exists() else {}
     if hasattr(src, "binding") and state.get("binding"):
         src.binding = state["binding"]
@@ -133,10 +137,10 @@ def sync_source(src, backlog: Path, state_path: Path, dry_run: bool,
               f"scope (cap {max(cap, allow)}). Review with --dry-run, then "
               f"re-run with --allow-scope-exit {exits}.")
         return
-    new_text, assigned = apply_board(text, plan)
+    new_text, assigned = apply_board(text, plan, prefix=prefix)
     if new_text != text:
         atomic_write(backlog, new_text)
-    rows_after = parse_board(new_text)
+    rows_after = parse_board(new_text, prefix=prefix)
     created = src.apply(plan, assigned, rows_after)
     new_state = build_state(rows_after, items, plan, created, assigned, state)
     if getattr(src, "binding", None):
@@ -182,6 +186,9 @@ def build_source(name: str, args):
             priority_map=parse_map(args.notion_taskboard_priority_map),
             weight_map=parse_map(args.notion_taskboard_weight_map),
             owner=args.notion_taskboard_owner, props=props, types=types)
+    if name == "github":
+        # repo empty is fine: gh resolves the cwd's origin remote.
+        return GitHubSource(args.github_repo or "")
     if name == "hermes":
         if not args.hermes_home:
             sys.exit("hermes: set hermes_home in [sync] (.kit.toml) or pass "
@@ -217,6 +224,9 @@ def main(argv=None):
     ap.add_argument("--notion-db", help="bind an existing Notion database id")
     ap.add_argument("--notion-parent",
                     help="Notion page id to create the board under (bootstrap)")
+    ap.add_argument("--github-repo",
+                    help="owner/repo for the github app (default: the cwd's "
+                         "origin remote, as gh resolves it)")
     ap.add_argument("--hermes-target")
     ap.add_argument("--hermes-home")
     ap.add_argument("--notion-taskboard-db",

--- a/lib/sync/sources/github.py
+++ b/lib/sync/sources/github.py
@@ -1,0 +1,100 @@
+"""GitHub Issues spoke: drive the `gh` CLI only (auth, remotes, and retries
+stay gh's problem; no token ever passes through this process).
+
+The team-collab proposal (2026-07-04 §7) names GitHub Issues as the board
+surface for code repos; this is that adapter, same hub-and-spoke rules as the
+others: board wins on conflict, spoke deletions never touch the board.
+
+Capability envelope (GitHub has open/closed and nothing finer):
+  - create with a `bls: <ID>` body marker as the idempotency guard (GitHub has
+    no idempotency key; read() surfaces the marker so a re-run adopts instead
+    of duplicating)
+  - board shipped/done/resolved -> close; dropped/parked -> close with a
+    comment saying which, so the distinction survives in the thread
+  - reverse: a closed issue reads back as shipped (finer states cannot be
+    inferred from closed alone)
+  - unlike Hermes this spoke CAN reopen: a board row moving back to an active
+    state reopens its closed issue (git wins, visibly)
+  - sync_fields=False: title/body freeze at create. Teammates retitling an
+    issue must not stale-echo the board; the row is the record.
+"""
+
+import json
+import subprocess
+
+ACTIVE = {"queued", "claimed", "speccing", "validated", "executing"}
+COMPLETE_KWS = {"shipped", "done", "resolved"}
+MARKER = "bls: "
+
+
+def _gh_runner(argv: list) -> str:
+    r = subprocess.run(["gh"] + argv, capture_output=True, text=True,
+                       timeout=120)
+    if r.returncode != 0:
+        raise SystemExit(f"gh {' '.join(argv[:3])}... failed: "
+                         f"{r.stderr.strip()[:500]}")
+    return r.stdout
+
+
+class GitHubSource:
+    name = "github"
+    sync_fields = False
+
+    def __init__(self, repo: str = "", runner=None):
+        # repo empty = whatever `gh` resolves from the cwd's origin remote.
+        self.repo = repo
+        self.runner = runner or _gh_runner
+
+    def _flags(self) -> list:
+        return ["-R", self.repo] if self.repo else []
+
+    def read(self) -> list[dict]:
+        raw = self.runner(["issue", "list", *self._flags(), "--state", "all",
+                           "--limit", "500",
+                           "--json", "number,title,state,body"])
+        items = []
+        for t in json.loads(raw or "[]"):
+            closed = t.get("state") == "CLOSED"
+            # status stays None: closed carries no shipped-vs-dropped signal,
+            # and asserting "shipped" here overrides the engine's three-way
+            # merge (measured live: a re-sync flipped a dropped row to shipped
+            # because this claimed to know more than GitHub does). The `done`
+            # flag is the whole truth a binary spoke has; the engine derives
+            # the keyword against its snapshot, same as the Reminders spoke.
+            items.append({"rid": str(t["number"]),
+                          "title": t.get("title") or "",
+                          "done": closed,
+                          "body": t.get("body") or "",
+                          "status": None})
+        return items
+
+    def apply(self, plan, assigned: dict, rows_after: dict) -> dict:
+        created = {}
+        for bid, title, body, _kw in plan.src_create:
+            # The marker is the idempotency guard: read() returns bodies, so
+            # the planner has already matched rows to marked issues; anything
+            # still in src_create is genuinely new.
+            url = self.runner(["issue", "create", *self._flags(),
+                               "--title", title,
+                               "--body", f"{body}\n\n{MARKER}{bid}"]).strip()
+            rid = url.rstrip("/").rsplit("/", 1)[-1]
+            if not rid.isdigit():
+                raise SystemExit(f"github: create for {bid} returned no "
+                                 f"issue url: {url[:200]}")
+            created[bid] = rid
+        for _bid, rid in plan.src_scope_exit:
+            self.runner(["issue", "close", *self._flags(), rid,
+                         "-c", "left the sync scope on _meta/BACKLOG.md"])
+        for rid, kw in plan.src_set_status:
+            if kw in COMPLETE_KWS:
+                self.runner(["issue", "close", *self._flags(), rid,
+                             "-c", "closed on _meta/BACKLOG.md"])
+            elif kw in ("dropped", "parked"):
+                self.runner(["issue", "close", *self._flags(), rid,
+                             "-c", f"{kw} on _meta/BACKLOG.md"])
+            elif kw in ACTIVE:
+                # Board says live, issue is closed: reopen, git wins.
+                self.runner(["issue", "reopen", *self._flags(), rid,
+                             "-c", f"board row is {kw}; reopened from "
+                                   "_meta/BACKLOG.md"])
+        return created

--- a/lib/sync/sync_core.py
+++ b/lib/sync/sync_core.py
@@ -18,7 +18,6 @@ INBOX_HEADING = "### Reminders inbox"
 CLOSED_HEADING = "## Recently closed"
 TABLE_HEADER = "| ID | Item | Notes & source | Status |"
 TABLE_RULE = "|---|---|---|---|"
-TITLE_RE = re.compile(r"^(ID-\d+)\s*(?:[·:, -]\s*)?(.*)$")
 CELL_SPLIT = re.compile(r"(?<!\\)\|")
 
 # Board-id row recognizers. The two-way mesh is `ID-`-only (STRICT), exactly as
@@ -28,6 +27,10 @@ CELL_SPLIT = re.compile(r"(?<!\\)\|")
 # e.g. dfoundation DF-NN); it never mints or writes board ids, so widening its
 # READ view has no interaction with the strict minters.
 ID_TOKEN = r"[A-Z][A-Z0-9]*-\d+"
+# Any board prefix, not just ID-: spoke titles carry the row id of whichever
+# board minted them (WS-4 on whetstone), and a bid only links when it exists
+# in that board's rows, so the generic token cannot cross-link boards.
+TITLE_RE = re.compile(r"^(" + ID_TOKEN + r")\s*(?:[·:, -]\s*)?(.*)$")
 STRICT_ROW_RE = re.compile(r"^\| (ID-\d+) \|")
 GEN_ROW_RE = re.compile(r"^\| (" + ID_TOKEN + r") \|")
 
@@ -51,14 +54,29 @@ def split_row(line: str):
     return [p.strip() for p in parts[1:5]]
 
 
-def parse_board(text: str, strict_id: bool = True) -> dict[str, Row]:
+def detect_prefix(text: str) -> str:
+    """A board's own row prefix (`WS` for whetstone, `BK` for books, ...),
+    from its most common row token; `ID` when the board is empty. Every
+    cockpit repo has a unique prefix by design, so the two-way mesh must not
+    assume `ID-` or those boards silently parse as zero rows (the bug this
+    fixed: `board sync` on whetstone read 4 spoke items, 0 board rows, and
+    planned duplicate intake for every already-rowed issue)."""
+    counts: dict[str, int] = {}
+    for m in re.finditer(r"^\| ([A-Z][A-Z0-9]*)-\d+ \|", text, flags=re.M):
+        counts[m.group(1)] = counts.get(m.group(1), 0) + 1
+    return max(counts, key=counts.get) if counts else "ID"
+
+
+def parse_board(text: str, strict_id: bool = True,
+                prefix: str = "ID") -> dict[str, Row]:
     """Parse `| id | item | notes | status |` rows. `strict_id=True` (default,
-    the two-way mesh) recognizes ONLY `ID-NNN`, keeping the ID-minting path
-    (next_id/apply_board) consistent. `strict_id=False` (the one-way create
-    push) accepts any repo prefix `[A-Z]+-NNN` but never mints or writes ids.
+    the two-way mesh) recognizes ONLY `<prefix>-NNN` (one prefix per board,
+    keeping the ID-minting path consistent). `strict_id=False` (the one-way
+    create push) accepts any repo prefix `[A-Z]+-NNN` but never mints ids.
     """
-    row_re = STRICT_ROW_RE if strict_id else GEN_ROW_RE
-    id_full = r"ID-\d+" if strict_id else ID_TOKEN
+    row_re = (re.compile(r"^\| (" + re.escape(prefix) + r"-\d+) \|")
+              if strict_id else GEN_ROW_RE)
+    id_full = re.escape(prefix) + r"-\d+" if strict_id else ID_TOKEN
     rows: dict[str, Row] = {}
     for i, line in enumerate(text.splitlines()):
         if not row_re.match(line):
@@ -76,8 +94,9 @@ def parse_board(text: str, strict_id: bool = True) -> dict[str, Row]:
     return rows
 
 
-def next_id(text: str) -> int:
-    nums = [int(m) for m in re.findall(r"\bID-(\d+)\b", text)]
+def next_id(text: str, prefix: str = "ID") -> int:
+    nums = [int(m) for m in
+            re.findall(r"\b" + re.escape(prefix) + r"-(\d+)\b", text)]
     return max(nums, default=0) + 1
 
 
@@ -240,7 +259,17 @@ def plan_sync(rows: dict, items: list, state: dict,
         else:
             snap_kw = snap.get("status", board_kw)
             board_changed = board_kw != snap_kw
-            src_changed = src_kw is not None and src_kw != snap_kw
+            if it.get("status") is None:
+                # Binary spoke (GitHub, Reminders): open/done is the whole
+                # signal, so compare DONENESS, not the derived keyword.
+                # Comparing keywords oscillates: a dropped row's closed issue
+                # re-derives "shipped" != snapshot "dropped" on every sync and
+                # flips the board back (measured live on whetstone WS-5).
+                src_changed = it["done"] != (snap_kw not in ACTIVE_STATUSES)
+                if src_changed and not it["done"]:
+                    src_kw = "queued"  # reopened on the spoke
+            else:
+                src_changed = src_kw is not None and src_kw != snap_kw
             if board_changed and src_changed and board_kw != src_kw:
                 p.conflicts.append(f"{bid}: status changed on both sides; "
                                    f"board wins (board={board_kw} "
@@ -328,10 +357,11 @@ def plan_create_only(rows: dict, state: dict, skip_kw: set | None = None,
 # --- board apply -------------------------------------------------------------
 
 
-def apply_board(text: str, plan: Plan) -> tuple[str, dict[str, str]]:
+def apply_board(text: str, plan: Plan,
+                prefix: str = "ID") -> tuple[str, dict[str, str]]:
     """Apply board-side actions. Returns (new_text, {rid: assigned_board_id})."""
     lines = text.splitlines(keepends=True)
-    rows = parse_board(text)
+    rows = parse_board(text, prefix=prefix)
 
     def rewrite(bid: str, item: str | None = None, status_kw: str | None = None):
         row = rows[bid]
@@ -353,10 +383,10 @@ def apply_board(text: str, plan: Plan) -> tuple[str, dict[str, str]]:
 
     assigned: dict[str, str] = {}
     if plan.board_add:
-        nid = next_id(text)
+        nid = next_id(text, prefix)
         new_rows = []
         for rid, title, body, kw in plan.board_add:
-            bid = f"ID-{nid}"
+            bid = f"{prefix}-{nid}"
             nid += 1
             assigned[rid] = bid
             title = " ".join(title.split())  # newlines would break the table row

--- a/lib/sync/tests/test_github.py
+++ b/lib/sync/tests/test_github.py
@@ -1,0 +1,77 @@
+"""GitHub adapter tests against a fake gh transport (no network)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sources.github import GitHubSource  # noqa: E402
+from sync_core import Plan  # noqa: E402
+
+
+class FakeGh:
+    def __init__(self, outputs=None):
+        self.calls = []
+        self.outputs = list(outputs or [])
+
+    def __call__(self, argv):
+        self.calls.append(argv)
+        return self.outputs.pop(0) if self.outputs else ""
+
+
+def test_read_normalizes_states():
+    fake = FakeGh([json.dumps([
+        {"number": 7, "title": "fix panel", "state": "OPEN", "body": "b"},
+        {"number": 8, "title": "old bug", "state": "CLOSED", "body": ""},
+    ])])
+    items = GitHubSource(runner=fake).read()
+    assert items[0] == {"rid": "7", "title": "fix panel", "done": False,
+                        "body": "b", "status": None}
+    assert items[1]["done"] is True
+    # closed carries no shipped-vs-dropped signal; the engine derives the
+    # keyword from `done` + its snapshot. Asserting shipped here flipped a
+    # dropped row live.
+    assert items[1]["status"] is None
+    # repo unset: no -R flag leaks into the call
+    assert "-R" not in fake.calls[0]
+
+
+def test_repo_flag_threaded_through():
+    fake = FakeGh(["[]"])
+    GitHubSource(repo="dwarvesf/whetstone", runner=fake).read()
+    i = fake.calls[0].index("-R")
+    assert fake.calls[0][i + 1] == "dwarvesf/whetstone"
+
+
+def test_apply_creates_with_marker_and_returns_rid():
+    fake = FakeGh(["https://github.com/o/r/issues/12\n"])
+    plan = Plan(src_create=[("WS-4", "decide the thing", "notes", "queued")])
+    created = GitHubSource(runner=fake).apply(plan, {}, {})
+    assert created == {"WS-4": "12"}
+    argv = fake.calls[0]
+    body = argv[argv.index("--body") + 1]
+    assert "bls: WS-4" in body  # the idempotency marker
+
+
+def test_apply_close_drop_and_reopen_verbs():
+    fake = FakeGh(["", "", ""])
+    plan = Plan(src_set_status=[("7", "shipped"), ("8", "dropped"),
+                                ("9", "queued")])
+    GitHubSource(runner=fake).apply(plan, {}, {})
+    verbs = [c[1] for c in fake.calls]
+    assert verbs == ["close", "close", "reopen"]
+    # dropped keeps its name in the comment; the reopen says git wins
+    assert "dropped" in " ".join(fake.calls[1])
+    assert "queued" in " ".join(fake.calls[2])
+
+
+def test_apply_create_without_url_fails_closed():
+    fake = FakeGh(["not a url"])
+    plan = Plan(src_create=[("WS-9", "t", "b", "queued")])
+    try:
+        GitHubSource(runner=fake).apply(plan, {}, {})
+    except SystemExit as e:
+        assert "WS-9" in str(e)
+    else:
+        raise AssertionError("apply accepted a create with no issue url")

--- a/lib/sync/tests/test_prefix.py
+++ b/lib/sync/tests/test_prefix.py
@@ -1,0 +1,87 @@
+"""Per-board prefix support in the two-way mesh.
+
+The cockpit gives every repo a unique row prefix (WS-, BK-, DS-, ...), but the
+mesh was hardwired to ID-: on any non-ID board `board sync` read zero rows and
+planned duplicate intake for every already-rowed spoke item (found live on
+whetstone's first sync). These pin the fix: the prefix is detected from the
+board itself and threaded through parse, mint, and apply.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sync_core import (Plan, apply_board, detect_prefix,  # noqa: E402
+                       next_id, parse_board)
+
+WS_BOARD = """# BACKLOG
+
+| ID | Item | Notes & source | Status |
+|---|---|---|---|
+| WS-3 | review panel model | adopted gh#7 | queued |
+| WS-1 | newline trap | adopted gh#9 | queued |
+"""
+
+
+def test_detect_prefix_ws_and_empty_default():
+    assert detect_prefix(WS_BOARD) == "WS"
+    assert detect_prefix("# empty\n") == "ID"
+
+
+def test_detect_prefix_majority_wins():
+    mixed = WS_BOARD + "| ID-9 | stray | n | queued |\n"
+    assert detect_prefix(mixed) == "WS"
+
+
+def test_strict_parse_sees_prefixed_rows():
+    # the live bug: strict default (ID) reads 0 rows off a WS board
+    assert parse_board(WS_BOARD) == {}
+    rows = parse_board(WS_BOARD, prefix="WS")
+    assert set(rows) == {"WS-3", "WS-1"}
+
+
+def test_next_id_is_prefix_scoped():
+    assert next_id(WS_BOARD, "WS") == 4
+    assert next_id(WS_BOARD, "ID") == 1  # foreign prefix never inflates
+
+
+def test_apply_board_mints_with_board_prefix():
+    plan = Plan(board_add=[("77", "from spoke", "body", "queued")])
+    new_text, assigned = apply_board(WS_BOARD, plan, prefix="WS")
+    assert assigned == {"77": "WS-4"}
+    assert "| WS-4 | from spoke |" in new_text
+
+
+# --- binary-spoke doneness merge (the WS-5 oscillation) ----------------------
+
+from sync_core import plan_sync  # noqa: E402
+
+DROPPED_BOARD = """| ID | Item | Notes & source | Status |
+|---|---|---|---|
+| WS-5 | live test | e2e | dropped |
+"""
+
+
+def _state(status):
+    return {"map": {"WS-5": {"rid": "12", "title": "live test",
+                             "notes": "e2e", "status": status}}}
+
+
+def test_binary_spoke_dropped_row_closed_item_is_stable():
+    # closed issue + dropped row + snapshot dropped: NOTHING may move. The
+    # keyword compare re-derived shipped != dropped and flipped the board on
+    # every sync (live WS-5 bug); doneness compare holds it still.
+    rows = parse_board(DROPPED_BOARD, prefix="WS")
+    item = {"rid": "12", "title": "WS-5 · live test", "done": True,
+            "body": "e2e", "status": None}
+    p = plan_sync(rows, [item], _state("dropped"), sync_fields=False)
+    assert not p.board_set_status and not p.src_set_status
+
+
+def test_binary_spoke_reopen_flows_to_board_as_queued():
+    rows = parse_board(DROPPED_BOARD, prefix="WS")
+    item = {"rid": "12", "title": "WS-5 · live test", "done": False,
+            "body": "e2e", "status": None}
+    p = plan_sync(rows, [item], _state("dropped"), sync_fields=False)
+    assert p.board_set_status == [("WS-5", "queued")]


### PR DESCRIPTION
#### What's this PR do?

- [x] Adds the **GitHub Issues spoke** to the backlog-sync mesh — the adapter the team-collab proposal (2026-07-04 §7) reserved: `[sync] apps = "github"` in `.kit.toml`, same hub-and-spoke rules as Reminders / Notion / Hermes / Multica
- [x] Makes the two-way mesh **per-board-prefix aware** (`WS-`, `BK-`, `DS-`… not just `ID-`)
- [x] Fixes a **binary-spoke status oscillation** in the merge core (affected Reminders too)

#### What are the relevant Git tickets?

Implements the GitHub leg of the board-as-adapter-seam design (team-collab proposal §7). Pilot repo: `dwarvesf/whetstone`.

#### Any background context you want to provide?

Wiring the first non-`ID` board surfaced three real defects, each found live and now pinned by a test:

| Leg | Defect | Fix |
|---|---|---|
| parse | mesh hardwired to `ID-` rows → every cockpit repo with its own prefix parsed as **0 rows**, sync planned duplicate intake for everything | `detect_prefix` from the board file, threaded through `parse_board` / `next_id` / `apply_board`; default `ID` unchanged |
| link | `TITLE_RE` only matched `ID-` spoke titles → 4 rows + 4 matching issues planned 8 duplicates | generic token; a bid still only links when it exists in that board's rows |
| merge | dropped row + closed issue flipped to `shipped` **every sync** (engine re-derives `shipped` from `done`, compares keywords vs snapshot) — any open/done-only spoke oscillates | when a spoke reports `status: None`, doneness is the change signal; spoke-side reopen flows back as `queued` |

Adapter capability envelope (in the file header): gh CLI only, `bls: <ID>` body marker as the idempotency guard, shipped/dropped both close with the keyword in a comment, reopen supported (git wins visibly), `sync_fields=False` so issue retitles never stale-echo the board.

#### Verification

`docs/verification/board-github-adapter.md`: 170 tests pass (163 pre-existing + 7 new), live e2e on whetstone — cold link with zero duplicates, row→issue create with marker, dropped→closed, two consecutive quiet syncs, board-wins re-assert after a board edit. The three defects double as negative controls: each has a test asserting the old behavior fails.
