### PR TITLE
docs(skills): cite prior-art lineage for the bounded-revise engine

### DIFF
--- a/docs/research/2026-07-30-loop-engine-prior-art.md
+++ b/docs/research/2026-07-30-loop-engine-prior-art.md
@@ -1,0 +1,81 @@
+---
+title: Bounded-revise loop engine vs prior art (Evaluator-Optimizer, Self-Refine, Reflexion, CRITIC)
+date: 2026-07-30
+source: web research (WebSearch/WebFetch) dispatched to a general-purpose agent, cross-checked against commands/test-plan-review-team.md and docs/PHILOSOPHY.md "Loop boundaries"
+feeds: skills/loop-engineering/SKILL.md Lineage section; any future bounded-revise engine instantiation (see _meta/BACKLOG.md v2 candidates)
+benchmarked_against: commands/test-plan-review-team.md Step 2-4 (SPEC-203/204), docs/PHILOSOPHY.md "Loop boundaries (bounded in-session, not unbounded outer)" + "Feature rejection criteria"
+status: active
+---
+
+# Bounded-revise loop engine vs prior art
+
+## Why this note exists
+
+`skills/loop-engineering/SKILL.md`'s own Step 1 gate requires a source citation before a new
+loop counts as legitimate ("synthesize, don't originate," `docs/PHILOSOPHY.md`). Before trusting
+that gate on our own generalized "bounded-revise engine" pattern (extracted 2026-07-30 from
+`test-plan-review-team.md`), we checked whether it already exists elsewhere under a different
+name. Short answer: the coarse shape does; the specific four-property bundle does not.
+
+## What we built (recap)
+
+Dispatch N scanner subagents against an artifact in parallel -> merge findings, tag severity ->
+if findings exist, dispatch a **distinct** reviser (never one of the scanners) -> re-check ->
+repeat until clean or a hard cap of 3 rounds. The stop condition is severity-aware: a flat raw
+finding-count still counts as progress if the worst severity present dropped round over round.
+Non-convergence is reported as an explicit verdict (`RECONSIDER`), not a silent halt.
+
+## Prior-art survey
+
+| Name | Source | Generalizes across artifacts? | Severity-aware convergence? | Critic ≠ reviser enforced? | Hard cap + honest-halt? |
+|---|---|---|---|---|---|
+| Evaluator-Optimizer workflow | [Anthropic, "Building Effective Agents"](https://www.anthropic.com/research/building-effective-agents) | Yes, by design | No, binary "meets criteria" only | Not enforced (often blended role) | Not specified |
+| Reflection Loop / Reflection Agent | [LangGraph docs](https://www.langchain.com/blog/reflection-agents) | Yes (graph-generic) | No | Usually no (self-critique) | No |
+| Self-Refine | [Madaan et al. 2023](https://arxiv.org/abs/2303.17651) | Yes, tested on 7 task types | No | No, same LLM critiques and revises | No |
+| Reflexion | [Shinn et al. 2023](https://openreview.net/pdf?id=vAElhFcKW6) | Yes, pluggable Evaluator | No | Evaluator ≠ Actor, but no distinct reviser role | No |
+| CRITIC | [Gou et al. 2023](https://arxiv.org/abs/2305.11738) | Yes (tool-interactive) | No | No | No |
+| Constitutional AI critique-revise | [Bai et al. 2022](https://arxiv.org/pdf/2212.08073) | Yes, extended to other domains | No | No, same model does both steps | No |
+| VRR-Stop (2026) | [arXiv 2607.17641](https://arxiv.org/html/2607.17641) | No, scoped to verify-repair | Closest match: marginal-gain stopping, K_max=5 + keep-best fallback | Not its axis | Partial (reactive fallback, not pre-announced) |
+| Claude Code marketplace skills | Auto Review, Review Loop, adversarial-loop, looper (searched 2026-07-30) | No, all code-review-shaped | No, verdict/count-based | Incidental (Codex fixes, Claude reviews) not a stated rule | Capped 3-5 rounds, no honest-halt path found |
+
+## The three deltas that are actually ours
+
+1. **Severity-aware convergence.** Not found anywhere surveyed. Prevents two failure modes at
+   once: a false stall (a genuinely-improving round misread as stuck because raw count didn't
+   drop, our own SPEC-204 experience) and a false victory (clearing five LOW findings while a
+   CRITICAL from round 1 ages out unaddressed).
+2. **Distinct reviser, never a scorer, as an enforced rule.** Seen incidentally in practice
+   (e.g. one model reviews, a different one fixes) but never stated as a design contract.
+   Matters because Self-Refine's own limitations note the mechanism only helps when the model's
+   error-*detection* ability exceeds its error-*avoidance* ability; if the same weights wrote the
+   flaw, they're likely to miss it on re-read too.
+3. **Honest-halt as a reported verdict**, not a silent stop or best-effort return. Every
+   framework surveyed either loops until success or quietly returns its best attempt.
+   `RECONSIDER` makes non-convergence a first-class, human-visible outcome instead of a hidden
+   failure in an unattended run.
+
+## When to use which shape (decision framework)
+
+Not "ours is always better." The kit already runs BOTH shapes in production, matched to what
+the artifact actually needs:
+
+| Signal | Use the fuller engine (severity-aware, distinct reviser, honest-halt) | Use the simpler shape (binary stop, cap + escalate) |
+|---|---|---|
+| Artifact's quality bar | Graded, multiple independent findings with a real severity gradient (test plan, spec, code review) | Binary correctness (compiles, test passes, matches an AC) |
+| Lenses that apply | 2+ independent quality angles worth checking in parallel | One check, one verifier |
+| Cost of silent non-convergence | High, unattended run, no human watching each round | Low, already nested inside a pipeline with its own escalation |
+| Token/latency budget | Can afford N parallel scanners + a distinct reviser per round | Needs to be cheap and fast (tight retry loop) |
+| Existing kit precedent | `test-plan-review-team` (this shape) | `/kit:execute`'s worker -> task-verifier -> fix-agent (max 2) -> ESCALATE (already this shape, already kit-native, already has a distinct reviser and a cap, just no severity tiering because task ACs are binary by nature) |
+
+Reach for an **external framework** instead of building either kit-native shape when the loop
+isn't operating on a kit-authored artifact (spec/test-plan/code inside dwarves-kit's own SDLC),
+per `docs/PHILOSOPHY.md`'s own "When to recommend an external tool instead": a downstream
+consumer's own app-domain critique-revise loop fails the "serves 2+ kit lifecycle phases" gate
+and doesn't belong as a kit feature at all.
+
+## Recommendation carried into `skills/loop-engineering/SKILL.md`
+
+Don't rename the pattern, no single literature term covers the full bundle. Cite
+Evaluator-Optimizer as the lineage (satisfies the skill's own source-citation gate), name the
+three deltas above as the actual contribution, and pick the shape (fuller engine vs
+Execute-pipeline-style) per the decision table, not by default.

--- a/docs/research/2026-07-30-loop-engine-prior-art.md
+++ b/docs/research/2026-07-30-loop-engine-prior-art.md
@@ -12,18 +12,20 @@ status: active
 ## Why this note exists
 
 `skills/loop-engineering/SKILL.md`'s own Step 1 gate requires a source citation before a new
-loop counts as legitimate ("synthesize, don't originate," `docs/PHILOSOPHY.md`). Before trusting
-that gate on our own generalized "bounded-revise engine" pattern (extracted 2026-07-30 from
-`test-plan-review-team.md`), we checked whether it already exists elsewhere under a different
-name. Short answer: the coarse shape does; the specific four-property bundle does not.
+loop counts as legitimate (per "synthesize, do not originate," `docs/PHILOSOPHY.md`). Before we
+trusted that gate on our own generalized "bounded-revise engine" pattern, extracted 2026-07-30
+from `test-plan-review-team.md`, we checked whether it already existed elsewhere under a
+different name. Short answer: the coarse shape exists. The specific four-property bundle does
+not.
 
 ## What we built (recap)
 
-Dispatch N scanner subagents against an artifact in parallel -> merge findings, tag severity ->
-if findings exist, dispatch a **distinct** reviser (never one of the scanners) -> re-check ->
-repeat until clean or a hard cap of 3 rounds. The stop condition is severity-aware: a flat raw
-finding-count still counts as progress if the worst severity present dropped round over round.
-Non-convergence is reported as an explicit verdict (`RECONSIDER`), not a silent halt.
+Dispatch N scanner subagents against an artifact, in parallel. Merge their findings and tag
+each with a severity. If findings exist, dispatch a **distinct** reviser, never one of the
+scanners. Re-check. Repeat until clean, or until a hard cap of 3 rounds hits. The stop
+condition tracks severity: a flat raw finding-count still counts as progress if the worst
+severity present dropped round over round. Non-convergence gets reported as an explicit verdict
+(`RECONSIDER`), not a silent halt.
 
 ## Prior-art survey
 
@@ -40,44 +42,44 @@ Non-convergence is reported as an explicit verdict (`RECONSIDER`), not a silent 
 
 ## The three deltas that are actually ours
 
-1. **Severity-aware convergence.** Not found anywhere surveyed. Prevents two failure modes at
-   once: a false stall (a genuinely-improving round misread as stuck because raw count didn't
-   drop, our own SPEC-204 experience) and a false victory (clearing five LOW findings while a
-   CRITICAL from round 1 ages out unaddressed).
-2. **Distinct reviser, never a scorer, as an enforced rule.** Seen incidentally in practice
-   (e.g. one model reviews, a different one fixes) but never stated as a design contract.
-   Matters because Self-Refine's own limitations note the mechanism only helps when the model's
-   error-*detection* ability exceeds its error-*avoidance* ability; if the same weights wrote the
-   flaw, they're likely to miss it on re-read too.
-3. **Honest-halt as a reported verdict**, not a silent stop or best-effort return. Every
-   framework surveyed either loops until success or quietly returns its best attempt.
-   `RECONSIDER` makes non-convergence a first-class, human-visible outcome instead of a hidden
-   failure in an unattended run.
+1. **Severity-aware convergence.** No surveyed source has this. It prevents two failure modes
+   at once. A false stall: a genuinely-improving round reads as stuck, because raw count did
+   not drop. Our own SPEC-204 hit this. A false victory: the loop clears five LOW findings while
+   a CRITICAL from round 1 ages out unaddressed.
+2. **Distinct reviser, never a scorer, as an enforced rule.** Practice shows this incidentally.
+   One model reviews, a different model fixes. No source states it as a design contract. It
+   matters because Self-Refine's own limitations section names the risk: the mechanism only
+   helps when the model's error-*detection* ability exceeds its error-*avoidance* ability. If
+   the same weights wrote the flaw, they will likely miss it on re-read too.
+3. **Honest-halt as a reported verdict**, not a silent stop or a best-effort return. Every
+   surveyed framework either loops until success or quietly returns its best attempt.
+   `RECONSIDER` makes non-convergence a first-class, human-visible outcome, not a hidden failure
+   inside an unattended run.
 
 ## When to use which shape (decision framework)
 
-Not "ours is always better." The kit already runs BOTH shapes in production, matched to what
-the artifact actually needs:
+Ours is not always the better choice. The kit already runs both shapes in production, matched
+to what the artifact actually needs:
 
 | Signal | Use the fuller engine (severity-aware, distinct reviser, honest-halt) | Use the simpler shape (binary stop, cap + escalate) |
 |---|---|---|
 | Artifact's quality bar | Graded, multiple independent findings with a real severity gradient (test plan, spec, code review) | Binary correctness (compiles, test passes, matches an AC) |
 | Lenses that apply | 2+ independent quality angles worth checking in parallel | One check, one verifier |
 | Cost of silent non-convergence | High, unattended run, no human watching each round | Low, already nested inside a pipeline with its own escalation |
-| Token/latency budget | Can afford N parallel scanners + a distinct reviser per round | Needs to be cheap and fast (tight retry loop) |
+| Token/latency budget | Can afford N parallel scanners + a distinct reviser per round | Needs to stay cheap and fast (tight retry loop) |
 | Existing kit precedent | `test-plan-review-team` (this shape) | `/kit:execute`'s worker -> task-verifier -> fix-agent (max 2) -> ESCALATE (already this shape, already kit-native, already has a distinct reviser and a cap, just no severity tiering because task ACs are binary by nature) |
 
-Reach for an **external framework** instead of building either kit-native shape when the loop
-isn't operating on a kit-authored artifact (spec/test-plan/code inside dwarves-kit's own SDLC),
-per `docs/PHILOSOPHY.md`'s own "When to recommend an external tool instead": a downstream
-consumer's own app-domain critique-revise loop fails the "serves 2+ kit lifecycle phases" gate
-and doesn't belong as a kit feature at all.
+Reach for an **external framework** instead, and skip building either kit-native shape, when
+the loop does not operate on a kit-authored artifact (spec, test-plan, or code inside
+dwarves-kit's own SDLC). `docs/PHILOSOPHY.md`'s own "When to recommend an external tool
+instead" names this case: a downstream consumer's own app-domain critique-revise loop fails the
+"serves 2+ kit lifecycle phases" gate. It does not belong as a kit feature at all.
 
 ## Worked example (illustrative traces, not verbatim reproductions of the papers)
 
-One shared task, checking leap years, lets all four patterns run on the same starting bug so
-the mechanical differences are visible instead of abstract. It has a well-known subtle defect:
-the century exception (1900 is NOT a leap year, 2000 IS).
+One shared task, a leap-year check, lets all four patterns run on the same starting bug. This
+makes the mechanical differences visible instead of abstract. The task has a well-known subtle
+defect: the century exception. 1900 is not a leap year. 2000 is.
 
 Draft v0, what any of them start from:
 
@@ -86,20 +88,20 @@ def is_leap_year(year):
     return year % 4 == 0
 ```
 
-**Self-Refine** (same model critiques + revises):
+**Self-Refine** (same model critiques and revises):
 
 ```
 Round 1: model writes draft v0
 Model self-critiques: "year % 4 == 0 for 2024 -> True. Looks correct."
-No century exception considered , the model's own blind spot in GENERATING
+No century exception considered. The model's own blind spot in GENERATING
 the function is the same blind spot it uses to GRADE it.
 Reports PASS. Loop stops. Bug ships.
 ```
 
-Documented failure mode: only helps when error-*detection* exceeds error-*avoidance*. Same
+Documented failure mode: this only helps when error-*detection* exceeds error-*avoidance*. Same
 context, same blind spot, both times.
 
-**Reflexion** (external evaluator, e.g. real test execution; actor reflects and retries):
+**Reflexion** (external evaluator, e.g. real test execution, actor reflects and retries):
 
 ```
 Round 1: draft v0
@@ -114,9 +116,9 @@ Actor revises: year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
 Round 3: all tests pass -> STOP
 ```
 
-Real improvement (external test != the actor's own judgment, so it actually catches the bug),
-but the stop signal is still binary per round: FAIL just means "try again," no sense of
-"closer" vs "just as wrong."
+This is a real improvement: the external test, not the actor's own judgment, catches the bug.
+But the stop signal stays binary per round. FAIL just means "try again." It carries no sense of
+"closer" versus "just as wrong."
 
 **CRITIC** (tool-verified critique, not self-judgment):
 
@@ -129,8 +131,8 @@ Actor revises based on the TOOL's verified finding, not a guess.
 Repeat until tool-verification passes or a round cap.
 ```
 
-Same shape as Reflexion, grounded in an external tool rather than the actor's own reflection
-text, harder to fool, still binary pass/fail per round.
+This is the same shape as Reflexion, grounded in an external tool instead of the actor's own
+reflection text. It is harder to fool, but still binary pass or fail per round.
 
 **Evaluator-Optimizer** (Anthropic's generic workflow, our closest ancestor):
 
@@ -139,55 +141,56 @@ Generator produces draft v0.
 A SEPARATE Evaluator call checks named criteria ("handles century
 exception," "handles div-by-400") -> PASS/FAIL + feedback text.
 Optimizer revises on FAIL. Repeat until PASS.
-Anthropic's own writeup: no prescribed cap, no prescribed behavior on
-repeated failure , left to whoever implements it.
+Anthropic's own writeup names no prescribed cap and no prescribed behavior
+on repeated failure. It leaves both to whoever implements it.
 ```
 
-Structurally closest to ours (a distinct evaluator role is *encouraged*), but still no severity
-gradient and no contract for what happens if it never converges.
+This is structurally closest to ours. It encourages a distinct evaluator role, but still has no
+severity gradient and no contract for what happens if the loop never converges.
 
-**Ours, on the actual delta: severity-aware convergence.** None of the above can express this
-state, so here it is on a kit-native artifact (a `## Test plan` covering this same function),
-engineered to hit the exact case that matters:
+**Ours, on the actual delta: severity-aware convergence.** None of the patterns above can
+express this state, so here it is on a kit-native artifact, a `## Test plan` covering this same
+function, engineered to hit the exact case that matters:
 
 ```
 Round 1: 6 lenses scan the test plan
   -> lens 1 (coverage):    CRITICAL  "no test for century-boundary years (1900, 2000)"
   -> lens 2 (oracle):      HIGH      "expected output for year=2000 not a concrete assertion"
   -> lens 4 (test-ladder): LOW       "no test for year=0 or negative years"
-  K = 3.  Distinct reviser (not one of the 6 lenses) revises the plan:
-  adds century-boundary rows, makes assertions concrete , but introduces
-  a duplicate row and leaves the year=0 case still vague.
+  K = 3. Distinct reviser (not one of the 6 lenses) revises the plan:
+  it adds century-boundary rows and makes assertions concrete, but
+  introduces a duplicate row and leaves the year=0 case still vague.
 
 Round 2: re-scan
   -> CRITICAL and HIGH from round 1: gone
   -> 2 NEW findings appear: MEDIUM "duplicate test row", MEDIUM "year=0 still vague",
      plus an unrelated LOW nit
-  K = 3 again. SAME raw count as round 1.
+  K = 3 again. Same raw count as round 1.
 
-  Under a plain Evaluator-Optimizer / raw-count rule: K flat (3 == 3) -> HALT,
-  "not converging." This is the exact false stall SPEC-204 actually hit.
+  Under a plain Evaluator-Optimizer or raw-count rule: K stays flat (3 == 3),
+  so the loop halts, reporting "not converging." This is the exact false
+  stall SPEC-204 actually hit.
 
-  Under our rule: worst severity dropped CRITICAL -> MEDIUM even though K
-  didn't. Continue.
+  Under our rule: the worst severity dropped from CRITICAL to MEDIUM even
+  though K did not. The loop continues.
 
 Round 3: reviser clears the two MEDIUMs and the LOW. K = 0. Verdict: SOLID.
 ```
 
 The concrete payoff: none of Self-Refine, Reflexion, CRITIC, or Evaluator-Optimizer has a state
-that distinguishes "3 findings, one of them CRITICAL" from "3 findings, all MEDIUM", it's PASS
-or FAIL, full stop. A naive raw-count bounded loop (what we ourselves ran before the fix) would
-have halted at round 2 here, wrongly, and reported a working test plan as "stuck." That is not
-hypothetical, it is what SPEC-204 actually did.
+that distinguishes "3 findings, one of them CRITICAL" from "3 findings, all MEDIUM." Each treats
+it as PASS or FAIL, full stop. A naive raw-count bounded loop, what we ourselves ran before the
+fix, would have halted at round 2 here, wrongly, and reported a working test plan as "stuck."
+That is not hypothetical. It is what SPEC-204 actually did.
 
 ## Cost problem, and the hybrid fix (2026-07-30, same-day follow-up)
 
-The engine's real cost weakness: it dispatches N model-judged lenses every round regardless of
-whether a given finding was ever mechanical. A binary stop condition (Reflexion/CRITIC-style) is
-cheaper and just as correct whenever a criterion genuinely reduces to a measurable yes/no, the
-severity-graded machinery only earns its cost for the residual judgment calls a script can't
-make. The fix is not a new idea, it is `docs/WORKFLOW.md`'s own cheap-first
-verification-cost-routing principle (line 210), applied *inside* the engine's own scan step
+The engine's real cost weakness: it dispatches N model-judged lenses every round, regardless of
+whether a given finding was ever mechanical. A binary stop condition (Reflexion or CRITIC style)
+is cheaper, and just as correct, whenever a criterion genuinely reduces to a measurable yes or
+no. The severity-graded machinery earns its cost only for the residual judgment calls a script
+cannot make. The fix is not a new idea. It is `docs/WORKFLOW.md`'s own cheap-first
+verification-cost-routing principle (line 210), applied inside the engine's own scan step,
 instead of only across whole verifier tiers:
 
 ```
@@ -223,21 +226,21 @@ Reworking the leap-year test-plan example (round 1) under this rule:
 
 | Round 1 finding | Tier | Why |
 |---|---|---|
-| No test row for year=1900/2000 | Tier 1 | `grep` the test plan for the literal boundary years, either the row exists or it doesn't |
-| Expected output for year=2000 not a concrete assertion | Tier 1 | mechanical presence check: does the row contain a runnable assertion string, or a placeholder |
-| No test for year=0/negative years | Tier 2 | genuine judgment call, is this edge case in scope for the spec, a script can't decide that |
+| No test row for year=1900/2000 | Tier 1 | `grep` the test plan for the literal boundary years. The row exists or it does not. |
+| Expected output for year=2000 not a concrete assertion | Tier 1 | Mechanical presence check: does the row contain a runnable assertion string, or a placeholder. |
+| No test for year=0/negative years | Tier 2 | Genuine judgment call: is this edge case in scope for the spec. A script cannot decide that. |
 
 Two of the three round-1 findings never needed a model dispatch at all. Round 2 only re-runs
-the Tier-2 lens whose finding-space Tier 1 couldn't clear, not all 6, since Tier 1 already
-confirmed the century rows exist. Cost drops from "6 parallel model calls x 3 rounds" toward
-"2 grep checks + 1 model call x fewer rounds," while the severity-aware convergence rule still
-protects the genuinely judgment-heavy residual from the false-stall problem. This is folded
-into `skills/loop-engineering/SKILL.md` Step 2 as the engine's default scan shape, not an
-optional optimization.
+the Tier-2 lens whose finding-space Tier 1 could not clear, not all 6, since Tier 1 already
+confirmed the century rows exist. Cost drops from "6 parallel model calls across 3 rounds"
+toward "2 grep checks plus 1 model call across fewer rounds." The severity-aware convergence
+rule still protects the genuinely judgment-heavy residual from the false-stall problem. This is
+now folded into `skills/loop-engineering/SKILL.md` Step 2 as the engine's default scan shape,
+not an optional optimization.
 
 ## Recommendation carried into `skills/loop-engineering/SKILL.md`
 
-Don't rename the pattern, no single literature term covers the full bundle. Cite
-Evaluator-Optimizer as the lineage (satisfies the skill's own source-citation gate), name the
-three deltas above as the actual contribution, and pick the shape (fuller engine vs
-Execute-pipeline-style) per the decision table, not by default.
+Do not rename the pattern. No single literature term covers the full bundle. Cite
+Evaluator-Optimizer as the lineage, which satisfies the skill's own source-citation gate. Name
+the three deltas above as the actual contribution. Pick the shape, the fuller engine or the
+Execute-pipeline style, per the decision table, not by default.

--- a/docs/research/2026-07-30-loop-engine-prior-art.md
+++ b/docs/research/2026-07-30-loop-engine-prior-art.md
@@ -73,6 +73,113 @@ per `docs/PHILOSOPHY.md`'s own "When to recommend an external tool instead": a d
 consumer's own app-domain critique-revise loop fails the "serves 2+ kit lifecycle phases" gate
 and doesn't belong as a kit feature at all.
 
+## Worked example (illustrative traces, not verbatim reproductions of the papers)
+
+One shared task, checking leap years, lets all four patterns run on the same starting bug so
+the mechanical differences are visible instead of abstract. It has a well-known subtle defect:
+the century exception (1900 is NOT a leap year, 2000 IS).
+
+Draft v0, what any of them start from:
+
+```python
+def is_leap_year(year):
+    return year % 4 == 0
+```
+
+**Self-Refine** (same model critiques + revises):
+
+```
+Round 1: model writes draft v0
+Model self-critiques: "year % 4 == 0 for 2024 -> True. Looks correct."
+No century exception considered , the model's own blind spot in GENERATING
+the function is the same blind spot it uses to GRADE it.
+Reports PASS. Loop stops. Bug ships.
+```
+
+Documented failure mode: only helps when error-*detection* exceeds error-*avoidance*. Same
+context, same blind spot, both times.
+
+**Reflexion** (external evaluator, e.g. real test execution; actor reflects and retries):
+
+```
+Round 1: draft v0
+Evaluator runs: assert is_leap_year(1900) == False -> FAILS (returns True)
+Actor reflects: "Returned True for 1900, expected False. Need century rule."
+Actor revises: year % 4 == 0 and year % 100 != 0
+
+Round 2: Evaluator runs: assert is_leap_year(2000) == True -> FAILS (returns False)
+Actor reflects: "2000 is div by 100 but IS a leap year (div by 400 too)."
+Actor revises: year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+Round 3: all tests pass -> STOP
+```
+
+Real improvement (external test != the actor's own judgment, so it actually catches the bug),
+but the stop signal is still binary per round: FAIL just means "try again," no sense of
+"closer" vs "just as wrong."
+
+**CRITIC** (tool-verified critique, not self-judgment):
+
+```
+Round 1: draft v0
+CRITIC dispatches a tool call (code execution against known cases, or a
+lookup of the actual leap-year rule) instead of asking the model to judge
+itself: "Rule requires century exception; year=1900 check fails."
+Actor revises based on the TOOL's verified finding, not a guess.
+Repeat until tool-verification passes or a round cap.
+```
+
+Same shape as Reflexion, grounded in an external tool rather than the actor's own reflection
+text, harder to fool, still binary pass/fail per round.
+
+**Evaluator-Optimizer** (Anthropic's generic workflow, our closest ancestor):
+
+```
+Generator produces draft v0.
+A SEPARATE Evaluator call checks named criteria ("handles century
+exception," "handles div-by-400") -> PASS/FAIL + feedback text.
+Optimizer revises on FAIL. Repeat until PASS.
+Anthropic's own writeup: no prescribed cap, no prescribed behavior on
+repeated failure , left to whoever implements it.
+```
+
+Structurally closest to ours (a distinct evaluator role is *encouraged*), but still no severity
+gradient and no contract for what happens if it never converges.
+
+**Ours, on the actual delta: severity-aware convergence.** None of the above can express this
+state, so here it is on a kit-native artifact (a `## Test plan` covering this same function),
+engineered to hit the exact case that matters:
+
+```
+Round 1: 6 lenses scan the test plan
+  -> lens 1 (coverage):    CRITICAL  "no test for century-boundary years (1900, 2000)"
+  -> lens 2 (oracle):      HIGH      "expected output for year=2000 not a concrete assertion"
+  -> lens 4 (test-ladder): LOW       "no test for year=0 or negative years"
+  K = 3.  Distinct reviser (not one of the 6 lenses) revises the plan:
+  adds century-boundary rows, makes assertions concrete , but introduces
+  a duplicate row and leaves the year=0 case still vague.
+
+Round 2: re-scan
+  -> CRITICAL and HIGH from round 1: gone
+  -> 2 NEW findings appear: MEDIUM "duplicate test row", MEDIUM "year=0 still vague",
+     plus an unrelated LOW nit
+  K = 3 again. SAME raw count as round 1.
+
+  Under a plain Evaluator-Optimizer / raw-count rule: K flat (3 == 3) -> HALT,
+  "not converging." This is the exact false stall SPEC-204 actually hit.
+
+  Under our rule: worst severity dropped CRITICAL -> MEDIUM even though K
+  didn't. Continue.
+
+Round 3: reviser clears the two MEDIUMs and the LOW. K = 0. Verdict: SOLID.
+```
+
+The concrete payoff: none of Self-Refine, Reflexion, CRITIC, or Evaluator-Optimizer has a state
+that distinguishes "3 findings, one of them CRITICAL" from "3 findings, all MEDIUM", it's PASS
+or FAIL, full stop. A naive raw-count bounded loop (what we ourselves ran before the fix) would
+have halted at round 2 here, wrongly, and reported a working test plan as "stuck." That is not
+hypothetical, it is what SPEC-204 actually did.
+
 ## Recommendation carried into `skills/loop-engineering/SKILL.md`
 
 Don't rename the pattern, no single literature term covers the full bundle. Cite

--- a/docs/research/2026-07-30-loop-engine-prior-art.md
+++ b/docs/research/2026-07-30-loop-engine-prior-art.md
@@ -180,6 +180,61 @@ or FAIL, full stop. A naive raw-count bounded loop (what we ourselves ran before
 have halted at round 2 here, wrongly, and reported a working test plan as "stuck." That is not
 hypothetical, it is what SPEC-204 actually did.
 
+## Cost problem, and the hybrid fix (2026-07-30, same-day follow-up)
+
+The engine's real cost weakness: it dispatches N model-judged lenses every round regardless of
+whether a given finding was ever mechanical. A binary stop condition (Reflexion/CRITIC-style) is
+cheaper and just as correct whenever a criterion genuinely reduces to a measurable yes/no, the
+severity-graded machinery only earns its cost for the residual judgment calls a script can't
+make. The fix is not a new idea, it is `docs/WORKFLOW.md`'s own cheap-first
+verification-cost-routing principle (line 210), applied *inside* the engine's own scan step
+instead of only across whole verifier tiers:
+
+```
+TWO-TIER STOP CONDITION (best of both)
+
+  round N: scan <ARTIFACT>
+       │
+       ▼
+  ┌───────────────────────────────┐
+  │ TIER 1: deterministic checks   │  grep/bash, zero model cost,
+  │ (only criteria reducible to a  │  runs EVERY round, decisive
+  │  mechanical yes/no: row exists,│
+  │  command present, field set)   │
+  └───────────────┬─────────────────┘
+                  │
+         any FAIL? ──yes──▶ finding, CRITICAL by default, cheap to detect
+                  │ no (all Tier-1 pass)
+                  ▼
+  ┌───────────────────────────────┐
+  │ TIER 2: N-lens model critique  │  only dispatched for the RESIDUAL
+  │ (only genuinely non-mechanical │  judgment surface Tier 1 can't
+  │  judgment: oracle quality,     │  reduce to a script; skip any lens
+  │  ambiguity, determinism risk)  │  whose whole finding-space Tier 1
+  └───────────────┬─────────────────┘  already cleared
+                  │
+       merge findings, severity-graded (same convergence rule as before)
+                  │
+                  ▼
+   STOP = Tier-1 all clean AND (Tier-2 K=0 OR severity fell OR cap hit)
+```
+
+Reworking the leap-year test-plan example (round 1) under this rule:
+
+| Round 1 finding | Tier | Why |
+|---|---|---|
+| No test row for year=1900/2000 | Tier 1 | `grep` the test plan for the literal boundary years, either the row exists or it doesn't |
+| Expected output for year=2000 not a concrete assertion | Tier 1 | mechanical presence check: does the row contain a runnable assertion string, or a placeholder |
+| No test for year=0/negative years | Tier 2 | genuine judgment call, is this edge case in scope for the spec, a script can't decide that |
+
+Two of the three round-1 findings never needed a model dispatch at all. Round 2 only re-runs
+the Tier-2 lens whose finding-space Tier 1 couldn't clear, not all 6, since Tier 1 already
+confirmed the century rows exist. Cost drops from "6 parallel model calls x 3 rounds" toward
+"2 grep checks + 1 model call x fewer rounds," while the severity-aware convergence rule still
+protects the genuinely judgment-heavy residual from the false-stall problem. This is folded
+into `skills/loop-engineering/SKILL.md` Step 2 as the engine's default scan shape, not an
+optional optimization.
+
 ## Recommendation carried into `skills/loop-engineering/SKILL.md`
 
 Don't rename the pattern, no single literature term covers the full bundle. Cite

--- a/skills/loop-engineering/SKILL.md
+++ b/skills/loop-engineering/SKILL.md
@@ -63,6 +63,17 @@ Two different existing shapes, don't conflate them:
   (a flat K with lower max severity still counts as progress; see `test-plan-review-team.md`
   Step 4.3 for the exact wording).
 
+  **Scan step is two-tier, not "always dispatch all N lenses."** Per `docs/WORKFLOW.md`'s own
+  cheap-first verification-cost-routing principle, applied here: Tier 1 is a deterministic
+  check (grep/bash, zero model cost) for any criterion reducible to a mechanical yes/no (a row
+  exists, a command is present, a field is populated) , run every round, decisive on its own.
+  Tier 2 is the N-lens model critique, dispatched ONLY for the residual criteria Tier 1 can't
+  reduce to a script (oracle quality, ambiguity, determinism risk); skip any lens whose entire
+  finding-space Tier 1 already cleared. Stop condition becomes: Tier 1 all clean AND (Tier 2
+  K=0 OR severity fell OR cap hit). This is the fix for the engine's real cost problem, N
+  parallel model dispatches every round is expensive when most findings are actually mechanical;
+  see `docs/research/2026-07-30-loop-engine-prior-art.md` for the worked cost comparison.
+
 - **Campaign / worklist iteration** (driving an existing loop across many items): not a new
   engine, an outer wrapper. Shape: a worklist of untreated items -> run the existing
   loop/command on each in turn -> track progress -> stop when the worklist is exhausted or a

--- a/skills/loop-engineering/SKILL.md
+++ b/skills/loop-engineering/SKILL.md
@@ -81,6 +81,28 @@ Two different existing shapes, don't conflate them:
   logged there for feature-list reconciliation, doc-drift, agent-effectiveness, dependency
   patch, and the test-plan backfill campaign, they're worked examples of Step 1+2 output).
 
+## Lineage (satisfies Step 1's source-citation gate)
+
+The engine's coarse shape is not original: it's Anthropic's own **Evaluator-Optimizer /
+Reflection-loop** workflow (["Building Effective Agents"](https://www.anthropic.com/research/building-effective-agents)),
+the same lineage as Self-Refine (Madaan et al. 2023), Reflexion (Shinn et al. 2023), and CRITIC
+(Gou et al. 2023). What none of those, nor any Claude Code skill/plugin found on a 2026-07-30
+web sweep, package together is the specific bundle used here:
+
+- **Artifact-agnostic parameterization**, matches Evaluator-Optimizer's own framing; not a
+  kit invention.
+- **Severity-aware convergence** (a flat finding-count still counts as progress if the worst
+  severity dropped), not found in any literature or tool surveyed; this IS the kit's addition.
+- **Distinct reviser, never a scorer**, seen incidentally in practice (e.g. one model reviews,
+  a different one fixes) but never stated as an enforced rule; this IS the kit's addition.
+- **Hard cap with an honest-halt reporting path** (report "not converging" as a real outcome,
+  not a silent stop), pieces exist (max-round caps, keep-best fallbacks) but never packaged as
+  an explicit contract; this IS the kit's addition.
+
+So: cite Evaluator-Optimizer for the shape, don't claim the shape is novel. The three deltas
+above are what's actually new, and are the parts worth defending if this pattern gets
+challenged later.
+
 ## Reference
 
 Worked instantiation: `commands/test-plan-review-team.md` (the engine) +

--- a/skills/loop-engineering/SKILL.md
+++ b/skills/loop-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loop-engineering
-description: Use when the user wants to design or add a new bounded loop to the kit's own SDLC orchestration ("let's build a loop", "design a new loop for the orchestrator", "loop engineering", "make this a bounded loop", "is this worth a loop"). Walks the gate (should this even be a loop) then the anatomy (artifact / scanner / reviser / stop condition) reusing the kit's own generic bounded-revise engine. NOT for a one-off in-session Stop-hook goal (use goal-craft), NOT for the debug loop (already exists, use /kit:debug), NOT for building the loop's actual code once the shape is agreed (just build it).
+description: Use when the user wants to design or add a new bounded loop to the kit's own SDLC orchestration ("let's build a loop", "design a new loop for the orchestrator", "loop engineering", "make this a bounded loop", "is this worth a loop"), or mentions the Karpathy loop / autoresearch / hill-climb / search-and-select prompt or parameter tuning. Walks the gate (should this even be a loop) then the anatomy (artifact / scanner / reviser / stop condition), routing to one of three shapes: bounded-revise engine, campaign/worklist, or bounded search-select. NOT for a one-off in-session Stop-hook goal (use goal-craft), NOT for the debug loop (already exists, use /kit:debug), NOT for building the loop's actual code once the shape is agreed (just build it).
 disable-model-invocation: false
 ---
 
@@ -56,9 +56,11 @@ skill invents no new one:
 If any of these fail, the idea is not a loop. It may still work as a one-shot side-flow, like
 `kit-health` or `absorb`. A side-flow is simpler and does not need this skill.
 
-## Step 2: Pick the shape, engine, or campaign?
+## Step 2: Pick the shape
 
-Two shapes already exist. Do not conflate them:
+Three shapes exist. Do not conflate them. The routing question: does the loop make ONE thing
+good (engine), check MANY existing things (campaign, or the audit-loop pattern), or find the
+BEST VARIANT of one thing (search-select)?
 
 - **Bounded-revise engine.** Use this when the loop converges on one artifact. Dispatch N
   scanners against the artifact. Merge findings by severity. Revise the artifact. Re-check.
@@ -116,7 +118,32 @@ Two shapes already exist. Do not conflate them:
 
   This reuses the Goal loop's own shape: "keep working one objective until a verifiable stop
   holds." Here it points at a list instead of one objective. Do not build a second convergence
-  mechanic. Reuse the Goal loop.
+  mechanic. Reuse the Goal loop. For the audit flavor of this shape, enumerate a set, verdict
+  each item, gate through a PR, see `docs/patterns/audit-loop.md`.
+
+- **Bounded search-select.** Use this when the goal is the best VARIANT of one thing, not the
+  repair of one thing. Mutate a candidate, score it, keep it if the score improves, discard it
+  if not. Repeat under a fixed iteration budget. This is Karpathy's autoresearch loop
+  ([github.com/karpathy/autoresearch](https://github.com/karpathy/autoresearch)), bounded.
+
+  All three preconditions must hold, or this shape is wrong:
+
+  1. **A cheap, unambiguous numeric metric exists.** A training loss, a false-positive rate
+     against a corpus, a test pass count, a benchmark score. If a model must judge quality,
+     that judge becomes the metric, and the corpus bar below applies.
+  2. **Evaluation is fast enough to afford many shots.** Karpathy's budget math: about 5
+     minutes per experiment, about 100 overnight. One-hour evaluations make hill-climbing the
+     wrong economics.
+  3. **Losers carry no information the next attempt needs.** A discarded variant is thrown
+     away whole. If a failed attempt should teach the next one, use the bounded-revise engine
+     instead.
+
+  Two adaptations are mandatory, per `docs/PHILOSOPHY.md` "Loop boundaries": a fixed iteration
+  budget (never "loop forever until interrupted"), and an honest-halt report at the end, what
+  improved, what plateaued, which variant won. Kit targets already queued for this shape, and
+  their corpus bar (10-30+ real transcripts, not yet met): `docs/PHILOSOPHY.md` "AutoResearch
+  optimization". Full source verification and adoption verdict:
+  `docs/research/2026-07-31-karpathy-autoresearch-loop.md`.
 
 ## Step 3: Where it lands once shaped
 

--- a/skills/loop-engineering/SKILL.md
+++ b/skills/loop-engineering/SKILL.md
@@ -8,36 +8,62 @@ disable-model-invocation: false
 
 ## Overview
 
-The kit already runs 3 first-party bounded loops (Goal, Debug, Execute) plus a bounded-revise
-side-flow (`test-plan-review-team`, SPEC-203/204). This skill is the reusable *shape* extracted
-from that fourth one, so a new loop idea gets designed against a known pattern instead of
-re-derived from scratch each time.
+The kit runs 3 first-party bounded loops: Goal, Debug, Execute. It also runs a bounded-revise
+side-flow, `test-plan-review-team` (SPEC-203/204). This skill extracts the reusable shape from
+that fourth loop. Use it to design a new loop against a known pattern, instead of starting from
+scratch.
+
+## How to use this skill
+
+You do not need to design the stop condition or the output shape before you start. Describe the
+artifact and the itch. This skill runs the rest.
+
+**Step 1 needs**: the artifact, and why now. Example: "the README's feature list keeps drifting
+from the code." This skill checks it against the four gate criteria below and reports pass or
+fail.
+
+**Step 2 needs**: what good and bad look like, in plain words. You do not need to sort checks
+into Tier 1 or Tier 2 yourself. Describe what wrong looks like, for each check you want. This
+skill sorts them and shows you the split, so you can correct it.
+
+**Step 3 needs**: what the artifact should look like when done. Say whether it is a
+written-back section, a standalone report, or an applied edit. Say what verdict shape you want.
+If you do not say, this skill defaults to the kit's own shape: a written-back section, a
+three-way verdict (SOLID / REVISE / RECONSIDER), and an honest halt on non-convergence.
+
+**How it fires**: name it directly ("use the loop-engineering skill"), or describe the problem
+close to the trigger phrases in this file's frontmatter. No slash command is required.
+
+**A caveat on reuse across sessions**: a plugin skill fires in other sessions only after its
+change merges to `master`, and the installed plugin copy refreshes (`claude plugin marketplace
+update`). Until then, it runs only in a session that reads this file directly off its branch.
 
 ## Step 1: Gate, before designing anything
 
-`docs/PHILOSOPHY.md` "Loop boundaries" + "Feature rejection criteria" are the kit's own bar, not
-a new one invented here:
+`docs/PHILOSOPHY.md`'s "Loop boundaries" and "Feature rejection criteria" set the bar. This
+skill invents no new one:
 
-- **Bounded-in-session only.** A continuation that keeps working *inside* the current session
-  under a verifiable stop condition. An unbounded outer loop (external `while` re-spawning
-  sessions) is explicitly declined territory (GSD v2 / autonomous-runtime, not this kit).
-- **Serves 2+ lifecycle phases**, or is a named downstream-facing exception (like
-  `visual-team`/`ui-design`) with a real external consumer, not "might be useful someday."
-- **Explainable in one sentence.** If the README-table line for it would run long, it's too
-  complex as scoped.
-- **Has a source citation.** Trace it to a proven implementation or an existing kit pattern
-  (per "synthesize, don't originate"), not an invented mechanic.
+- **Bounded-in-session only.** The loop keeps working inside the current session, under a
+  verifiable stop condition. An unbounded outer loop (an external `while` that re-spawns
+  sessions) belongs to autonomous-runtime tools like GSD v2, not this kit.
+- **Serves 2+ lifecycle phases.** Or names a real external consumer, like `visual-team` /
+  `ui-design` does, as a downstream-facing exception. "Might be useful someday" does not count.
+- **Explainable in one sentence.** If the README-table line for it runs long, the scope is too
+  complex.
+- **Has a source citation.** Trace it to a proven implementation, or to an existing kit pattern
+  (per "synthesize, do not originate"). Do not invent a mechanic from nothing.
 
-Any of these failing kills the idea as a *loop*; it may still be worth a one-shot side-flow
-(like `kit-health` / `absorb`), which is simpler and doesn't need this skill.
+If any of these fail, the idea is not a loop. It may still work as a one-shot side-flow, like
+`kit-health` or `absorb`. A side-flow is simpler and does not need this skill.
 
 ## Step 2: Pick the shape, engine, or campaign?
 
-Two different existing shapes, don't conflate them:
+Two shapes already exist. Do not conflate them:
 
-- **Bounded-revise engine** (converging on one artifact): dispatch N scanners against an
-  artifact -> merge findings by severity -> revise the artifact -> re-check -> repeat until
-  clean or capped. This is `test-plan-review-team.md` Step 2-4, generalized:
+- **Bounded-revise engine.** Use this when the loop converges on one artifact. Dispatch N
+  scanners against the artifact. Merge findings by severity. Revise the artifact. Re-check.
+  Repeat until clean, or until the round cap hits. This generalizes `test-plan-review-team.md`
+  Step 2-4:
 
   ```
   dispatch N scanners against <ARTIFACT>
@@ -58,64 +84,74 @@ Two different existing shapes, don't conflate them:
       verdict: SOLID / REVISE / RECONSIDER
   ```
 
-  Parameterize: what's the artifact, who scans it (N lenses), who revises it (a distinct
-  reviser, never one of the scanners). Convergence rule is severity-aware, not raw-count
-  (a flat K with lower max severity still counts as progress; see `test-plan-review-team.md`
-  Step 4.3 for the exact wording).
+  Parameterize three things: the artifact, who scans it (N lenses), and who revises it. The
+  reviser must be distinct from every scanner. The convergence rule tracks severity, not raw
+  count. A flat K still counts as progress if the worst severity dropped. See
+  `test-plan-review-team.md` Step 4.3 for the exact wording.
 
-  **Scan step is two-tier, not "always dispatch all N lenses."** Per `docs/WORKFLOW.md`'s own
-  cheap-first verification-cost-routing principle, applied here: Tier 1 is a deterministic
-  check (grep/bash, zero model cost) for any criterion reducible to a mechanical yes/no (a row
-  exists, a command is present, a field is populated) , run every round, decisive on its own.
-  Tier 2 is the N-lens model critique, dispatched ONLY for the residual criteria Tier 1 can't
-  reduce to a script (oracle quality, ambiguity, determinism risk); skip any lens whose entire
-  finding-space Tier 1 already cleared. Stop condition becomes: Tier 1 all clean AND (Tier 2
-  K=0 OR severity fell OR cap hit). This is the fix for the engine's real cost problem, N
-  parallel model dispatches every round is expensive when most findings are actually mechanical;
-  see `docs/research/2026-07-30-loop-engine-prior-art.md` for the worked cost comparison.
+  **The scan step runs in two tiers. It does not dispatch all N lenses every round.**
+  `docs/WORKFLOW.md` already states a cheap-first verification-cost-routing principle. This
+  section applies that principle inside the engine's own scan step.
 
-- **Campaign / worklist iteration** (driving an existing loop across many items): not a new
-  engine, an outer wrapper. Shape: a worklist of untreated items -> run the existing
-  loop/command on each in turn -> track progress -> stop when the worklist is exhausted or a
-  budget/blocker hits. This is the Goal loop's own "keep working one objective until a
-  verifiable stop holds" shape, pointed at a list instead of a single objective. Don't build a
-  second convergence mechanic for this; reuse the Goal loop.
+  Tier 1 runs a deterministic check: grep or bash, zero model cost. Use it for any criterion
+  that reduces to a mechanical yes-or-no, like a row that exists, a command that is present, or
+  a field that is set. Tier 1 runs every round and decides on its own.
+
+  Tier 2 runs the N-lens model critique. Dispatch it only for the criteria Tier 1 cannot reduce
+  to a script, like oracle quality, ambiguity, or determinism risk. Skip any lens whose whole
+  finding-space Tier 1 already cleared.
+
+  The stop condition becomes: Tier 1 is all clean, and Tier 2 hits K=0, or its severity drops,
+  or the round cap hits.
+
+  This fixes the engine's real cost problem. N parallel model dispatches every round cost too
+  much when most findings are mechanical. See `docs/research/2026-07-30-loop-engine-prior-art.md`
+  for the worked cost comparison.
+
+- **Campaign / worklist iteration.** Use this when you drive an existing loop across many
+  items. It is not a new engine. It wraps an existing one.
+
+  Shape: build a worklist of untreated items. Run the existing loop or command on each item in
+  turn. Track progress. Stop when the worklist runs out, or a budget or blocker hits.
+
+  This reuses the Goal loop's own shape: "keep working one objective until a verifiable stop
+  holds." Here it points at a list instead of one objective. Do not build a second convergence
+  mechanic. Reuse the Goal loop.
 
 ## Step 3: Where it lands once shaped
 
-- New bounded-revise engine instantiation -> a new `/kit:<name>` side-flow, registered in
-  `docs/WORKFLOW.md`'s "Opt-in side-flows" table + `docs/workflow-map.md`'s mirror (both, same
-  commit, per that section's own companion-drift note).
-- New campaign wrapper -> likely a `/kit:<name>` command that itself invokes the Goal loop
-  machinery, not a new engine.
-- Not yet committed, just an idea -> `_meta/BACKLOG.md` "v2 candidates" tier (see the entries
-  logged there for feature-list reconciliation, doc-drift, agent-effectiveness, dependency
-  patch, and the test-plan backfill campaign, they're worked examples of Step 1+2 output).
+- A new bounded-revise engine becomes a new `/kit:<name>` side-flow. Register it in
+  `docs/WORKFLOW.md`'s "Opt-in side-flows" table, and in `docs/workflow-map.md`'s mirror.
+  Update both in the same commit, per that section's own companion-drift note.
+- A new campaign wrapper usually becomes a `/kit:<name>` command. That command invokes the Goal
+  loop machinery. It does not become a new engine.
+- An idea with no commitment yet goes into `_meta/BACKLOG.md`'s "v2 candidates" tier. The
+  entries already logged there, feature-list reconciliation, doc-drift, agent-effectiveness,
+  dependency patch, and the test-plan backfill campaign, show what Step 1 and Step 2 output
+  looks like.
 
 ## Lineage (satisfies Step 1's source-citation gate)
 
-The engine's coarse shape is not original: it's Anthropic's own **Evaluator-Optimizer /
-Reflection-loop** workflow (["Building Effective Agents"](https://www.anthropic.com/research/building-effective-agents)),
-the same lineage as Self-Refine (Madaan et al. 2023), Reflexion (Shinn et al. 2023), and CRITIC
-(Gou et al. 2023). What none of those, nor any Claude Code skill/plugin found on a 2026-07-30
-web sweep, package together is the specific bundle used here:
+The engine's coarse shape is not original. It comes from Anthropic's own **Evaluator-Optimizer
+/ Reflection-loop** workflow (["Building Effective Agents"](https://www.anthropic.com/research/building-effective-agents)).
+Self-Refine (Madaan et al. 2023), Reflexion (Shinn et al. 2023), and CRITIC (Gou et al. 2023)
+share the same lineage. A 2026-07-30 web sweep found no framework, paper, or Claude Code skill
+that packages the specific bundle used here:
 
-- **Artifact-agnostic parameterization**, matches Evaluator-Optimizer's own framing; not a
-  kit invention.
-- **Severity-aware convergence** (a flat finding-count still counts as progress if the worst
-  severity dropped), not found in any literature or tool surveyed; this IS the kit's addition.
-- **Distinct reviser, never a scorer**, seen incidentally in practice (e.g. one model reviews,
-  a different one fixes) but never stated as an enforced rule; this IS the kit's addition.
-- **Hard cap with an honest-halt reporting path** (report "not converging" as a real outcome,
-  not a silent stop), pieces exist (max-round caps, keep-best fallbacks) but never packaged as
-  an explicit contract; this IS the kit's addition.
+- **Artifact-agnostic parameterization.** This matches Evaluator-Optimizer's own framing. The
+  kit did not invent it.
+- **Severity-aware convergence.** A flat finding-count still counts as progress if the worst
+  severity dropped. No surveyed literature or tool does this. The kit added it.
+- **Distinct reviser, never a scorer.** Practice shows this incidentally, one model reviews, a
+  different model fixes, but no source states it as an enforced rule. The kit added it.
+- **Hard cap with an honest-halt reporting path.** The loop reports "not converging" as a real
+  outcome, not a silent stop. Pieces of this exist, max-round caps, keep-best fallbacks, but no
+  source packages them as an explicit contract. The kit added it.
 
-So: cite Evaluator-Optimizer for the shape, don't claim the shape is novel. The three deltas
-above are what's actually new, and are the parts worth defending if this pattern gets
-challenged later.
+Cite Evaluator-Optimizer for the shape. Do not claim the shape itself is new. The three deltas
+above are the real contribution. Defend those three if this pattern gets challenged later.
 
 ## Reference
 
-Worked instantiation: `commands/test-plan-review-team.md` (the engine) +
-`_meta/BACKLOG.md` v2 candidates (four more engine instantiations sketched, one campaign
-sketched, none built yet).
+`commands/test-plan-review-team.md` is the worked engine instantiation. `_meta/BACKLOG.md`'s v2
+candidates sketch four more engine instantiations and one campaign. None are built yet.


### PR DESCRIPTION
## Summary
- Web research found the loop-engineering skill's engine shape traces to Anthropic's own Evaluator-Optimizer/Reflection-loop workflow (plus Self-Refine/Reflexion/CRITIC in the literature), satisfying the skill's own "must cite a real precedent" gate.
- Adds a Lineage section naming the three actual deltas (severity-aware convergence, distinct-reviser-never-scorer, hard-cap-with-honest-halt) that no surveyed framework or Claude Code skill packages together.

## Test plan
- [x] `bash tests/test-meta.sh` — 710/718, same 8 pre-existing failures, no regression