### PR TITLE
fix(install): render kit.toml via temp file, never onto itself

### DIFF
--- a/docs/verification/install-toml-self-clobber.md
+++ b/docs/verification/install-toml-self-clobber.md
@@ -1,0 +1,83 @@
+# Proof of done: install.sh no longer clobbers its own kit.toml
+
+Change under proof:
+
+1. `install.sh` `kit_render_install_toml()` renders to `$dst.tmp.$$` and `mv`s it
+   into place, instead of redirecting straight to `> "$dst"`.
+2. `tests/test-install-modules.sh` gains an `NC in-place layout` case (6 checks)
+   covering the `src == dst` install shape that every existing case misses.
+
+## The bug
+
+`kit_render_install_toml "$KIT_DIR/kit.toml" "$KIT_TOML"` (install.sh L672) is
+handed the SAME path twice under README Option 2, which clones the kit to
+`~/.claude/dwarves-kit` and installs from there: `KIT_DIR` and
+`$CLAUDE_DIR/dwarves-kit` are one directory.
+
+The shell sets up `> "$dst"` — truncating the file — before `awk` opens `src`.
+`echo` then writes the 5-line header into that now-empty file, `awk` opens the
+same path, reads back the header it just wrote, and passes it through its
+catch-all `{ print }`. Net effect of ONE install run: a 160-line, 9-section
+`kit.toml` becomes a 12-line stub holding the header twice. Every non-`[modules]`
+key stops resolving; `kit_config_get` silently falls through to each caller's
+hardcoded default, so nothing errors and nothing warns.
+
+Why CI never caught it: every existing case in `tests/test-install-modules.sh`
+installs FROM this checkout INTO a temp `HOME` (`HOME="$H1" bash
+"$KIT_DIR/install.sh"`), so `src != dst` and the truncation is harmless. The
+documented user-facing layout was the one shape untested.
+
+## Confirmation run-table
+
+| # | Check | Command | Result | Verdict |
+|---|---|---|---|---|
+| 1 | New case passes with the fix | `bash tests/test-install-modules.sh` | 43 passed, 0 failed | PASS |
+| 2 | New case FAILS without the fix (`git stash push install.sh`) | `bash tests/test-install-modules.sh` | 37 passed, **6 failed** | PASS (fails as designed) |
+| 3 | Plugin-compat path unchanged | `bash tests/test-install-compat.sh` | `PASS: install compat` | PASS |
+| 4 | Contract deploy unchanged | `bash tests/test-install-contract.sh` | `PASS=4 FAIL=0` | PASS |
+| 5 | CLI shims unchanged | `bash tests/test-install-clis.sh` | all 20 passed | PASS |
+| 6 | Resolver unchanged | `bash tests/test-config.sh` | `PASS kit-config selftest` | PASS |
+| 7 | Reserved-key guard unchanged | `bash tests/test-reserved-config-guard.sh` | 9 run, 9 passed | PASS |
+| 8 | Sync cron install unchanged | `bash tests/test-sync-cron-install.sh` | 29/29 passed | PASS |
+
+`tests/test-config-registry.sh` reports 17/19 both with and without this change
+(`0 orphans on the live tree`, `TIER4_CLOSE strips the annotation`) — pre-existing
+on a clean `1f7209c`, untouched here.
+
+## Negative control
+
+Row 2 is the negative control, and it is the load-bearing one: with `install.sh`
+stashed back to the buggy version, all 6 new checks fail with the exact clobber
+signature, so the test cannot pass vacuously.
+
+```
+FAIL  in-place install: rendered kit.toml keeps every section (missing: [ledger] [mega] [gate] [features] [sync])
+FAIL  in-place install: kit.toml did not shrink (160 -> 12 lines)
+FAIL  in-place install: render header appears exactly once (got 2)
+FAIL  in-place install: resolver still reads a non-[modules] key (mega.wave_cap=<unset>)
+FAIL  in-place install: [modules] recomputed from --with board (board=true)
+FAIL  in-place install: [modules] recomputed from --with board (stats=false)
+```
+
+With the fix, the same 6 report `160 -> 166 lines`, header count 1, and
+`mega.wave_cap=2`.
+
+## Reproduce
+
+```bash
+SB=$(mktemp -d); mkdir -p "$SB/home/.claude"
+git clone -q https://github.com/dwarvesf/dwarves-kit.git "$SB/home/.claude/dwarves-kit"
+wc -l "$SB/home/.claude/dwarves-kit/kit.toml"            # 160
+cd "$SB/home/.claude/dwarves-kit"
+env HOME="$SB/home" CLAUDE_DIR="$SB/home/.claude" bash install.sh >/dev/null 2>&1
+wc -l "$SB/home/.claude/dwarves-kit/kit.toml"            # 12 before the fix, 166 after
+```
+
+## Recovery for an already-clobbered install
+
+The checkout is a git repo and `kit.toml` is tracked, so the stub is one command
+away from repaired — no reinstall needed:
+
+```bash
+git -C ~/.claude/dwarves-kit checkout -- kit.toml
+```

