### PR TITLE
fix(gauntlet): root-only config read for runner_host + probe_key_ref

### DIFF
--- a/docs/verification/gauntlet-config-root-read.md
+++ b/docs/verification/gauntlet-config-root-read.md
@@ -1,0 +1,53 @@
+# Proof of done: root-only config read for gauntlet security-bearing keys
+
+Change: `run-remote.sh` resolved `gauntlet.runner_host` and
+`gauntlet.probe_key_ref` via `kit_config_get`, which honors a project
+`.kit.toml`. A committed project toml rides inside an untrusted PR, so a PR
+could redirect a gauntlet round to an arbitrary ssh host that then resolves a
+1Password secret there. Fix: add `kit_config_get_root` (kit-root file only)
+and switch both reads to it.
+
+## Green run
+
+| Field | Value |
+|---|---|
+| Command | `bash lib/config/kit-config.sh selftest` |
+| Exit | 0 |
+| Verdict | PASS |
+
+```
+ok   root-only ignores project override
+ok   root-only reads kit-root value
+ok   root-only falls to caller default
+ok   legacy accessor still overridable
+PASS kit-config selftest
+```
+
+The selftest fixture plants `[gauntlet] runner_host = "evil-host"` in the
+project `.kit.toml`. `kit_config_get_root gauntlet.runner_host` returns
+`local` (override ignored); `kit_config_get gauntlet.runner_host` returns
+`evil-host` (legacy accessor still overridable, proving the project toml IS
+read and the two accessors genuinely differ).
+
+## Negative control (revert -> RED -> restore)
+
+Broke `kit_config_get_root` to consult the project overlay first (simulates
+the pre-fix hole), re-ran the selftest:
+
+```
+FAIL root-only ignores project override: got [evil-host] want [local]
+SELFTEST FAILED   (exit 1)
+```
+
+The injected `evil-host` then wins, exactly the redirect the fix prevents.
+Restored via `git checkout -- lib/config/kit-config.sh`; selftest returns to
+`PASS kit-config selftest`.
+
+## Regression check
+
+- `bash -n tests/gauntlet/cleanroom/run-remote.sh` parses.
+- `shellcheck` clean on both changed files (two SC2015 infos are on
+  pre-existing selftest lines, not this change).
+- `tests/test-config-registry.sh`: 17/19, identical on pristine
+  `origin/master` (the 2 fails are pre-existing `bin/config` drift, unrelated
+  to this change; flagged, not touched, per surgical-changes).

--- a/lib/config/kit-config.sh
+++ b/lib/config/kit-config.sh
@@ -61,6 +61,19 @@ kit_config_get() {
   printf '%s' "$def"
 }
 
+# kit_config_get_root <section.key> [default] -- kit-root ONLY, project overlay SKIPPED.
+# For security-bearing keys a committed project .kit.toml must NOT be able to set: a
+# project toml rides inside an untrusted PR, so a key that selects a runner host, a
+# secret ref, or a dispatch target must resolve from the operator-owned kit-root file
+# alone. Same read-model the kit already applies to enabled_agent_clis.
+kit_config_get_root() {
+  local dotkey="$1" def="${2:-}" section key v
+  section="${dotkey%%.*}"; key="${dotkey#*.}"
+  v="$(_kit_toml_get "$(kit_config_root)" "$section" "$key")"
+  [ -n "$v" ] && { printf '%s' "$v"; return 0; }
+  printf '%s' "$def"
+}
+
 # --- self-test: `bash lib/config/kit-config.sh selftest` (ponytail: one runnable check) ---
 # EXECUTED-directly guard: a sourced file inherits the CALLER's "$@". Without this, any
 # verb-taking CLI that sources this lib and is invoked with `selftest` (e.g. `queue.sh
@@ -80,6 +93,8 @@ TOML
   cat > "$d/proj/.kit.toml" <<'TOML'
 [ledger]
 location = "isolated"
+[gauntlet]
+runner_host = "evil-host"
 TOML
   export KIT_CONFIG_ROOT="$d/root" KIT_PROJECT_ROOT="$d/proj"
   fail=0
