### PR TITLE
docs(impl-playbook): distill three lessons from an estate proxy session

### DIFF
--- a/docs/impl-playbook/bash.md
+++ b/docs/impl-playbook/bash.md
@@ -6,8 +6,9 @@ Distills the Google Shell Style Guide, ShellCheck, and the "bash strict mode" co
 - Small utility/wrapper scripts with straightforward control flow. Once logic grows non-trivial (real data structures, complex branching, or roughly 100+ lines per the Google Shell Style Guide's own threshold), move to Go or Python.
 
 ## Error handling
-- Start every script with `set -euo pipefail`. Know its gaps: `set -e` does not fire inside `if`/`&&`/`||`/command substitution, and `pipefail` can misfire on a legitimate `SIGPIPE` (`cmd | head`).
+- Start every script with `set -euo pipefail`. Know its gaps: `set -e` does not fire inside `if`/`&&`/`||`, and `pipefail` can misfire on a legitimate `SIGPIPE` (`cmd | head`).
 - `((i++))` under `set -e` can silently exit the script when the expression evaluates to zero. Use `i=$((i+1))` instead.
+- A command substitution used as an ARGUMENT is exempt from `-e` (`echo "$(false)"` does not exit), but a PLAIN ASSIGNMENT is not: `x=$(false)` does trigger `-e`, and with `pipefail` set, `x=$(cmd1 | cmd2)` triggers it too if `cmd1` fails even though `cmd2` succeeds. A `grep` with no match is exit 1, so `x=$(grep ... | cut ...)` silently kills the whole script the first time the pattern is absent, not just returns empty. Append `|| true` when "no match" is a legitimate outcome, not an error.
 - Check exit codes explicitly for anything strict mode's gaps could hide.
 
 ## Quoting
@@ -24,9 +25,12 @@ Distills the Google Shell Style Guide, ShellCheck, and the "bash strict mode" co
 ## Tooling
 - ShellCheck is a hard gate, not advisory. It catches the quoting/word-splitting class of bug that strict mode cannot.
 
+## Testing
+- Test a parsing/extraction snippet under the SAME shell options the real script runs with (`set -euo pipefail`), not a lenient throwaway harness. A harness missing `-e` can pass on exactly the input that kills the real script; verified live, where a one-off test without `-e` was green while the deployed script aborted on the first profile lacking the field being extracted.
+
 ## Sources
 - [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
 - [ShellCheck wiki](https://www.shellcheck.net/wiki/)
-- [BashFAQ/105: Why doesn't `set -e` do what I expected?](https://mywiki.wooledge.org/BashFAQ/105) (the canonical reference for the strict-mode gaps above)
+- [BashFAQ/105: Why doesn't `set -e` do what I expected?](https://mywiki.wooledge.org/BashFAQ/105) (the canonical reference for the strict-mode gaps above, including the plain-assignment case)
 
-Verified: 2026-07-29.
+Verified: 2026-08-09.

--- a/docs/impl-playbook/coding-hygiene.md
+++ b/docs/impl-playbook/coding-hygiene.md
@@ -18,10 +18,11 @@ Distills the Twelve-Factor App's config principle (factor III) and standard clea
 
 ## Duplication
 - The same logic in two or more places is a bug waiting to happen, since only one copy gets fixed. Extract to one shared function once a third occurrence appears (the rule of three); extracting on the first duplication is premature abstraction.
+- A restated FACT is a worse duplication than restated logic, because it can drift on the SECOND occurrence, not just the third: two places independently deciding the same thing (which network a service belongs on, which role a caller holds) will disagree the moment only one of them is updated, and the resulting bug is often silent (a check that returns empty and skips, rather than one that errors). Prefer reading the fact back from wherever it was first decided over recomputing it a second way, even when that is not a shared function, just one arrow from decision to derived state instead of two independent boxes answering the same question.
 
 ## Sources
 - [The Twelve-Factor App, III. Config](https://12factor.net/config)
 - Clean Code (Robert C. Martin), chapters on naming and functions, the canonical source for the naming/magic-value/function-size rules above.
 - Refactoring (Martin Fowler), the rule of three on duplication, credited to Don Roberts.
 
-Verified: 2026-07-29.
+Verified: 2026-08-09.

--- a/docs/impl-playbook/threat-modeling.md
+++ b/docs/impl-playbook/threat-modeling.md
@@ -12,11 +12,16 @@ Distills STRIDE (Microsoft's threat-modeling framework) and the OWASP Threat Mod
 
 Run this as a five-minute pass on any feature that crosses a trust boundary (accepts external input, talks to another service, stores user data). Skip it for pure internal utility code with no external input.
 
+## Verifying a suspected authorization gap
+Read the code and reason about it, then PROVE it live rather than trust the reasoning. From the lower-trust side, send a request carrying a deliberately INVALID value (a nonexistent record, an unknown alias) to a route that should be out of reach. A hard rejection before the request is even parsed means the boundary held. An application-level error that names real schema (`unknown database "x", allowed: A, B, C`) means the request passed authentication and reached business logic, which proves reachability without ever touching real data. Keep this negative-value probe in the proof-of-done next to the fix, not only in the finding writeup, so the next reader can re-run it instead of re-deriving it.
+
 ## Defense-in-depth defaults
 - Assume any single layer can fail; do not rely on one control (app-level validation and a DB constraint, not just one).
 - Fail closed, not open: an auth check that errors should deny access, not grant it.
 - Least privilege by default (also in `security.md`): a component gets only the access its one job needs, nothing broader "in case."
-- Do not trust the network, even internal traffic: authenticate service-to-service calls; a private network is not a security boundary by itself.
+- Do not trust the network, even internal traffic: authenticate service-to-service calls; a private network is not a security boundary by itself. Exception, stated so it is not silently overridden: when the CALLER is untrusted code (an LLM-driven sandbox) that must never hold a credential at all, giving it one to authenticate with is worse, since it becomes a secret that caller can leak, not a control. There, isolating callers of different trust onto separate networks IS the boundary, and the real credential stays server-side, injected only by the process sitting on the higher-trust network.
+- A safety invariant that lives only as a comment or a second, independently maintained data structure is not a control. Nothing re-checks it when the surrounding code changes, so it drifts, and the drift is silent by construction. Verified live twice in one session: a comment claiming a shared route "never moves money without a human downstream" stopped being true a few commits later with nobody re-reading it, and a network mapping restated in a second script location silently stopped covering a newly added consumer. Derive the second copy from the first's actual output; never re-encode the same decision independently.
+- Splitting a shared credential into per-consumer copies needs two assertions, not one: that a lower-trust consumer does NOT hold the higher-trust credential, AND that the higher-trust consumer still HOLDS what its own routes need. The first alone can ship an outage disguised as a fix, since a split that quietly drops a still-needed key fails closed in a way indistinguishable from a successful hardening pass until something calls that route.
 
 ## When this becomes a real red-team engagement
 If the next step is an actual authorized penetration test or red-team exercise, not just designing your own code defensively, that is a separate gated process. See `red-team-engagement.md` for the rules-of-engagement gate and the PTES phase list.
@@ -26,4 +31,4 @@ If the next step is an actual authorized penetration test or red-team exercise, 
 - [The STRIDE Threat Model (Microsoft Learn, archived Commerce Server docs)](https://learn.microsoft.com/en-us/previous-versions/commerce-server/ee823878(v=cs.20))
 - [Microsoft Learn: Threat modeling (current)](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats) (the archived link above can vanish without notice)
 
-Verified: 2026-07-29.
+Verified: 2026-08-09.


### PR DESCRIPTION
Distills three general lessons out of a live estate-proxy tier-isolation session in a consumer repo, into the shared playbook so future security/bash reviews start with the sharper version.

## bash.md

The `set -e` claim was imprecise enough to mislead: a command substitution used as an argument IS exempt, but a plain assignment is not, and under `pipefail` a failed first stage in a piped assignment triggers `-e` even when a later stage succeeds. Confirmed live: a `grep` with no match fed a plain assignment and killed a real deploy mid-run.

Also adds a Testing section: test an extraction under the same shell options the real script runs with. A throwaway test without `-e` passed on exactly the input that killed the real script.

## threat-modeling.md

Three additions:

- A verification technique for proving reachability without touching real data: send an invalid value from the lower-trust side, read whether the response is a hard rejection or an application error that names real schema.
- A named exception to "authenticate service-to-service calls," for the shape where the caller is untrusted LLM-driven code that must never hold a credential at all. Handing it one to authenticate with just gives it a secret to leak, which is worse than the network-trust problem the rule exists to prevent.
- Two defense-in-depth bullets: a safety invariant stated only in a comment or a second data structure is not a control, since nothing re-checks it when the surrounding code changes; and splitting a shared credential needs an isolation assertion AND a completeness assertion, or the split can ship an outage disguised as a fix.

## coding-hygiene.md

A restated fact is a worse duplication than restated logic, since it can drift on the SECOND occurrence rather than needing a third to earn extraction. Prefer reading a fact back from where it was decided over recomputing it independently.

## Sourcing

Each addition is a corollary of the source that file already cites (BashFAQ/105's plain-assignment case, the OWASP Threat Modeling Cheat Sheet's defense-in-depth framing, the rule-of-three duplication source), not a new claim needing a new citation. `Verified` bumped on the three files touched, per this playbook's own README: "Real work turns up a case where the file's rule was wrong or the source has clearly moved past it."

Built in an isolated worktree off `origin/master`; this branch touches only the three files listed.
