### PR TITLE
feat(workflow): wire scenario generation into every altitude

### DIFF
--- a/commands/design.md
+++ b/commands/design.md
@@ -32,6 +32,15 @@ Present the chosen design in sections scaled to complexity. After EACH section, 
 - **Diagram + ADR link(s) (ADR-0031 §1), when the design is design-bearing** (new component/module, non-obvious control flow, a schema/data-model change, an external integration, an irreversible choice, or 2+ viable approaches): ask which diagram shape actually clarifies it (sequence / state / ER / flowchart / C4 container-or-component, LITE, ONE level only), sketch it in Mermaid with the user, and note the ADR(s) that record any lasting/irreversible call the design makes. Skip this bullet entirely for obviously non-design-bearing work; do not manufacture a diagram nobody needs.
 Go back and revise when the user pushes back. Do not advance a section the user has not approved.
 
+### Step 4b: Carry the scenario sketch forward
+
+<!-- scenario-gen --> If the brief carries a `## Survival scenarios` block (the
+`/kit:think` sketch), walk it against the chosen design: keep, refine, or add
+rows (the design usually exposes new move-2 inversions: each interface and
+failure mode it names is a promise to invert, per
+`docs/patterns/scenario-generation.md`). Never drop an upstream row silently;
+a dropped row carries a one-line reason. Still situations, still no oracles.
+
 ### Step 5: Write the Solution (and Design) into the brief
 Once the user approves the design, **append** a `## Solution` section (and `## Failure modes` / an I/O contract sub-section if produced) to `docs/briefs/DECISION-BRIEF.md`, using the SPEC-008 sub-section shape: `### Approaches considered`, `### Chosen approach + why`, `### Extensibility & boundaries`. **If Step 4 produced a diagram + ADR link(s)** (the design was design-bearing), also **append a `## Design` section** with `### Diagram` (the Mermaid block) and `### ADR link(s)` , the shape `/kit:spec`'s own `## Design` block expects (ADR-0031 §1). Skip the `## Design` append entirely when the design was not design-bearing; `/kit:spec`'s template collapses it to `obvious: <why>` on its own. **Do NOT overwrite** the brief's existing product framing. If the brief does not exist, create it with a one-line Problem stub plus the Solution.
 

--- a/commands/grill.md
+++ b/commands/grill.md
@@ -247,7 +247,11 @@ decided:
   or none at all, is refused (exit 64) rather than silently landing on the ledger.
 
 End by proposing the `Done =` line the answers imply (the phase-0 definition the task loop
-requires before any work runs), plus the re-classification check: if the answers changed the
+requires before any work runs). <!-- scenario-gen --> Pair it with 2-3
+must-NOT-happen scenarios, the negative space of Done, derived by inverting the
+guarantees the answers surfaced (`docs/patterns/scenario-generation.md`, move
+2); they ride the goal draft's Context next to the digest. Then the
+re-classification check: if the answers changed the
 work's type or weight, re-run `task-type-classify` / `lane-classify` and say so, the floor
 check (`lane-classify.sh check`) guards the downgrade direction.
 

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -201,6 +201,10 @@ Rule: observable, not narrated. If a bullet cannot be verified by reading a file
 The exact command(s) that prove this spec done, so a pointer-/goal and the loop can check it. Name real commands, not "tests pass". Example: `bash tests/test-meta.sh && bash tests/test-hooks.sh`.
 
 ## Edge Cases
+<!-- scenario-gen: seed from the brief's Survival scenarios block, then extend
+with a full three-move pass (journey walk, guarantee inversion, category
+sweep) per docs/patterns/scenario-generation.md. Every implicit guarantee in
+this spec's own prose gets an inversion row or a stated skip. -->
 1. [specific edge case and expected behavior]
 2. [specific edge case and expected behavior]
 

