### PR TITLE
feat(gate): warn when test-plan matrix rows lack proof coverage

### DIFF
--- a/docs/implementation-notes/coverage-map-warn.md
+++ b/docs/implementation-notes/coverage-map-warn.md
@@ -1,0 +1,39 @@
+# Implementation notes -- coverage-map-warn (ID-466)
+
+Task: warn (advisory, never block) at the ship boundary when the active spec carries a `## Test plan` but the proof-of-done doc has no coverage map, or the map leaves matrix rows unmapped.
+
+## 2026-08-10 parsing home: proof-gate.sh subcommand, not inline awk in the hook
+
+Context: the task scoped the change to `hooks/ship-gate.sh` and/or `lib/gate/proof-gate.sh` without picking a split.
+Decision: the matrix/map parsing lives in `proof-gate.sh coverage <spec> [proof.md ...]` (always exit 0, one-line verdict); the hook only wires the call and prints the `[advisory]` line.
+Why: proof-gate.sh is the proof-shape brain and is directly unit-testable; the hook stays a thin wiring layer like every other advisory it carries.
+Alternatives: all-inline in ship-gate.sh (untestable without driving the whole hook); proof-ledger.sh (out of the task's named scope).
+Impact: one new subcommand, no new files in lib/.
+
+## 2026-08-10 row identity: `#` column when numeric, ordinal fallback otherwise
+
+Context: real specs use two matrix dialects, the canonical `| # | Case | ... |` (numbered) and the older `| Category | Case | How |` (no id column, e.g. SPEC-195).
+Decision: a row's id is its first cell when that cell is a bare integer, else its ordinal position (1..N) among data rows. The coverage map's `Row` column uses the same rule.
+Why: the task says "each matrix row id" but half the fleet has no id column; ordinals keep the older dialect covered without retrofitting specs.
+Impact: documented in docs/verification/README.md next to the owed shape.
+
+## 2026-08-10 which proof files the hook scans
+
+Decision: the hook hands proof-gate.sh the repo-root convention files for the slug, `docs/verification/<slug>.md` plus `docs/verification/<slug>/*.md` and `<slug>/runs/*.md`. Co-located `tools/*/docs/proof-of-done.md` is NOT scanned.
+Why: the advisory keys on the spec's slug; a co-located proof has no slug linkage the hook can resolve cheaply, and a false warning on a monorepo tool is an acceptable advisory miss for now.
+Open question: extend to co-located proofs if a consumer repo hits the false warning in practice.
+
+## 2026-08-10 header/separator detection is look-ahead, not keyword
+
+Decision: inside the section, a `|` row is a separator when it contains only `| :-` chars; a row is a header when the NEXT row is a separator. No header keyword list.
+Why: keyword lists (`#`, `Case`, `Category`) break on every new dialect; the separator-follows-header rule is structural and dialect-free.
+
+## 2026-08-10 section match is exact
+
+Decision: the spec section matches `^## Test plan[ \t]*$` only, so `## Test plan critique` (written by /kit:test-plan-review-team) never counts as a plan. The proof section is `^## Test plan coverage[ \t]*$`.
+
+## 2026-08-10 new test file is not registered in CI
+
+Context: `.github/workflows/test.yml` lists tests explicitly, but this unattended run must not write `.github/*`.
+Decision: `tests/test-ship-gate-coverage-map.sh` ships unregistered, matching the existing `test-ship-gate-fail-closed.sh` / `test-ship-gate-profiles.sh`, which are also absent from CI.
+Open question: operator may want to add all three ship-gate tests to the workflow in a follow-up.

--- a/docs/implementation-notes/coverage-map-warn.md
+++ b/docs/implementation-notes/coverage-map-warn.md
@@ -32,6 +32,13 @@ Why: keyword lists (`#`, `Case`, `Category`) break on every new dialect; the sep
 
 Decision: the spec section matches `^## Test plan[ \t]*$` only, so `## Test plan critique` (written by /kit:test-plan-review-team) never counts as a plan. The proof section is `^## Test plan coverage[ \t]*$`.
 
+## 2026-08-10 pre-existing drift left alone: README/architecture command counts
+
+Context: `tests/test-meta.sh` fails 10 checks on this branch AND on master identically (command-count tables say 35, the tree has 36 commands; `docs/FEATURES.md` staleness). During local test runs something self-healed the two count lines in `README.md` and `docs/architecture.md` in the working tree.
+Decision: reverted those two files; this branch ships only the ID-466 change.
+Why: surgical-diff rule; the count drift is its own row, and mixing a drive-by docs fix into a gate change muddies review.
+Open question: operator should file the 36th-command (gauntlet) doc-count drift as its own board item if not already tracked.
+
 ## 2026-08-10 new test file is not registered in CI
 
 Context: `.github/workflows/test.yml` lists tests explicitly, but this unattended run must not write `.github/*`.

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -293,6 +293,31 @@ Rules:
 - **A run file is never overwritten.** A re-run is a NEW file (new timestamp). History is the
   point.
 
+## Test plan coverage map (owed when the spec has a `## Test plan`)
+
+When the active spec carries a `## Test plan` matrix (`/kit:test-plan`), the proof of done
+owes a **coverage map**: a `## Test plan coverage` section, in the flat `<slug>.md` or in any
+file of the `<slug>/` directory layout, mapping **each matrix row** to the run that exercised
+it, or an explicit skip reason:
+
+```markdown
+## Test plan coverage
+| Row | Run / skip reason |
+|---|---|
+| 1 | R1 (runs/2026-08-10-0912.md) |
+| 2 | R2, negative control |
+| 3 | skipped: environment-only case, covered by row 1's revert leg |
+```
+
+`Row` is the matrix row's `#` cell; when the matrix has no numeric `#` column (the older
+`| Category | Case | How |` dialect), it is the row's ordinal, counted top to bottom. A skip
+is honest, not a loophole: name the reason, the same rule as the exempt marker above.
+
+The ship-gate **WARNS, never blocks** (detect-not-dictate) when the spec has a test plan but
+no proof doc for the slug carries the map, or the map leaves matrix rows unmapped. Check by
+hand with `bash lib/gate/proof-gate.sh coverage <spec> <proof.md ...>` (`OK` / `NO-MAP` /
+`UNMAPPED: <rows>`). A spec with no `## Test plan` owes nothing new.
+
 ## Who writes it
 
 - `/kit:execute` , appends a run record at each phase checkpoint and at completion.

