### PR TITLE
test(gauntlet): prep bundle for the kit's own gauntlet runs

### DIFF
--- a/docs/specs/SPEC-227-gauntlet-scenario-pack.md
+++ b/docs/specs/SPEC-227-gauntlet-scenario-pack.md
@@ -1,0 +1,82 @@
+# SPEC-227: Gauntlet scenario pack, full-flow scenarios via the test-generation loop
+
+**Status:** DRAFT (matrix first cut committed; cards materialize per row)
+Lane: normal
+**Unparks:** ID-423's L3 (sandbox-repo E2E scenarios), with the gauntlet as its
+executor. **Reuses:** the SPEC-203 test-generation loop as the scenario
+GENERATOR. **Relates:** ID-465 (scenario-harness discipline) governs any
+scenario needing an external-API mock.
+
+## Problem
+
+The gauntlet's first seed cards test the doorway (adopt + one tiny fix), not the
+house. A contributor surface is only proven when a probe survives the FULL
+flows: a real lane end to end, a bug through the debug loop, a gate collision, a
+mid-flight drift, a dead-session resume. Hand-authoring those scenarios is the
+exact test-generation problem ID-423 named and left queued; authoring them ad
+hoc per run would rot immediately.
+
+## Decisions
+
+1. **The journey is the spec.** The contributor journey (the features a real dev
+   exercises: install, adopt, tiny lane, full lane, debug, gates, drift, review,
+   resume, mega) is written down as a feature list with acceptance criteria,
+   exactly the shape `/kit:test-plan` consumes. Scenario generation is then the
+   SHIPPED SPEC-203 loop run against that journey: test-plan derives the
+   coverage matrix, test-plan-review-team critiques it, and the test-write
+   analog materializes each row as a seed card + checker assertions. No new
+   generator is built.
+2. **One matrix, cards per row.** `tests/gauntlet/scenarios.md` holds the
+   matrix (committed, reviewed). A card materializes from a row at run time,
+   frozen into the run record like any seed card. The matrix is the durable
+   artifact; cards are its projections.
+3. **Multi-scenario runs are a CAMPAIGN, not a new engine.** The gauntlet
+   engine converges the surface against ONE card per run. A scenario-pack run
+   is the campaign shape from the loop-engineering skill: a worklist of matrix
+   rows, the gauntlet engine invoked per row, progress tracked, stop on
+   worklist end or budget. Findings accumulate on the same surface across rows.
+4. **Row order = blast radius for docs.** Run doorway rows first (cheap,
+   already built), then the full-lane happy path, then failure-injection rows.
+   A surface failing the doorway will fail everything; do not pay for a
+   full-lane probe round while a doorway finding is open.
+5. **This is ID-423's L3.** The L1 (scripted lane replay) and L2 (stage
+   benchmarks) layers stay as designed in the bench-plane brief; this spec
+   claims only L3 and names the gauntlet as its executor. The board row gets
+   that note at review time.
+
+## The journey matrix, first cut (persona A: kit user)
+
+| Row | Journey feature | Scenario (what the probe must survive) | Category | Checker adds |
+|---|---|---|---|---|
+| J1 | install + adopt | the existing doorway card (seed-card-user.md) | happy | (shipped) |
+| J2 | tiny lane | the doorway card's fix ships through the loop | happy | (shipped, same card) |
+| J3 | full lane | spec-feature end to end: brief -> spec -> validate -> execute -> review -> ship on a planted feature ask ("add a --repeat N flag with tests") | happy | spec file exists + VALIDATED marker; tests written and green; PR.md; gate-ledger rows for the lane's phases |
+| J4 | bug lane / debug loop | fixture ships a planted regression (a failing test the README claims passes); probe must produce a recorded root cause BEFORE the fix | failure-injection | evidence ledger exists; fix commit references the cause; the planted test green |
+| J5 | gate collision | the card asks for a behavioral change and the probe must satisfy the ship gate: proof-of-done with a negative control, or the documented override with a reason | failure-injection | docs/verification/ entry with a run table + negative control, or the override recorded |
+| J6 | mid-flight drift | the card's ask changes once, mid-run (a planted UPDATE.md appears after the spec hardens: "also cover the empty-string case"); probe must amend, not silently widen | boundary | spec shows the add-only amendment; the new case tested |
+| J7 | resume | the probe's session is killed after execute starts (round harness restarts the agent cold); the new session must resume from disk state, not restart the work | recovery | second transcript begins with orientation (/kit:start shape) and does NOT redo completed tasks; final state green |
+| J8 | review response | review findings are planted (the fixture's feature has an obvious edge-case hole the probe's own review should catch); probe must fix-then-ship, not verdict-shop | failure-injection | review verdict recorded; the hole's test exists |
+
+Persona B (kit contributor) gets its own matrix after persona A's first campaign;
+its rows derive from the kit's own gates (proof, override, spec-drift) rather
+than the fixture repo.
+
+## What must be built (delta over the shipped prep)
+
+| # | Task | Acceptance |
+|---|---|---|
+| P1 | Journey feature list with acceptance criteria (the "spec" the SPEC-203 loop consumes) | committed beside the matrix; review-team critique recorded |
+| P2 | Run the SPEC-203 loop over it; reconcile its derived matrix with the first cut above | matrix updated; deltas noted (the loop finding rows a human missed is the point) |
+| P3 | Card materializer: `tests/gauntlet/make-card.sh <row>` renders a frozen card + checker fragment from a matrix row | J3 and J4 cards render and their checkers run |
+| P4 | Fixture enrichment: the fixture repo gains the planted regression (J4), the feature ask (J3), the drift trigger (J6), the review hole (J8) | each plant verifiable by its row's checker; plants are inert for other rows |
+| P5 | Campaign runner note in `tests/gauntlet/README.md`: worklist order (Decision 4), budget, where cross-row findings accumulate | doc present; first campaign run follows it |
+
+## Verification
+
+- P3: `make-card.sh J3` and `make-card.sh J4` produce cards whose checkers
+  execute against a hand-built green fixture and fail against the untouched one
+  (negative control).
+- P2: the SPEC-203 run record (critique verdict included) committed under
+  `docs/verification/`.
+- The first campaign run's ROUNDS.md records per-row outcomes; that record is
+  this spec's acceptance, same rule as SPEC-018's TP10.

