### PR TITLE
docs: retire literal roster counts, keep row-completeness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Within one spec, tasks run sequentially. Across specs, `/kit:dispatch` fans out 
 ## What it does
 
 <details>
-<summary><b>Hooks</b> (25, automatic, event-triggered)</summary>
+<summary><b>Hooks</b> (automatic, event-triggered)</summary>
 
 | Hook | Event | What it does |
 |------|-------|-------------|
@@ -252,7 +252,7 @@ Which hooks BLOCK vs warn vs neither is a declared contract: `docs/architecture.
 </details>
 
 <details>
-<summary><b>Commands</b> (36, manual, human-triggered)</summary>
+<summary><b>Commands</b> (manual, human-triggered)</summary>
 
 | Command | Phase | What it does |
 |---------|-------|-------------|
@@ -296,7 +296,7 @@ Which hooks BLOCK vs warn vs neither is a declared contract: `docs/architecture.
 </details>
 
 <details>
-<summary><b>Agents</b> (28, dispatched by commands) and <b>Skills</b> (9, Claude-triggered)</summary>
+<summary><b>Agents</b> (dispatched by commands) and <b>Skills</b> (Claude-triggered)</summary>
 
 | Agent | Dispatched by | What it does |
 |-------|--------------|-------------|
@@ -372,9 +372,9 @@ dwarves-kit/
   .claude-plugin/               Plugin install path (plugin.json, marketplace.json)
   .github/workflows/test.yml    CI: macOS + Ubuntu test matrix
   bin/                          STABLE consumer entrypoints (SPEC-184, one `<subsystem> <verb>` grammar per ADR-0034): `board`/`classify`/`gate`/`goal`/`learn`/`mega`/`queue`/`session`/`spec`/`stats` thin forwarders to `lib/<subsystem>/`, plus the two module CLIs (`prose-rag`, `worktree-provision`) that keep their module names. A consumer (an adopted repo's board shim, the adopt-injected CLAUDE.md block) references `$DWARVES_KIT/bin/<name>`, NEVER a deep lib path, so an internal lib reorg cannot silently break it (the board-shim class of bug). Deployed by install.sh next to lib/.
-  agents/                       (28 files) Subagents dispatched by commands
-  commands/                     (36 markdown command prompts)
-  hooks/                        (25 scripts + hooks.json plugin manifest)
+  agents/                       Subagents dispatched by commands
+  commands/                     Markdown command prompts
+  hooks/                        Hook scripts + hooks.json plugin manifest
   lib/gate/dispatch-gate.sh          Disjointness gate + drift guard for /kit:dispatch (pure-bash concurrency moat)
   lib/classify/lane-classify.sh          Deterministic task-type -> risk-lane classifier + advisory floor check (used by /kit:assign + /kit:dispatch); optional `--files "<paths>"` on classify/explain/check escalates the kit-machinery gate on an actual EDIT to lib/ or hooks/, not a mere textual mention (SPEC-105, edit-vs-mention)
   lib/goal/goal-registry.sh          Cross-session running-goal registry: claim/list/log/release (multi-session moat + monitor)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,8 +78,6 @@ Where they meet: the native `claude agents` view monitors the subagents inside *
 
 Every command and agent mapped to its V-model arm, grouped so the left side (BUILD) and the right side (TEST) read at a glance. The **left arm** decomposes and implements; the **right arm** plans, executes, and reports the tests; **Code** is the vertex. **Static quality gates** verify each artifact by review (not test execution) at its phase; **cross-phase** entries sit outside it.
 
-Total: 36 commands + 28 agents = **64 entries**.
-
 ### Left arm: BUILD (decompose + implement)
 
 | Entry | Type | V-phase | Arm | Note |

--- a/docs/verification/no-roster-counts.md
+++ b/docs/verification/no-roster-counts.md
@@ -1,0 +1,67 @@
+# Proof of done: no-counts policy (retire literal roster numbers from the docs)
+
+Profile: fix   Proof class: behavioral
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | README.md and docs/architecture.md carry no literal roster counts (headers, layout comments, headline tally) | PASS | R1 |
+| 2 | Row-completeness checks survive: live tree vs doc table rows, both sides computed, no maintained number | PASS | R1 |
+| 3 | A reintroduced count fails the new tripwire (negative control) | PASS | R2 |
+| 4 | `sync_counts` (whose sole job was maintaining those numbers) is gone; a suite run leaves the tree byte-identical | PASS | R3 |
+
+## 2. Rationale and implementation
+
+Operator policy (2026-08-10): roster counts in prose churn on every addition and cost more to
+maintain than they inform. The ops-toolkit convention already says it: "no hardcoded counts in
+docs; if a count is load-bearing, derive it."
+
+| Aspect | Detail |
+|---|---|
+| Docs | README.md: numbers stripped from the Hooks/Commands/Agents+Skills summary headers and the three directory-layout comments. architecture.md: the `Total: N commands + N agents = **N entries**.` headline removed (the inventory table itself is the truth). |
+| Registry | `lib/registry/feature-registry.sh` loses `sync_counts` and its call: with no numbers to sync, its only remaining effect was rewriting files. `generate` still produces `docs/FEATURES.md` unchanged. |
+| Tests | `tests/test-meta.sh`: the literal-number assertions (SPEC-113 layout counts, SG-10 header counts, architecture headline, SPEC-085 summary parity) are replaced by two NO-COUNT tripwires (a stray number failing loudly) while every row-completeness check stays: README hooks/commands/agents/skills table rows == live files, architecture inventory rows == live count. A new command still cannot ship without its doc rows. |
+| Reversibility | `git revert`. |
+
+## 3. Confirmation (runs)
+
+| Run | Command | Exit | Verdict |
+|---|---|---|---|
+| R1 | `bash tests/test-meta.sh` on the de-numbered tree | 0 | PASS (799/799) |
+| R2 | reintroduce `(36, ` in the Commands header, rerun | 1 | RED: `README carries no literal roster counts ... got '1'` |
+| R3 | checksum README/architecture/FEATURES, run suite, re-verify | 0 | byte-identical |
+
+## 4. Run detail
+
+### R1 GREEN
+```
+Passed: 799 / 799
+All meta tests passed.
+```
+(Total assertions drop from 809: the retired count assertions leave the suite, the two
+tripwires join it.)
+
+### R2 NEGATIVE CONTROL
+```
+FAIL README carries no literal roster counts (headers/layout) (expected '0', got '1')
+```
+A process note for honesty: the first restore after this control used `git checkout --
+README.md` while the de-numbering edits were still unstaged, reverting them to the committed
+(counted) version; the tripwire then reported all 6 original counts, which is itself a second
+demonstration that it catches real strays. Edits re-applied and staged; final state green.
+
+### R3 NO-MUTATION
+```
+suite exit=0
+README.md: OK
+docs/architecture.md: OK
+docs/FEATURES.md: OK
+```
+
+## 5. Reproduce
+
+```
+bash tests/test-meta.sh
+grep -cE '<b>(Agents|Commands|Skills|Hooks)</b> \([0-9]+' README.md   # 0
+```

--- a/lib/registry/feature-registry.sh
+++ b/lib/registry/feature-registry.sh
@@ -199,55 +199,6 @@ generate() {
     hooks_table
   } > "$tmp"
   mv -f "$tmp" "$out"
-  # Only auto-heal the hand-maintained README/architecture.md count strings when
-  # regenerating the REAL registry in place. A caller regenerating to a throwaway
-  # path (tests/test-meta.sh's SPEC-219 freshness check runs `generate` against a
-  # tempfile to diff, never to keep) is a read-only drift check and must never
-  # mutate other files as a side effect -- that silently masked drift instead of
-  # reporting it.
-  if [ "$out" = "$KIT_DIR/docs/FEATURES.md" ]; then
-    sync_counts
-  fi
-}
-
-# Patches the hand-maintained "N commands / N agents / ..." count strings in
-# README.md and docs/architecture.md to the live file counts. Everything here
-# is arithmetic derived from `ls`; no judgment, no prose to write. Table ROWS
-# (one sentence per command/agent) still need a human , this only kills the
-# recompute-and-retype-the-numbers step.
-sync_counts() {
-  local cmd_count agt_count hook_count skill_count total
-  cmd_count=$(ls "$KIT_DIR"/commands/*.md 2>/dev/null | wc -l | tr -d ' ')
-  agt_count=$(ls "$KIT_DIR"/agents/*.md 2>/dev/null | wc -l | tr -d ' ')
-  hook_count=$(ls "$KIT_DIR"/hooks/*.sh 2>/dev/null | wc -l | tr -d ' ')
-  skill_count=$(ls "$KIT_DIR"/skills/*/SKILL.md 2>/dev/null | wc -l | tr -d ' ')
-  total=$((cmd_count + agt_count))
-
-  local readme="$KIT_DIR/README.md"
-  local rtmp="$readme.tmp.$$"
-  trap "rm -f '$rtmp'" EXIT
-  sed -E \
-    -e "s/(agents\/ *\()[0-9]+( files)/\\1${agt_count}\\2/" \
-    -e "s/(commands\/ *\()[0-9]+( markdown)/\\1${cmd_count}\\2/" \
-    -e "s/(hooks\/ *\()[0-9]+( scripts)/\\1${hook_count}\\2/" \
-    -e "s/(<b>Agents<\/b> \()[0-9]+(,)/\\1${agt_count}\\2/" \
-    -e "s/(<b>Commands<\/b> \()[0-9]+(,)/\\1${cmd_count}\\2/" \
-    -e "s/(<b>Skills<\/b> \()[0-9]+(,)/\\1${skill_count}\\2/" \
-    -e "s/(<b>Hooks<\/b> \()[0-9]+(,)/\\1${hook_count}\\2/" \
-    "$readme" > "$rtmp"
-  mv -f "$rtmp" "$readme"
-
-  local arch="$KIT_DIR/docs/architecture.md"
-  local atmp="$arch.tmp.$$"
-  trap "rm -f '$rtmp' '$atmp'" EXIT
-  # drops the untested "(N build · N code · ...)" phase breakdown: it drifted
-  # silently (no test ever checked it) and the inventory table above already
-  # shows each entry's Arm; keeping a second, unverified tally of the same
-  # data was pure toil for zero signal.
-  sed -E \
-    -e "s/^Total: [0-9]+ commands \+ [0-9]+ agents = \*\*[0-9]+ entries\*\*.*/Total: ${cmd_count} commands + ${agt_count} agents = **${total} entries**./" \
-    "$arch" > "$atmp"
-  mv -f "$atmp" "$arch"
 }
 
 case "${1:-}" in

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -1560,30 +1560,21 @@ LIVE_COUNT=$((CMD_COUNT + AGT_COUNT))
 assert_eq "architecture.md inventory table rows == live file count ($ARCH_TABLE_ROWS == $LIVE_COUNT)" \
   "$LIVE_COUNT" "$ARCH_TABLE_ROWS"
 
