### PR TITLE
fix(queue): detect tail-rendered pending input in _mux_submit

### DIFF
--- a/docs/verification/submit-detect.md
+++ b/docs/verification/submit-detect.md
@@ -1,0 +1,61 @@
+# Proof of done: queue submit-detection fix (the 3-for-3 stranded-goal glitch)
+
+Profile: fix   Proof class: behavioral
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | A dropped Enter with the goal rendered tail-first (no `/goal` substring in the pane) is detected as still-pending and re-Entered until the input clears | PASS | R1 (T9) |
+| 2 | A bare prompt exits after one Enter, no retry storm | PASS | R1 (T10) |
+| 3 | Reverting only `lib/queue/queue.sh` reproduces the stranding in miniature: the loop exits after one dropped Enter and the pending input survives (negative control) | PASS | R2 |
+| 4 | Queue suite delta vs master is zero (the 3 pre-existing NC failures are identical on both) | PASS | R3 |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | `_mux_submit`'s still-pending check matched the literal `[>❯]\s*/goal`, but a long typed goal renders TAIL-first in the input box (`❯ (or "EXIT_SIGNAL...`), so `/goal` never appears at the prompt. The check reported "submitted" after the first (dropped) Enter and the row sat stranded with no journal entry. Three consecutive live runs reproduced it; one manual Enter unstuck each. New check: still pending iff any line renders a prompt char with content after it (`^\s*[>❯]\s*[^\s]`); a bare prompt means submitted. Warn on exhausting the 5 tries instead of silent success. |
+| Where | `lib/queue/queue.sh` `_mux_submit`; `tests/fixtures/queue/fake-mux` gains a `.pending` counter simulating the dropped-Enter state; `tests/test-queue.bats` T9/T10. |
+| Asymmetry argument | False "still pending" costs at most 4 harmless extra Enters on an empty prompt; false "submitted" strands the row. The check errs pending. |
+| Reversibility | `git revert`; behavior-only, no state. |
+
+## 3. Confirmation (runs)
+
+| Run | Command | Exit | Verdict |
+|---|---|---|---|
+| R1 | `bats tests/test-queue.bats -f "T9\|T10"` | 0 | PASS (2/2) |
+| R2 | `git stash push -- lib/queue/queue.sh` then re-run T9 | 1 | RED-as-expected, then restored green |
+| R3 | full `bats tests/test-queue.bats` on this branch AND on a pristine master worktree | - | identical failure sets (NC2, NC6, NC7 pre-existing on both; delta zero) |
+
+## 4. Run detail
+
+### R1 GREEN
+```
+ok 1 T9 submit-retry: tail-rendered pending input is re-Entered until clear
+ok 2 T10 submit-bare-prompt: bare prompt exits after one Enter
+```
+T9 seeds `pending=2` (two dropped Enters), asserts the pending state clears and exactly 2 Enters were sent. Its premise guard asserts the stuck rendering contains NO `/goal` substring, the exact condition that blinded the old regex.
+
+### R2 NEGATIVE CONTROL
+```
+$ git stash push -q -- lib/queue/queue.sh    # old detection back
+not ok 2 T9 submit-retry: tail-rendered pending input is re-Entered until clear
+#   `[ ! -f "$QSTUB/s7.pending" ]                    # input eventually cleared' failed
+$ git stash pop -q
+ok 2 T9 submit-retry: tail-rendered pending input is re-Entered until clear
+```
+The failure lands on "input eventually cleared": with the old regex the loop exits after one dropped Enter believing it submitted, leaving the goal pending, the live failure mode in miniature.
+
+### R3 delta-zero
+```
+branch: not ok 9 NC2 / not ok 13 NC6 / not ok 14 NC7
+master: not ok 9 NC2 / not ok 13 NC6 / not ok 14 NC7
+```
+Identical sets. The three pre-existing failures are false-done/stall guards and are filed as their own board row; this branch neither fixes nor worsens them.
+
+## 5. Reproduce
+
+```
+bats tests/test-queue.bats -f "T9|T10"
+```

--- a/lib/queue/queue.sh
+++ b/lib/queue/queue.sh
@@ -396,18 +396,26 @@ _mux_wait_ready() {  # slug
 }
 
 # Submit the typed goal, then VERIFY it actually submitted and re-issue Enter if not. The live
-# smoke proved a single early Enter can be dropped while the text stays sitting on the `/goal`
-# input line; re-issuing until the prompt no longer shows the pending `/goal` command makes the
-# submit deterministic. Bounded (5 tries); an extra Enter on an empty prompt is a harmless no-op.
+# smoke proved a single early Enter can be dropped while the text stays sitting on the input
+# line; re-issuing until the input line is BARE makes the submit deterministic. Bounded (5
+# tries); an extra Enter on an empty prompt is a harmless no-op.
+#
+# Detection is "prompt char followed by ANY content", not the literal `/goal`: a long paste
+# renders TAIL-first in the input box (the pane shows `❯ (or "EXIT_SIGNAL...`, never `❯ /goal`),
+# so the old `/goal` match reported submitted after one dropped Enter and stranded the row with
+# no journal entry. Three consecutive live runs reproduced it; one manual Enter unstuck each.
+# False "still pending" only costs harmless extra Enters, false "submitted" strands the row,
+# so the check errs pending.
 _mux_submit() {  # slug
   local slug="$1" tries=0
   while [ "$tries" -lt 5 ]; do
     _mux_enter "$slug"
     sleep "$QUEUE_SUBMIT_SETTLE_SECS"
-    # unsent iff the input prompt line still carries the pending `/goal` command
-    _mux_capture "$slug" 2>/dev/null | grep -qE '[>❯][[:space:]]*/goal' || return 0
+    # submitted iff no line renders a prompt char with content still after it
+    _mux_capture "$slug" 2>/dev/null | grep -qE '^[[:space:]]*[>❯][[:space:]]*[^[:space:]]' || return 0
     tries=$((tries + 1))
   done
+  _warn "queue: $slug submit unconfirmed after $tries tries; the goal may still be sitting unsubmitted in the window."
   return 0
 }
 

--- a/tests/fixtures/queue/fake-mux
+++ b/tests/fixtures/queue/fake-mux
@@ -35,6 +35,13 @@ case "$verb" in
     last="${args[$(( ${#args[@]} - 1 ))]:-}"
     if [ "$last" = "Enter" ]; then
       printf 'enter slug=%s\n' "$slug" >> "$QLOG"
+      # stuck-input simulation: each Enter decrements the pending counter; at 0 the input
+      # clears (the submit finally took), mirroring the live dropped-Enter failure mode
+      if [ -f "$QSTUB/$slug.pending" ]; then
+        n="$(cat "$QSTUB/$slug.pending")"
+        n=$((n - 1))
+        if [ "$n" -le 0 ]; then rm -f "$QSTUB/$slug.pending"; else printf '%s' "$n" > "$QSTUB/$slug.pending"; fi
+      fi
     else
       # the literal typed text is the last arg (after `-l --`); record it verbatim (NC5 proof)
       printf 'type slug=%s text=%s\n' "$slug" "$last" >> "$QLOG"
@@ -42,6 +49,11 @@ case "$verb" in
     exit 0 ;;
   capture-pane)
     [ -f "$QSTUB/$slug.dead" ] && exit 1
