### PR TITLE
fix(config): reconcile 22 registry orphans + align TIER4_CLOSE (17/19 -> 19/19)

### DIFF
--- a/docs/verification/config-registry-reconcile.md
+++ b/docs/verification/config-registry-reconcile.md
@@ -1,0 +1,51 @@
+# Proof of done: config-registry drift reconciliation
+
+Change: `tests/test-config-registry.sh` was 17/19 on master (pre-existing,
+identical on a pristine master worktree). Two failures, both fixed:
+
+- AC1 drift lint: 22 seed-regex env vars in `lib/hooks/bin` had no registry
+  row. 21 are real env-overridable knobs, registered with their source
+  defaults; 1 (`QUEUE_SH`) is a computed script-local path, allowlisted like
+  its sibling `MEGA_SH`.
+- AC5: the `TIER4_CLOSE` registry cell said the default was `` `1` (truthy) ``
+  but kit.toml sets `tier4_close = true`, so `config get` (which resolves
+  kit.toml, above the registry default) returned `true`. Aligned the cell to
+  `true` and fixed the stale assertion.
+
+## Green run
+
+| Field | Value |
+|---|---|
+| Command | `bash tests/test-config-registry.sh` |
+| Exit | 0 |
+| Verdict | PASS (19/19; was 17/19) |
+
+## Negative control (revert -> RED -> restore)
+
+Reverted ONLY `lib/config/module-registry.md` to `origin/master`, re-ran:
+
+```
+ORPHAN: QUEUE_SANITIZE_PROMPT
+ORPHAN: QUEUE_SH
+ORPHAN: QUEUE_WAIT_POLL_SECS
+=== 18/19 passed ===
+```
+
+The orphans return and AC1 fails again, proving the registry rows are
+load-bearing. Restored via `git checkout HEAD -- lib/config/module-registry.md`
+(from the feature commit): back to 19/19.
+
+## Regression check
+
+| Command | Result |
+|---|---|
+| `bash tests/test-meta.sh` | 799/799, all pass |
+
+## Notes
+
+- The 22nd orphan `QUEUE_WAIT_POLL_SECS` was introduced by PR #378 (the
+  `queue wait` verb); it did not regress a green test (this lint was already
+  red on master) but is folded into this reconciliation with its family.
+- The `QUEUE_*` knobs are registered `env-only [impl] queue` matching the
+  existing queue-section rows; defaults are transcribed from the `${VAR:-...}`
+  assignments in `lib/queue/queue.sh` and `lib/queue/sanitize.sh`.