--- a/commands/test-plan.md
+++ b/commands/test-plan.md
@@ -22,6 +22,14 @@ If Step 1 finds no spec with acceptance criteria, and the feature under test alr
 
 Detect the active `docs/specs/SPEC-NNN-<slug>.md` the way `/kit:next` does (branch-aware). If several specs match, ask the user which one. `/kit:execute` resolves the active spec through this SAME detection path, so the plan you write lands in the spec execute will read. Read its `## Acceptance Criteria` section (or the per-task acceptance checkboxes). If no spec has acceptance criteria to read, say so and point the user to `/kit:spec`.
 
+<!-- scenario-gen --> Also read the spec's scenario set: `## Edge Cases` +
+`## Failure modes` (and any `Survival scenarios` the brief contributed). The
+matrix derives from SCENARIOS + ACs together, not ACs alone, that is what
+keeps the spec author's blind spots out of the coverage. If the spec carries no
+scenario set, run the three-move pass from
+`docs/patterns/scenario-generation.md` FIRST, write the rows back into the
+spec's `## Edge Cases` (add-only), and only then derive the matrix.
+
 ### Step 1b: Pick the dialect from the work's type
 
 ```bash

--- a/commands/think.md
+++ b/commands/think.md
@@ -29,6 +29,13 @@ Bracket the phase for timing (SPEC-129) before starting: `bash lib/gate/gate-led
    **Q5: What breaks at scale?**
    If 1000 people used this tomorrow, what falls apart first? Data model? Auth? Performance? Cost? Don't hand-wave. Name the specific bottleneck.
 
+   <!-- scenario-gen --> While Q5 is open, run a quick scenario sketch per
+   `docs/patterns/scenario-generation.md`: 3-5 survival scenarios, mostly from
+   move 2 (guarantee inversion: what the idea implicitly promises, and what
+   makes each promise false). Situations only, no oracles. These ride into the
+   brief below and flow downhill (design -> spec -> test plan) instead of being
+   regenerated later at a more expensive altitude.
+
    **Q6: What's the exit criteria?**
    How will you know if this worked or failed? Name a specific metric and a specific number. "More users" is not a metric. "50 weekly active users by day 30" is.
 
@@ -43,6 +50,10 @@ Bracket the phase for timing (SPEC-129) before starting: `bash lib/gate/gate-led
 ## If BUILD: recommended scope for v1
 ## If RETHINK: what needs to change before building
 ## If KILL: what would have to be true to reconsider
+## Survival scenarios
+<!-- scenario-gen: 3-5 rows from the Q5 sketch; situations, no oracles -->
+| # | Scenario | Category |
+|---|---|---|
 ```
 
 4. Save the brief to `docs/briefs/DECISION-BRIEF.md` if the verdict is BUILD.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -15,6 +15,7 @@ name. Full tour: `/kit:onboard`. Story-name lookup: `docs/glossary.md`.
 - Agents have no invocation, they are dispatched by commands.
 - Self-intro banner: every `/kit:` command opens its first reply with one line, `[kit:<name>] <one-line purpose>` (from its frontmatter description), and every dispatched agent's report opens the same way, so you always see what is running and why (AGENTS.md "Self-intro").
 - Teach on bad input: a command handed a bad or missing input names it, teaches why it matters in one line, and offers the concrete fix, never a dry "invalid input", never proceeding silently. Overrides run but get recorded. Convention + per-command tables: `docs/patterns/teach-on-bad-input.md`.
+- Scenarios ride every shaping beat: think/design/grill/spec/test-plan surface survival and must-NOT-happen scenarios via one shared method, generated once at the cheapest altitude and refined downhill, never re-brainstormed from blank. Method: `docs/patterns/scenario-generation.md`; user guide: `docs/guides/scenarios.md`.
 
 ## Drive it by intent (start here)
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -28,6 +28,7 @@ never overrides those, it translates them.
 | Guide | Read it when |
 |---|---|
 | [v-model.md](v-model.md) | you wonder why the kit tests at every altitude, or why all-green tasks still failed acceptance |