--- a/docs/verification/coverage-map-warn.md
+++ b/docs/verification/coverage-map-warn.md
@@ -20,7 +20,7 @@ Advisory only; no blocking path added or changed.
 - Verdict: PASS
 - Note: covers all three required cases -- (a) plan + mapless proof warns without blocking, (b) fully mapped emits no warning, (c) no test plan emits no warning -- plus unit coverage of both matrix dialects and the `## Test plan critique` exclusion.
 
-## 2026-08-10 RED-as-expected -- coverage-map-warn [negative-control]
+## 2026-08-10 RED-as-expected -- coverage-map-warn [NEGATIVE CONTROL]
 - Command: `bash <copy>/tests/test-ship-gate-coverage-map.sh` where `<copy>` is a scratch copy of this branch with `hooks/ship-gate.sh` and `lib/gate/proof-gate.sh` restored from master (the change reverted; the shared checkout untouched)
 - Exit: 1
 - Output (excerpt):

--- a/docs/verification/coverage-map-warn.md
+++ b/docs/verification/coverage-map-warn.md
@@ -1,0 +1,49 @@
+# Proof of done -- coverage-map-warn (ID-466)
+
+Behavioral change: `proof-gate.sh coverage` subcommand + ship-gate advisory when a spec's
+`## Test plan` matrix rows are not mapped in the proof doc's `## Test plan coverage` section.
+Advisory only; no blocking path added or changed.
+
+## 2026-08-10 PASS -- coverage-map-warn [green]
+- Command: `bash tests/test-ship-gate-coverage-map.sh`
+- Exit: 0
+- Output (excerpt):
+  ```
+  ok - coverage: partial map -> UNMAPPED: 2 3
+  ok - coverage: all rows mapped -> OK (critique table not counted)
+  ok - (a) plan + mapless proof -> advisory emitted, exit 0 (not blocked)
+  ok - (b) all rows mapped -> no coverage advisory, exit 0
+  ok - (c) no test plan -> no coverage advisory, exit 0
+  ok - (d) partial map -> advisory names unmapped row 2, exit 0
+  PASS=10 FAIL=0
+  ```
+- Verdict: PASS
+- Note: covers all three required cases -- (a) plan + mapless proof warns without blocking, (b) fully mapped emits no warning, (c) no test plan emits no warning -- plus unit coverage of both matrix dialects and the `## Test plan critique` exclusion.
+
+## 2026-08-10 RED-as-expected -- coverage-map-warn [negative-control]
+- Command: `bash <copy>/tests/test-ship-gate-coverage-map.sh` where `<copy>` is a scratch copy of this branch with `hooks/ship-gate.sh` and `lib/gate/proof-gate.sh` restored from master (the change reverted; the shared checkout untouched)
+- Exit: 1
+- Output (excerpt):
+  ```
+  usage: proof-gate.sh {class "<desc>"|requirement "<desc>"|contract "<desc>"|classes}
+  NOT ok - mapless proof should report NO-MAP
+  NOT ok - (a) expected exit 0 + coverage advisory; got exit 0, stderr: [advisory] delivery-ratio: ...
+  PASS=2 FAIL=8
+  ```
+- Verdict: RED-as-expected
+- Note: 8/10 fail without the change. Cases (b) and (c) assert the ABSENCE of a warning, so they are trivially green on the reverted code; the presence cases (a)/(d) and all six unit cases go RED.
+
+## 2026-08-10 PASS -- existing suites stay green
+- Command: `bash tests/test-hooks.sh && bash tests/test-ship-gate-fail-closed.sh && bash tests/test-ship-gate-profiles.sh && bash tests/test-docs-wiring.sh`
+- Exit: 0
+- Output (excerpt):
+  ```
+  Passed: 492 / 492            (test-hooks.sh)
+  PASS=5 FAIL=0                (test-ship-gate-fail-closed.sh)
+  ALL PASS (3 profiles x allow+block)
+  === 22/22 passed ===         (test-docs-wiring.sh)
+  ```
+- Verdict: PASS
+- Note: `tests/test-meta.sh` reports 799/809 on this branch AND on master (same 10 pre-existing failures: command-count tables, FEATURES.md freshness); the delta from this branch is zero.
+
+Reversibility: pure git revert; the advisory writes nothing and never changes an exit code.

