### PR TITLE
fix(gitignore): un-ignore .claude/memory/ so repo memory actually tracks

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,4 @@
+# dwarves-kit memory index
+
+- [North-star direction: check every proposal against PHILOSOPHY §6 N1-N7 (N4-N7 = Han's standing directions)](north-star-direction.md)
+- [#auto queue-watcher pilot: proven twice (ID-463, ID-309), two mechanism bugs unfixed, parked for gauntlet/mega-goal work](auto-queue-watcher-pilot.md)

--- a/.claude/memory/auto-queue-watcher-pilot.md
+++ b/.claude/memory/auto-queue-watcher-pilot.md
@@ -1,0 +1,38 @@
+---
+name: auto-queue-watcher-pilot
+description: The #auto backlog-row + queue-watcher mechanism (SPEC-217) was proven twice, unattended, on ID-463 and ID-309; two known bugs are still unfixed.
+metadata:
+  type: project
+---
+
+`bin/queue watch --apply` (tag a queued board row `#auto` plus a
+`#queue{repo=,pointer=}` token, point it at a `.claude/goals/<slug>.md` file)
+shipped as SPEC-217 back on 2026-07-31 but had never actually been run before
+2026-08-01/02. Two small, well-scoped rows went through it end to end: real
+diagnosis, real fix, real tests, a real draft PR, each checked by hand
+afterward with an independent negative control before merge (ID-463: PR #342,
+a test-suite `$HOME`-sandboxing bug; ID-309: PR #344, the board-sync
+id-collision guard). Both held up.
+
+Two mechanism bugs surfaced, still unfixed:
+
+- The `/goal` submit sometimes lands in the input box but never actually
+  sends, the launched session sits idle with the goal text unsubmitted.
+  Reproduced twice in a row on ID-309's run; a single manual `Enter` sent to
+  the tmux window unstuck it both times. `_mux_submit`'s retry-detection
+  (`lib/queue/queue.sh`) checks for a literal `❯ /goal` at the prompt, which
+  can miss a long single-line paste that renders with only its tail visible.
+- Fixed prompt overhead (the XPIA preamble + the EXIT_SIGNAL/draft-PR
+  suffixes `_goal_line` appends) eats roughly 1500 of `/goal`'s 4000-char
+  budget, leaving well under 2500 chars for the actual pointer content, with
+  no pre-flight check or truncation. A slightly-too-long pointer silently
+  strands the row: no journal entry, no error, just an idle session.
+
+Both pilot rows ran directly against the operator's main checkout (the
+dirty-tree + on-default-branch guards make a side worktree structurally
+impossible to use here), so treat the main checkout as a shared, sometimes
+busy resource, not an isolated pilot sandbox.
+
+Parked while Han works the gauntlet, tech generation, and mega-goal workflow
+instead. Revisit to fix the two bugs above, or to widen the pilot to more
+rows, once that other work settles.

--- a/.claude/memory/north-star-direction.md
+++ b/.claude/memory/north-star-direction.md
@@ -1,0 +1,35 @@
+---
+name: north-star-direction
+description: Every kit proposal/absorb/solution must align with PHILOSOPHY §6 N1-N7; N4-N7 are Han's standing directions (modularity, autonomy, self-improvement, serve-the-team)
+metadata:
+  type: project
+---
+
+Han set four standing DIRECTIONS for the kit on 2026-07-25, recorded as
+north-star criteria N4-N7 in `docs/PHILOSOPHY.md` §6 (joining N1-N3 from
+2026-06-10):
+
+- **N4 Modularity**: every part stands alone (works with the kit deleted),
+  composes via the manifest, and is swappable as techniques evolve.
+- **N5 Autonomy**: long-running multi-agent orchestration, hands-off in the
+  middle; attention only at define-done and judge-artifact.
+- **N6 Self-improvement**: the kit learns from its own runs through the stage
+  loop (Shape/Build/Watch/Check/Learn); propose-never-dispose.
+- **N7 Serve the team**: cognitive off-load for humans + agents together; weigh
+  every feature for the second and fifth user.
+
+§6 also carries Han's meta-principles (attention-at-two-points, evidence before
+claims, plain files + plain words, risk buys ceremony, propose-never-dispose,
+defer-don't-own, queue-and-route with receipts).
+
+**How to apply:** when discussing, adding, or absorbing ANYTHING for the kit,
+check the proposal against §6 BEFORE recommending it; state which criterion it
+serves; surface (never silently absorb) any conflict with a criterion. A
+proposal serving no criterion and no §1 principle is a NO-list candidate by
+default.
+
+**Module classification is a filing default (Han 2026-07-25):** every kit
+board row gets a module/surface tag at intake (#classify #grill #assign
+#test-plan #onboard #adopt #queue #ship #stats #telemetry #gate #advisor
+#absorb #install #proof, per the stage map in module-registry.md), stated
+alongside the #u-/#f- tags. Mechanical wiring rides ID-397's lens.

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,13 @@ node_modules/
 # Tool caches (serena local index; the kit uses codebase-memory, not serena)
 .serena/
 
-# Local Claude Code user state and per-machine settings
-.claude/
+# Local Claude Code user state and per-machine settings, except repo memory
+# (git-tracked by design so it rides the repo, per this repo's CLAUDE.md).
+# `.claude/*` (not `.claude/`) so git still descends into .claude/ to see
+# the negation below; a plain `.claude/` directory-match would exclude the
+# whole tree from traversal and no `!` pattern inside it could ever apply.
+.claude/*
+!.claude/memory/
 
 # Legacy / retired artifacts the kit no longer writes: review output now lives in
 # the spec's `## Review` section, and the spec location unified onto docs/specs/

--- a/docs/verification/repo-memory-gitignore.md
+++ b/docs/verification/repo-memory-gitignore.md
@@ -1,0 +1,86 @@
+# Proof of done: repo-memory .gitignore fix
+
+Profile: fix   Proof class: behavioral
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | A new file under `.claude/memory/` is NOT ignored by git | PASS | R1 |
+| 2 | A new file under any other `.claude/` subdir (`.claude/goals/`, `.claude/worktrees/`) IS still ignored | PASS | R1 |
+| 3 | Reverting to the old `.gitignore` line reproduces the ignore on the same `.claude/memory/` file (negative control) | PASS | R2 |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | `.gitignore`'s blanket `.claude/` line silently ignored `.claude/memory/` too, so the repo-memory notes this repo's own `CLAUDE.md` documents as git-tracked never actually left the machine. Switched the line to `.claude/*` (a glob over direct children) plus `!.claude/memory/` (a negation), and committed the two notes that had been sitting locally, uncommitted, for an unknown span. |
+| Where | `.gitignore` (the one line), plus the two orphaned notes it had been hiding. |
+| Root cause | A plain `.claude/` pattern is a directory match: git excludes the whole subtree from traversal, so no `!` negation pattern nested inside it can ever apply (a standard gitignore limitation, not specific to this repo). `.claude/*` matches only direct children, so git still descends into `.claude/` to evaluate the negation. |
+| Reversibility | `git revert` the commit; no runtime behavior changes, only what `git status`/`git add` sees. |
+
+## 3. Confirmation (runs)
+
+| Run | Command | Exit | Verdict |
+|---|---|---|---|
+| R1 | `echo probe >\| .claude/memory/probe.md && git check-ignore -v .claude/memory/probe.md` | 1 | PASS (not ignored) |
+| R1b | `git check-ignore -v .claude/goals/telemetry-closure.md` / `.claude/worktrees` | 0 / 0 | PASS (still ignored) |
+| R2 | Same probe file, `.gitignore` swapped to the pre-fix `.claude/` line | 0 | RED-as-expected (ignored) |
+| R2b | `.gitignore` restored via `git checkout -- .gitignore` | 1 | PASS (not ignored again) |
+
+## 4. Run detail
+
+### R1 GREEN
+```
+$ echo probe >| .claude/memory/probe.md && git check-ignore -v .claude/memory/probe.md
+GREEN exit=1
+```
+No match printed, exit 1: the file is not ignored.
+
+### R1b other `.claude/` subdirs still ignored
+```
+$ git check-ignore -v .claude/goals/telemetry-closure.md
+.gitignore:17:.claude/*	.claude/goals/telemetry-closure.md
+$ git check-ignore -v .claude/worktrees
+.gitignore:17:.claude/*	.claude/worktrees
+```
+Both still match and are ignored, exit 0, confirming the fix is scoped to `.claude/memory/` only.
+
+### R2 NEGATIVE CONTROL
+```
+$ git show HEAD~1:.gitignore >| .gitignore.negctrl && cat .gitignore.negctrl >| .gitignore
+$ git check-ignore -v .claude/memory/probe.md
+.gitignore:13:.claude/	.claude/memory/probe.md
+RED exit=0
+```
+With the pre-fix `.gitignore` line restored, the exact same probe file is ignored again, confirming the fix (not some unrelated cache state) is what changes the outcome.
+
+### R2b restore
+```
+$ git checkout -- .gitignore
+$ git check-ignore -v .claude/memory/probe.md
+RESTORED exit=1
+```
+Fixed `.gitignore` restored from the index; the probe file is not ignored again.
+
+## 5. Reproduce
+
+```
+echo probe >| .claude/memory/probe.md
+git check-ignore -v .claude/memory/probe.md   # exit 1, not ignored
+```
+
+## Before/after
+
+**Before:**
+```
+.claude/
+```
+Excludes the whole `.claude/` subtree from traversal; any note written to `.claude/memory/` sits permanently untracked no matter what the repo's own docs claim.
+
+**After:**
+```
+.claude/*
+!.claude/memory/
+```
+Direct children of `.claude/` are still ignored by default (`.claude/goals/`, `.claude/worktrees/`, etc.), but git still descends into `.claude/` to evaluate the negation, so `.claude/memory/` and everything under it is tracked.


### PR DESCRIPTION
## Summary
- `.gitignore`'s blanket `.claude/` line silently ignored `.claude/memory/` too, so the repo-memory notes this repo's own CLAUDE.md documents as git-tracked never actually left the machine.
- Switches the line to `.claude/*` + `!.claude/memory/` (a glob plus negation, since git never descends into a directory-matched exclude to see a nested negation).
- Commits the two notes that had been sitting locally, uncommitted, plus a new one about the `#auto` queue-watcher pilot.

## Test plan
- [x] A new file under `.claude/memory/` is not ignored (green run)
- [x] Other `.claude/` subdirs (`goals/`, `worktrees/`) stay ignored
- [x] Negative control: reverting the gitignore line reproduces the ignore on the same file, then restoring fixes it again
- Full transcript: `docs/verification/repo-memory-gitignore.md`