+| [scenarios.md](scenarios.md) | the kit starts surfacing "survival scenarios" and "must-NOT-happen" rows while you shape work |
 | [gates-and-proof.md](gates-and-proof.md) | something BLOCKED (ship gate, proof of done, iron law) and you want the way through |
 | [review.md](review.md) | you got a SHIP / FIX THEN SHIP / DO NOT SHIP verdict |
 | [gauntlet.md](gauntlet.md) | you are about to let outside devs into a repo, or just rewrote its contributor docs |

--- a/docs/guides/scenarios.md
+++ b/docs/guides/scenarios.md
@@ -1,0 +1,56 @@
+# Scenarios (user guide)
+
+Everywhere you shape work with the kit, it will now surface SCENARIOS, the
+situations your thing must survive, before anyone writes a test. You do not
+invoke this; it rides the beats you already use. This guide is what you will
+see and what a good scenario set looks like.
+
+```
+ you explore an idea ──── /kit:think ──► brief gains "Survival scenarios"
+        │                                (3-5 situations, no test detail)
+ you shape the design ── /kit:design ─► sketch refined, new promises inverted
+        │
+ you get interviewed ─── /kit:grill ──► Done= arrives WITH 2-3
+        │                               "must NOT happen" scenarios
+ the spec hardens ────── /kit:spec ───► Edge Cases seeded from the sketch,
+        │                               extended by a full pass
+ tests get derived ───── /kit:test-plan► matrix rows built from
+                                        scenarios + acceptance criteria
+        downhill: each step REFINES what the last one named;
+        nothing is re-brainstormed from blank at a costlier step
+```
+
+## What a scenario is (and is not)
+
+A scenario is a situation with an actor: "a new contributor's session dies
+mid-build; they reopen tomorrow". It is NOT a test case ("assert resume skips
+completed tasks", that comes later, derived from it) and NOT a category ("the
+system fails", no actor, too vague to invert).
+
+## What you do
+
+- **React to the sketch, don't author it.** The kit generates; your value is
+  vetoing rows that can't happen in your world and naming the one situation
+  only you know about (the weird client, the legacy cron, the person who
+  always pastes rich text).
+- **Take the must-NOT-happen rows seriously.** They are the cheapest insurance
+  in the whole flow: one line at grill time ("money moves without approval")
+  becomes a gate later; unnamed, it becomes an incident.
+- **Expect adversarial and recovery rows.** The generator deliberately covers
+  the two categories humans skip (what games the check; what happens after an
+  interruption). Their absence should carry a stated reason, not silence.
+- **Defining a new loop?** It is not "designed" until its five survival rows
+  exist (convergence, non-convergence, bad input, interruption, gamed
+  metric). The kit will hold you to that.
+
+## Common questions
+
+- **"This feels like extra ceremony at idea time."** It is 3-5 rows sketched
+  while you are already answering "what breaks at scale". The expensive
+  version is discovering the same rows in production.
+- **"Where do the rows end up?"** In the brief, then the spec's Edge Cases,
+  then the test matrix, then (for contributor surfaces) gauntlet cards. Same
+  rows, progressively sharpened; you can trace any test back to the situation
+  that justified it.
+- **"Can I skip a category?"** Yes, with a reason. "No concurrent access by
+  construction, single-writer daemon" is a fine skip; silence is not.