--- a/hooks/ship-gate.sh
+++ b/hooks/ship-gate.sh
@@ -146,6 +146,25 @@ fi
 # Resolve the spec for this slug; fail open if there is no spec-driven run.
 SPEC=$(ls "$ROOT"/docs/specs/SPEC-*-"$SLUG".md 2>/dev/null | head -1 || true)
 [ -n "$SPEC" ] || exit 0
+
+# ID-466 advisory (never blocks): the spec carries a ## Test plan, so the proof-of-done owes
+# a ## Test plan coverage map -- each matrix row mapped to the run that exercised it, or an
+# explicit skip reason (shape: docs/verification/README.md "Test plan coverage map"). WARNS
+# on a missing map or unmapped rows; no test plan in the spec = no new requirement.
+PGATE="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/dwarves-kit}/lib/gate/proof-gate.sh"
+if [ -f "$PGATE" ] && grep -qE '^## Test plan[[:space:]]*$' "$SPEC" 2>/dev/null; then
+  # repo-root proof homes for this slug (flat file, dir layout, runs/); co-located
+  # tools/*/docs/proof-of-done.md has no slug linkage, deliberately not scanned.
+  PFILES=$(ls "$ROOT/docs/verification/$SLUG.md" "$ROOT/docs/verification/$SLUG"/*.md \
+              "$ROOT/docs/verification/$SLUG"/runs/*.md 2>/dev/null || true)
+  # shellcheck disable=SC2086  # PFILES is a newline list of repo paths, splitting intended
+  COV=$(bash "$PGATE" coverage "$SPEC" $PFILES 2>/dev/null || true)
+  case "$COV" in
+    NO-MAP*)   echo "[advisory] test-plan coverage: spec '$SLUG' has a ## Test plan ($COV) but no proof doc for the slug carries a '## Test plan coverage' map; map each matrix row to its run or an explicit skip reason (docs/verification/README.md)" >&2 ;;
+    UNMAPPED*) echo "[advisory] test-plan coverage: proof map for '$SLUG' leaves test-plan matrix rows unmapped ($COV); map each row to a run or an explicit skip reason" >&2 ;;
+  esac
+fi
+
 LANE=$(grep -m1 -iE '^Lane:' "$SPEC" 2>/dev/null | sed -E 's/^[Ll]ane:[[:space:]]*//; s/[[:space:]].*$//' || true)
 if [ -z "$LANE" ]; then
   # Spec exists but declares no lane. In an ADOPTED repo (proof marker present) this is a gap,

--- a/lib/gate/proof-gate.sh
+++ b/lib/gate/proof-gate.sh
@@ -117,14 +117,68 @@ proof_contract() {
   echo "rigor: $(proof_requirement "$desc")"
 }
 
+# ID-466: test-plan -> proof-of-done coverage (ADVISORY; always exit 0). When the active
+# spec carries a `## Test plan` matrix, the proof doc owes a `## Test plan coverage` map
+# (docs/verification/README.md "Test plan coverage map") mapping each matrix row to the run
+# that exercised it, or an explicit skip reason. This subcommand only REPORTS; the warn
+# lives in hooks/ship-gate.sh and never blocks ("Detect, don't dictate").
+
+# _matrix_first_cells <file> <section-title> <ordinal-fallback:0|1>
+# Prints the first cell of each DATA row of the tables inside `## <section-title>` (exact
+# heading match, so "## Test plan critique" never counts as "## Test plan"). Structural
+# header detection, no keyword list: a `|` row is a separator when it holds only `| :-`
+# chars, and a row is a header when the NEXT row is a separator. With ordinal-fallback=1 a
+# non-integer first cell (the older `| Category | Case | How |` dialect) yields the row's
+# ordinal (1..N) instead, so both matrix dialects produce comparable row ids.
+_matrix_first_cells() {
+  awk -v sec="$2" -v ordfall="$3" '
+    substr($0, 1, 3) == "## " {
+      t = substr($0, 4); gsub(/[ \t]+$/, "", t)
+      insec = (t == sec); next
+    }
+    insec && /^\|/ { lines[++n] = $0 }
+    END {
+      for (i = 1; i <= n; i++) {
+        if (lines[i] ~ /^[| :\t-]+$/) continue                      # separator row
+        if (i < n && lines[i+1] ~ /^[| :\t-]+$/) continue           # header row
+        split(lines[i], a, "|"); c = a[2]; gsub(/^[ \t]+|[ \t]+$/, "", c)
+        if (c == "") continue
+        rows++
+        if (ordfall == 1 && c !~ /^[0-9]+$/) print rows; else print c
+      }
+    }' "$1" 2>/dev/null
+}
+
+proof_coverage() {
+  local spec="${1:-}"; shift 2>/dev/null || true
+  [ -n "$spec" ] && [ -f "$spec" ] || { echo "usage: proof-gate.sh coverage <spec-file> [proof.md ...]" >&2; return 64; }
+  local ids mapped="" f
+  ids="$(_matrix_first_cells "$spec" "Test plan" 1)"
+  [ -n "$ids" ] || { echo "no-test-plan"; return 0; }
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    mapped+="$(_matrix_first_cells "$f" "Test plan coverage" 0)"$'\n'
+  done
+  if [ -z "$(printf '%s' "$mapped" | tr -d '[:space:]')" ]; then
+    echo "NO-MAP rows=$(printf '%s\n' "$ids" | grep -c .)"; return 0
+  fi
+  local missing="" id
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    printf '%s\n' "$mapped" | grep -qxF "$id" || missing="$missing $id"
+  done <<< "$ids"
+  if [ -n "$missing" ]; then echo "UNMAPPED:$missing"; else echo "OK"; fi
+}
+
 main() {
   local sub="${1:-}"; shift || true
   case "$sub" in
     class)       proof_class "$@";;
     requirement) proof_requirement "$@";;
     contract)    proof_contract "$@";;
