### PR TITLE
fix(tests): sandbox HOME in test-install-compat.sh

### DIFF
--- a/docs/implementation-notes/install-compat-home-sandbox.md
+++ b/docs/implementation-notes/install-compat-home-sandbox.md
@@ -1,0 +1,79 @@
+## 2026-08-01 12:00 Sandbox HOME in test-install-compat.sh
+
+### Context
+
+`tests/test-install-compat.sh` runs `install.sh` twice with only `CLAUDE_DIR`
+overridden, never `HOME`. Faking a plugin-cache dir under `CLAUDE_DIR` trips
+`install.sh`'s compat branch, which unconditionally writes a CLI shim to
+`$HOME/.local/bin/<name>` for every known module (board, session,
+worktree-provision, prose-rag), regardless of `--with`. With the real `$HOME`
+in play, that overwrote 4 live shims on 2026-08-01, retargeting them at the
+test's own `mktemp` dir; once the test's `trap ... EXIT` deleted that dir, the
+shims dangled and broke a live hook. Hand-fixed same day; this closes the
+suite-level gap.
+
+### Decision
+
+Give both `install.sh` invocations in `test-install-compat.sh` their own
+`mktemp -d` `HOME` (`HOME_SB1`, `HOME_SB2`), so the compat branch's shim write
+lands in a throwaway dir instead of the operator's real `~/.local/bin`. Added
+a tripwire check at the end of the same suite: scan the REAL `$HOME/.local/bin`
+(the script never reassigns its own `$HOME`, only the install.sh subshells'),
+and fail if any dwarves-kit-managed shim's `exec` target points inside this
+run's `$TMP`/`$TMP2`.
+
+### Why here, not install.sh itself
+
+`install.sh`'s compat-mode shim write targeting `$HOME/.local/bin` is correct
+behavior for a real machine (README Option 2 dev install), the bug is the
+*test* exercising that code path without sandboxing, not the script itself.
+No other suite hits this: every other `install.sh` invocation in `tests/`
+already sets `HOME=` explicitly, or runs the full (non-compat) path with no
+`--with`, which enables zero CLI-shim modules by default.
+
+### Verification (revert-to-red proof)
+
+Green, with the fix in place:
+
+```
+$ bash tests/test-install-compat.sh
+ok   took the compat branch
+ok   lib symlink created
+ok   WORKFLOW.md symlink created
+ok   docs/WORKFLOW.md symlink created (SPEC-185 bulk)
+ok   AGENTS.md symlink created
+ok   settings.json NOT written (no double hooks)
+ok   compat lib resolves to a real script
+ok   KIT_FORCE_FULL bypasses compat
+ok   tripwire: real ~/.local/bin shims never point into this test's $TMPDIR (leaked: none)
+PASS: install compat
+Exit: 0
+```
+
+Red, with the `HOME_SB1` sandbox reverted (first `install.sh` call restored to
+`CLAUDE_DIR="$TMP" bash "$KIT_DIR/install.sh"`, run under a throwaway fake
+"real HOME" so the demonstration never touches this machine's actual
+`~/.local/bin`):
+
+```
+$ FAKE_REAL_HOME="$(mktemp -d)"; mkdir -p "$FAKE_REAL_HOME/.local/bin"
+$ HOME="$FAKE_REAL_HOME" bash tests/test-install-compat-revert.sh
+ok   took the compat branch
+... (unchanged checks) ...
+ok   KIT_FORCE_FULL bypasses compat
+Exit: 1
+$ ls "$FAKE_REAL_HOME/.local/bin"
+board  prose-rag  session  worktree-provision   # all 4 shims leaked into the fake real HOME
+```
+
+The reverted run aborts (`set -euo pipefail`) at `[ -z "$LEAKED" ]` once the
+tripwire finds the leaked shims, exit 1, the same abort-on-failed-assertion
+idiom this file already uses for every other `chk` line. Nonzero exit is what
+a suite runner checks; the tripwire class of bug is caught.
+
+`bash tests/test-meta.sh`: 806/806 passed, unaffected.
+
+### Impact
+
+No production code changed (`install.sh` untouched). Scope held to the
+offending suite; no other test file touched.

--- a/docs/verification/install-home-sandbox.md
+++ b/docs/verification/install-home-sandbox.md
@@ -1,0 +1,96 @@
+# Proof of done: install-home-sandbox (test-install-compat.sh HOME isolation)
+
+Class: behavioral. Verified 2026-08-01. Three parts: a green real run, a
+negative control, and reproducibility.
+
+## Context
+
+`tests/test-install-compat.sh` ran `install.sh` with only `CLAUDE_DIR`
+overridden, never `HOME`. Faking a plugin-cache dir under `CLAUDE_DIR` trips
+`install.sh`'s compat branch, which unconditionally writes a CLI shim to
+`$HOME/.local/bin/<name>` for every known module. With the real `$HOME` in
+play this clobbered 4 live shims on 2026-08-01, retargeting them at the
+test's own `mktemp` dir; once the test's exit trap deleted that dir, the
+shims dangled and broke a live hook. Hand-fixed same day; this closes the
+suite-level gap that let it happen.
+
+## GREEN (real run)
+
+Command: `bash tests/test-install-compat.sh`
+Exit: 0
+VERDICT: PASS
+Output:
+
+```
+ok   took the compat branch
+ok   lib symlink created
+ok   WORKFLOW.md symlink created
+ok   docs/WORKFLOW.md symlink created (SPEC-185 bulk)
+ok   AGENTS.md symlink created
+ok   settings.json NOT written (no double hooks)
+ok   compat lib resolves to a real script
+ok   KIT_FORCE_FULL bypasses compat
+ok   tripwire: real ~/.local/bin shims never point into this test's $TMPDIR (leaked: none)
+PASS: install compat
+```
+
+Command: `bash tests/test-meta.sh`
+Exit: 0
+VERDICT: PASS
+Output excerpt:
+
+```
+=== Results ===
+Passed: 806 / 806
+All meta tests passed.
+```
+
+## NEGATIVE CONTROL (revert -> RED -> restore)
+
+Reverted the first `install.sh` call back to unsandboxed
+(`CLAUDE_DIR="$TMP" bash "$KIT_DIR/install.sh"`, dropping the `HOME="$HOME_SB1"`
+prefix) and ran it under a throwaway fake "real HOME" so the demonstration
+never touches this machine's actual `~/.local/bin`.
+
+Command:
+```
+cp tests/test-install-compat.sh tests/test-install-compat-revert.sh
+# (edit: drop HOME="$HOME_SB1" from the first install.sh call)
+FAKE_REAL_HOME="$(mktemp -d)"; mkdir -p "$FAKE_REAL_HOME/.local/bin"
+HOME="$FAKE_REAL_HOME" bash tests/test-install-compat-revert.sh
+```
+
+Exit while reverted: 1
+
+```
+ok   took the compat branch
+ok   lib symlink created
+ok   WORKFLOW.md symlink created
+ok   docs/WORKFLOW.md symlink created (SPEC-185 bulk)
+ok   AGENTS.md symlink created
+ok   settings.json NOT written (no double hooks)
+ok   compat lib resolves to a real script
+ok   KIT_FORCE_FULL bypasses compat
+```
+
+Script aborts (`set -euo pipefail`) at `[ -z "$LEAKED" ]` once the tripwire
+finds the leak, matching the existing `cmd; chk ... $?` idiom this file
+already uses for every other check. Real cause, confirmed on disk:
+
+```
+$ ls "$FAKE_REAL_HOME/.local/bin"
+board  prose-rag  session  worktree-provision
+```
+
+All 4 shims leaked into the fake "real" HOME, each `exec`-ing into the
+test's own `$TMP`, the exact incident class from 2026-08-01, reproduced
+and caught.
+
+Restore: `rm -f tests/test-install-compat-revert.sh` (temp file, never
+committed; the real fix in `tests/test-install-compat.sh` was untouched
+throughout this control).
+
+## Reproducibility
+
+Both `Command:` lines above are re-runnable as-is from a clean checkout;
+no fixture setup beyond what the suites already do inline.

--- a/tests/test-install-compat.sh
+++ b/tests/test-install-compat.sh
@@ -8,9 +8,16 @@ fail=0
 chk() { if [ "$2" -eq 0 ]; then echo "ok   $1"; else echo "FAIL $1"; fail=1; fi; }
 
 # --- plugin present -> compat-only ---
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP" "${TMP2:-}"' EXIT
+# ID-463: the compat branch (install.sh's plugin-detected path) unconditionally
+# writes a CLI shim to $HOME/.local/bin for every known module, regardless of
+# --with. Without a sandboxed HOME that lands in the REAL ~/.local/bin, pointing
+# at this test's own $TMP -- which the trap below deletes on exit, leaving a
+# dangling shim. Incident: this clobbered 4 live shims on 2026-08-01. HOME_SB1/2
+# give install.sh its own throwaway HOME so ~/.local/bin is never touched.
+TMP="$(mktemp -d)"; HOME_SB1="$(mktemp -d)"; HOME_SB2="$(mktemp -d)"
+trap 'rm -rf "$TMP" "${TMP2:-}" "$HOME_SB1" "$HOME_SB2"' EXIT
 mkdir -p "$TMP/plugins/cache/dwarves-marketplace/kit/1.0.0/lib"
-out="$(CLAUDE_DIR="$TMP" bash "$KIT_DIR/install.sh" 2>&1)"
+out="$(HOME="$HOME_SB1" CLAUDE_DIR="$TMP" bash "$KIT_DIR/install.sh" 2>&1)"
 
 printf '%s' "$out" | grep -q 'COMPAT-ONLY'; chk "took the compat branch" $?
 [ -L "$TMP/dwarves-kit/lib" ];         chk "lib symlink created" $?
@@ -23,7 +30,22 @@ printf '%s' "$out" | grep -q 'COMPAT-ONLY'; chk "took the compat branch" $?
 # --- KIT_FORCE_FULL bypasses compat even with the plugin present ---
 TMP2="$(mktemp -d)"
 mkdir -p "$TMP2/plugins/cache/dwarves-marketplace/kit/1.0.0/lib"
-out2="$(CLAUDE_DIR="$TMP2" KIT_FORCE_FULL=1 bash "$KIT_DIR/install.sh" 2>&1 || true)"
+out2="$(HOME="$HOME_SB2" CLAUDE_DIR="$TMP2" KIT_FORCE_FULL=1 bash "$KIT_DIR/install.sh" 2>&1 || true)"
 if printf '%s' "$out2" | grep -q 'COMPAT-ONLY'; then echo "FAIL KIT_FORCE_FULL still compat"; fail=1; else echo "ok   KIT_FORCE_FULL bypasses compat"; fi
+
+# --- Tripwire (ID-463): the compat branch's CLI-shim write must never escape
+# into the REAL $HOME, no matter what changes upstream in install.sh. $HOME is
+# never reassigned in THIS script (only the install.sh subshells above got a
+# sandboxed one), so it still names the operator's real home here.
+REAL_BIN="$HOME/.local/bin"
+LEAKED=""
+if [ -d "$REAL_BIN" ]; then
+  for f in "$REAL_BIN"/*; do
+    [ -f "$f" ] || continue
+    grep -q "dwarves-kit CLI shim" "$f" 2>/dev/null || continue
+    grep -qE "exec \"($TMP|$TMP2)/" "$f" 2>/dev/null && LEAKED="$LEAKED $(basename "$f")"
+  done
+fi
+[ -z "$LEAKED" ]; chk "tripwire: real ~/.local/bin shims never point into this test's \$TMPDIR (leaked:${LEAKED:- none})" $?
 
 [ "$fail" -eq 0 ] && echo "PASS: install compat" || { echo "SOME TESTS FAILED"; exit 1; }


### PR DESCRIPTION
## Summary
- `tests/test-install-compat.sh` ran `install.sh` with only `CLAUDE_DIR` sandboxed, never `HOME`; the compat branch it exercises writes CLI shims straight to `$HOME/.local/bin`, so the real home got clobbered (4 shims retargeted at a mktemp dir that vanished on test exit, breaking a live hook on 2026-08-01)
- Give both `install.sh` calls in that suite their own throwaway `HOME`, and add a tripwire assertion that fails if any dwarves-kit-managed shim in the real `~/.local/bin` ever points back into the test's own `$TMPDIR`
- No production code touched; `install.sh` itself is unchanged

## Test plan
- [x] `bash tests/test-install-compat.sh` — PASS, tripwire green (leaked: none)
- [x] `bash tests/test-meta.sh` — 806/806 passed
- [x] Revert-to-red proof: reran the suite with the `HOME` sandbox removed from the first `install.sh` call, under a throwaway fake "real HOME" — all 4 shims leaked and the suite aborted red; full transcript in `docs/verification/install-home-sandbox.md`

[unattended orchestrator run; journal queue-journal.tsv; slug dwarves-kit__ID-463]
