### PR TITLE
fix(queue): pre-flight the /goal 4000-char cap before a window opens

### DIFF
--- a/docs/verification/goal-char-budget.md
+++ b/docs/verification/goal-char-budget.md
@@ -1,0 +1,60 @@
+# Proof of done: /goal char-budget pre-flight
+
+Profile: fix   Proof class: behavioral
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | A pointer whose `/goal` line exceeds the 4000-char cap fails fast to journal `error`, no window opened | PASS | R1 (T11) |
+| 2 | A normal-size pointer is unaffected: window opens, run completes | PASS | R1 (T12) |
+| 3 | Reverting the length check alone reproduces the silent-strand shape on the same fixture (negative control) | PASS | R2 |
+| 4 | Full queue suite delta vs master is zero | PASS | R3 |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | The interactive `/goal` command refuses anything over 4000 chars, but nothing in the launcher checked this before typing. An over-budget pointer used to open a real window, type text `/goal` silently rejected, and sit there forever: no journal entry, no error, just an idle pane. Reproduced live once (ID-309's first attempt). New `QUEUE_GOAL_CHAR_LIMIT` (default 4000) is checked in `_launch_once` right after `_goal_line` computes the full text, BEFORE `_mux_open`, so an over-budget pointer never wastes a window at all, on either the first attempt or the single retry. |
+| Where | `lib/queue/queue.sh`: one new env default, `_launch_once` reordered so `_goal_line` runs before `_mux_open`. `tests/test-queue.bats` T11/T12. |
+| Reversibility | `git revert`; pure pre-flight check, no state. |
+
+## 3. Confirmation (runs)
+
+| Run | Command | Exit | Verdict |
+|---|---|---|---|
+| R1 | `bats tests/test-queue.bats -f "T11\|T12"` | 0 | PASS (2/2) |
+| R2 | `git stash push -- lib/queue/queue.sh`, re-run T11 | 1 | RED-as-expected; restore green |
+| R3 | full `bats tests/test-queue.bats` on this branch vs a pristine master worktree | - | identical failure set (NC2/NC6/NC7, filed as ID-468) |
+
+## 4. Run detail
+
+### R1 GREEN
+```
+ok 1 T11 goal-over-budget: fails fast to error, no window opened
+ok 2 T12 goal-under-budget: unaffected, window opens and completes
+```
+T11 seeds a 4200-char pointer file (well past the ~4000 cap even after the `/goal ` prefix and
+the EXIT_SIGNAL/draft-PR suffixes), asserts the journal verdict is `error` and that
+`new-window slug=big11` never appears in the mux verb log.
+
+### R2 NEGATIVE CONTROL
+```
+$ git stash push -q -- lib/queue/queue.sh
+not ok 1 T11 goal-over-budget: fails fast to error, no window opened
+#   `[ "$(jverdict big11)" = "error" ]' failed
+$ git stash pop -q
+ok 1 T11 goal-over-budget: fails fast to error, no window opened
+```
+Without the check, the oversized pointer no longer journals `error` (the old code has no
+concept of the budget at all, so the run proceeds to open a window and, in the real product,
+would sit there with the goal silently rejected).
+
+### R3 delta-zero
+Same three pre-existing failures (NC2, NC6, NC7) on this branch and on pristine master.
+
+## 5. Reproduce
+
+```
+bats tests/test-queue.bats -f "T11|T12"
+```

--- a/lib/queue/queue.sh
+++ b/lib/queue/queue.sh
@@ -93,6 +93,11 @@ QUEUE_RETRY_SLEEP_SECS="${QUEUE_RETRY_SLEEP_SECS:-1800}"
 # submits. Both configurable; tests set them to 0.
 QUEUE_STARTUP_SECS="${QUEUE_STARTUP_SECS:-20}"
 QUEUE_SUBMIT_SETTLE_SECS="${QUEUE_SUBMIT_SETTLE_SECS:-2}"
+# The interactive `/goal` command itself refuses anything over 4000 chars ("Goal condition is
+# limited to 4000 characters"). Checked before a window ever opens (_launch_once), not caught
+# after typing: a silent over-budget goal used to strand the row with no window, no journal
+# entry, nothing but an idle tmux pane an operator had to notice by hand.
+QUEUE_GOAL_CHAR_LIMIT="${QUEUE_GOAL_CHAR_LIMIT:-4000}"
 QUEUE_BOARD_CMD="${QUEUE_BOARD_CMD:-board}"
 # SPEC-200 I3 / SPEC-097: the journal lives under the ONE durable root, resolved by the ONE
 # resolver (KIT_LEDGER_DIR -> DWARVES_KIT_LOG_DIR -> kit.toml [ledger].location -> XDG state).
@@ -508,15 +513,19 @@ _launch_once() {  # slug repo pointer
   local slug="$1" repo="$2" pointer="$3"
   # A stale status file from a PREVIOUS attempt would answer for this one. Clear before launching.
   local sf; sf=$(_run_file "$slug" status 2>/dev/null) && [ -n "$sf" ] && rm -f "$sf" 2>/dev/null
-  _beat "$slug"
-  _mux_open "$slug" "$repo" || return 2
-  _mux_wait_ready "$slug"
-  # Captured before typing, so a sanitizer that cannot run refuses the launch instead of typing an
-  # empty prompt (a `$( )` failure is invisible to the command it feeds).
+  # Computed BEFORE any window opens: _goal_line depends on nothing window-related (pointer file
+  # + slug + env), so an over-budget or unsanitizable pointer fails fast here, no window wasted.
   local goal
   goal=$(_goal_line "$pointer" "$slug") || {
     _warn "queue: $slug refusing to launch (the untrusted-input pass could not run)"
-    _mux_kill "$slug"; return 2; }
+    return 2; }
+  if [ "${#goal}" -gt "$QUEUE_GOAL_CHAR_LIMIT" ]; then
+    _warn "queue: $slug refusing to launch; goal is ${#goal} chars, over the ${QUEUE_GOAL_CHAR_LIMIT}-char /goal limit. Shorten the pointer file (.claude/goals/<slug>.md)."
+    return 2
+  fi
+  _beat "$slug"
+  _mux_open "$slug" "$repo" || return 2
+  _mux_wait_ready "$slug"
   _mux_type "$slug" "$goal" || { _mux_kill "$slug"; return 2; }
   _mux_submit "$slug"
 

--- a/tests/test-queue.bats
+++ b/tests/test-queue.bats
@@ -292,3 +292,33 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
   _mux_submit s8
   [ "$(grep -c 'enter slug=s8' "$QLOG")" -eq 1 ]
 }
+
+# =============================================================================================
+# T11 goal-over-budget: a pointer whose /goal line exceeds the interactive 4000-char cap fails
+# fast to `error`, with NO window ever opened -- pins the fix for the silent-strand bug (an
+# over-budget goal used to type into a real window and sit there forever, no journal entry,
+# nothing but an idle pane an operator had to notice by hand across 3 live runs).
+@test "T11 goal-over-budget: fails fast to error, no window opened" {
+  local repo="$WORK/r11"; mkrepo "$repo"
+  python3 -c "print('x' * 4200)" > "$WORK/p11.txt"
+  row big11 "$repo" "$WORK/p11.txt" > "$WORK/q.tsv"
+
+  QUEUE_RETRY_SLEEP_SECS=0 run bash "$QUEUE" run "$WORK/q.tsv"
+  [ "$status" -eq 0 ]
+  [ "$(jverdict big11)" = "error" ]
+  ! grep -q "new-window slug=big11" "$QLOG"
+}
+
+# T12 goal-under-budget: a normal-size pointer is unaffected by the new check (regression guard
+# alongside T1, run through the SAME real `queue run` path with the length check now present).
+@test "T12 goal-under-budget: unaffected, window opens and completes" {
+  local repo="$WORK/r12"; mkrepo "$repo"
+  echo "report HEAD then end" > "$WORK/p12.txt"
+  seed_transcript ok12 "  RUNNER_DONE"
+  row ok12 "$repo" "$WORK/p12.txt" > "$WORK/q.tsv"
+
+  run bash "$QUEUE" run "$WORK/q.tsv"
+  [ "$status" -eq 0 ]
+  [ "$(jverdict ok12)" = "done" ]
+  grep -q "new-window slug=ok12" "$QLOG"
+}


### PR DESCRIPTION
## Summary
- Interactive `/goal` refuses anything over 4000 chars, but the launcher never checked this before typing, so an over-budget pointer opened a real window, typed a silently-rejected goal, and sat idle forever with no journal entry (reproduced live on ID-309's first attempt).
- New `QUEUE_GOAL_CHAR_LIMIT` (default 4000), checked in `_launch_once` right after `_goal_line` computes the text and before `_mux_open`, so both the first attempt and the single retry fail fast to `error`, zero windows wasted.

## Test plan
- [x] T11: a 4200-char pointer journals `error`, no window ever opened
- [x] T12: a normal-size pointer unaffected, window opens and completes
- [x] Negative control: reverting the check alone reproduces the missed-strand on the same fixture
- [x] Full suite delta vs master: zero (NC2/NC6/NC7 pre-existing, filed as ID-468)
- Full transcript: `docs/verification/goal-char-budget.md`