+    coverage)    proof_coverage "$@";;
     classes)     printf 'stateful\nbehavioral\ninert\n';;
-    *) echo "usage: proof-gate.sh {class \"<desc>\"|requirement \"<desc>\"|contract \"<desc>\"|classes}" >&2; return 64;;
+    *) echo "usage: proof-gate.sh {class \"<desc>\"|requirement \"<desc>\"|contract \"<desc>\"|coverage <spec> [proof.md ...]|classes}" >&2; return 64;;
   esac
 }
 

--- a/tests/test-ship-gate-coverage-map.sh
+++ b/tests/test-ship-gate-coverage-map.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# test-ship-gate-coverage-map.sh -- ID-466: spec ## Test plan -> proof-of-done coverage map.
+# The ship-gate WARNS (advisory, never blocks) when the spec has a test plan but the proof
+# doc carries no ## Test plan coverage map, or the map leaves matrix rows unmapped. No test
+# plan = no new requirement. Drives proof-gate.sh coverage directly, then hooks/ship-gate.sh
+# with crafted stdin (same harness shape as test-ship-gate-fail-closed.sh).
+set -uo pipefail
+KIT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+ok() { PASS=$((PASS + 1)); echo "ok - $1"; }
+no() { FAIL=$((FAIL + 1)); echo "NOT ok - $1"; }
+
+LOGDIR="$(mktemp -d)"   # isolate the gate-ledger store from the real one
+PG="$KIT/lib/gate/proof-gate.sh"
+
+# --- unit: proof-gate.sh coverage ---------------------------------------------------------
+FIX="$(mktemp -d)"
+cat > "$FIX/spec.md" <<'EOF'
+# Spec: x
+Lane: full
+
+## Test plan
+
+| # | Case | Category | Covers (AC) | Expected | Proof |
+|---|------|----------|-------------|----------|-------|
+| 1 | happy | happy-path | AC-1 | ok | cmd |
+| 2 | edge | boundary | AC-1 | ok | cmd |
+| 3 | fail | failure-injection | AC-2 | err | cmd |
+
+### Coverage notes
+- none
+
+## Test plan critique
+| # | Finding |
+|---|---|
+| 9 | a critique row, must not count as a plan row |
+
+## Verification
+EOF
+cat > "$FIX/spec-dialect.md" <<'EOF'
+## Test plan
+
+| Category | Case | How |
+|---|---|---|
+| Happy path | a | run it |
+| Edge | b | run it |
+EOF
+cat > "$FIX/spec-noplan.md" <<'EOF'
+# Spec: y
+Lane: tiny
+## Verification
+EOF
+cat > "$FIX/proof-full.md" <<'EOF'
+## Test plan coverage
+| Row | Run / skip reason |
+|---|---|
+| 1 | R1 |
+| 2 | R2 |
+| 3 | skipped: env-only |
+EOF
+cat > "$FIX/proof-partial.md" <<'EOF'
+## Test plan coverage
+| Row | Run / skip reason |
+|---|---|
+| 1 | R1 |
+EOF
+cat > "$FIX/proof-nomap.md" <<'EOF'
+Command: `x` Exit: 0 Verdict: PASS
+NEGATIVE CONTROL
+EOF
+
+[ "$(bash "$PG" coverage "$FIX/spec-noplan.md" "$FIX/proof-full.md")" = "no-test-plan" ] \
+  && ok "coverage: no ## Test plan -> no-test-plan" || no "no-plan spec should report no-test-plan"
+[ "$(bash "$PG" coverage "$FIX/spec.md" "$FIX/proof-nomap.md")" = "NO-MAP rows=3" ] \
+  && ok "coverage: plan + proof without map -> NO-MAP rows=3" || no "mapless proof should report NO-MAP"
+[ "$(bash "$PG" coverage "$FIX/spec.md")" = "NO-MAP rows=3" ] \
+  && ok "coverage: plan + no proof files -> NO-MAP" || no "no proof files should report NO-MAP"
+[ "$(bash "$PG" coverage "$FIX/spec.md" "$FIX/proof-partial.md")" = "UNMAPPED: 2 3" ] \
+  && ok "coverage: partial map -> UNMAPPED: 2 3" || no "partial map should report the unmapped rows"
+[ "$(bash "$PG" coverage "$FIX/spec.md" "$FIX/proof-full.md")" = "OK" ] \
+  && ok "coverage: all rows mapped -> OK (critique table not counted)" || no "full map should report OK"
+[ "$(bash "$PG" coverage "$FIX/spec-dialect.md" "$FIX/proof-partial.md")" = "UNMAPPED: 2" ] \
+  && ok "coverage: no-# dialect falls back to ordinals" || no "dialect matrix should use ordinal row ids"
+
+# --- hook: ship-gate advisory wiring ------------------------------------------------------
+mkrepo() { # $1=dir  (adopted repo: proof marker present)
+  git init -q -b master "$1"
+  git -C "$1" config user.email t@t; git -C "$1" config user.name t
+  mkdir -p "$1/docs/specs" "$1/docs/verification"
+  echo marker > "$1/docs/verification/README.md"
+  git -C "$1" add -A; git -C "$1" commit -qm init
+}
+
+gate() { # $1=repo  $2=command  $3=stderr-capture  -> echoes exit code
+  ( cd "$1" && printf '{"tool_input":{"command":"%s"}}' "$2" \
+      | CLAUDE_PLUGIN_ROOT="$KIT" DWARVES_KIT_LOG_DIR="$LOGDIR" bash "$KIT/hooks/ship-gate.sh" >/dev/null 2>"$3"; echo $? )
+}
+
+record_gates() { # $1=slug -- record every gate the full lane requires, so the lane arm passes
+  while read -r g; do
+    DWARVES_KIT_LOG_DIR="$LOGDIR" bash "$KIT/lib/gate/gate-ledger.sh" record "$1" "$g" ran "test" >/dev/null 2>&1
+  done < <(DWARVES_KIT_LOG_DIR="$LOGDIR" bash "$KIT/lib/gate/gate-ledger.sh" required full)
+}
+
+spec_with_plan() { # $1=path -- a full-lane spec carrying a 2-row ## Test plan
+  cat > "$1" <<'EOF'
+# Spec: x
+Status: DRAFT
+Lane: full
+
+## Test plan
+
+| # | Case | Category | Covers (AC) | Expected | Proof |
+|---|------|----------|-------------|----------|-------|
+| 1 | happy | happy-path | AC-1 | ok | cmd |
+| 2 | edge | boundary | AC-1 | ok | cmd |
+EOF
+}
+
+# (a) test plan + proof WITHOUT coverage map -> warning emitted, merge NOT blocked
+TA="$(mktemp -d)"; mkrepo "$TA"
+git -C "$TA" switch -qc feat/cmapa
+spec_with_plan "$TA/docs/specs/SPEC-001-cmapa.md"
+printf 'Command: `x`\nExit: 0\nVerdict: PASS\nNEGATIVE CONTROL\n' > "$TA/docs/verification/cmapa.md"
+git -C "$TA" add -A; git -C "$TA" commit -qm work
+record_gates cmapa
+EA="$(mktemp)"
+RCA="$(gate "$TA" 'git push -u origin HEAD' "$EA")"
+[ "$RCA" = 0 ] && grep -q '\[advisory\] test-plan coverage' "$EA" \
+  && ok "(a) plan + mapless proof -> advisory emitted, exit 0 (not blocked)" \
+  || no "(a) expected exit 0 + coverage advisory; got exit $RCA, stderr: $(cat "$EA")"
+
+# (b) all rows mapped -> no warning
+TB="$(mktemp -d)"; mkrepo "$TB"
+git -C "$TB" switch -qc feat/cmapb
+spec_with_plan "$TB/docs/specs/SPEC-001-cmapb.md"
+printf 'NEGATIVE CONTROL\nVerdict: PASS\n\n## Test plan coverage\n| Row | Run / skip reason |\n|---|---|\n| 1 | R1 |\n| 2 | skipped: covered by row 1 |\n' > "$TB/docs/verification/cmapb.md"
+git -C "$TB" add -A; git -C "$TB" commit -qm work
+record_gates cmapb
+EB="$(mktemp)"
+RCB="$(gate "$TB" 'git push -u origin HEAD' "$EB")"
+[ "$RCB" = 0 ] && ! grep -q '\[advisory\] test-plan coverage' "$EB" \
+  && ok "(b) all rows mapped -> no coverage advisory, exit 0" \
+  || no "(b) expected exit 0 + no coverage advisory; got exit $RCB, stderr: $(cat "$EB")"
+
+# (c) spec with NO test plan -> no warning (no new requirement, pass path unchanged)
+TC="$(mktemp -d)"; mkrepo "$TC"
+git -C "$TC" switch -qc feat/cmapc
+printf '# Spec: x\nStatus: DRAFT\nLane: full\n' > "$TC/docs/specs/SPEC-001-cmapc.md"
+git -C "$TC" add -A; git -C "$TC" commit -qm work
+record_gates cmapc
+EC="$(mktemp)"
+RCC="$(gate "$TC" 'git push -u origin HEAD' "$EC")"
+[ "$RCC" = 0 ] && ! grep -q '\[advisory\] test-plan coverage' "$EC" \
+  && ok "(c) no test plan -> no coverage advisory, exit 0" \
+  || no "(c) expected exit 0 + no coverage advisory; got exit $RCC, stderr: $(cat "$EC")"
+
+# (d) partially mapped -> advisory names the unmapped rows, still not blocked
+TD="$(mktemp -d)"; mkrepo "$TD"
+git -C "$TD" switch -qc feat/cmapd
+spec_with_plan "$TD/docs/specs/SPEC-001-cmapd.md"
+printf 'NEGATIVE CONTROL\nVerdict: PASS\n\n## Test plan coverage\n| Row | Run / skip reason |\n|---|---|\n| 1 | R1 |\n' > "$TD/docs/verification/cmapd.md"
+git -C "$TD" add -A; git -C "$TD" commit -qm work
+record_gates cmapd
+ED="$(mktemp)"
+RCD="$(gate "$TD" 'git push -u origin HEAD' "$ED")"
+[ "$RCD" = 0 ] && grep -q 'UNMAPPED: 2' "$ED" \
+  && ok "(d) partial map -> advisory names unmapped row 2, exit 0" \
+  || no "(d) expected exit 0 + UNMAPPED: 2 advisory; got exit $RCD, stderr: $(cat "$ED")"
+
+echo "---"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements ID-466: the test-plan-to-proof link was one-directional. `/kit:execute` consumes the spec's `## Test plan` Proof cells, but the ship-gate checked proof SHAPE only (green run + negative control), so a run could ignore the test plan entirely and still merge.