--- a/lib/config/module-registry.md
+++ b/lib/config/module-registry.md
@@ -69,6 +69,9 @@ real reader consumes it today (all rows below are, except where noted).
 | KIT_CONFIG_ROOT | env-only | `${DWARVES_KIT:-$HOME/.claude/dwarves-kit}` | [impl] | config | Override where the kit-root `kit.toml` itself is read from (this IS the resolver's own bootstrap knob; it cannot have a `kit.toml` key). |
 | KIT_PROJECT_ROOT | env-only | `$PWD` | [impl] | config | Override which project's `.kit.toml` is consulted. |
 | DWARVES_KIT_DEBUG | env-only | `0` | [impl] | (none) | Verbose hook/command debug logging; cross-cutting, not config-subsystem-specific. |
+| DWARVES_KIT_LICENSE | env-only | `$HOME/.config/dwarves-kit/license` | [impl] | config | `bin/activate`: path to the license keyfile the activation check reads. |
+| KIT_TOOL_POLICY | env-only | `$HOME/.claude/dwarves-kit/tool-policy.json` | [impl] | config | `hooks/tool-policy-guard.sh`: path to the tool-policy JSON the guard enforces. |
+| DWARVES_KIT_LANES_D | env-only | `$HOME/.config/dwarves-kit/lanes.d` | [impl] | config | `lib/gate/gate-ledger.sh`: dropin dir for per-lane `.plan` files. |
 
 ### Data-plane keys ([ledger] section + the durable telemetry root)
 
@@ -105,7 +108,7 @@ real reader consumes it today (all rows below are, except where noted).
 | Env var | kit.toml key | Default | Status | Module | Doc |
 |---|---|---|---|---|---|
 | WAVE_CAP | mega.wave_cap | `2` | [impl] | mega | Max concurrent sub-goals admitted per wave. |
-| TIER4_CLOSE | mega.tier4_close | `1` (truthy) | [impl] | mega | Enables the Tier-4 mega-close auto-verify+hold sequence (SPEC-118). |
+| TIER4_CLOSE | mega.tier4_close | `true` | [impl] | mega | Enables the Tier-4 mega-close auto-verify+hold sequence (SPEC-118). |
 | MULTIPLEXER | mega.multiplexer | `0` (off) | [impl] | mega | Opt-in wave pane multiplexing (SPEC-119); only engages when a wave actually admits >=1 sub-goal concurrently. |
 | MEGA_MERGE_POSTURE | mega.mega_merge_posture | `"auto-to-final"` | [impl] | mega | `"auto-to-final"` or `"per-pr-review"` merge posture. |
 | - | mega.merge_autonomy | `"gated-final"` | [design] | mega | `"gated-final"` or `"full-auto"`; no env override found. |
@@ -141,6 +144,23 @@ real reader consumes it today (all rows below are, except where noted).
 | QUEUE_BOARD_CMD | env-only | `board` | [impl] | queue | Override the board CLI command name. |
 | QUEUE_JOURNAL | env-only | `${DWARVES_KIT_LOG_DIR:-$HOME/.claude/dwarves-kit/logs}/queue-journal.tsv` | [impl] | queue | Path to the queue's TSV journal. |
 | QUEUE_ALLOWED_POINTER_GLOB | env-only | `_meta/megagoals/* .claude/goals/*` | [impl] | queue | Glob allowlist for pointer files the queue may submit. |
+| QUEUE_GOAL_CHAR_LIMIT | env-only | `4000` | [impl] | queue | `/goal` char ceiling; an over-budget pointer fails fast before a window opens. |
+| QUEUE_WAIT_POLL_SECS | env-only | `5` | [impl] | queue | Poll interval (seconds) for the `queue wait` verb. |
+| QUEUE_BEAT_STALE_SECS | env-only | `600` | [impl] | queue | Beat age past which the conductor is presumed gone (SPEC-221). |
+| QUEUE_BEAT_DEAD_SECS | env-only | `3600` | [impl] | queue | Beat age past which the reaper writes a verdict (SPEC-221). |
+| QUEUE_MAX_STALLS | env-only | `3` | [impl] | queue | Stalls before a slug is quarantined (empty retry_after). |
+| QUEUE_COOLDOWN_SECS | env-only | `1800` | [impl] | queue | Breaker cooldown before an `error` row is re-picked. |
+| QUEUE_NOPROGRESS_TRIP | env-only | `3` | [impl] | queue | Consecutive no-progress runs that trip the breaker. |
+| QUEUE_SAMEERROR_TRIP | env-only | `5` | [impl] | queue | Consecutive `error` runs that trip the breaker. |
+| QUEUE_RETRY_JITTER_MIN | env-only | `5` | [impl] | queue | Floor (minutes) of the jittered retry window after a stall. |
+| QUEUE_RETRY_JITTER_SPAN | env-only | `11` | [impl] | queue | Span (minutes) of the jittered retry window after a stall. |
+| QUEUE_PR_READY | env-only | `0` | [impl] | queue | `1` opens a normal PR; `0` keeps the unattended draft-PR default (SPEC-224). |
+| QUEUE_MAX_TOOL_CALLS | env-only | `0` | [impl] | queue | Per-row ceiling on the run's self-reported TOOL_CALLS (`0` = off). |
+| QUEUE_MAX_TOTAL_TOOL_CALLS | env-only | `0` | [impl] | queue | Queue-wide TOOL_CALLS ceiling across rows this run (`0` = off). |
+| QUEUE_SANITIZE_PROMPT | env-only | `0` | [impl] | queue | `1` treats the pointer body as untrusted (SPEC-223 XPIA pass); implied by `--from-boards`. |
+| QUEUE_MAX_PROMPT_CHARS | env-only | `20000` | [impl] | queue | `lib/queue/sanitize.sh`: max prompt chars accepted before the pointer is rejected. |
+| QUEUE_PROTECTED_GLOBS | env-only | `.claude/* CLAUDE.md AGENTS.md .github/* _meta/BACKLOG.md` | [impl] | queue | `lib/queue/sanitize.sh`: protected-path globs a gated run may not write. |
+| QUEUE_PERL_CMD | env-only | `perl` | [impl] | queue | `lib/queue/sanitize.sh`: perl binary override for the sanitize pass. |
 
 ### board
 
@@ -148,6 +168,7 @@ real reader consumes it today (all rows below are, except where noted).
 |---|---|---|---|---|---|
 | BACKLOG_FILE | env-only | `$BACKLOG_DIR/../../_meta/BACKLOG.md` | [impl] | board | Override which `BACKLOG.md` the CLI reads/writes. |
 | BACKLOG_ID_RE | env-only | `[A-Z]+-[0-9]+` | [impl] | board | Regex for what counts as a backlog item ID. |
+| KIT_BOARDS_REGISTRY | env-only | `<repo-root>/_meta/boards.txt` | [impl] | board | `lib/mega/runs-dashboard.py`: override the boards registry the cross-repo cockpit reads (beats the repo-root default, loses to `--registry`). |
 
 ### sync (two-way spoke mirror, `board sync` -> `lib/sync/backlog_sync.py`)
 
@@ -283,6 +304,7 @@ against any of these bare tokens as covered without a registry row.
 | KIT_KNOWN_MODULES | `install.sh`: a hardcoded bash array literal, never read from the environment. |
 | KIT_LIB | Script-local computed dir in most readers (e.g. `lib/telemetry/lane-telemetry.sh`); the real env-overridable cousin is `DWARVES_KIT_LIB` (Python, `lib/stats/src/stats/config.py`), which the bash-oriented seed regex cannot see (no `$` sigil in Python source) , documented here rather than silently dropped: see `lib/stats/README.md`'s own env table for `DWARVES_KIT_LIB`'s default (this repo's own `lib/`, kit-internal). |
 | MEGA_SH | `lib/board/board.sh`: computed `$BOARD_DIR/../mega/mega.sh`. |
+| QUEUE_SH | `lib/queue/watch-board.sh`: computed `$WATCH_DIR/queue.sh`, script-local sibling path, never env-read (same shape as `MEGA_SH`). |
 | PANE_VIEWER_ALLOWED | `lib/queue/orchestrate.sh`: a hardcoded allowlist string, not itself env-read; it validates `PANE_VIEWER`. |
 | STATS_DB_REMOVED | Dead/vestigial test-fixture token, see its row above , no product reader exists. Kept OUT of the drift-fail set (registered above instead of silently dropped, per the scope fence) but also allowlisted so the lint does not double-count it as a live undocumented knob. |
 

--- a/tests/test-config-registry.sh
+++ b/tests/test-config-registry.sh
@@ -102,7 +102,7 @@ echo "=== AC5: bin/config functional smoke (list/get/explain + provenance fixtur
 # cell's human markdown (backticks / parenthetical annotations) -- review finding, 2026-07-12.
 assert_eq "get WAVE_CAP (default, no overrides) is the clean scalar 2" "$(env -u WAVE_CAP bash "$CONFIG_BIN" get WAVE_CAP)" '2'
 assert_eq "get mega.wave_cap (dotted-key lookup) is the clean scalar 2" "$(env -u WAVE_CAP bash "$CONFIG_BIN" get mega.wave_cap)" '2'
-assert_eq "get TIER4_CLOSE strips the annotation ((truthy)) from the default cell" "$(env -u TIER4_CLOSE bash "$CONFIG_BIN" get TIER4_CLOSE)" '1'
+assert_eq "get TIER4_CLOSE returns the resolved boolean from kit.toml (matches the list source)" "$(env -u TIER4_CLOSE bash "$CONFIG_BIN" get TIER4_CLOSE)" 'true'
 assert_eq "get MEGA_MERGE_POSTURE unquotes the default (one \" layer, like _kit_toml_get)" "$(env -u MEGA_MERGE_POSTURE bash "$CONFIG_BIN" get MEGA_MERGE_POSTURE)" 'auto-to-final'
 if bash "$CONFIG_BIN" get NOT_A_REAL_KEY >/dev/null 2>&1; then RC=1; else RC=0; fi
 assert "get on an unknown key fails (exit != 0)" $RC


### PR DESCRIPTION
## What

`tests/test-config-registry.sh` was 17/19 on master (pre-existing drift, identical on pristine master). Two failures fixed:

**AC1 drift lint (22 orphans):** seed-regex env vars in `lib/hooks/bin` with no registry row, the newer queue knobs (SPEC-221/223/224 guards + `QUEUE_WAIT_POLL_SECS` from #378) plus four cross-cutting path knobs (`DWARVES_KIT_LICENSE`, `KIT_TOOL_POLICY`, `DWARVES_KIT_LANES_D`, `KIT_BOARDS_REGISTRY`). Registered all 21 real env knobs with their source defaults; allowlisted `QUEUE_SH` (a computed script-local path, same shape as the already-allowlisted `MEGA_SH`).

**AC5 (TIER4_CLOSE):** the registry cell claimed the default was ``1` (truthy)` but kit.toml sets `tier4_close = true`, so `config get` (resolves kit.toml, above the registry default) correctly returned `true`. Every other key's registry cell matches its kit.toml value; aligned this one to `true` and fixed the stale assertion that expected the registry default it never reaches.

## Proof

`docs/verification/config-registry-reconcile.md`: 19/19 green + revert-to-red negative control (revert the registry -> orphans return, 18/19 -> restore -> 19/19) + meta-suite 799/799 regression check.

## Provenance

The drift was surfaced while dogfooding the passive Mini queue runner: a row that looked like a clean `#auto` test-fix turned out to be a 22-key register-vs-allowlist reconciliation (correctly kept OFF the autonomous path). `QUEUE_WAIT_POLL_SECS` (from #378, my own prior PR) is one of the 22, folded in with its family; it did not regress a green test (this lint was already red on master).