--- a/docs/patterns/scenario-generation.md
+++ b/docs/patterns/scenario-generation.md
@@ -1,0 +1,68 @@
+# The scenario-generation pattern
+
+One shared method for producing test SCENARIOS, the situations an artifact must
+survive, used by every workflow beat that needs them (think, design, grill,
+spec, test-plan, loop-engineering, gauntlet). A scenario is not a test case: a
+scenario is a situation ("the session dies mid-execute"); test cases are its
+projections into runnable checks. Scenarios are generated ONCE at the cheapest
+altitude that can see them, then flow downhill; a beat never regenerates from
+scratch what an earlier beat already named.
+
+## The three generation moves (run all three, in this order)
+
+1. **Journey walk.** Name the actor(s), walk their path step by step, and at
+   each step ask "what does the actor need here, and what happens when it is
+   missing?" Every step is a scenario seed. The gauntlet's J-matrix is this
+   move with actor = new contributor; a feature spec's actor is the end user; a
+   loop's actor is the operator driving it.
+2. **Guarantee inversion.** List every promise the artifact makes (explicit
+   acceptance criteria AND implicit ones: "merge does not deploy", "the loop
+   halts", "no secret leaves the vault"). For each, ask "what makes this
+   false?" Each answer is a failure-injection scenario. Implicit promises are
+   where the blind spots live; spend most of the time here.
+3. **Category sweep.** Check the set against the standard categories and fill
+   holes deliberately or skip them with a stated reason:
+   happy-path / boundary (empty, max, off-by-one, unicode) / failure-injection
+   (dependency down, bad input, partial state) / recovery (interruption,
+   resume, rollback) / adversarial (gaming the check, hostile input, the
+   answer-key read) / concurrent (two actors, two sessions, a race).
+
+Output shape, every time: a table `| # | Scenario | Category | Source move |`,
+5-12 rows for a normal artifact. Fewer than 5 means move 2 was skipped; more
+than ~12 at explore altitude means test cases are masquerading as scenarios,
+collapse them.
+
+## Where each beat fires and what flows downhill
+
+| Altitude | Beat | Produces | Flows into |
+|---|---|---|---|
+| explore (`/kit:think`, `/kit:design`) | scenario sketch: 3-5 survival scenarios, majority from move 2 | situations only, no oracles | the Decision Brief |
+| define (`/kit:grill` phase-0) | the done scenario + 2-3 must-NOT-happen scenarios | the negative space of Done= | the goal draft |
+| contract (`/kit:spec`) | `## Edge Cases` + `## Failure modes` seeded FROM the sketch, extended by a full three-move pass | the reviewed scenario set (spec-validate critiques it) | the spec |
+| verify design (`/kit:test-plan`) | the coverage matrix derived from scenarios + ACs; if the spec carries no scenario set, run the three moves FIRST, write them back, then derive | runnable cases with oracles | tests / gauntlet cards |
+| define a loop (`skills/loop-engineering`) | the loop's own survival set (convergence, non-convergence, bad input, interrupted run, gamed metric) as a mandatory anatomy slot | the loop's spec + its tests | the new engine |
+
+The downhill rule is the point of the wiring: the explore-time sketch is made
+by the person/agent with the most context and the least sunk cost; every later
+beat REFINES it (adds oracles, splits rows, prunes with a reason) instead of
+starting blank at a more expensive altitude.
+
+## Quality bar (what review checks)
+
+- Every implicit guarantee named in the artifact's own prose has an inversion
+  row or a stated skip.
+- At least one recovery and one adversarial row exist, or their absence is
+  argued, these are the two categories humans skip most.
+- Each row names its actor. An actorless scenario ("the system fails") is a
+  category, not a scenario; re-run move 1 on it.
+- Rows carry NO oracles above the test-plan altitude. An explore-time oracle
+  is premature precision that hardens a guess.
+
+## Lineage
+
+Move 1 generalizes the gauntlet's journey matrix (SPEC-227) and classic
+user-journey mapping. Move 2 is fault-tree thinking scaled down (invert the
+guarantee, not the gate). Move 3 is the category matrix the kit's test-design
+standard and `/kit:test-plan` already enforce, applied earlier. The downhill
+rule mirrors the kit's state-stores principle: nothing re-entered between
+phases.

--- a/docs/specs/SPEC-228-scenario-gen-wiring.md
+++ b/docs/specs/SPEC-228-scenario-gen-wiring.md
@@ -1,0 +1,56 @@
+# SPEC-228: Scenario generation wired into every workflow altitude
+
+**Status:** BUILT (prompt-artifact edits land in this PR; this spec records the
+wiring and its contract)
+Lane: normal
+**Foundation:** `docs/patterns/scenario-generation.md` (the shared three-move
+method). **Relates:** SPEC-227 (the gauntlet's journey matrix is the pattern's
+move 1 instance), SPEC-203 (test-generation loop, unchanged, now fed better
+input), ID-423 (bench plane, unchanged).
+
+## Problem
+
+Scenario thinking fires in exactly one place today, inside `/kit:test-plan`,
+after a spec exists, keyed to the spec's own acceptance criteria. Three costs:
+the matrix inherits the spec's blind spots (criteria the author never thought
+to write get no rows); scenarios surface at the most expensive altitude to act
+on (post-contract); and beats that never reach a spec (loop definitions,
+explorations, gauntlet prep) get no scenario set at all unless someone
+improvises one.
+
+## Decision
+
+One shared generation method (the pattern doc's three moves: journey walk,
+guarantee inversion, category sweep) + a small beat at each altitude that calls
+it, with the DOWNHILL rule: generate once at the cheapest altitude that can see
+the scenario, refine below, never regenerate blank.
+
+## Wiring (one edit per surface, marked `<!-- scenario-gen -->`)
+
+| Surface | Edit |
+|---|---|
+| `commands/think.md` | the Decision Brief gains a `Survival scenarios` block (3-5 rows, move-2-heavy, no oracles), seeded during Q5's "what breaks" beat |
+| `commands/design.md` | the Solution section carries the sketch forward and may add rows; it never drops an upstream row without a stated reason |
+| `commands/grill.md` | the closing `Done =` proposal now pairs with 2-3 must-NOT-happen scenarios (the negative space of done) |
+| `commands/spec.md` | `## Edge Cases` is seeded from the brief's sketch and extended by a full three-move pass; the template says so instead of showing bare placeholders |
+| `commands/test-plan.md` | Step 1 reads the spec's scenario set (Edge Cases + Failure modes) alongside ACs; if the spec carries none, run the three moves FIRST, write them back into the spec, then derive the matrix |
+| `skills/loop-engineering/SKILL.md` | the anatomy gains a mandatory slot: a new loop ships its survival set (convergence, non-convergence, bad input, interrupted run, gamed metric) before it is considered designed |
+
+## Non-goals
+
+- No new command, no new agent, no lib code. Every edit is a prompt beat
+  calling the shared pattern.
+- No change to SPEC-203's loop mechanics; it now receives specs that already
+  carry scenario sets, which is the point.
+- Gauntlet-specific generation stays SPEC-227's (journey-as-spec is move 1 at
+  full depth).
+
+## Verification
+
+- Grep contract: each of the six surfaces contains the marker
+  `<!-- scenario-gen -->` and a reference to
+  `docs/patterns/scenario-generation.md` (recorded run below in the proof).
+- Negative control: reverting one surface drops its marker (grep fails).
+- Behavioral acceptance (deferred to first live use, recorded then): the next
+  `/kit:think` run produces a brief with a `Survival scenarios` block; the next
+  spec written from it carries the rows into `## Edge Cases`.

