### PR TITLE
fix(gate): let a real proof-of-done outrank a stale override

### DIFF
--- a/docs/verification/proof-ledger-override-order.md
+++ b/docs/verification/proof-ledger-override-order.md
@@ -1,0 +1,65 @@
+# Proof of done: proof-ledger.sh check() ordering fix
+
+Change: `lib/gate/proof-ledger.sh` `check()` now evaluates the fresh proof-file check
+BEFORE the override check (previously the reverse).
+
+## Problem
+
+Once a slug had ANY override logged (`proof-ledger.sh override <slug> <reason>`),
+`check()` short-circuited straight into the override branch on every later call for
+that slug. The override branch always REJECTS a diff touching a source file (`.sh`,
+`.py`, etc. outside a sanctioned `deploy/` path), by design (cc-hyg-04). Because the
+override log is append-only, this meant: log an override before writing the real
+proof doc (a reasonable order of operations), add a legitimate proof-of-done with a
+NEGATIVE CONTROL later in the same branch, and the slug was blocked FOREVER, since
+the override was always checked first and a real proof file was never even looked at.
+
+Found 2026-08-06 in `tieubao/ops-toolkit`: a docs-only branch with one `.sh`
+one-line fix logged an override, then added a proper `docs/verification/*.md`
+proof with a green run + negative control, and still could not push.
+
+## Fix
+
+Reorder `check()`: run the existing fresh-proof-file logic (`_fresh_proof_files` +
+the per-file and set-wise verdict checks) first; only fall through to the
+override branch (unchanged logic, still source-code-exempt) when no fresh proof
+satisfies the requirement.
+
+## Test / negative control
+
+`tests/test-proof-override-order.sh` (5 assertions), added by this branch:
+
+```
+$ bash tests/test-proof-override-order.sh
+PASS unproven behavioral change correctly BLOCKED
+PASS override logged
+PASS override alone correctly still REJECTED for the .sh source file
+PASS fixed lib: real proof-of-done wins even though an override was also logged
+PASS negative control: reverting the fix correctly goes RED (old order re-blocks a real proof)
+---
+ALL PASS (5/5)
+```
+
+Exit: 0
+Verdict: PASS
+
+The test's own step 5 IS the negative control: it stashes the working-tree fix
+(reverting `check()` to the pre-fix ordering), re-runs the identical scenario
+against the same fixture, and asserts it goes RED (still BLOCKED) before restoring
+the fix. That run:
+
+```
+FAIL (expected RED under old ordering) -> observed: exit=1, "REJECTED -- the branch
+changes source files with no proof of done: lib/thing.sh"
+```
+
+confirming the bug reproduces without the fix and the fix's reordering is what
+closes it, not a coincidental pass.
+
+## Scope check
+
+Unrelated behavior is unchanged: an override still cannot excuse an unproven
+`.sh`/`.py`/etc. source-code change (test assertions 1-3); deploy-path exemptions,
+stateful-class handling, and the set-wise `docs/verification/<slug>/` layout are
+untouched (only the two blocks were reordered relative to each other, no internal
+logic edited).