@@ -90,5 +105,12 @@ TOML
   chk "commented key -> caller default" "$(kit_config_get mega.over_test off)" "off"
   chk "missing key -> caller default"   "$(kit_config_get nope.nope fallback)" "fallback"
   chk "missing section -> empty"        "$(kit_config_get ghost.key)"          ""
+  # root-only read: a malicious project .kit.toml MUST NOT win a security-bearing key.
+  chk "root-only ignores project override" "$(kit_config_get_root gauntlet.runner_host local)" "local"
+  chk "root-only reads kit-root value"     "$(kit_config_get_root mega.wave_cap)"               "2"
+  chk "root-only falls to caller default"  "$(kit_config_get_root gauntlet.nope fallback)"      "fallback"
+  # negative control: the LEGACY accessor still lets the project override through (proves
+  # the two accessors differ, and that the project toml IS being read).
+  chk "legacy accessor still overridable"  "$(kit_config_get gauntlet.runner_host local)"       "evil-host"
   [ "$fail" = 0 ] && echo "PASS kit-config selftest" || { echo "SELFTEST FAILED"; exit 1; }
 fi

--- a/tests/gauntlet/cleanroom/run-remote.sh
+++ b/tests/gauntlet/cleanroom/run-remote.sh
@@ -18,8 +18,13 @@ OUT="${3:-${KIT_ROOT}/docs/verification/gauntlet/$(date +%Y-%m-%d)-${PERSONA}-${
 
 # shellcheck source=lib/config/kit-config.sh
 source lib/config/kit-config.sh
-HOST="${GAUNTLET_RUNNER_HOST:-$(kit_config_get gauntlet.runner_host local)}"
-KEY_REF="$(kit_config_get gauntlet.probe_key_ref "op://Toolkit/anthropic-api-key/credential")"
+# Root-only reads: runner_host picks a machine we ship committed state to and run
+# a probe on, probe_key_ref resolves a 1P secret ON that machine. A committed
+# project .kit.toml rides inside an untrusted PR, so neither may be set there; both
+# resolve from the operator-owned kit-root kit.toml alone. GAUNTLET_RUNNER_HOST (an
+# operator-controlled env var) still overrides.
+HOST="${GAUNTLET_RUNNER_HOST:-$(kit_config_get_root gauntlet.runner_host local)}"
+KEY_REF="$(kit_config_get_root gauntlet.probe_key_ref "op://Toolkit/anthropic-api-key/credential")"
 
 # The prompt lives in /work/PROMPT.txt (written by run.sh); the command never
 # quotes it. Keeping data out of command strings is what ended the quoting-bug


### PR DESCRIPTION
## What

`run-remote.sh` resolved `gauntlet.runner_host` and `gauntlet.probe_key_ref` via `kit_config_get`, which honors a project `.kit.toml`. A committed project toml rides inside an untrusted PR, so a PR could redirect a gauntlet round to an arbitrary ssh host that then resolves a 1Password secret there.

Adds `kit_config_get_root` (kit-root file only, project overlay skipped) and switches both security-bearing reads to it. `GAUNTLET_RUNNER_HOST` (operator env) still overrides. Same read-model the kit already applies to `enabled_agent_clis`.

## Proof

`docs/verification/gauntlet-config-root-read.md`: green selftest (4 new checks) + revert-to-red negative control. The selftest plants a malicious project `runner_host = evil-host`; root-only returns `local` (ignored), legacy accessor returns `evil-host` (proves the toml is read and the accessors differ).

## Provenance

Surfaced by the SPEC-230 gauntlet-cloud-runner `/kit:spec-validate` pass. The cloud runner itself is **blocked** on a separate platform finding (`docs/verification/gauntlet/2026-08-10-p0-cloud-dispatch/P0-RESULT.md`): `Agent(isolation:"remote")` resolves to a local worktree and `claude --cloud` is TTY-only, so cloud cannot be an automated gauntlet runner. This PR is the standalone security win that fell out of that investigation.

## Note

Pre-existing: `tests/test-config-registry.sh` is 17/19 on master (2 `bin/config` drift fails, unrelated); not touched here.