### PR TITLE
docs(wayfind): spec handoff must name the map path

### DIFF
--- a/commands/wayfind.md
+++ b/commands/wayfind.md
@@ -107,7 +107,7 @@ Invoked with a map (path or slug); a named ticket is optional.
 
 Nothing left to decide: hand off, never straight to execute.
 
-- Single bounded feature -> `/kit:spec`; the map's Decisions so far becomes the spec's Context.
+- Single bounded feature -> `/kit:spec`; the map's Decisions so far becomes the spec's Context, and the Context NAMES THE MAP PATH with the gists keeping their `[NN-<slug>]` pointers: the gists are summaries, so the spec must link back to the primary source (the ticket bodies), never carry only the summaries.
 - A build needing ordered sub-goals -> write `ROADMAP.md` beside map.md and run it as a mega-goal (`/kit:mega`, ADR-0032); the map stays as the decision record.
 - Flip the umbrella board row to reflect the handoff (`bash lib/board/backlog.sh set <ID> speccing` for the single-spec path, `executing` once a ROADMAP run starts); the map goes read-only.
 


### PR DESCRIPTION
One contract line in the Exit section of commands/wayfind.md.

**Why.** Re-eval of the wayfinder adoption against the source video (Matt Pocock, F3lL98Pj90o) found one gap: upstream's stated advantage over grill-with-docs is that the spec links back to the decision tickets, so an agent reads the primary source instead of trusting a summary. Our Exit contract only imported the Decisions-so-far gists, which ARE summaries, the exact weakness the mechanism exists to fix.

**Fix.** The /kit:spec handoff bullet now requires the spec's Context to name the map path and keep the `[NN-<slug>]` ticket pointers.

Docs-only, no behavior change; proof-of-done override logged (slug `wayfind-map-pointer`). Adoption design: docs/research/2026-07-31-mattpocock-trio-adoption.md §1 (ID-450, shipped).