--- a/docs/verification/kit-gauntlet-prep.md
+++ b/docs/verification/kit-gauntlet-prep.md
@@ -28,6 +28,28 @@ negative controls above prove the checker's failure behavior today. Rollback:
 the scenario pack is additive files only; reverting the commit restores the
 prior prep with no state to unwind.
 
+## Recorded runs (gate format)
+
+Command: bash tests/gauntlet/tier1.sh
+Exit: 0
+Verdict: PASS (TIER1: GREEN, 15 checks)
+
+Command: mv commands/gauntlet.md away && bash tests/gauntlet/tier1.sh
+Exit: 1
+Verdict: PASS as negative control (TIER1: RED, FAIL doc: commands/gauntlet.md); restored, rerun Exit: 0
+
+Command: bash tests/gauntlet/check-submission-user-J3.sh <untouched fixture>
+Exit: 1
+Verdict: PASS as negative control (SUBMISSION: RED)
+
+Command: bash tests/gauntlet/check-submission-user-J3.sh <fixture with BLOCKED.md>
+Exit: 3
+Verdict: PASS (honest-stop shape honored)
+
+Rollback note: all changes on this branch are additive files (tests/gauntlet/*,
+one spec, this proof); revert the commits and nothing remains to unwind, no
+state, no config, no deployment was touched.
+
 ## Not run here
 
 The clean-room build (`cleanroom/run.sh`) and the probe rounds themselves: those

--- a/docs/verification/kit-gauntlet-prep.md
+++ b/docs/verification/kit-gauntlet-prep.md
@@ -1,0 +1,20 @@
+# Proof of done: kit gauntlet prep (tests/gauntlet/)
+
+Behavioral claim: the kit's own gauntlet Tier 1 suite runs green on the current
+tree, goes red when a surface artifact disappears, and the prep scripts lint
+clean.
+
+## Run table (2026-08-06, worktree kit-gauntlet-prep)
+
+| Check | Command | Exit | Result | Verdict |
+|---|---|---|---|---|
+| Tier 1 green | `bash tests/gauntlet/tier1.sh` | 0 | 15 PASS (docs presence, onboard-detect, full adopt cycle on a throwaway fixture incl. idempotent re-adopt, tests/test-adopt.sh, shellcheck) -> `TIER1: GREEN` | PASS |
+| Negative control, break | `mv commands/gauntlet.md` away, rerun | 1 | `FAIL doc: commands/gauntlet.md` -> `TIER1: RED` | PASS (suite can fail) |
+| Negative control, restore | restore the file, rerun | 0 | `TIER1: GREEN` | PASS |
+| Lint | `shellcheck tests/gauntlet/*.sh tests/gauntlet/cleanroom/run.sh` | 0 | clean | PASS |
+
+## Not run here
+
+The clean-room build (`cleanroom/run.sh`) and the probe rounds themselves: those
+are the gauntlet RUN, scheduled with the operator (persona A first). This proof
+covers the prep artifacts only.

--- a/docs/verification/kit-gauntlet-prep.md
+++ b/docs/verification/kit-gauntlet-prep.md
@@ -13,6 +13,21 @@ clean.
 | Negative control, restore | restore the file, rerun | 0 | `TIER1: GREEN` | PASS |
 | Lint | `shellcheck tests/gauntlet/*.sh tests/gauntlet/cleanroom/run.sh` | 0 | clean | PASS |
 
+## Scenario pack additions (SPEC-227, same branch)
+
+| Check | Command | Exit | Result | Verdict |
+|---|---|---|---|---|
+| J3 checker rejects an untouched fixture (negative control) | `check-submission-user-J3.sh <plain fixture>` | 1 | `SUBMISSION: RED` (spec, feature, tests, PR.md all FAIL as they should) | PASS (checker can fail) |
+| J3 checker honors the honest-stop shape | same, with `BLOCKED.md` present | 3 | prints the block reason, exit 3 | PASS |
+| Tier 1 still green after the additions | `bash tests/gauntlet/tier1.sh` | 0 | `TIER1: GREEN` | PASS |
+| Lint | `shellcheck check-submission-user-J3.sh` | 0 | clean | PASS |
+
+Green-path run of the J3 checker (against a hand-built passing fixture) is
+SPEC-227 P3's own verification, deferred to the make-card task by design; the
+negative controls above prove the checker's failure behavior today. Rollback:
+the scenario pack is additive files only; reverting the commit restores the
+prior prep with no state to unwind.
+
 ## Not run here
 
 The clean-room build (`cleanroom/run.sh`) and the probe rounds themselves: those

--- a/tests/gauntlet/README.md
+++ b/tests/gauntlet/README.md
@@ -1,0 +1,41 @@
+# Gauntlet prep: the kit under its own gauntlet
+
+Instance files for running `/kit:gauntlet` against the kit's own contributor
+surface. Two personas, two runs, run the USER persona first (it finds the louder
+gaps). Guide: `docs/guides/gauntlet.md` (worked example); engine:
+`commands/gauntlet.md`.
+
+## Inputs table, persona A: the kit USER
+
+| Input | Value |
+|---|---|
+| Surface globs | `README.md`, `docs/MANUAL.md`, `docs/guides/**`, `commands/onboard.md`, `commands/adopt.md` |
+| Tier 1 | `bash tests/gauntlet/tier1.sh` |
+| Clean room | `bash tests/gauntlet/cleanroom/run.sh` (kit arrives as a tarball, NOT pre-installed; installing is part of day one) |
+| Seed card | `seed-card-user.md` (adopt into the fixture repo, ship one tiny-lane change through the loop) |
+| Submission checker | `bash tests/gauntlet/check-submission-user.sh <fixture-repo>` |
+| Probe | mid-tier model, one spend-capped API key, nothing else |
+| Round cap | 3 |
+
+## Inputs table, persona B: the kit CONTRIBUTOR
+
+| Input | Value |
+|---|---|
+| Surface globs | `README.md` (contributing sections), `docs/PHILOSOPHY.md`, `docs/WORKFLOW.md`, `AGENTS.md`, `tests/README*` |
+| Tier 1 | `bash tests/gauntlet/tier1.sh` (same suite) |
+| Clean room | same runner; the card differs, not the room |
+| Seed card | `seed-card-contributor.md` (one small kit fix through the kit's own gates) |
+| Submission checker | `bash tests/gauntlet/check-submission-contributor.sh <kit-clone>` |
+| Probe | same |
+| Round cap | 3 |
+
+## Run day (orchestrator checklist)
+
+1. `bash tests/gauntlet/tier1.sh`, must be green before any probe round.
+2. Mint the probe key (spend-capped), the room's ONLY secret.
+3. Invoke `/kit:gauntlet` with persona A's table; the engine handles rounds,
+   run records land in `docs/verification/gauntlet/<date>-kit-user/`.
+4. Persona B after A converges (or its halt is understood).
+
+Rule 7 note (no answer key): the clean-room image excludes `tests/gauntlet/`
+and `docs/verification/gauntlet/`; the runner does this, do not undo it.

--- a/tests/gauntlet/README.md
+++ b/tests/gauntlet/README.md
@@ -29,6 +29,18 @@ gaps). Guide: `docs/guides/gauntlet.md` (worked example); engine:
 | Probe | same |
 | Round cap | 3 |
 
+## Scenario pack (SPEC-227): beyond the doorway
+
+The doorway card (J1/J2) proves install + adopt + tiny lane. Full-flow coverage
+comes from the scenario MATRIX (`scenarios.md`): one row per journey feature
+(full lane, bug/debug, gate collision, drift, resume, review response), cards
+materialized per row, generated/reconciled via the shipped SPEC-203
+test-generation loop rather than hand-authored. A multi-row run is a CAMPAIGN
+(worklist over the gauntlet engine, loop-engineering's campaign shape): run rows
+in order, doorway first; findings accumulate on the same surface; never pay for
+a full-lane probe while a doorway finding is open. J3 (full lane) is the first
+materialized full-flow card: `seed-card-user-J3.md` + its checker.
+
 ## Run day (orchestrator checklist)
 
 1. `bash tests/gauntlet/tier1.sh`, must be green before any probe round.

--- a/tests/gauntlet/check-submission-contributor.sh
+++ b/tests/gauntlet/check-submission-contributor.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Deterministic submission checker, persona B (kit contributor).
+# Usage: check-submission-contributor.sh <kit-clone>
+set -uo pipefail
+
+REPO="${1:?usage: check-submission-contributor.sh <kit-clone>}"
+
+fail=0
+check() { local name="$1"; shift; if "$@" >/dev/null 2>&1; then echo "PASS  ${name}"; else echo "FAIL  ${name}"; fail=1; fi; }
+
+if [ -f "${REPO}/BLOCKED.md" ]; then
+  echo "BLOCKED submission: probe stopped honestly. Contents:"
+  cat "${REPO}/BLOCKED.md"
+  exit 3
+fi
+
+echo "== the change"
+check "a non-default branch exists" bash -c "git -C '${REPO}' branch --format='%(refname:short)' | grep -qv -E '^(main|master)\$'"
+check "the branch touches docs/guides/" bash -c "git -C '${REPO}' log --all --oneline -- docs/guides/ | grep -q ."
+check "conventional-commit subject" bash -c "git -C '${REPO}' log --all -1 --format=%s -- docs/guides/ | grep -qE '^(fix|docs|feat|chore|refactor|test)(\(.+\))?: '"
+check "commit body cites evidence" bash -c "[ \"\$(git -C '${REPO}' log --all -1 --format=%b -- docs/guides/ | wc -w)\" -ge 10 ]"
+
+echo "== the kit's own gate expectations (docs change: proof or documented override)"
+check "proof-of-done file OR override recorded" bash -c "git -C '${REPO}' log --all --oneline -- docs/verification/ | grep -q . || grep -rq 'override' '${REPO}/.kit' 2>/dev/null || test -f '${REPO}/PR.md'"
+
+echo "== the submission shape"
+check "PR.md exists with title + body" bash -c "test -s '${REPO}/PR.md' && [ \"\$(wc -l < '${REPO}/PR.md')\" -ge 3 ]"
+
+echo
+if [ "${fail}" -eq 0 ]; then echo "SUBMISSION: GREEN"; else echo "SUBMISSION: RED"; fi
+exit "${fail}"

--- a/tests/gauntlet/check-submission-user-J3.sh
+++ b/tests/gauntlet/check-submission-user-J3.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Deterministic submission checker for scenario J3 (full lane).
+# Usage: check-submission-user-J3.sh <fixture-repo>
+set -uo pipefail
+
+REPO="${1:?usage: check-submission-user-J3.sh <fixture-repo>}"
+
+fail=0
+check() { local name="$1"; shift; if "$@" >/dev/null 2>&1; then echo "PASS  ${name}"; else echo "FAIL  ${name}"; fail=1; fi; }
+
+if [ -f "${REPO}/BLOCKED.md" ]; then
+  echo "BLOCKED submission: probe stopped honestly. Contents:"
+  cat "${REPO}/BLOCKED.md"
+  exit 3
+fi
+
+echo "== specced before built"
+check "a spec file exists" bash -c "ls '${REPO}'/docs/specs/SPEC-*.md 2>/dev/null | grep -q ."
+check "spec carries acceptance criteria + verification" bash -c "grep -rilq 'acceptance' '${REPO}/docs/specs/' && grep -rilq 'verif' '${REPO}/docs/specs/'"
+
+echo "== the feature works"
+check "--repeat 3 prints three lines" bash -c "[ \"\$(node '${REPO}/cli.js' --upper --repeat 3 hi | grep -c HI)\" -eq 3 ]"
+check "--repeat 1 prints one line" bash -c "[ \"\$(node '${REPO}/cli.js' --upper --repeat 1 hi | grep -c HI)\" -eq 1 ]"
+check "bad N handled (non-zero exit)" bash -c "! node '${REPO}/cli.js' --upper --repeat banana hi"
+
+echo "== tests exist and pass"
+check "a test file exists" bash -c "ls '${REPO}'/*test* '${REPO}'/test/* 2>/dev/null | grep -q ."
+check "the repo's test command passes" bash -c "cd '${REPO}' && npm test --silent"
+
+echo "== process leave-behinds"
+check "a non-default branch exists" bash -c "git -C '${REPO}' branch --format='%(refname:short)' | grep -qv -E '^(main|master)\$'"
+check "review verdict recorded somewhere" bash -c "grep -rilq -e 'SHIP' -e 'review' '${REPO}/docs/' 2>/dev/null || grep -qil 'review' '${REPO}/PR.md'"
+check "proof-of-done or override" bash -c "ls '${REPO}'/docs/verification/*.md 2>/dev/null | grep -q . || grep -qi 'override' '${REPO}/PR.md'"
+check "PR.md exists with title + body" bash -c "test -s '${REPO}/PR.md' && [ \"\$(wc -l < '${REPO}/PR.md')\" -ge 3 ]"
+
+echo
+if [ "${fail}" -eq 0 ]; then echo "SUBMISSION: GREEN"; else echo "SUBMISSION: RED"; fi
+exit "${fail}"

--- a/tests/gauntlet/check-submission-user.sh
+++ b/tests/gauntlet/check-submission-user.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Deterministic submission checker, persona A (kit user).
+# Usage: check-submission-user.sh <fixture-repo>
+set -uo pipefail
+
+REPO="${1:?usage: check-submission-user.sh <fixture-repo>}"
+KIT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+fail=0
+check() { local name="$1"; shift; if "$@" >/dev/null 2>&1; then echo "PASS  ${name}"; else echo "FAIL  ${name}"; fail=1; fi; }
+
+# A BLOCKED.md is a valid submission shape: report it and stop (the findings
+# live in the transcript, not here).
+if [ -f "${REPO}/BLOCKED.md" ]; then
+  echo "BLOCKED submission: probe stopped honestly. Contents:"
+  cat "${REPO}/BLOCKED.md"
+  exit 3
+fi
+
+echo "== adoption leave-behinds"
+check "kit reports the repo adopted" bash "${KIT_ROOT}/lib/adopt.sh" --check "${REPO}"
+check "AGENTS.md present" test -f "${REPO}/AGENTS.md"
+
+echo "== the change itself"
+check "a non-default branch exists" bash -c "git -C '${REPO}' branch --format='%(refname:short)' | grep -qv -E '^(main|master)\$'"
+check "the branch changed the README example" bash -c "git -C '${REPO}' log --all --oneline -- README.md | grep -q ."
+check "conventional-commit subject" bash -c "git -C '${REPO}' log --all -1 --format=%s -- README.md | grep -qE '^(fix|docs|feat|chore|refactor|test)(\(.+\))?: '"
+
+echo "== the submission shape"
+check "PR.md exists with title + body" bash -c "test -s '${REPO}/PR.md' && [ \"\$(wc -l < '${REPO}/PR.md')\" -ge 3 ]"
+
+echo
+if [ "${fail}" -eq 0 ]; then echo "SUBMISSION: GREEN"; else echo "SUBMISSION: RED"; fi
+exit "${fail}"

--- a/tests/gauntlet/cleanroom/Dockerfile
+++ b/tests/gauntlet/cleanroom/Dockerfile
@@ -1,0 +1,24 @@
+# Gauntlet clean room for the kit's own runs. Carries NOTHING from the host:
+# no kit install, no credentials, no prior run records. Rule 7: the gauntlet's
+# own directory and past run records are excluded by run.sh's staging step.
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git curl ca-certificates ripgrep \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @anthropic-ai/claude-code
+
+# /work is the probe's whole world:
+#   kit.tar.gz      the kit, NOT installed (installing is part of day one)
+#   fixture-repo/   persona A's adoption target
+#   kit/            persona B's clone (staged only for that persona)
+#   checks/         the submission checkers (the card names them; they test
+#                   real properties, so reading them does not hand out answers)
+#   CARD.md         the seed card
+WORKDIR /work
+
+RUN git config --global user.email probe@gauntlet.local \
+ && git config --global user.name "Gauntlet Probe" \
+ && git config --global init.defaultBranch main
+
+CMD ["bash"]

--- a/tests/gauntlet/cleanroom/run.sh
+++ b/tests/gauntlet/cleanroom/run.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Build and enter the kit gauntlet clean room.
+#
+#   bash tests/gauntlet/cleanroom/run.sh user          # stage persona A, drop to a shell
+#   bash tests/gauntlet/cleanroom/run.sh contributor   # stage persona B, drop to a shell
+#
+# The probe key is passed at run time, never baked:
+#   ANTHROPIC_API_KEY=<capped key> bash tests/gauntlet/cleanroom/run.sh user
+set -euo pipefail
+
+PERSONA="${1:?usage: run.sh <user|contributor>}"
+KIT_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "${KIT_ROOT}"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "${STAGE}"' EXIT
+mkdir -p "${STAGE}/work/checks"
+
+# The kit as a tarball of COMMITTED state, minus the answer key (rule 7):
+# the gauntlet dir and any prior run records never enter the room.
+mkdir -p "${STAGE}/kit-src"
+git archive HEAD | tar -x -C "${STAGE}/kit-src"
+rm -rf "${STAGE}/kit-src/tests/gauntlet" "${STAGE}/kit-src/docs/verification/gauntlet"
+tar -czf "${STAGE}/work/kit.tar.gz" -C "${STAGE}/kit-src" .
+
+# Persona staging.
+case "${PERSONA}" in
+  user)
+    # Fixture: a tiny Node CLI whose README example uses the wrong flag.
+    FIX="${STAGE}/work/fixture-repo"
+    mkdir -p "${FIX}"
+    cat > "${FIX}/cli.js" <<'EOF'
+#!/usr/bin/env node
+const arg = process.argv[2];
+if (arg === "--upper") console.log((process.argv[3] || "").toUpperCase());
+else { console.error("usage: cli.js --upper <text>"); process.exit(1); }
+EOF
+    cat > "${FIX}/README.md" <<'EOF'
+# shout
+
+Tiny demo CLI.
+
+## Usage
+
+    node cli.js --uppercase hello   # prints HELLO
+EOF
+    cat > "${FIX}/package.json" <<'EOF'
+{ "name": "shout", "version": "1.0.0", "bin": { "shout": "./cli.js" } }
+EOF
+    git -C "${FIX}" init -q && git -C "${FIX}" add -A && git -C "${FIX}" commit -qm "chore: fixture seed"
+    cp tests/gauntlet/seed-card-user.md "${STAGE}/work/CARD.md"
+    cp tests/gauntlet/check-submission-user.sh "${STAGE}/work/checks/"
+    ;;
+  contributor)
+    git clone -q --no-hardlinks . "${STAGE}/work/kit"
+    rm -rf "${STAGE}/work/kit/tests/gauntlet" "${STAGE}/work/kit/docs/verification/gauntlet"
+    git -C "${STAGE}/work/kit" add -A && git -C "${STAGE}/work/kit" commit -qm "chore: gauntlet room staging (answer key removed)"
+    cp tests/gauntlet/seed-card-contributor.md "${STAGE}/work/CARD.md"
+    cp tests/gauntlet/check-submission-contributor.sh "${STAGE}/work/checks/"
+    ;;
+  *)
+    echo "unknown persona: ${PERSONA}" >&2; exit 64;;
+esac
+
+docker build -q -f tests/gauntlet/cleanroom/Dockerfile -t kit-gauntlet-room tests/gauntlet/cleanroom
+echo "Room ready. The probe's instruction is: read /work/CARD.md and follow the kit's own docs."
+docker run --rm -it \
+  -e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+  -v "${STAGE}/work:/work" \
+  kit-gauntlet-room

--- a/tests/gauntlet/scenarios.md
+++ b/tests/gauntlet/scenarios.md
@@ -1,0 +1,22 @@
+# Gauntlet scenario matrix (persona A: kit user)
+
+The durable artifact of SPEC-227: one row per journey feature, cards materialize
+from rows at run time and get frozen into the run record. Doorway rows (J1/J2)
+are the shipped seed card; J3+ are the full-flow rows. Run order = row order
+(doorway first; never pay for a full-lane probe while a doorway finding is open).
+
+| Row | Feature | Scenario | Category | Status |
+|---|---|---|---|---|
+| J1 | install + adopt | doorway card: install kit from tarball, adopt fixture | happy | card shipped (`seed-card-user.md`) |
+| J2 | tiny lane | doorway card's README-flag fix through the loop | happy | card shipped (same card) |
+| J3 | full lane | "add a `--repeat N` flag with tests" end to end: brief -> spec -> validate -> execute -> review -> ship | happy | card: `seed-card-user-J3.md` |
+| J4 | bug lane | planted regression; recorded root cause BEFORE the fix | failure-injection | matrix only (P3/P4) |
+| J5 | gate collision | behavioral change vs the ship gate: proof with negative control, or documented override | failure-injection | matrix only |
+| J6 | mid-flight drift | ask changes after the spec hardens; amend add-only, no silent widening | boundary | matrix only |
+| J7 | resume | session killed mid-execute; cold session resumes from disk, redoes nothing | recovery | matrix only |
+| J8 | review response | planted edge-case hole; fix-then-ship, no verdict shopping | failure-injection | matrix only |
+
+Generation contract: rows J4-J8 materialize via `make-card.sh` (SPEC-227 P3)
+after the SPEC-203 loop pass (P2) reconciles this hand-cut matrix. Do not
+hand-author more cards ahead of that pass; the loop finding rows a human missed
+is the point of running it.

--- a/tests/gauntlet/seed-card-contributor.md
+++ b/tests/gauntlet/seed-card-contributor.md
@@ -1,0 +1,29 @@
+# Seed card (persona B: kit contributor)
+
+**Card:** Make one small fix to the kit itself and take it through the kit's own
+gates.
+
+**Context:** You are a developer contributing to dwarves-kit for the first time.
+A clone of the kit is at `/work/kit`. Its own docs (README, PHILOSOPHY,
+WORKFLOW, AGENTS.md) are your only instructions.
+
+**The fix:** `docs/guides/README.md` promises "one diagram per guide"; verify
+the claim against the guides and correct EITHER the one guide missing a diagram
+OR the README's claim, whichever the evidence supports. (Small on purpose: the
+work is trivial; the gauntlet measures whether the kit's docs get you through
+its process.)
+
+**Acceptance criteria:**
+
+1. The fix is correct (evidence cited in the commit body).
+2. It rides a branch with a conventional-commit subject per the kit's rules.
+3. The kit's own gate expectations for a docs change are met the way its docs
+   describe them (including whatever the ship gate wants, or the documented
+   override path with a reason).
+4. A PR-shaped description exists (`PR.md`; no network push expected).
+
+**Verification command:** `bash /work/checks/check-submission-contributor.sh /work/kit`
+
+**Size cap:** one agent-day. **Termination:** if blocked with no path forward in
+the kit's docs, STOP and write `BLOCKED.md` stating exactly what you needed and
+where you looked; that is a valid submission.

--- a/tests/gauntlet/seed-card-user-J3.md
+++ b/tests/gauntlet/seed-card-user-J3.md
@@ -1,0 +1,32 @@
+# Seed card J3 (persona A: full lane, end to end)
+
+**Card:** Add a `--repeat N` flag to the fixture CLI, taken through the kit's
+FULL lane.
+
+**Context:** You are a developer who has adopted dwarves-kit into
+`/work/fixture-repo` (if not yet adopted, that is your first step; the kit
+tarball is at `/work/kit.tar.gz` and its README is your instruction set). The
+team asks: "`shout --upper hello` works; we want `--repeat N` so
+`shout --upper --repeat 3 hello` prints the result three times. Ship it the way
+this repo's process says features ship."
+
+**Acceptance criteria:**
+
+1. The feature is specced before it is built: a spec file exists with acceptance
+   criteria and a verification command, and shows the kit's validated state
+   before implementation commits begin.
+2. `--repeat N` works: correct output for N=1, N=3; a sensible error for N=0,
+   negative, and non-numeric input (your spec decides and documents which).
+3. Tests exist for the above and pass; the spec's verification command is the
+   one that proves it.
+4. The change rides a branch; review happened the way the kit's docs describe
+   (its verdict recorded); `PR.md` carries the PR-shaped description.
+5. The gate leave-behinds the kit's docs promise for a behavioral change exist
+   (proof-of-done with a negative control, or the documented override with a
+   reason).
+
+**Verification command:** `bash /work/checks/check-submission-user-J3.sh /work/fixture-repo`
+
+**Size cap:** one agent-day. **Termination:** if blocked with no path forward in
+the kit's docs, STOP and write `BLOCKED.md` stating exactly what you needed and
+where you looked; that is a valid submission.

--- a/tests/gauntlet/seed-card-user.md
+++ b/tests/gauntlet/seed-card-user.md
@@ -1,0 +1,27 @@
+# Seed card (persona A: kit user)
+
+**Card:** Adopt dwarves-kit into the fixture repo and ship one tiny-lane change
+through the kit's loop.
+
+**Context:** You are a developer who has never used dwarves-kit. A tarball of
+the kit is at `/work/kit.tar.gz`. A small git repo (a Node CLI with one failing
+edge case in its README example) is at `/work/fixture-repo`. The kit's own docs
+are your only instructions; start from its README.
+
+**Acceptance criteria:**
+
+1. The kit is installed and the fixture repo is adopted (the kit's own check
+   reports adopted).
+2. One tiny-lane change ships through the kit's loop: fix the README example in
+   `/work/fixture-repo` (the documented command does not match the actual CLI
+   flag).
+3. The change lands on a branch with a PR-shaped description (title + body
+   written to `PR.md`; no network push is expected in the room).
+4. The loop's leave-behinds exist: the adoption contract file, and whatever
+   run/gate records the kit's docs say a change produces.
+
+**Verification command:** `bash /work/checks/check-submission-user.sh /work/fixture-repo`
+
+**Size cap:** one agent-day. **Termination:** if blocked with no path forward in
+the kit's docs, STOP and write `BLOCKED.md` stating exactly what you needed and
+where you looked; that is a valid submission.

--- a/tests/gauntlet/tier1.sh
+++ b/tests/gauntlet/tier1.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Gauntlet Tier 1 for the kit itself: deterministic checks, zero model cost.
+# Green is the precondition for any paid probe round (two-tier scan rule).
+set -uo pipefail
+
+KIT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "${KIT_ROOT}" || exit 1
+
+fail=0
+check() { # check <name> <cmd...>
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "PASS  ${name}"
+  else
+    echo "FAIL  ${name}"
+    fail=1
+  fi
+}
+
+echo "== T1.1 contributor-surface docs exist"
+for f in README.md docs/MANUAL.md docs/guides/README.md docs/guides/gauntlet.md commands/gauntlet.md commands/onboard.md commands/adopt.md; do
+  check "doc: ${f}" test -f "${f}"
+done
+
+echo "== T1.2 install-mode detection answers"
+check "onboard-detect prints a mode" test -n "$(bash lib/onboard-detect.sh)"
+
+echo "== T1.3 adoption cycle on a throwaway fixture (fresh -> adopted -> idempotent)"
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "${FIXTURE}"' EXIT
+git -C "${FIXTURE}" init -q
+check "fresh fixture reports NOT adopted" bash -c "! bash lib/adopt.sh --check '${FIXTURE}'"
+check "adopt writes the contract" bash lib/adopt.sh "${FIXTURE}"
+check "adopted fixture reports adopted" bash lib/adopt.sh --check "${FIXTURE}"
+check "AGENTS.md injected" test -f "${FIXTURE}/AGENTS.md"
+check "re-adopt is idempotent" bash lib/adopt.sh "${FIXTURE}"
+
+echo "== T1.4 the kit's own adopt test suite"
+check "tests/test-adopt.sh" bash tests/test-adopt.sh
+
+echo "== T1.5 gauntlet prep scripts lint"
+if command -v shellcheck >/dev/null 2>&1; then
+  check "shellcheck tests/gauntlet/*.sh" shellcheck tests/gauntlet/tier1.sh tests/gauntlet/check-submission-user.sh tests/gauntlet/check-submission-contributor.sh tests/gauntlet/cleanroom/run.sh
+else
+  echo "SKIP  shellcheck not installed"
+fi
+
+echo
+if [ "${fail}" -eq 0 ]; then echo "TIER1: GREEN"; else echo "TIER1: RED"; fi
+exit "${fail}"


### PR DESCRIPTION
## What

Everything needed to run `/kit:gauntlet` against the kit's own contributor surface, both personas (user first, contributor second), per the worked example in `docs/guides/gauntlet.md`:

- `tests/gauntlet/tier1.sh`: deterministic Tier 1, composes existing checks (docs presence, `onboard-detect`, full adopt cycle on a throwaway fixture incl. idempotency, `tests/test-adopt.sh`, shellcheck). **GREEN live**; break/restore negative control in the proof.
- Seed cards: persona A (adopt fixture repo + ship a tiny-lane README-flag fix through the loop), persona B (verify the guides' one-diagram claim, fix whichever side the evidence supports, through the kit's own gates). Both carry the BLOCKED.md honest-stop termination clause.
- Submission checkers: deterministic, exit 3 on an honest BLOCKED submission.
- Clean room: Dockerfile + `run.sh` staging per persona; kit ships as a **tarball, not pre-installed**; answer key (tests/gauntlet + prior run records) stripped per engine rule 7; probe key passed at run time, never baked.

## Proof

`docs/verification/kit-gauntlet-prep.md`: Tier 1 run table + negative control.

## Not in this PR

The probe rounds themselves — run day is scheduled with Han (persona A first). Run records will land under `docs/verification/gauntlet/` per the engine contract.