--- a/docs/verification/scenario-gen-wiring.md
+++ b/docs/verification/scenario-gen-wiring.md
@@ -1,0 +1,29 @@
+# Proof of done: scenario-generation wiring (SPEC-228)
+
+Behavioral claim: all six workflow surfaces carry the `scenario-gen` beat and
+reference the shared pattern doc; removing a surface's edit is detectable.
+
+## Recorded runs (gate format)
+
+Command: rg -l "scenario-gen" commands/think.md commands/design.md commands/grill.md commands/spec.md commands/test-plan.md skills/loop-engineering/SKILL.md | wc -l
+Exit: 0
+Verdict: PASS (6 of 6 surfaces carry the marker)
+
+Command: rg -l "patterns/scenario-generation" commands/ skills/loop-engineering/ | wc -l
+Exit: 0
+Verdict: PASS (6 files reference the shared pattern doc)
+
+Command: git stash push commands/think.md && rg -l "scenario-gen" commands/think.md
+Exit: 1 (no match)
+Verdict: PASS as negative control (reverting a surface drops its marker); restored via stash pop, marker count 3 in think.md
+
+Rollback note: prompt-artifact edits only (six marked blocks + two new docs);
+revert the commit and every command behaves exactly as before, no state, no
+config, no lib code touched.
+
+## Deferred (behavioral acceptance, recorded at first live use)
+
+The next `/kit:think` run produces a brief with a `Survival scenarios` block;
+the next spec written from that brief carries the rows into `## Edge Cases`;
+the next `/kit:test-plan` on a scenario-less spec writes rows back before
+deriving. Each gets appended here when it happens.

