### PR TITLE
fix(registry): derive skill dispatchers for agents

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -6,7 +6,7 @@ generator: lib/registry/feature-registry.sh
 
 # Feature registry
 
-GENERATED , do not hand-edit. Regenerate: `bash lib/registry/feature-registry.sh generate`. One row per live feature; freshness pinned by `tests/test-meta.sh` (regenerate-and-diff). Trigger classes per `docs/workflow-paths.md` section 1: `[H]` human-typed, `[H/I]` human-or-intent, `[I]` intent-read, `[E]` event-fired, `[D]` dispatched. Refs are exact-token greps: Specs over `docs/specs/`, Tests over `tests/*.sh`, Dispatched-by over `commands/*.md`; `-` means no reference found (a coverage gap, not always a defect: read-only agents may be deliberately untested).
+GENERATED , do not hand-edit. Regenerate: `bash lib/registry/feature-registry.sh generate`. One row per live feature; freshness pinned by `tests/test-meta.sh` (regenerate-and-diff). Trigger classes per `docs/workflow-paths.md` section 1: `[H]` human-typed, `[H/I]` human-or-intent, `[I]` intent-read, `[E]` event-fired, `[D]` dispatched. Refs are exact-token greps: Specs over `docs/specs/`, Tests over `tests/*.sh`, Dispatched-by over `commands/*.md` + `skills/*/SKILL.md` (skill dispatchers marked `(skill)`); `-` means no reference found (a coverage gap, not always a defect: read-only agents may be deliberately untested).
 
 ## Commands
 