-# SPEC-113: the README directory-layout counts stay pinned to the LIVE file counts (the 11-vs-live
-# agents drift class , "died untested once, never again" , dies like the architecture pin above).
-README_AGT=$(grep -oE 'agents/ *\([0-9]+ files\)' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
-README_HOOK=$(grep -oE 'hooks/ *\([0-9]+ ' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
+# No-counts policy (2026-08-10): the docs carry NO literal roster numbers (they churned on
+# every addition and cost more to maintain than they informed; the operator retired them).
+# Completeness is still pinned below by the ROW checks, live tree vs table rows, both sides
+# computed, no hand-maintained number anywhere.
 HOOK_COUNT=$(ls "$KIT_DIR/hooks/"*.sh 2>/dev/null | wc -l | tr -d ' ')
-assert_eq "README agents/ layout count == live agents ($README_AGT == $AGT_COUNT)" "$AGT_COUNT" "$README_AGT"
-assert_eq "README hooks/ layout count == live hooks ($README_HOOK == $HOOK_COUNT)" "$HOOK_COUNT" "$README_HOOK"
 
 # SG-10 (harness-loop): the README inventory TABLES (not just the layout comment) stay
 # pinned to live counts , the agents table sat at 11 rows against 25 files because only
 # the layout number was pinned. Both the <summary> header number and the table row count
 # are computed and compared; a new agent/command/skill without a README row fails here.
-README_CMD_LAYOUT=$(grep -oE 'commands/ *\([0-9]+ ' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
-assert_eq "README commands/ layout count == live commands ($README_CMD_LAYOUT == $CMD_COUNT)" "$CMD_COUNT" "$README_CMD_LAYOUT"
-
-AGT_HDR=$(grep -oE '<b>Agents</b> \([0-9]+' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
-CMD_HDR=$(grep -oE '<b>Commands</b> \([0-9]+' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
-SKILL_HDR=$(grep -oE 'Skills</b> \([0-9]+' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
-HOOK_HDR=$(grep -oE '<b>Hooks</b> \([0-9]+' "$KIT_DIR/README.md" | grep -oE '[0-9]+' | head -1)
 SKILL_COUNT=$(ls "$KIT_DIR/skills/"*/SKILL.md 2>/dev/null | wc -l | tr -d ' ')
-assert_eq "README Agents header count == live agents ($AGT_HDR == $AGT_COUNT)" "$AGT_COUNT" "$AGT_HDR"
-assert_eq "README Commands header count == live commands ($CMD_HDR == $CMD_COUNT)" "$CMD_COUNT" "$CMD_HDR"
-assert_eq "README Skills header count == live skills/*/SKILL.md ($SKILL_HDR == $SKILL_COUNT)" "$SKILL_COUNT" "$SKILL_HDR"
-assert_eq "README Hooks header count == live hooks ($HOOK_HDR == $HOOK_COUNT)" "$HOOK_COUNT" "$HOOK_HDR"
+# No-counts policy: header/layout numbers retired; a stray survivor fails here so one can
+# never quietly come back and start drifting again.
+assert_eq "README carries no literal roster counts (headers/layout)" "0" \
+  "$(grep -cE '<b>(Agents|Commands|Skills|Hooks)</b> \([0-9]+|(agents|commands|hooks)/ *\([0-9]+' "$KIT_DIR/README.md" | tr -d ' ')"
 
 # Table row counts (data rows only: exclude the header row and |--- separator).
 AGT_DETAILS=$(sed -n '/<summary><b>Agents<\/b>/,/<\/details>/p' "$KIT_DIR/README.md")
@@ -1598,14 +1589,9 @@ assert_eq "README skills table rows == live skills ($README_SKILL_ROWS == $SKILL
 assert_eq "README commands table rows == live commands ($README_CMD_ROWS == $CMD_COUNT)" "$CMD_COUNT" "$README_CMD_ROWS"
 assert_eq "README hooks table rows == live hooks ($README_HOOK_ROWS == $HOOK_COUNT)" "$HOOK_COUNT" "$README_HOOK_ROWS"
 
-# architecture.md headline numbers (the "25 commands + 15 agents = 40" drift class):
-# all three computed from the live tree, never hand-trusted.
-ARCH_HEAD_CMD=$(grep -oE 'Total: [0-9]+ commands' "$KIT_DIR/docs/architecture.md" | grep -oE '[0-9]+' | head -1)
-ARCH_HEAD_AGT=$(grep -oE '\+ [0-9]+ agents' "$KIT_DIR/docs/architecture.md" | grep -oE '[0-9]+' | head -1)
-ARCH_HEAD_TOT=$(grep -oE '= \*\*[0-9]+ entries\*\*' "$KIT_DIR/docs/architecture.md" | grep -oE '[0-9]+' | head -1)
-assert_eq "architecture.md headline commands == live ($ARCH_HEAD_CMD == $CMD_COUNT)" "$CMD_COUNT" "$ARCH_HEAD_CMD"
-assert_eq "architecture.md headline agents == live ($ARCH_HEAD_AGT == $AGT_COUNT)" "$AGT_COUNT" "$ARCH_HEAD_AGT"
-assert_eq "architecture.md headline total == live ($ARCH_HEAD_TOT == $LIVE_COUNT)" "$LIVE_COUNT" "$ARCH_HEAD_TOT"
+# No-counts policy: the architecture.md headline tally is retired the same way.
+assert_eq "architecture.md carries no headline roster tally" "0" \
+  "$(grep -cE '^Total: [0-9]+ commands' "$KIT_DIR/docs/architecture.md" | tr -d ' ')"
 
 # The README five-stage table covers every module the registry assigns a stage (ADR-0034
 # decision 3 rendered without omissions; the two tables share one truth). "leg" renamed to
@@ -2734,17 +2720,12 @@ echo ""
 echo "=== SPEC-085: operator doc sync (ID-070) ==="
 # ============================================================
 RM85="$KIT_DIR/README.md"
-# parity: hooks , summary number == file count == row count (all computed)
+# parity: ROW counts only (summary-header numbers retired by the no-counts policy 2026-08-10)
 HF=$(ls "$KIT_DIR"/hooks/*.sh | wc -l | tr -d ' ')
-HSUM=$(grep -oE '<summary><b>Hooks</b> \(([0-9]+)' "$RM85" | grep -oE '[0-9]+' || echo 0)
 HROWS=$(awk '/<summary><b>Hooks<\/b>/,/<\/details>/' "$RM85" | grep -cE '^\| [a-z]' || true)
-assert_eq "README hooks summary == hook files ($HF)" "$HF" "$HSUM"
 assert_eq "README hooks rows == hook files ($HF)" "$HF" "$HROWS"
-# parity: commands
 CF=$(ls "$KIT_DIR"/commands/*.md | wc -l | tr -d ' ')
-CSUM=$(grep -oE '<summary><b>Commands</b> \(([0-9]+)' "$RM85" | grep -oE '[0-9]+' || echo 0)
 CROWS=$(awk '/<summary><b>Commands<\/b>/,/<\/details>/' "$RM85" | grep -cE '^\| /kit:' || true)
-assert_eq "README commands summary == command files ($CF)" "$CF" "$CSUM"
 assert_eq "README commands rows == command files ($CF)" "$CF" "$CROWS"
 # content: the hard hook is in the public table; the two missing commands exist
 RC=0; awk '/<summary><b>Hooks<\/b>/,/<\/details>/' "$RM85" | grep -q '^| ship-gate' || RC=1


### PR DESCRIPTION
## Summary
- Operator policy (2026-08-10): no literal roster counts in the docs, they churn on every addition and cost more to maintain than they inform.
- README summary headers, directory-layout comments, and architecture.md's `Total: N + N = N` headline lose their numbers. `sync_counts` (sole job: maintaining them) is removed from `feature-registry.sh`.
- `test-meta.sh`'s literal-number assertions (SPEC-113 layout, SG-10 headers, architecture headline, SPEC-085 summary parity) become two no-count tripwires; every row-completeness check stays (live tree vs table rows, both sides computed), so a new command still cannot ship without its doc rows.

## Test plan
- [x] 799/799 on the de-numbered tree
- [x] Negative control: reintroducing `(36, ` in a header fails the tripwire
- [x] Suite run leaves README/architecture/FEATURES byte-identical (checksummed)
- Full transcript: `docs/verification/no-roster-counts.md`