--- a/skills/loop-engineering/SKILL.md
+++ b/skills/loop-engineering/SKILL.md
@@ -145,6 +145,24 @@ BEST VARIANT of one thing (search-select)?
   optimization". Full source verification and adoption verdict:
   `docs/research/2026-07-31-karpathy-autoresearch-loop.md`.
 
+## Step 2b: The loop's survival set (mandatory before "designed")
+
+<!-- scenario-gen --> A loop is not designed until its own survival scenarios
+are named, per `docs/patterns/scenario-generation.md` (the actor of move 1 is
+the operator driving the loop). Minimum set, every new loop:
+
+- convergence (the happy path reaches the stop condition)
+- non-convergence (the cap hits; the honest-halt report is right)
+- bad input (the teach-on-bad-input path fires, never a dry failure)
+- interrupted run (killed mid-round; state on disk lets a fresh session resume
+  or cleanly restart, and says which)
+- gamed metric (the scanner/checker can be satisfied without the artifact
+  actually improving; name the cheapest gaming move and the counter)
+
+These rows ride into the loop's spec and become its first test plan. The
+gauntlet's rules 7-10 are this set's worked answers for one engine; a new loop
+answers the same five for itself.
+
 ## Step 3: Where it lands once shaped
 
 - A new bounded-revise engine becomes a new `/kit:<name>` side-flow. Register it in


### PR DESCRIPTION
## What

SPEC-228: scenario generation becomes a standing beat at every workflow altitude, backed by ONE shared method (`docs/patterns/scenario-generation.md`: journey walk, guarantee inversion, category sweep) with a downhill rule — generate once at the cheapest altitude that can see the scenario, refine below, never regenerate blank.

| Surface | Beat |
|---|---|
| `/kit:think` | Decision Brief gains a **Survival scenarios** block (3-5 rows, sketched during Q5, no oracles) |
| `/kit:design` | carries the sketch forward; each interface/failure mode named is a new promise to invert; no silent row drops |
| `/kit:grill` | `Done =` now pairs with 2-3 **must-NOT-happen** scenarios (the negative space of done) |
| `/kit:spec` | `## Edge Cases` seeds from the sketch + a full three-move pass; every implicit guarantee gets an inversion row or a stated skip |
| `/kit:test-plan` | matrix derives from **scenarios + ACs**, not ACs alone; a scenario-less spec gets the pass first, written back add-only |
| `skills/loop-engineering` | every NEW loop ships a mandatory five-row survival set (convergence, non-convergence, bad input, interruption, gamed metric) before it counts as designed |

## Why

Scenario thinking fired in exactly one place (test-plan, post-spec, AC-keyed), so matrices inherited the spec author's blind spots and beats that never reach a spec (loop definitions, explorations) got nothing. This closes the loop Han named: 'when we explore or define, the kit comes up with the crucial scenario set'.

## Relates

SPEC-227 (gauntlet journey matrix = move 1 at full depth), SPEC-203 (loop unchanged, now fed specs that already carry scenario sets), ID-423 (bench plane untouched).

## Proof

`docs/verification/scenario-gen-wiring.md`: 6/6 grep contract + stash negative control. Behavioral acceptance deferred to first live use of each beat, appended to the proof as they happen.