@@ -53,9 +53,9 @@ GENERATED , do not hand-edit. Regenerate: `bash lib/registry/feature-registry.sh
 |---|---|---|---|---|---|
 | `acceptance-verifier` | `[D]` | verify | Dynamically executes the active spec's acceptance criteria via its `## Verification` section and reports whether the build actually satisfi… | SPEC-035, SPEC-090, SPEC-092 +2 | test-every-step-review.sh, test-kit-contract.sh, test-meta.sh +1 |
 | `advisor` | `[D]` | adopt, mega, review-team +1 | The single cross-cutting generic review lens (ADR-0028 SG-05/P5-P6). Runs in TWO modes at the final integration/UAT boundary -- critique (a… | SPEC-090, SPEC-091, SPEC-092 +15 | proof-loop-09-scenario-b.sh, test-adopt.sh, test-advisor-ledger-emit.sh +12 |
-| `agent-effectiveness` | `[D]` | draft-agent | Validates an agent definition's EFFECTIVENESS (not just its structure) across four lenses -- tools minimal-yet-sufficient, description trig… | SPEC-088, SPEC-090, SPEC-091 +2 | test-advisor.sh, test-agent-effectiveness.sh, test-meta.sh +1 |
+| `agent-effectiveness` | `[D]` | draft-agent, loop-engineering (skill) | Validates an agent definition's EFFECTIVENESS (not just its structure) across four lenses -- tools minimal-yet-sufficient, description trig… | SPEC-088, SPEC-090, SPEC-091 +2 | test-advisor.sh, test-agent-effectiveness.sh, test-meta.sh +1 |
 | `api-reviewer` | `[D]` | review-team | Reviews a diff through the API-CONTRACT lens only (breaking changes, versioning, request/response schema, error codes, backward compat, ide… | SPEC-111 | test-meta.sh |
-| `audit-scanner` | `[D]` | - | Shared read-only Tier-2 evidence scanner for audit-loop instances (doc-drift, feature-map, future ones). Dispatched by an audit skill with … | SPEC-220 | test-audit-scanner-contract.sh |
+| `audit-scanner` | `[D]` | doc-drift (skill), feature-map (skill) | Shared read-only Tier-2 evidence scanner for audit-loop instances (doc-drift, feature-map, future ones). Dispatched by an audit skill with … | SPEC-220 | test-audit-scanner-contract.sh, test-meta.sh |
 | `brief-reviewer` | `[D]` | think | Statically reviews a design brief or requirement (DECISION-BRIEF.md, a spec's Problem/Context section, or an equivalent requirement doc) fo… | SPEC-092, SPEC-108 | test-every-step-review.sh, test-kit-contract.sh, test-meta.sh +1 |
 | `claim-verifier` | `[D]` | - | Adversarially verifies an ARBITRARY free-text claim before it is trusted. Runs an in-harness panel of N independent skeptics, each told to … | SPEC-195 | - |
 | `code-reviewer` | `[D]` | devs-team, review-team, visual-team | Focused code reviewer. Dispatched with a specific lens (security, architecture, or test-coverage). Read-only. Used by /review-team for para… | SPEC-090, SPEC-092, SPEC-109 +7 | test-meta.sh, test-review-team-plants.sh |
@@ -83,8 +83,8 @@ GENERATED , do not hand-edit. Regenerate: `bash lib/registry/feature-registry.sh
 
 | Skill | Trigger | Description | Specs | Tests |
 |---|---|---|---|---|
-| `doc-drift` | `[I]` | Use for the whole-estate doc audit, "run the doc-drift loop", "audit the docs against the code", "are the docs still true", "doc drift swee… | SPEC-029, SPEC-216, SPEC-218 +1 | test-audit-scanner-contract.sh |
-| `feature-map` | `[I]` | Use to audit the kit's feature estate against its path map, "run the feature-map loop", "is the workflow path map still complete", "does ev… | SPEC-218, SPEC-219, SPEC-220 | test-audit-scanner-contract.sh |
+| `doc-drift` | `[I]` | Use for the whole-estate doc audit, "run the doc-drift loop", "audit the docs against the code", "are the docs still true", "doc drift swee… | SPEC-029, SPEC-216, SPEC-218 +1 | test-audit-scanner-contract.sh, test-meta.sh |
+| `feature-map` | `[I]` | Use to audit the kit's feature estate against its path map, "run the feature-map loop", "is the workflow path map still complete", "does ev… | SPEC-218, SPEC-219, SPEC-220 | test-audit-scanner-contract.sh, test-meta.sh |
 | `get-api-docs` | `[I]` | Fetch curated API documentation using Context Hub (chub) before coding against any external API. Use when the task involves calling a third… | - | test-kit-foldin-hooks.sh |
 | `loop-engineering` | `[I]` | Use when the user wants to design or add a new bounded loop to the kit's own SDLC orchestration ("let's build a loop", "design a new loop f… | SPEC-209 | test-loop-engineering-contract.sh, test-research-arch-contract.sh |
 | `memory-tidy` | `[I]` | Use when auditing, consolidating, or cleaning a repo's .claude/memory store, "dọn memory", "memory tidy", the biweekly memory audit, dupl… | SPEC-208 | test-memory-tidy-contract.sh, test-research-arch-contract.sh |

--- a/docs/verification/registry-skill-dispatchers.md
+++ b/docs/verification/registry-skill-dispatchers.md
@@ -1,0 +1,38 @@
+# Proof of done: registry-skill-dispatchers
+
+## Acceptance criteria
+
+| AC | Claim | Status |
+|---|---|---|
+| AC-1 | `dispatched_by` also greps `skills/*/SKILL.md`; skill dispatchers rendered as `<name> (skill)` | MET (run 1) |
+| AC-2 | `audit-scanner` row shows `doc-drift (skill), feature-map (skill)` instead of `-` | MET (run 1) |
+| AC-3 | Regenerated `docs/FEATURES.md` committed; freshness pin green | MET (run 2) |
+| AC-4 | Test coverage: assertion that audit-scanner's dispatched-by cell names both skills | MET (run 2) |
+| AC-5 | Determinism: double run byte-identical | MET (run 2) |
+| AC-6 | Negative control: agent token renamed in one skill file drops that skill from the cell | MET (run 3) |
+
+## Confirmation runs
+
+| # | Check | Command | Result |
+|---|---|---|---|
+| 1 | before/after cell | `bash lib/registry/feature-registry.sh generate` then grep the row | before: `\| audit-scanner \| [D] \| - \|`; after: `\| audit-scanner \| [D] \| doc-drift (skill), feature-map (skill) \|` (also `agent-effectiveness` correctly gains `loop-engineering (skill)`) |
+| 2 | full suite incl. freshness + determinism + new assertion | `bash tests/test-meta.sh` | 742/742 PASS, exit 0 |
+| 3 | negative control | `sd 'audit-scanner' 'audit-scannerX' skills/doc-drift/SKILL.md`, regenerate to a temp outfile, grep, restore | cell drops to `feature-map (skill)` only; skill file restored via `git checkout --` |
+
+## Run detail
+
+Run 1: the regenerated projection changed exactly three rows: the header blurb (Dispatched-by scope now names `skills/*/SKILL.md`), `audit-scanner` (the target fix), and `agent-effectiveness` (picked up `loop-engineering (skill)`, a genuine skill dispatcher previously invisible). No other rows moved.
+
+Run 2: the first `test-meta.sh` run after adding the new assertion FAILED the freshness pin, because the assertion's own tokens (`audit-scanner`, `doc-drift`, `feature-map`) added `test-meta.sh` to those rows' Tests columns. A second regeneration converged; re-run is 742/742 with the determinism double-run green.
+
+Run 3: with the token renamed in `skills/doc-drift/SKILL.md`, a temp regeneration shows the cell as `feature-map (skill)` only, proving the derivation reads the skill files and discriminates per file.
+
+## Reproduce
+
+```
+bash lib/registry/feature-registry.sh generate && grep '`audit-scanner`' docs/FEATURES.md
+bash tests/test-meta.sh
+sd 'audit-scanner' 'audit-scannerX' skills/doc-drift/SKILL.md
+T=$(mktemp); bash lib/registry/feature-registry.sh generate "$T"; grep '`audit-scanner`' "$T"   # expect feature-map (skill) only
+git checkout -- skills/doc-drift/SKILL.md
+```

--- a/lib/registry/feature-registry.sh
+++ b/lib/registry/feature-registry.sh
@@ -17,7 +17,8 @@
 #   [I]   any other skill
 #   [E]   hook; event(s) looked up in hooks/hooks.json (statusline.sh rides the
 #         settings.json statusLine key); wired nowhere -> event `-`
-#   [D]   agent; dispatched-by derived by token-grepping commands/*.md
+#   [D]   agent; dispatched-by derived by token-grepping commands/*.md and
+#         skills/*/SKILL.md (skill dispatchers marked `(skill)`)
 #
 # Usage:
 #   feature-registry.sh generate [outfile]   # default: docs/FEATURES.md
@@ -66,8 +67,12 @@ test_refs() { # <token-pattern>
 }
 
 dispatched_by() { # <token-pattern>
-  grep -lE "$1" "$KIT_DIR"/commands/*.md 2>/dev/null \
-    | sed -E 's|.*/||; s|\.md$||' | sort -u | cap_list
+  {
+    grep -lE "$1" "$KIT_DIR"/commands/*.md 2>/dev/null \
+      | sed -E 's|.*/||; s|\.md$||'
+    grep -lE "$1" "$KIT_DIR"/skills/*/SKILL.md 2>/dev/null \
+      | sed -E 's|/SKILL\.md$||; s|.*/||; s|$| (skill)|'
+  } | sort -u | cap_list
 }
 
 hook_events() { # <basename.sh>
@@ -180,7 +185,7 @@ generate() {
     echo ""
     echo "# Feature registry"
     echo ""
-    echo "GENERATED , do not hand-edit. Regenerate: \`bash lib/registry/feature-registry.sh generate\`. One row per live feature; freshness pinned by \`tests/test-meta.sh\` (regenerate-and-diff). Trigger classes per \`docs/workflow-paths.md\` section 1: \`[H]\` human-typed, \`[H/I]\` human-or-intent, \`[I]\` intent-read, \`[E]\` event-fired, \`[D]\` dispatched. Refs are exact-token greps: Specs over \`docs/specs/\`, Tests over \`tests/*.sh\`, Dispatched-by over \`commands/*.md\`; \`-\` means no reference found (a coverage gap, not always a defect: read-only agents may be deliberately untested)."
+    echo "GENERATED , do not hand-edit. Regenerate: \`bash lib/registry/feature-registry.sh generate\`. One row per live feature; freshness pinned by \`tests/test-meta.sh\` (regenerate-and-diff). Trigger classes per \`docs/workflow-paths.md\` section 1: \`[H]\` human-typed, \`[H/I]\` human-or-intent, \`[I]\` intent-read, \`[E]\` event-fired, \`[D]\` dispatched. Refs are exact-token greps: Specs over \`docs/specs/\`, Tests over \`tests/*.sh\`, Dispatched-by over \`commands/*.md\` + \`skills/*/SKILL.md\` (skill dispatchers marked \`(skill)\`); \`-\` means no reference found (a coverage gap, not always a defect: read-only agents may be deliberately untested)."
     echo ""
     commands_table
     agents_table

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -2959,6 +2959,11 @@ REG_TMP2=$(mktemp)
 bash "$KIT_DIR/lib/registry/feature-registry.sh" generate "$REG_TMP2" 2>/dev/null
 cmp -s "$REG_TMP" "$REG_TMP2"
 assert_true "feature-registry generator is deterministic (double run byte-identical, SPEC-219)" $?
+# Skill-dispatcher derivation pin: an agent dispatched only by skills must not
+# show `-`; audit-scanner is dispatched by the doc-drift + feature-map skills.
+ASROW=$(grep -E '^\| `audit-scanner` ' "$KIT_DIR/docs/FEATURES.md")
+RC=0; { echo "$ASROW" | grep -q 'doc-drift (skill)' && echo "$ASROW" | grep -q 'feature-map (skill)'; } || RC=1
+assert_eq "audit-scanner dispatched-by names both skill dispatchers (doc-drift + feature-map)" 0 $RC
 rm -f "$REG_TMP" "$REG_TMP2"
 
 echo ""


### PR DESCRIPTION
## Problem

The `dispatched_by` derivation in `lib/registry/feature-registry.sh` grepped only `commands/*.md`, so an agent dispatched exclusively by skills showed `-` in `docs/FEATURES.md`. `audit-scanner` (dispatched by the `doc-drift` and `feature-map` skills) was the visible gap.

## Fix

Extend the scan to also grep `skills/*/SKILL.md`, rendering skill dispatchers as `<name> (skill)` next to command dispatchers. Header blurb and script comment updated to match.

## Result

| Row | Before | After |
|---|---|---|
| `audit-scanner` | `-` | `doc-drift (skill), feature-map (skill)` |
| `agent-effectiveness` | `draft-agent` | `draft-agent, loop-engineering (skill)` |

## Verification

- `bash tests/test-meta.sh` 742/742 PASS (freshness pin, determinism double-run, new assertion pinning audit-scanner's cell to both skill dispatchers)
- Negative control: token renamed in `skills/doc-drift/SKILL.md` on a scratch regeneration drops the cell to `feature-map (skill)` only
- Proof of done: `docs/verification/registry-skill-dispatchers.md`
