### PR TITLE
fix(sync): github spoke runs gh in the backlog's repo, not the process cwd

### DIFF
--- a/lib/sync/backlog_sync.py
+++ b/lib/sync/backlog_sync.py
@@ -187,8 +187,11 @@ def build_source(name: str, args):
             weight_map=parse_map(args.notion_taskboard_weight_map),
             owner=args.notion_taskboard_owner, props=props, types=types)
     if name == "github":
-        # repo empty is fine: gh resolves the cwd's origin remote.
-        return GitHubSource(args.github_repo or "")
+        # repo empty is fine: gh resolves origin from the backlog's own repo
+        # (KIT_PROJECT_ROOT), never the process cwd, which under launchd is
+        # nowhere near the checkout.
+        return GitHubSource(args.github_repo or "",
+                            cwd=os.environ.get("KIT_PROJECT_ROOT"))
     if name == "hermes":
         if not args.hermes_home:
             sys.exit("hermes: set hermes_home in [sync] (.kit.toml) or pass "

--- a/lib/sync/sources/github.py
+++ b/lib/sync/sources/github.py
@@ -27,9 +27,9 @@ COMPLETE_KWS = {"shipped", "done", "resolved"}
 MARKER = "bls: "
 
 
-def _gh_runner(argv: list) -> str:
+def _gh_runner(argv: list, cwd: str | None = None) -> str:
     r = subprocess.run(["gh"] + argv, capture_output=True, text=True,
-                       timeout=120)
+                       timeout=120, cwd=cwd or None)
     if r.returncode != 0:
         raise SystemExit(f"gh {' '.join(argv[:3])}... failed: "
                          f"{r.stderr.strip()[:500]}")
@@ -40,10 +40,16 @@ class GitHubSource:
     name = "github"
     sync_fields = False
 
-    def __init__(self, repo: str = "", runner=None):
-        # repo empty = whatever `gh` resolves from the cwd's origin remote.
+    def __init__(self, repo: str = "", runner=None, cwd: str | None = None):
+        # repo empty = whatever `gh` resolves from the origin remote of `cwd`
+        # (the repo that owns the backlog, threaded in as KIT_PROJECT_ROOT by
+        # cmd_sync). Relying on the PROCESS cwd broke the first launchd run:
+        # the cron launcher starts nowhere near the checkout, gh saw "not a
+        # git repository", and every scheduled sync exited 1. Interactive runs
+        # never caught it because a shell is always inside the repo.
         self.repo = repo
-        self.runner = runner or _gh_runner
+        self.cwd = cwd
+        self.runner = runner or (lambda argv: _gh_runner(argv, self.cwd))
 
     def _flags(self) -> list:
         return ["-R", self.repo] if self.repo else []

--- a/lib/sync/tests/test_github.py
+++ b/lib/sync/tests/test_github.py
@@ -75,3 +75,13 @@ def test_apply_create_without_url_fails_closed():
         assert "WS-9" in str(e)
     else:
         raise AssertionError("apply accepted a create with no issue url")
+
+
+def test_default_runner_binds_backlog_repo_cwd():
+    # Under launchd the process cwd is nowhere near the checkout; gh must run
+    # in the backlog's own repo (first scheduled run failed exit 1 on this).
+    src = GitHubSource(cwd="/some/repo")
+    assert src.cwd == "/some/repo"
+    # injected runners (tests, future transports) are never wrapped
+    fake = FakeGh(["[]"])
+    assert GitHubSource(runner=fake, cwd="/x").runner is fake


### PR DESCRIPTION
#### What's this PR do?
- [x] `GitHubSource` default runner executes `gh` with `cwd=KIT_PROJECT_ROOT` (the backlog's own repo)

#### What are the relevant Git tickets?
Follow-up to #295, found by the FIRST scheduled run of the whetstone LaunchAgent: exit 1, `fatal: not a git repository`. launchd's cwd is nowhere near the checkout; interactive shells always were, which is why every live test in #295 passed.

#### Verification
171 tests pass (new: `test_default_runner_binds_backlog_repo_cwd`). The real proof is the kickstarted agent run going green post-merge, recorded in the PR conversation.