### PR TITLE
fix(sync): refuse id-collided spoke items at link time

### DIFF
--- a/docs/verification/id-309-collision-guard.md
+++ b/docs/verification/id-309-collision-guard.md
@@ -1,0 +1,86 @@
+# Proof of done: board-sync id-collision guard (ID-309)
+Profile: feature   Proof class: behavioral
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | `next_id` mints above the max id seen in RAW board text, even when a row never parses via `parse_board` | PASS | R1 |
+| 2 | At link time, a spoke item whose id matches an existing board row but whose title disagrees (beyond whitespace/case) is refused: not linked, board row untouched, a collision note is emitted naming both titles | PASS | R1, R2 |
+| 3 | Existing `lib/sync/tests/` suite stays green | PASS | R1 |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | `plan_sync`'s title-prefix link step (`lib/sync/sync_core.py`) now checks `titles_agree(it_title, rows[bid].item)` before adopting a spoke item into `linked[bid]`; on mismatch it appends an `id collision: ...` note and skips instead of linking. |
+| Where | `lib/sync/sync_core.py`: new `titles_agree()` helper (near `parse_title`), guard added in `plan_sync`'s title-prefix link loop. `next_id()` needed no change: it already regexes the raw board `text` for `<prefix>-NNN` tokens, not the parsed `rows` dict, so a pipe-broken row that `parse_board` cannot see is still counted. |
+| How it runs | Pure function, no I/O; exercised by `lib/sync/tests/test_core.py`. |
+| Reversibility | `git revert` the commit; no persistent state touched (planner is pure, board writes happen only via `apply_board` on a separate, unaffected plan field). |
+
+Root cause: the title-prefix link (`plan_sync`, the "snapshot map first, then title prefix" adoption loop) trusted `bid in rows` alone as proof of identity. When a board row is repaired after having been invisible to `parse_board` (so its id got reused by a spoke-born item), the id now matches but the titles never did. The fix adds the one missing check at the single link site all downstream status/title flow depends on, rather than patching the individual write sites (`board_edit_item`, `board_set_status`) that the bad link fanned out into.
+
+## 3. Confirmation (runs)
+
+| Run | When | Command | Exit | Verdict |
+|---|---|---|---|---|
+| R1 | 2026-08-02 | `uv run --python 3.12 --with pytest pytest lib/sync/tests/ -q` | 0 | PASS (173/173, incl. 2 new tests) |
+| R2 | 2026-08-02 | `git stash push -- lib/sync/sync_core.py && uv run --python 3.12 --with pytest pytest lib/sync/tests/test_core.py -k collision -v` (then `git stash pop`) | 1 | RED-as-expected |
+
+## 4. Run detail
+
+### R1 GREEN
+- Command: `uv run --python 3.12 --with pytest pytest lib/sync/tests/ -q`
+- Exit: 0
+- Output (excerpt):
+  ```
+  ........................................................................ [ 41%]
+  ........................................................................ [ 83%]
+  .............................                                            [100%]
+  173 passed in 0.14s
+  ```
+- Verdict: PASS
+- Note: covers AC1-AC3. 171 pre-existing tests + `test_next_id_skips_id_in_malformed_row` (AC1) + `test_link_skips_title_mismatched_id_collision` (AC2).
+
+### R2 NEGATIVE CONTROL
+- Command: `git stash push -- lib/sync/sync_core.py` (reverts only the fix, keeps the new test), then `uv run --python 3.12 --with pytest pytest lib/sync/tests/test_core.py -k collision -v`, then `git stash pop` to restore.
+- Exit: 1
+- Output (excerpt):
+  ```
+  lib/sync/tests/test_core.py::test_link_skips_title_mismatched_id_collision FAILED [100%]
+  >       assert any("id collision" in n and "ID-309" in n and "done" in n
+                    for n in p.notes)
+  E       assert False
+  ======================= 1 failed, 31 deselected in 0.02s =======================
+  ```
+- Verdict: RED-as-expected
+- Note: confirms the test actually exercises the fix (without the `titles_agree` guard, ID-309's spoke item would have linked silently, no collision note, and downstream `board_edit_item`/`board_set_status` writes for ID-309 would have fired, reproducing the 2026-07-21 incident). `titles_agree` and the guard were restored via `git stash pop` immediately after (verified byte-identical via `git diff`).
+
+## 5. Reproduce
+
+```
+uv run --python 3.12 --with pytest pytest lib/sync/tests/ -q
+```
+
+## Before/after
+
+**Before** (link loop trusted `bid in rows` alone):
+```python
+if bid in rows:
+    linked[bid] = it
+    claimed_rids.add(it["rid"])
+```
+A spoke item titled `ID-309 · done` would silently adopt the real `ID-309` row ("Queue-watcher pilot widening"), then flow through the field-sync section and flip the board row's item text to "done" and its status to shipped, on the very next sync round after the row was repaired.
+
+**After** (title must agree beyond the shared id prefix):
+```python
+if bid in rows:
+    if not titles_agree(it_title, rows[bid].item):
+        p.notes.append(
+            f"id collision: {bid} title mismatch, not linked "
+            f"(board={rows[bid].item!r} spoke={it_title!r})")
+        continue
+    linked[bid] = it
+    claimed_rids.add(it["rid"])
+```
+The mismatched item is never linked; the board row is never touched by it; a warning names both titles so a human can see the collision and resolve it (e.g. re-title the spoke item, or manually re-mint its id).

--- a/lib/sync/sync_core.py
+++ b/lib/sync/sync_core.py
@@ -119,6 +119,14 @@ def parse_title(title: str):
     return None, title.strip()
 
 
+def titles_agree(spoke_title: str, board_title: str) -> bool:
+    """Same id, different item text (beyond whitespace/case) is a collision,
+    not a link: a bare/empty side has nothing to disagree about."""
+    a = " ".join(spoke_title.split()).casefold()
+    b = " ".join(board_title.split()).casefold()
+    return not a or not b or a == b
+
+
 def extract_tags(notes: str) -> list[str]:
     return sorted(set(re.findall(r"#([a-z0-9][a-z0-9-]*)", notes)))
 
@@ -204,13 +212,18 @@ def plan_sync(rows: dict, items: list, state: dict,
     for it in items:
         if it["rid"] in claimed_rids:
             continue
-        bid, _ = parse_title(it["title"])
+        bid, it_title = parse_title(it["title"])
         if bid is None:
             continue
         if bid in linked:
             p.notes.append(f"duplicate item for {bid}: {it['title']!r} ignored")
             continue
         if bid in rows:
+            if not titles_agree(it_title, rows[bid].item):
+                p.notes.append(
+                    f"id collision: {bid} title mismatch, not linked "
+                    f"(board={rows[bid].item!r} spoke={it_title!r})")
+                continue
             linked[bid] = it
             claimed_rids.add(it["rid"])
         else:

--- a/lib/sync/tests/test_core.py
+++ b/lib/sync/tests/test_core.py
@@ -69,6 +69,15 @@ def test_parse_board_skips_malformed():
     assert parse_board("| ID-1 | too | many | cells | here | queued |\n") == {}
 
 
+def test_next_id_skips_id_in_malformed_row():
+    """A pipe-broken row is invisible to parse_board, but its literal ID
+    token must still block reuse: next_id scans raw text, not parsed rows,
+    so a malformed row can never let a later spoke-born item mint its id."""
+    broken = BOARD + "| ID-309 | Queue-watcher pilot widening | notes\n"
+    assert "ID-309" not in parse_board(broken)  # confirms invisibility
+    assert next_id(broken) == 310
+
+
 def test_next_id_and_title_and_tags():
     assert next_id(BOARD) == 14
     assert parse_title("ID-10 · Fix it") == ("ID-10", "Fix it")
@@ -177,6 +186,23 @@ def test_board_add_skips_duplicate_title():
     p = plan_sync(parse_board(BOARD), items, {})
     assert not p.board_add
     assert any("already on board" in n for n in p.notes)
+
+
+def test_link_skips_title_mismatched_id_collision():
+    """Repaired-row scenario: ID-309 now exists on the board, but a
+    spoke-born item that reused the id (minted while the row was broken and
+    invisible to parse_board) carries an unrelated title. The title-prefix
+    link must refuse to adopt it rather than let the spoke item silently
+    overwrite the real row's title/status."""
+    board = BOARD + ("\n| ID-309 | Queue-watcher pilot widening | real row "
+                     "| executing |\n")
+    rows = parse_board(board)
+    items = [item("spoke-1", "ID-309 · done", done=True)]
+    p = plan_sync(rows, items, {})
+    assert not p.board_edit_item
+    assert not any(bid == "ID-309" for bid, _ in p.board_set_status)
+    assert any("id collision" in n and "ID-309" in n and "done" in n
+              for n in p.notes)
 
 
 def test_title_sync_board_wins_and_spoke_edit_pulls():


### PR DESCRIPTION
## Summary
- Board-sync's title-prefix link step now checks that the spoke item's title agrees with the board row's title (beyond whitespace/case) before adopting it into the link map; on mismatch it emits a collision note and skips the link instead of silently overwriting the row.
- Added a regression test pinning down that `next_id` already scans raw board text (not parsed rows), so a pipe-broken row invisible to `parse_board` can never cause id reuse.

Root cause: a repaired board row could be silently adopted by a spoke item that reused its id while the row was pipe-broken and invisible to `parse_board`. The old link step trusted `bid in rows` alone; the fix adds the missing title check at that single link site, which is what all downstream status/title writes depend on.

## Test plan
- [x] `uv run --python 3.12 --with pytest pytest lib/sync/tests/ -q` — 173/173 pass (171 existing + 2 new)
- [x] `bash tests/test-meta.sh` — 806/806 pass, no regressions
- [x] Negative control: reverted the fix only (kept the new test), confirmed it goes RED, restored the fix — see `docs/verification/id-309-collision-guard.md`

[unattended orchestrator run; journal queue-journal.tsv; slug dwarves-kit__ID-309]