+    if [ -f "$QSTUB/$slug.pending" ]; then
+      # a long typed goal renders TAIL-first in the input box: no `/goal` substring anywhere
+      printf '❯ (or "EXIT_SIGNAL: false" if you are not done), plus "REASON: <why>".\n'
+      exit 0
+    fi
     [ -f "$QSTUB/$slug.transcript" ] && cat "$QSTUB/$slug.transcript"
     exit 0 ;;
   *) exit 0 ;;

--- a/tests/test-queue.bats
+++ b/tests/test-queue.bats
@@ -268,3 +268,27 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
   [ -z "$(jverdict s3n)" ]                       # row 3 never attempted -> no journal row
   echo "$output" | grep -q "STOP THE NIGHT"
 }
+
+# =============================================================================================
+# T9 submit-retry: a dropped Enter with the goal rendered TAIL-first (no `/goal` substring in
+# the pane) is detected as still-pending and re-Entered until the input clears. Pins the fix
+# for the 3-for-3 live stranding: the old `[>❯]\s*/goal` match saw the tail rendering, reported
+# submitted after one dropped Enter, and the row sat idle with no journal entry.
+@test "T9 submit-retry: tail-rendered pending input is re-Entered until clear" {
+  . "$QUEUE"
+  printf '2' > "$QSTUB/s7.pending"                # first 2 Enters drop; 3rd not needed
+  # premise guard: the stuck rendering must NOT contain `/goal` (what broke the old regex)
+  "$MUX_CMD" capture-pane -t "q:s7" | grep -vq '/goal'
+  _mux_submit s7
+  [ ! -f "$QSTUB/s7.pending" ]                    # input eventually cleared
+  [ "$(grep -c 'enter slug=s7' "$QLOG")" -eq 2 ]  # exactly the 2 Enters needed, then stopped
+}
+
+# T10 submit-bare-prompt: an already-clear (bare `❯`) prompt submits on the first Enter, no
+# retry storm -- the empty-input rendering must not read as pending.
+@test "T10 submit-bare-prompt: bare prompt exits after one Enter" {
+  . "$QUEUE"
+  printf '❯ \n' > "$QSTUB/s8.transcript"
+  _mux_submit s8
+  [ "$(grep -c 'enter slug=s8' "$QLOG")" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- The queue launcher's submit verification matched `❯ /goal` at the prompt, but a long typed goal renders TAIL-first in the input box, so a dropped Enter read as submitted and the row stranded silently (3-for-3 across the live #auto pilot runs; each needed one manual Enter).
- New detection: still pending iff any line renders a prompt char with content after it; bare prompt = submitted. Warn on retry exhaustion instead of silent success. False-pending costs harmless extra Enters; false-submitted strands the row, so the check errs pending.

## Test plan
- [x] T9: pending=2 simulation clears after exactly 2 Enters; premise guard proves the stuck rendering has no `/goal` substring
- [x] T10: bare prompt exits after one Enter, no retry storm
- [x] Negative control: reverting queue.sh alone re-strands the pending input (T9 red), restore green
- [x] Full queue suite delta vs master: zero (NC2/NC6/NC7 fail identically on both, pre-existing, filed separately)
- Full transcript: `docs/verification/submit-detect.md`