### PR TITLE
docs(typescript): add process-lifecycle rule for child_process signal handling

### DIFF
--- a/docs/impl-playbook/typescript.md
+++ b/docs/impl-playbook/typescript.md
@@ -20,11 +20,17 @@ Distills the Google TypeScript Style Guide plus Effective TypeScript's core advi
 ## Errors
 - Model expected failures in the return type (a result-shaped union or a typed thrown error). Do not leave a `catch (e)` with `e` unhandled as `unknown`.
 
+## Process lifecycle
+- A child process spawned via `execFileSync`/`execSync`/plain `spawn` inherits the parent's process group. Killing the parent's PID signals only that one process; a child already forked (a test runner's own worker pool, for example) is orphaned to init and keeps running instead of dying with it.
+- Any script that shells out to a long-running or pool-spawning subprocess (a test runner, a build watcher, a mutation-testing harness) and needs to be interruptible: spawn with `detached: true`, keep the child handle in scope, and on both `SIGINT` and `SIGTERM` kill the whole group with `process.kill(-child.pid, "SIGTERM")`, not `child.kill()`. `execFileSync`/`execSync` give no handle to kill, so an interruptible subprocess call must use async `spawn`.
+- Handle `SIGTERM`, not only `SIGINT`. A plain `kill <pid>` sends `SIGTERM`; a script that only registers `SIGINT` cleans up on Ctrl-C but leaks its subprocess tree on an ordinary `kill`.
+
 ## Tooling
 - `pnpm` for package management. ESLint plus `strict: true` in tsconfig are the enforced layer.
 
 ## Sources
 - [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html)
 - [Effective TypeScript (official companion repo, 2nd ed.)](https://github.com/danvk/effective-typescript)
+- [Node.js child_process docs, `detached` option](https://nodejs.org/api/child_process.html#optionsdetached)
 
-Verified: 2026-07-29.
+Verified: 2026-08-05.


### PR DESCRIPTION
## Summary
- Adds a "Process lifecycle" section to `docs/impl-playbook/typescript.md`: a child process spawned via `execFileSync`/`execSync`/plain `spawn` inherits the parent's process group, so killing the parent's PID orphans an already-forked worker pool instead of taking it down.
- States the fix: spawn detached, keep the child handle, cascade `SIGTERM`/`SIGINT` via `process.kill(-child.pid)`.

## Why
Distilled from a real incident tonight: a mutation-testing script (`execFileSync` shelling out to `vitest run`) left 18 orphaned `node (vitest)` worker processes running after a plain `kill` on its top PID, because the workers stayed in the same process group and reparented to launchd instead of dying.

## Test plan
- [x] File renders correctly (added section matches existing file's format, cites Node's `child_process` docs like the other Sources entries)
- [x] No code changes, docs-only