--- a/install.sh
+++ b/install.sh
@@ -266,8 +266,15 @@ kit_toml_modules_section_true() {
 # (uses the caller's $KIT_ENABLED_MODULES). Every other section (`[ledger]`, `[mega]`,
 # `[gate]`, `[features]`, `[team]`) rides through unchanged, so the install copy is
 # the full schema, not just the old minimal manifest.
+#
+# Renders to a temp file and mv's it into place. That indirection is LOAD-BEARING,
+# not tidiness: README Option 2 clones the kit to ~/.claude/dwarves-kit, which makes
+# `src` and `dst` THE SAME PATH. A direct `> "$dst"` truncates the file before awk
+# ever opens it, so the whole schema is lost and awk reads back only the header this
+# function just wrote -- a silent 160-line -> 12-line clobber. Covered by the
+# "in-place layout" case in tests/test-install-modules.sh.
 kit_render_install_toml() {
-  local src="$1" dst="$2"
+  local src="$1" dst="$2" tmp="$2.tmp.$$"
   {
     echo "# --- Rendered by install.sh from the repo-root kit.toml + --with (SPEC-183). ---"
     echo "# Do not hand-edit the [modules] section; re-run \`install.sh --with <modules>\`"
@@ -286,7 +293,8 @@ kit_render_install_toml() {
       }
       { print }
     ' "$src"
-  } > "$dst"
+  } > "$tmp"
+  mv "$tmp" "$dst"
 }
 
 KIT_WITH_ARG=""

--- a/tests/test-install-modules.sh
+++ b/tests/test-install-modules.sh
@@ -205,6 +205,51 @@ DEV_VAL="$(KIT_CONFIG_ROOT="$KIT_DIR" KIT_PROJECT_ROOT="$(mktemp -d)" bash -c "s
 assert_true "dev regime: resolver reads the REPO-ROOT kit.toml directly (mega.wave_cap=2, no install needed)" "$([ "$DEV_VAL" = "2" ]; echo $?)"
 
 # ============================================================
+echo "== NC in-place layout: install.sh does not clobber its own kit.toml (src == dst) =="
+# ============================================================
+# README Option 2 clones the kit TO ~/.claude/dwarves-kit and installs from there,
+# so install.sh's KIT_DIR and CLAUDE_DIR/dwarves-kit are the SAME directory and
+# kit_render_install_toml is handed src == dst. Every OTHER case above installs
+# from this checkout into a temp HOME (src != dst), which is exactly why a direct
+# `> "$dst"` -- truncating before awk opens src -- passed CI while silently
+# reducing a real user's kit.toml to a 12-line header stub.
+H5="$(mktemp -d)"
+mkdir -p "$H5/.claude/dwarves-kit"
+(cd "$KIT_DIR" && tar --exclude=./.git -cf - .) | (cd "$H5/.claude/dwarves-kit" && tar -xf -)
+SRC_LINES="$(wc -l < "$H5/.claude/dwarves-kit/kit.toml" | tr -d ' ')"
+HOME="$H5" bash "$H5/.claude/dwarves-kit/install.sh" --with board >/tmp/kitmod-h5.log 2>&1
+INPLACE_TOML="$H5/.claude/dwarves-kit/kit.toml"
+
+# The whole schema survives: a stub keeps only the header, so every section is a probe.
+MISSING=""
+for sec in '[modules]' '[ledger]' '[mega]' '[gate]' '[features]' '[sync]'; do
+  grep -qF "$sec" "$INPLACE_TOML" || MISSING="$MISSING $sec"
+done
+assert_true "in-place install: rendered kit.toml keeps every section (missing:${MISSING:-none})" \
+  "$([ -z "$MISSING" ]; echo $?)"
+
+DST_LINES="$(wc -l < "$INPLACE_TOML" | tr -d ' ')"
+assert_true "in-place install: kit.toml did not shrink (${SRC_LINES} -> ${DST_LINES} lines)" \
+  "$([ "$DST_LINES" -ge "$SRC_LINES" ]; echo $?)"
+
+# The self-read signature: awk echoing back the header install.sh just wrote.
+HDRS="$(grep -c '^# --- Rendered by install.sh' "$INPLACE_TOML" || true)"
+assert_true "in-place install: render header appears exactly once (got $HDRS)" \
+  "$([ "$HDRS" -eq 1 ]; echo $?)"
+
+# A non-[modules] key still resolves -- the user-visible symptom of the clobber.
+INPLACE_VAL="$(KIT_CONFIG_ROOT="$H5/.claude/dwarves-kit" KIT_PROJECT_ROOT="$(mktemp -d)" \
+  bash -c "source '$RESOLVER'; kit_config_get mega.wave_cap '<unset>'")"
+assert_true "in-place install: resolver still reads a non-[modules] key (mega.wave_cap=$INPLACE_VAL)" \
+  "$([ "$INPLACE_VAL" = "2" ]; echo $?)"
+
+# [modules] is still recomputed from THIS run's --with, not just copied through.
+assert_true "in-place install: [modules] recomputed from --with board (board=true)" \
+  "$(grep -qx 'board = true' "$INPLACE_TOML"; echo $?)"
+assert_true "in-place install: [modules] recomputed from --with board (stats=false)" \
+  "$(grep -qx 'stats = false' "$INPLACE_TOML"; echo $?)"
+
+# ============================================================
 echo "== COVERAGE-DELTA: every module in the manifest maps to a real installable unit =="
 # ============================================================
 # Each optional module either has >=1 hook that exists on disk, or is a documented