## What changed

- `lib/gate/proof-gate.sh`: new `coverage <spec> [proof.md ...]` subcommand (always exit 0, one-line verdict: `OK` / `NO-MAP rows=N` / `UNMAPPED: <rows>` / `no-test-plan`). Exact heading match, so `## Test plan critique` never counts as a plan. Header/separator rows are detected structurally (a row is a header when the next row is a separator), no keyword list. The older `| Category | Case | How |` dialect with no `#` column falls back to row ordinals.
- `hooks/ship-gate.sh`: after the spec resolves, when it carries a `## Test plan`, the hook scans the repo-root proof homes for the slug (flat `<slug>.md`, `<slug>/*.md`, `<slug>/runs/*.md`) and WARNS on a missing `## Test plan coverage` map or unmapped rows. Advisory only, stderr only, never changes an exit code (detect-not-dictate). No spec test plan = no new requirement; the existing pass path is byte-unchanged.
- `docs/verification/README.md`: documents the owed coverage-map shape (Row = the matrix `#` cell, or the ordinal for the no-`#` dialect; a skip needs a named reason).
- `tests/test-ship-gate-coverage-map.sh`: 6 unit + 4 hook cases, covering the three required behaviors: (a) plan + mapless proof warns without blocking, (b) all rows mapped emits no warning, (c) no test plan emits no warning, plus (d) partial map names the unmapped rows.

## Verification

Proof of done with negative control: `docs/verification/coverage-map-warn.md`. Green: new test 10/10, `test-hooks.sh` 492/492, both existing ship-gate tests, docs-wiring 22/22. Negative control: the new test run against master's gate scripts fails 8/10 (the two passes are absence assertions, noted honestly). `test-meta.sh` shows the same 10 pre-existing failures on this branch and on master (zero delta; the command-count drift is flagged in the implementation notes as its own follow-up).

Implementation notes (deltas + open questions): `docs/implementation-notes/coverage-map-warn.md`. Notably: the new test file is not registered in `.github/workflows/test.yml` because this unattended run must not write `.github/*` (the two existing ship-gate tests are also unregistered); co-located `tools/*/docs/proof-of-done.md` is deliberately not scanned (no slug linkage).

[unattended orchestrator run; journal queue-journal.tsv; slug dwarves-kit__ID-466]