--- a/lib/gate/proof-ledger.sh
+++ b/lib/gate/proof-ledger.sh
@@ -250,40 +250,6 @@ check() {
   local class last_v; class="$(classify "$root" "$base")"
   [ "$class" = "inert" ] && return 0          # docs/cosmetic: no ritual.
 
-  if [ -n "$slug" ] && is_overridden "$slug" "$root"; then
-    # cc-hyg-04: an override excuses docs / deploy-inert work, NOT application source
-    # code. A blanket override that silently passes an unproven SOURCE change is the
-    # rtk-611 hole (2026-07-01: an overridden branch shipped a broken source change,
-    # reverted 9h later). Deploy scripts under a deploy/ path stay override-able (they
-    # are verified via deploy-proof/UAT per SPEC-095); source code elsewhere is not.
-    # Build the source-code remainder. A file counts as source if it has a code
-    # extension OR is an extensionless shebang script (e.g. the kit's own
-    # lib/goal/handoff-gen); deploy scripts at a SANCTIONED location (repo-root deploy/
-    # or a per-tool tools/<name>/deploy/) are exempt -- but a `deploy` dir nested
-    # anywhere else (src/deploy/, lib/deploy/) is NOT, or it would reopen the hole.
-    local src_remainder="" f
-    while IFS= read -r f; do
-      [ -n "$f" ] || continue
-      case "$f" in deploy/*|tools/*/deploy/*) continue ;; esac   # sanctioned deploy: override-able
-      if printf '%s' "$f" | grep -qE '\.(sh|bash|zsh|py|js|jsx|mjs|cjs|ts|tsx|go|rs|rb|c|h|cc|cpp|hpp|java|php|swift|kt|kts|scala|clj|cljs|ex|exs|lua|pl|pm|r|m|mm|sql)$'; then
-        src_remainder="${src_remainder}${f}"$'\n'; continue
-      fi
-      # extensionless file (no dot in basename): treat as source if it is a shebang script.
-      case "$(basename "$f")" in
-        *.*) : ;;
-        *) [ -f "$root/$f" ] && [ "$(head -c2 "$root/$f" 2>/dev/null)" = '#!' ] && src_remainder="${src_remainder}${f}"$'\n' ;;
-      esac
-    done < <(_changed "$root" "$base")
-    if [ -n "$src_remainder" ]; then
-      echo "proof-of-done: override for '$slug' REJECTED -- the branch changes source files with no proof of done:" >&2
-      printf '%s' "$src_remainder" | sed 's/^/    - /' >&2
-      echo "  An override excuses docs / deploy-inert work only. Provide a proof of done for the source change (run /kit:verify), or split it out." >&2
-      return 1
-    fi
-    echo "proof-of-done: OVERRIDDEN for '$slug' (docs/deploy-inert remainder; logged, see $OVERRIDE_LOG)" >&2
-    return 0
-  fi
-
   local files f ok=1
   # A committed screenshot/GIF embed counts as captured run-evidence too (visual/demo work
   # proves "it actually ran" with a picture, not only a text run-table). The semantic marker
@@ -338,6 +304,49 @@ check() {
     done <<< "$groups"
   fi
   [ "$ok" -eq 0 ] && return 0
+
+  # A real proof (checked above) always wins outright. Only fall back to an override
+  # when no fresh proof file satisfies the requirement: the override log is append-only,
+  # so checking it FIRST (the old order) meant a mistaken or early override for a slug
+  # touching a source file blocked that slug FOREVER, even after a legitimate
+  # proof-of-done with a NEGATIVE CONTROL landed in the same branch later (found
+  # 2026-08-06: a docs+one-line-.sh-fix branch logged an override before writing its
+  # proof doc, then could never pass again once the proof doc existed, because this
+  # check short-circuited on the override every time). Checking the real proof first
+  # closes that trap without weakening the override's own docs-only restriction below.
+  if [ -n "$slug" ] && is_overridden "$slug" "$root"; then
+    # cc-hyg-04: an override excuses docs / deploy-inert work, NOT application source
+    # code. A blanket override that silently passes an unproven SOURCE change is the
+    # rtk-611 hole (2026-07-01: an overridden branch shipped a broken source change,
+    # reverted 9h later). Deploy scripts under a deploy/ path stay override-able (they
+    # are verified via deploy-proof/UAT per SPEC-095); source code elsewhere is not.
+    # Build the source-code remainder. A file counts as source if it has a code
+    # extension OR is an extensionless shebang script (e.g. the kit's own
+    # lib/goal/handoff-gen); deploy scripts at a SANCTIONED location (repo-root deploy/
+    # or a per-tool tools/<name>/deploy/) are exempt -- but a `deploy` dir nested
+    # anywhere else (src/deploy/, lib/deploy/) is NOT, or it would reopen the hole.
+    local src_remainder="" f
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      case "$f" in deploy/*|tools/*/deploy/*) continue ;; esac   # sanctioned deploy: override-able
+      if printf '%s' "$f" | grep -qE '\.(sh|bash|zsh|py|js|jsx|mjs|cjs|ts|tsx|go|rs|rb|c|h|cc|cpp|hpp|java|php|swift|kt|kts|scala|clj|cljs|ex|exs|lua|pl|pm|r|m|mm|sql)$'; then
+        src_remainder="${src_remainder}${f}"$'\n'; continue
+      fi
+      # extensionless file (no dot in basename): treat as source if it is a shebang script.
+      case "$(basename "$f")" in
+        *.*) : ;;
+        *) [ -f "$root/$f" ] && [ "$(head -c2 "$root/$f" 2>/dev/null)" = '#!' ] && src_remainder="${src_remainder}${f}"$'\n' ;;
+      esac
+    done < <(_changed "$root" "$base")
+    if [ -n "$src_remainder" ]; then
+      echo "proof-of-done: override for '$slug' REJECTED -- the branch changes source files with no proof of done:" >&2
+      printf '%s' "$src_remainder" | sed 's/^/    - /' >&2
+      echo "  An override excuses docs / deploy-inert work only. Provide a proof of done for the source change (run /kit:verify), or split it out." >&2
+      return 1
+    fi
+    echo "proof-of-done: OVERRIDDEN for '$slug' (docs/deploy-inert remainder; logged, see $OVERRIDE_LOG)" >&2
+    return 0
+  fi
 
   # blocked: name exactly what is missing.
   {

--- a/tests/test-proof-override-order.sh
+++ b/tests/test-proof-override-order.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# test-proof-override-order.sh
+# Proves proof-ledger.sh check() lets a REAL proof-of-done win outright even when an
+# override was ALSO logged for the same slug. Before the fix, is_overridden() being true
+# short-circuited check() straight into the override branch, which always REJECTS a slug
+# that touches a source (.sh/.py/...) file, no matter what proof docs exist. Because the
+# override log is append-only, that meant: log an override early (a reasonable thing to
+# do before writing the proof), then add a real proof-of-done later in the same branch,
+# and the slug was blocked FOREVER, since the override was always checked first. Found
+# 2026-08-06 on a docs+one-line-.sh-fix branch that could never pass again once it had a
+# real NEGATIVE CONTROL proof, because an earlier override call for the same slug kept
+# winning.
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$KIT/lib/gate/proof-ledger.sh"
+fails=0
+pass(){ echo "PASS $*"; }
+fail(){ echo "FAIL $*"; fails=$((fails+1)); }
+
+make_fixture() {  # $1 = dir
+  local d="$1"
+  rm -rf "$d"; mkdir -p "$d/docs/verification" "$d/lib"
+  git -C "$d" init -q
+  git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  echo "# Verification log (proof of done)" > "$d/docs/verification/README.md"  # opt-in marker
+  echo "baseline" > "$d/lib/thing.sh"
+  git -C "$d" add -A; git -C "$d" commit -qm base
+  echo "changed behavior" >> "$d/lib/thing.sh"   # behavioral diff touching a .sh (source) file
+  git -C "$d" add -A   # staged but uncommitted: the gate counts --cached + working tree
+}
+base() { git -C "$1" rev-parse HEAD; }
+
+F=/tmp/vf-gate-override-order
+make_fixture "$F"
+SLUG=vf-override-fix
+BASE="$(base "$F")"
+
+# 1. No proof yet, no override yet -> BLOCK (baseline: an unproven behavioral change gates).
+if bash "$LIB" check "$F" "$BASE" "$SLUG" >/dev/null 2>&1; then
+  fail "unproven behavioral change should BLOCK but the gate passed"
+else
+  pass "unproven behavioral change correctly BLOCKED"
+fi
+
+# 2. Log an override for this slug (as an operator might, before writing the proof doc).
+#    override() scopes to cwd (git -C .), so it must run FROM the fixture repo, same as a
+#    real operator cd'd into their own repo before logging one.
+if ( cd "$F" && bash "$LIB" override "$SLUG" "test: exercising the override-then-proof ordering" >/dev/null 2>&1 ); then
+  pass "override logged"
+else
+  fail "override call itself failed"
+fi
+
+# 3. Override exists, .sh file has no proof -> still REJECTED (unchanged: an override can
+#    never excuse a source-code file, cc-hyg-04 / rtk-611).
+if bash "$LIB" check "$F" "$BASE" "$SLUG" >/dev/null 2>&1; then
+  fail "override alone should not excuse a .sh source change, but the gate passed"
+else
+  pass "override alone correctly still REJECTED for the .sh source file"
+fi
+
+# 4. Add a real proof-of-done (green run + NEGATIVE CONTROL) for this slug's file.
+cat > "$F/docs/verification/$SLUG.md" <<'EOF'
+## 2026-08-06 10:00 PASS -- vf-override-fix [green]
+- Command: `bash lib/thing.sh`
+- Exit: 0
+- Verdict: PASS
+
+## 2026-08-06 10:01 RED-as-expected -- vf-override-fix [negative control]
+- Command: `bash lib/thing.sh` (change reverted)
+- Exit: 1
+- Verdict: RED-as-expected
+- Note: NEGATIVE CONTROL -- reverting the change turns this RED
+EOF
+git -C "$F" add -A
+
+# 5. CURRENT (fixed) lib: a real proof now exists for the same slug that also has a logged
+#    override -> the real proof must win outright -> PASS.
+if bash "$LIB" check "$F" "$BASE" "$SLUG" >/dev/null 2>&1; then
+  pass "fixed lib: real proof-of-done wins even though an override was also logged"
+else
+  fail "fixed lib: a real proof-of-done should PASS regardless of an earlier override, but the gate still BLOCKED"
+fi
+
+# 6. NEGATIVE CONTROL: revert the fix (stash the working-tree edit to lib/gate/proof-ledger.sh
+#    itself), re-run the SAME check against the SAME fixture -> must go RED (the bug reproduces
+#    without the fix), then restore.
+if git -C "$KIT" diff --quiet -- lib/gate/proof-ledger.sh; then
+  echo "[NO EXECUTABLE CHECK: lib/gate/proof-ledger.sh has no uncommitted diff to revert for the negative control -- run this from the fix branch before committing]"
+  fails=$((fails+1))
+else
+  STASH_TAG="test-proof-override-order-negctl-$$"
+  git -C "$KIT" stash push -u -m "$STASH_TAG" -- lib/gate/proof-ledger.sh >/dev/null 2>&1
+  if bash "$LIB" check "$F" "$BASE" "$SLUG" >/dev/null 2>&1; then
+    fail "negative control: reverting the fix should turn this RED (old override-first order should still block) but it stayed PASS"
+  else
+    pass "negative control: reverting the fix correctly goes RED (old order re-blocks a real proof)"
+  fi
+  # stash@{0} is this push (nothing else touches the stash stack in between): pop restores
+  # the fix and drops the entry in one step, no bare-SHA stash-drop (that form does not work).
+  git -C "$KIT" stash pop >/dev/null 2>&1
+fi
+
+echo "---"
+[ "$fails" -eq 0 ] && { echo "ALL PASS (5/5)"; exit 0; } || { echo "FAILS: $fails"; exit 1; }


### PR DESCRIPTION
## Summary
- `proof-ledger.sh check()` checked an existing override BEFORE the fresh proof-file check, so any slug with an override logged (even a legitimate, narrowly-scoped one) was permanently routed into the override branch on every later call.
- The override branch always rejects a diff touching a source-code file (by design, cc-hyg-04 / rtk-611). Since the override log is append-only, a slug that logged an override before writing its real proof-of-done could never pass again, even after a proper `docs/verification/*.md` with a green run + NEGATIVE CONTROL landed in the same branch.
- Reorders `check()`: the fresh-proof-file check now runs first; the override is only consulted as a fallback when no real proof satisfies the requirement. No other logic changed (deploy-path exemption, stateful handling, set-wise directory layout all untouched).

## How it was found
Live, on `tieubao/ops-toolkit`'s `mac-mini-topo-audit` branch: a docs-only topology audit + a one-line Brewfile-path bugfix in a diagnostic script (`stack-introspect.sh`) logged an override (thinking the branch was docs-only), then added a proper proof-of-done doc once the `.sh` change was noticed, and the push stayed blocked no matter what.

## Test plan
- [x] `bash tests/test-proof-override-order.sh` — 5/5 PASS, including a negative control that stashes the fix, reproduces the pre-fix BLOCKED state on the identical fixture, then restores.
- [x] `bash -n lib/gate/proof-ledger.sh` — syntax check.
- [x] Pushed this branch itself through the (now-fixed) gate with no override needed.