### PR DESCRIPTION
## Problem

`install.sh` silently reduces the kit-root `kit.toml` from 160 lines / 9 sections to a 12-line header stub — on the layout README Option 2 documents.

`kit_render_install_toml "$KIT_DIR/kit.toml" "$KIT_TOML"` (L672) gets the same path twice when the kit is cloned to `~/.claude/dwarves-kit` and installed from there: `KIT_DIR` **is** `$CLAUDE_DIR/dwarves-kit`. The shell truncates `> "$dst"` before `awk` opens `src`; `echo` writes the header into the now-empty file; `awk` opens the same path, reads back that header, and passes it through its catch-all `{ print }` — which is why the stub carries the header **twice from a single run**.

Fallout: every non-`[modules]` key stops resolving. `kit_config_get mega.wave_cap` → empty instead of `2`, `gate.understanding_gate` → empty instead of `true`. Nothing errors, because each caller passes its own default — the config layer just quietly stops existing.

```bash
SB=$(mktemp -d); mkdir -p "$SB/home/.claude"
git clone -q https://github.com/dwarvesf/dwarves-kit.git "$SB/home/.claude/dwarves-kit"
wc -l "$SB/home/.claude/dwarves-kit/kit.toml"            # 160
cd "$SB/home/.claude/dwarves-kit"
env HOME="$SB/home" CLAUDE_DIR="$SB/home/.claude" bash install.sh >/dev/null 2>&1
wc -l "$SB/home/.claude/dwarves-kit/kit.toml"            # 12
```

## Fix

Render to `$dst.tmp.$$`, then `mv` into place, so truncation cannot precede the read. The comment above the function says why the indirection is load-bearing, so nobody "tidies" it back.

## Why CI missed it

Every existing case in `tests/test-install-modules.sh` installs **from this checkout into a temp `HOME`**:

```bash
HOME="$H1" bash "$KIT_DIR/install.sh"
```

so `src != dst` and the truncation is harmless. The one shape never exercised was the shape the README tells users to use.

This PR adds an `NC in-place layout` case that copies the kit into `$H5/.claude/dwarves-kit` and installs **from there**, asserting:

- every section (`[modules]` `[ledger]` `[mega]` `[gate]` `[features]` `[sync]`) survives
- the file did not shrink
- the render header appears exactly once (the self-read signature)
- `kit_config_get mega.wave_cap` still resolves to `2`
- `[modules]` is still recomputed from this run's `--with`, not merely copied through

## Verification

Full run-table in `docs/verification/install-toml-self-clobber.md`.

| Check | Result |
|---|---|
| `tests/test-install-modules.sh` with fix | 43 passed, 0 failed |
| same, with `install.sh` stashed to the buggy version | 37 passed, **6 failed** |
| `test-install-compat.sh` / `test-install-contract.sh` / `test-install-clis.sh` | PASS / `PASS=4 FAIL=0` / all 20 passed |
| `test-config.sh` / `test-reserved-config-guard.sh` / `test-sync-cron-install.sh` | PASS / 9 passed / 29/29 |

The negative control is the load-bearing row: against the unfixed `install.sh` all 6 new checks fail with the exact clobber signature (`160 -> 12 lines`, `header ... got 2`, `mega.wave_cap=<unset>`), so the test cannot pass vacuously.

`tests/test-config-registry.sh` reports 17/19 both with and without this change (`0 orphans on the live tree`, `TIER4_CLOSE strips the annotation`) — pre-existing on a clean `1f7209c`, not touched here.

## Note for anyone already affected

`kit.toml` is tracked, so a clobbered install repairs without a reinstall:

```bash
git -C ~/.claude/dwarves-kit checkout -- kit.toml
```

Found on macOS, kit `892d25c` (v2.0.0); reproduced on `1f7209c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
