### PR TITLE
fix(cloud): close three project-tier escapes and the unverified gate

### DIFF
--- a/docs/verification/cloud-session-support.md
+++ b/docs/verification/cloud-session-support.md
@@ -9,6 +9,14 @@ Pinned to commit `f1612c0` on `feat/cloud-session-support`, tree clean. Every
 number below was produced at that commit; re-running at a later commit and
 getting a different count is drift, not a discrepancy.
 
+SUPERSEDED IN PART. An adversarial review after this pin found three
+project-tier keys that reached outside the repo and, worse, that the cloud gate
+was UNVERIFIED: the suite below passed 118/118 with the `CLAUDE_CODE_REMOTE`
+gate deleted from both hooks. Commit `547076e` fixes both. The current counts,
+the per-gate red runs and the per-key before/after controls are the dated
+section in `lib/cloud/docs/proof-of-done.md`. Read that first; this file is the
+historical record of the pre-review state.
+
 Design + scope: `lib/cloud/SPEC.md`. Per-invariant assertion map:
 `lib/cloud/docs/proof-of-done.md`.
 

--- a/kit.toml
+++ b/kit.toml
@@ -57,15 +57,22 @@ team_mode      = false          # reserved , install.sh hard-rejects it today
                                 #     CLOUD_<KEY> variable; a project .kit.toml is IGNORED,
                                 #     because the value selects code to run or names a
                                 #     credential (lib/config/kit-config.sh kit_config_get_root).
-                                # Every key also takes a CLOUD_<KEY> env override. Unset keys
-                                # fall back to a neutral default, so provisioning still does the
-                                # generic work with no config at all.
-# --- PROJECT tier (names something inside this repo) ---
-# workspace  = "~/workspace"    # where sibling repos are cloned. default $HOME/workspace
+                                # Every key also takes a CLOUD_<KEY> env override; for an
+                                # OPERATOR key the environment is the trust anchor, not just an
+                                # override (CLOUD_PROVISION, the module's master switch, is
+                                # env-only). Unset keys fall back to a neutral default, so
+                                # provisioning still does the generic work with no config at all.
+# --- PROJECT tier (names a path inside this repo; repo_path REFUSES anything else) ---
 # map        = ""               # repo-relative routing map printed by `cloud map`
 # rules      = ""               # repo-relative cloud-rules file. default lib/cloud/CLOUD-RULES.md
-# op_version = "v2.31.1"        # pinned 1Password CLI release
 # --- OPERATOR tier (reaches outside the repo, runs code, or names a credential) ---
+# workspace  = "~/workspace"    # where the session repo is linked and siblings are cloned. It
+#                               # names a directory OUTSIDE the repo and a symlink is created
+#                               # there, so a project value pointed it at ~/.claude/skills and
+#                               # made a PR-authored root SKILL.md a live skill
+# op_version = "v2.31.1"        # pinned 1Password CLI release. The value is interpolated into a
+#                               # download URL for a binary that is then chmod +x and put on
+#                               # PATH; validated against ^v?[0-9]+(\.[0-9]+)*$ on top
 # repos      = "a,b/c"          # sibling repos to clone: <name> or <owner>/<name>. A clone
 #                               # runs no code, but its AGENTS.md/CLAUDE.md are then NAMED
 #                               # to the model as files to read

--- a/lib/cloud/README.md
+++ b/lib/cloud/README.md
@@ -85,6 +85,11 @@ git clone --depth 1 https://github.com/dwarvesf/dwarves-kit.git \
 bash "$HOME/.claude/dwarves-kit/bin/cloud" vm-setup || true
 ```
 
+Both `|| true` guards are load-bearing, not decoration. A non-zero exit anywhere
+in the Setup script aborts the environment build. Every `cloud` VERB exits 0 by
+design, but an UNKNOWN verb exits 1, so a typo in this field would otherwise
+abort the session with no session to read the error in.
+
 ## Consumer config
 
 A project's `.kit.toml` rides inside the repo, so a pull request can change it.
@@ -92,15 +97,15 @@ Config therefore resolves in two tiers.
 
 | Tier | Resolution | Why |
 |---|---|---|
-| PROJECT | `CLOUD_<KEY>` env, then the project's `.kit.toml` `[cloud]`, then the kit-root default | the value is inert data: a path to print, a clone target, a directory name |
-| OPERATOR | `CLOUD_<KEY>` env, then the kit-root `kit.toml` only. A project `.kit.toml` is IGNORED | the value selects code to run or names a credential, so a branch under review must not be able to set it |
+| PROJECT | `CLOUD_<KEY>` env, then the project's `.kit.toml` `[cloud]`, then the kit-root default | the value is inert data naming something INSIDE this repo, and `repo_path` enforces that |
+| OPERATOR | `CLOUD_<KEY>` env, then the kit-root `kit.toml` only. A project `.kit.toml` is IGNORED | the value reaches outside the repo, selects code to run, or names a credential, so a branch under review must not be able to set it |
 
 | Key | Tier | Default | What it drives |
 |---|---|---|---|
-| `workspace` | project | `$HOME/workspace` | where the session repo is linked and siblings are cloned |
 | `map` | project | none | repo-relative routing map printed by `cloud map` |
 | `rules` | project | `lib/cloud/CLOUD-RULES.md` | repo-relative cloud-rules file for this repo |
-| `op_version` | project | `v2.31.1` | pinned 1Password CLI release |
+| `workspace` | operator | `$HOME/workspace` | where the session repo is linked and siblings are cloned |
+| `op_version` | operator | `v2.31.1` | pinned 1Password CLI release |
 | `repos` | operator | none | comma-separated sibling repos to clone: `<name>` or `<owner>/<name>` |
 | `repo_owner` | operator | none | default owner for a bare name in `repos` |
 | `plugins` | operator | none | behavioral plugins to install: comma-separated `<id>\|<marketplace-slug>` |
@@ -112,13 +117,31 @@ Example, in a consumer repo's `.kit.toml`:
 
 ```toml
 [cloud]
-workspace = "~/workspace/acme"
-map       = "docs/REPO-MAP.md"
-rules     = "docs/CLOUD-RULES.md"
+map   = "docs/REPO-MAP.md"
+rules = "docs/CLOUD-RULES.md"
 ```
 
+Both project keys are PATHS, and both are resolved against the repo root by
+`repo_path`, which refuses an absolute path, a leading `~`, a `..` segment, a
+directory that resolves outside the repo, and a final component that is a
+symlink. A refused value is reported as a `!!` line and dropped: `map` prints
+nothing, `rules` falls back to the kit's own template. Naming a key "project
+tier" is a comment; this check is the control.
+
 Operator-tier keys go in the kit-root `kit.toml`, or in the cloud environment as
-`CLOUD_REPOS`, `CLOUD_PLUGINS`, `CLOUD_HOOKS_PATH` and so on.
+`CLOUD_WORKSPACE`, `CLOUD_REPOS`, `CLOUD_PLUGINS`, `CLOUD_HOOKS_PATH` and so on.
+The kit-root path is pinned to the kit install the hook runs from, so
+`KIT_CONFIG_ROOT` cannot redirect the operator half at a file inside the repo.
+
+`workspace` is operator-tier because it names a directory OUTSIDE the repo and
+the assemble step creates a symlink in it. A project-settable value pointed it
+at `$HOME/.claude/skills`, which made a PR-authored root `SKILL.md` a live skill
+in the same session, loaded immediately because the hook emits `reloadSkills`.
+Constraining it to "under the home" would not have helped: that path IS under
+the home. `op_version` is operator-tier because it selects a binary that is
+downloaded, `chmod +x`, prepended to PATH and persisted into `CLAUDE_ENV_FILE`;
+it is validated against `^v?[0-9]+(\.[0-9]+)*$` on top, because operator-tier is
+not a reason to skip validating a value that lands in a URL.
 
 Why the operator tier exists, plainly. Installing a plugin normally requires a
 human on the machine to approve a project-declared plugin from an external
@@ -149,7 +172,12 @@ path into every later turn.
 | the SessionStart matcher is `startup\|resume` | without it the whole assembly re-ran on every `clear` and every compaction |
 | plugins are installed imperatively | declaring them in a project's settings duplicates the record in the operator's shared per-user plugin registry |
 | each hook checks its own switch FIRST | the plugin manifest is not filtered by the enabled module set, so `modules.cloud = false` alone does not turn the hooks off for a plugin consumer |
-| operator-tier keys skip the project overlay | a project `.kit.toml` rides inside the repo, so a branch under review could otherwise arm `core.hooksPath`, install a plugin, redirect the secret probe, or clone a repo whose instruction files are then named to the model |
+| operator-tier keys skip the project overlay | a project `.kit.toml` rides inside the repo, so a branch under review could otherwise arm `core.hooksPath`, install a plugin, redirect the secret probe, choose the workspace, or clone a repo whose instruction files are then named to the model |
+| a project-tier PATH resolves inside the repo or is refused | `map` and `rules` both took an absolute path, so a project value printed a file from outside the repo into model context |
+| `op_version` is validated as a version | the value is interpolated into a download URL; `vEVIL/../../../../attacker-path` produced a traversal-shaped URL |
+| the kit-root config path is pinned to the kit install | `KIT_CONFIG_ROOT` otherwise redirects the operator-owned half of the tier split at a file inside the repo |
+| the `safe.directory` write is gated to a Linux cloud session | it writes the operator's GLOBAL `~/.gitconfig`, and a hand-run on a workstation did |
+| the sibling-clone loop carries a total budget | the 60s cap bounds ONE clone; three unreachable siblings plus the gh install exceeded the SessionStart budget, which kills the whole hook |
 | a `~` in a config value is expanded | a tilde read out of a file is a literal character, so `mkdir -p` silently created a directory named `~` under the repo |
 
 ## Test
@@ -157,6 +185,13 @@ path into every later turn.
 ```bash
 bash lib/cloud/tests/smoke.sh    # "smoke: all N passed"
 ```
+
+Each hook has THREE gates: its own switch, `CLAUDE_CODE_REMOTE`, and Linux. The
+suite proves each one INDIVIDUALLY: neutering any single gate turns it red. An
+earlier version proved only that SOME gate fired, because the OFF cases ran
+without the `uname` stub, so on macOS the Linux gate short-circuited before the
+cloud gate was ever read, and the suite stayed fully green with the cloud gate
+deleted.
 
 The suite runs on macOS with a stubbed `uname`, which proves which BRANCH the
 code takes, never that the branch works. The CI workflow includes an

--- a/lib/cloud/SPEC.md
+++ b/lib/cloud/SPEC.md
@@ -74,15 +74,57 @@ Config follows the kit's existing seam, not a new one: `--repo-root` /
 resolver for values. It resolves in two tiers, because a project's `.kit.toml`
 rides inside the repo and a pull request can therefore set it.
 
-| Tier | Resolver | Rule |
-|---|---|---|
-| PROJECT | `CLOUD_<KEY>` env, then `kit_config_get` | the key may only name something INSIDE this repo |
-| OPERATOR | `CLOUD_<KEY>` env, then `kit_config_get_root` | anything that reaches outside the repo, runs code, or names a credential |
+| Tier | Keys | Resolver | Rule |
+|---|---|---|---|
+| PROJECT | `map`, `rules` | `CLOUD_<KEY>` env, then `kit_config_get` | the key may only name something INSIDE this repo, and `repo_path` enforces it |
+| OPERATOR | `workspace`, `op_version`, `repos`, `repo_owner`, `plugins`, `hooks_path`, `vault`, `canary_ref` | `CLOUD_<KEY>` env, then `kit_config_get_root` | anything that reaches outside the repo, runs code, or names a credential |
 
 The two lists are declared once in `provision.sh`
 (`CLOUD_PROJECT_KEYS` / `CLOUD_OPERATOR_KEYS`) and the suite fails if a key is
-read through the wrong resolver or belongs to neither list, so the next key
-cannot silently pick the wrong tier.
+read through the wrong resolver or belongs to neither list.
+
+**That lint checks CONSISTENCY, not CORRECTNESS**, and the earlier claim that it
+stops the next key picking the wrong tier was wrong. It proves each key is read
+through the resolver its own list names; it cannot know whether the list is the
+right one. Three keys sat in the PROJECT list, passed the lint on every run of
+this branch, and each reached outside the repo: `workspace` accepted any
+absolute path and pointed the assemble symlink at `$HOME/.claude/skills`, which
+turned a PR-authored root `SKILL.md` into a live skill in the same session;
+`map` and `rules` accepted any absolute path and printed a file from outside the
+repo into model context; `op_version` selected a downloaded binary.
+
+The correctness half is therefore enforced in code, per key class:
+
+| Enforcement | Applies to | What it does |
+|---|---|---|
+| tier | every key | operator keys skip the project overlay entirely |
+| `repo_path` | every PROJECT-tier PATH | resolves against the repo root and REFUSES an absolute path, a leading `~`, a `..` segment, a directory that resolves outside the repo, or a final component that is a symlink |
+| shape validation | `op_version` | must match `^v?[0-9]+(\.[0-9]+)*$` before it is interpolated into a download URL |
+
+The kit-root config path is PINNED to the kit install `provision.sh` belongs to.
+`kit-config.sh` otherwise takes it from `KIT_CONFIG_ROOT`/`DWARVES_KIT`, so the
+operator-owned half of the split could be redirected at a file inside the repo,
+which would have made the tier split decorative.
+
+### What the operator tier trusts
+
+The environment. `CLOUD_<KEY>` sits ABOVE both config tiers for operator keys,
+and `CLOUD_PROVISION` (the master switch for the whole module) is env-only with
+no config channel at all. The environment is therefore the trust anchor, not
+just an override.
+
+That is deliberate. In a cloud VM the kit-root `kit.toml` arrives inside the git
+clone, so the environment's variables are the only per-environment operator
+channel that exists. Removing the env tier for operator keys while the master
+switch stays env-read would close nothing: an actor who can set environment
+variables sets `CLOUD_PROVISION=1` and owns the module regardless of where the
+individual keys resolve.
+
+UNVERIFIED, and it decides whether this trust holds: whether a repo-committed
+`.claude/settings.json` `env` block reaches a hook subprocess in a cloud VM. If
+it does, the environment is repo-writable and this whole layer needs a
+kit-wide env-hardening pass, not a cloud-local one. Only a real cloud VM answers
+it. Recorded in `docs/proof-of-done.md` under "Not proved here".
 
 ## Invariants
 
@@ -100,11 +142,18 @@ every row.
 6. The dash guard rewrites prose files only, skips fenced and inline code, skips
    a file with unbalanced fences whole, and matches horizontal whitespace
    (`[ \t]`), never `\s`.
-7. `repos`, `repo_owner`, `plugins`, `hooks_path`, `vault` and `canary_ref`
-   resolve at the operator tier only. A project `.kit.toml` cannot set them, and
-   `hooks_path` is never inferred from a directory found in the tree.
-8. The suite carries its failures into its exit code, proved by a self-check
-   that re-invokes the suite with one planted failure.
+7. `workspace`, `op_version`, `repos`, `repo_owner`, `plugins`, `hooks_path`,
+   `vault` and `canary_ref` resolve at the operator tier only. A project
+   `.kit.toml` cannot set them, and `hooks_path` is never inferred from a
+   directory found in the tree.
+8. A PROJECT-tier path resolves INSIDE the repo root or it is refused, and the
+   refusal is explained. Naming the tier is not the control; `repo_path` is.
+9. `op_version` matches a version shape before it reaches a download URL.
+10. Each hook's THREE gates (its switch, `CLAUDE_CODE_REMOTE`, Linux) is proved
+    individually. Neutering any one of them turns the suite red. The suite used
+    to prove only that SOME gate fired.
+11. The suite carries its failures into its exit code, proved by a self-check
+    that re-invokes the suite with one planted failure.
 
 ## Verification
 

--- a/lib/cloud/cloud.sh
+++ b/lib/cloud/cloud.sh
@@ -10,8 +10,14 @@
 #   cloud secrets                       just the secrets step
 #   cloud plugins                       just the behavioral-plugin step
 #
-# Every verb exits 0 by design: this subsystem runs on the cloud startup path,
+# Every VERB exits 0 by design: this subsystem runs on the cloud startup path,
 # where a non-zero exit aborts the session before Claude Code starts.
+#
+# ONE exception, and it matters on that same path: an UNKNOWN verb exits 1, so a
+# typo in the environment's Setup-script field would abort the session. That is
+# why the documented Setup-script line ends in `|| true`, and why the `|| true`
+# is load-bearing rather than decorative. The dispatcher keeps the non-zero exit
+# because a silent 0 on a misspelled verb hides the typo forever.
 set -uo pipefail
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/lib/cloud/docs/proof-of-done.md
+++ b/lib/cloud/docs/proof-of-done.md
@@ -203,3 +203,50 @@ prove and the CI leg that has not been dispatched. Added by this round:
 | a repo-committed `.claude/settings.json` `env` block does NOT reach a hook subprocess in a cloud VM | UNVERIFIED, and it is the load-bearing assumption under the operator tier. If it DOES reach one, a PR can set `CLOUD_PROVISION=1` plus any operator key and the tier split is bypassed. That needs a kit-wide env-hardening pass, not a cloud-local one. Only a real cloud VM answers it |
 | the 90s sibling-clone budget is the right number against the real SessionStart timeout | UNVERIFIED. The platform's hook timeout is not documented; 90s leaves room for the 150s gh install under a 300s assumption. A real VM run calibrates it |
 | the `safe.directory` gate does not break a real cloud session | UNVERIFIED on the platform. The write now needs `CLAUDE_CODE_REMOTE=true` and Linux, which is exactly the context the comment names, but only a VM run confirms root still resolves the repo root there |
+
+---
+
+## 2026-08-11: independent verification round, and the one gap it left
+
+An independent pass re-ran every claimed fix by BREAKING it rather than
+reading it, in more shapes than the fixing round tested: 8 escape shapes per
+constrained key, 3 gate neuterings beyond the 5 already recorded, 3
+config-redirect vectors, plus glob, command-substitution and multi-line
+values. Every fix reproduced with a demonstrated before and after.
+
+Two results worth recording beyond "it holds":
+
+- The config-root pinning closed a hole that was LIVE on the pre-fix branch:
+  `KIT_CONFIG_ROOT=<repo>` and `DWARVES_KIT=<repo>` each armed
+  `core.hooksPath=.githooks` from a repo-committed file, which is arbitrary
+  code execution on the next git command. Verified armed before, inert after.
+- The original false green was confirmed real: on the pre-fix tree with the
+  cloud gate DELETED from both hooks, the suite still reported
+  `smoke: all 118 passed`, exit 0.
+
+### N1 (LOW), found and fixed here
+
+The `op_version` validator used `printf '%s' "$V" | grep -qE '...'`. `grep`
+matches LINE-wise, so a multi-line value passes when ANY line matches and the
+rest still reaches the URL.
+
+| Input | grep form | case form |
+|---|---|---|
+| `v1.0\n../../../../attacker-path` | ACCEPTED | rejected |
+| `vEVIL/../../../../attacker-path` | rejected | rejected |
+| `v1.0;id`, `$(id)`, empty | rejected | rejected |
+| `v2.31.1`, `2.30.0`, `v2.31` | accepted | accepted |
+
+Replaced with a `case` glob, which tests the whole string. Host was pinned
+either way so severity was low, but operator tier is not a reason to skip
+validating a value that lands in a URL.
+
+Suite after the change: `smoke: all 146 passed`, shellcheck clean.
+
+### Still unverified, and it caps what the tier split is worth
+
+Whether a repo-committed `.claude/settings.json` `env` block reaches a hook
+subprocess in a cloud VM. If it does, a pull request sets `CLOUD_PROVISION=1`
+plus an operator key and bypasses the split. Until a real VM answers it, treat
+the operator tier as defense in depth, not a boundary. This is a kit-wide
+settings/env question, not a cloud-local one.

--- a/lib/cloud/docs/proof-of-done.md
+++ b/lib/cloud/docs/proof-of-done.md
@@ -1,17 +1,19 @@
 # Proof of done: cloud-session support
 
 Change class: behavioral (two hooks, a provisioning engine, two installers).
-The proof is the suite, its negative controls, and two observed REDs.
+The proof is the suite, its negative controls, and the observed REDs.
 
-Pinned to commit `f1612c0`. The full run record, including the real install and
+Pinned to commit `547076e`. The full run record, including the real install and
 adopt flows and every negative control, is
-`docs/verification/cloud-session-support.md`.
+`docs/verification/cloud-session-support.md`. The adversarial-review round that
+followed the first pin is the dated section at the bottom of this file; the
+counts below are the post-review ones.
 
 ## Green run
 
 | Check | Command | Result |
 |---|---|---|
-| the cloud suite | `bash lib/cloud/tests/smoke.sh` | `smoke: all 118 passed`, exit 0 |
+| the cloud suite | `bash lib/cloud/tests/smoke.sh` | `smoke: all 146 passed`, exit 0 |
 | hook behavior | `bash tests/test-hooks.sh` | 492 / 492, exit 0 |
 | structural integrity | `bash tests/test-meta.sh` | 799 / 799, exit 0 |
 | bin forwarders + census | `bash tests/test-bin-forwarders.sh` | 33 passed, exit 0 |
@@ -27,7 +29,7 @@ adopt flows and every negative control, is
 |---|---|---|
 | every path exits 0 | `provision exit code with a broken gh install`, `install-gh exit code with everything broken`, `vm-setup exit code`, `assemble exits 0 with every step exercised` | the same runs must still print a `!!` line and must NOT print a false `ok  gh`; a run with nothing failing must reach `CLOUD-READY` |
 | the gate is `CLAUDE_CODE_REMOTE` | `<hook> gates on CLAUDE_CODE_REMOTE`, `<hook> has no '-d $HOME/...' cloud probe` | the same pattern is shown firing on a fixture byte-identical to the historical gate shape |
-| the gate really switches behavior | section 2 (OFF: silent, file byte-identical) | section 3 (ON: the same fixture is rewritten). Section 2 alone passes for a permanently broken hook |
+| the gate really switches behavior, and WHICH gate | sections 2 and 3 (OFF silent and byte-identical, ON rewritten) plus the Darwin-stub block at the end of section 3 | neutering any ONE of the three gates turns the suite red: the switch, `CLAUDE_CODE_REMOTE`, and Linux each have their own run. Recorded below |
 | each hook needs its own switch | `<hook> checks <SWITCH>`, `<hook> checks the switch before CLAUDE_CODE_REMOTE`, and the no-switch runs leave the file byte-identical | the order check is shown reporting `no` on a fixture whose switch comes second |
 | Linux gate at the install point | `install-gh.sh dry-run branch precedes its Linux gate` | section 6e runs both installers behind a `uname` stub answering Darwin and asserts nothing landed in the prefix |
 | no `eval` over an environment variable | `provision.sh runs no eval` (comment lines stripped) | a planted `eval echo ~$SUDO_USER` fixture, with an `eval` mention in a comment, is caught once, not twice |
@@ -36,8 +38,10 @@ adopt flows and every negative control, is
 | `CLAUDE_ENV_FILE` append-once | `CLAUDE_ENV_FILE holds the PATH export` then `append-once across two runs` | a wrong canary prints a `!!` line and no `canary verified` line |
 | the consumer-config seam | `rules verb reads [cloud] rules from the project .kit.toml`, `assemble honours [cloud] workspace`, `CLOUD_<KEY> beats a conflicting project value` | with no project config the kit's own `lib/cloud/CLOUD-RULES.md` is named instead |
 | a `~` in a config value expands | `a ~ workspace lands in HOME` | no literal `~` directory was created under the repo |
-| the operator tier holds | 5 assertions that a hostile `.kit.toml` reaches neither the plugin installer, the hooks arming, the secrets step, nor the sibling clone | the same keys DO take effect from the operator tier, and a PROJECT-tier key from the same hostile file is still honoured |
-| the tier split cannot drift | `every [cloud] key is declared in exactly one tier and read through it` | the extraction is asserted non-empty, so the check cannot pass vacuously |
+| the operator tier holds | 6 assertions that a hostile `.kit.toml` reaches neither the plugin installer, the hooks arming, the secrets step, the sibling clone, nor the workspace choice | the same keys DO take effect from the operator tier, and `rules`, a real PROJECT-tier key naming a real in-repo path in the SAME hostile file, is still honoured |
+| the tier split is internally consistent | `every [cloud] key is declared in exactly one tier and read through it` | the extraction is asserted non-empty, so the check cannot pass vacuously. This is a CONSISTENCY check only: it cannot tell whether a key sits in the right list, and three keys that reached outside the repo passed it |
+| a project-tier PATH stays inside the repo | section 5b-3: for both `map` and `rules`, an absolute path, a `..` traversal and a committed symlink out of the repo are each refused with a `!!` line | the legitimate repo-relative use of both keys is still printed |
+| `op_version` cannot shape the download URL | section 5b-3: a project `.kit.toml` value never reaches the URL, and a traversal-shaped value is refused at the operator tier too | the operator tier DOES set a real pin, and the URL carries it |
 | the assemble pipeline's supporting steps | 9 assertions over one run: background layer (memory count, AGENTS.md, CLAUDE.md), toolchain report, hooks arming, board smoke, sibling-clone failure, plugin no-op | a run with nothing failing reaches `CLOUD-READY`, so the `CLOUD-PARTIAL` row is not a provision that always fails |
 | the SessionStart JSON contract | `hookSpecificOutput keys`, `hookEventName is SessionStart`, `reloadSkills is true` | a malformed payload prints `BADJSON` into every field, so the assertions fail rather than skip |
 | adopt reaches every tenant repo | `both cloud hooks wired into the tenant settings.json`, `the SessionStart entry keeps the startup\|resume matcher` | a repo adopted without `--with cloud` carries neither hook |
@@ -70,8 +74,132 @@ FAIL board smoke ran against the repo's kanban
 
 A test never seen failing is not a test.
 
+## 2026-08-11 adversarial review round (commit `547076e`)
+
+An adversarial review demonstrated each finding live rather than describing it.
+One finding is that the previous version of THIS file was wrong: it claimed the
+gate "really switches behavior" and the suite did not prove that.
+
+### Findings, fixes, controls
+
+| # | Sev | Finding | Fix | Control |
+|---|---|---|---|---|
+| 1 | CRITICAL | `workspace` accepted any absolute path from a project `.kit.toml`. `workspace = "$HOME/.claude/skills"` made provisioning create `~/.claude/skills/<repo> -> <repo>`, so a PR-authored root `SKILL.md` became a live skill, loaded in the same session because the hook emits `reloadSkills` | moved to the OPERATOR tier. Constraining it to "under the repo or the home" would not have closed it: `$HOME/.claude/skills` IS under the home | below |
+| 2 | HIGH | `map` accepted any absolute path, so a project value printed a file from outside the repo into model context | stays project-tier, resolved by `repo_path` | below |
+| 3 | HIGH | `rules` same shape | stays project-tier, resolved by `repo_path`; a refused value falls back to the kit's own template | below |
+| 4 | MEDIUM | `op_version` was project-tier and selected a binary that is downloaded, `chmod +x`, prepended to PATH and persisted into `CLAUDE_ENV_FILE`, interpolated unvalidated into the URL | moved to OPERATOR and validated against `^v?[0-9]+(\.[0-9]+)*$` | below |
+| 5 | HIGH | the suite passed 118/118 with the `CLAUDE_CODE_REMOTE` gate DEAD in both hooks. The static check grepped comments, and `guard_off()` plus the OFF session-start run had no `ON_PATH`, so the macOS `uname` gate short-circuited before the cloud gate was read | `has_gate` matches the executable line; both OFF entry points carry `ON_PATH`; a Darwin-stub block pins the Linux gate on its own | below |
+| 6 | MEDIUM | `install_op`'s curl had no `--max-time` while both siblings cap theirs, and it leaked its `mktemp -d` on every path | `--max-time 120` and an explicit `rm -rf` on both paths | shellcheck + suite green |
+| 7 | MEDIUM | the 60s cap bounds ONE clone. Three siblings plus the 150s gh install exceed the SessionStart budget, and blowing it kills the whole hook | a 90s total deadline on the loop, reported as a `!!` line naming the skipped siblings | suite green; the unreachable-sibling row still lands `CLOUD-PARTIAL` |
+| 8 | MEDIUM | `cloud.sh` said "Every verb exits 0 by design" while the unknown-verb path exits 1, which a typo in the Setup-script field turns into an aborted session | the exception is named in `cloud.sh`, and the README marks its `\|\| true` load-bearing | `bin/cloud rejects an unknown verb (exit 1)` already asserts the behavior |
+| 9 | MEDIUM | the global `git config --global --add safe.directory` write sat outside any gate, so a hand-run on a Mac mutated `~/.gitconfig` | gated to `CLAUDE_CODE_REMOTE=true` AND Linux | suite green |
+| 10 | overclaim | the PR body and `SPEC.md` said the tier lint means "the next key cannot silently pick the wrong tier". It checks CONSISTENCY, not CORRECTNESS, and all three holes above passed it | claim softened in `SPEC.md`, the README and `provision.sh`; the correctness half is `repo_path` plus the `op_version` shape check | the new 5b-3 assertions |
+| 11 | unverified | whether a repo-committed `.claude/settings.json` `env` block reaches a hook subprocess in a cloud VM | see "Environment trust" below | none possible off-platform |
+
+### Control: each key, before and after
+
+Same hostile `.kit.toml` run against the unfixed branch (`0448b56`) and the
+fixed one (`547076e`), through a `uname` stub answering Linux.
+
+```
+=========== workspace: [cloud] workspace = $HOME/.claude/skills ===========
+BEFORE   ~/.claude/skills/repo -> CREATED (.../repo)  <-- the PR SKILL.md is now a live skill
+AFTER    ~/.claude/skills/repo -> not created
+positive control:
+AFTER    $W/ws-operator/repo symlink: present          (operator tier still sets it)
+
+=========== map: [cloud] map = an absolute path outside the repo ===========
+BEFORE   cloud map -> SECRET OUTSIDE THE REPO
+AFTER    cloud map ->   !! map: '/.../.secret-outside-repo' is absolute; a project
+                        key may only name a path inside this repo
+positive control AFTER (repo-relative map) -> IN-REPO MAP MARKER
+
+=========== rules: [cloud] rules = an absolute path outside the repo ===========
+BEFORE   cloud rules -> SECRET OUTSIDE THE REPO
+AFTER    cloud rules ->   !! rules: '/.../.secret-outside-repo' is absolute; a project
+                          key may only name a path inside this repo
+                          # Cloud session rules (portable template)   <-- safe fallback
+positive control AFTER (repo-relative rules) -> IN-REPO RULES MARKER
+
+=========== op_version: a traversal-shaped pin in the download URL ===========
+BEFORE   URL -> https://cache.agilebits.com/dist/1P/op2/pkg/vEVIL/../../../../attacker-path/op_linux_arm64_vEVIL/../../../../attacker-path.zip
+AFTER    URL -> https://cache.agilebits.com/dist/1P/op2/pkg/v2.31.1/op_linux_arm64_v2.31.1.zip
+positive control AFTER (a real pin from the operator tier):
+AFTER    URL -> https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.0/op_linux_arm64_v2.30.0.zip
+```
+
+The `..` traversal and the committed-symlink shapes of the same three escapes
+are asserted in the suite, section 5b-3, not only here.
+
+### Control: the gate suite goes red, per gate
+
+Each run neuters ONE gate by changing `|| exit 0` to `|| :`, leaving the literal
+variable name in place, then restores. Tree clean after each.
+
+| Neutered | Result |
+|---|---|
+| nothing (baseline) | `PASS 146  FAIL 0`, exit 0 |
+| `CLAUDE_CODE_REMOTE` in BOTH hooks | `PASS 134  FAIL 6`, exit 1 |
+| `CLAUDE_CODE_REMOTE` in `cloud-session-start.sh` only | `PASS 136  FAIL 4`, exit 1 |
+| `CLAUDE_CODE_REMOTE` in `cloud-dash-guard.sh` only | `PASS 137  FAIL 3`, exit 1 |
+| the Linux gate in BOTH hooks | `PASS 142  FAIL 4`, exit 1 |
+
+The both-hooks cloud-gate run:
+
+```
+FAIL cloud-session-start.sh gates on CLAUDE_CODE_REMOTE
+FAIL cloud-dash-guard.sh gates on CLAUDE_CODE_REMOTE
+FAIL dash guard OFF leaves the file byte-identical
+FAIL session-start hook OFF is silent
+FAIL session-start hook OFF assembled nothing
+FAIL NC: the same re-invocation with nothing planted exits 0
+PASS 134  FAIL 6
+```
+
+Before this round the identical mutation produced `smoke: all 118 passed`.
+
+### Suites at `547076e`
+
+| Suite | Result |
+|---|---|
+| `bash lib/cloud/tests/smoke.sh` | `smoke: all 146 passed`, exit 0 |
+| `bash tests/test-meta.sh` | `Passed: 799 / 799`, exit 0 |
+| `bash tests/test-hooks.sh` | `Passed: 492 / 492`, exit 0 |
+| `bash tests/test-bin-forwarders.sh` | `all 33 passed, 0 skipped`, exit 0 |
+| `bash tests/test-install-modules.sh` | `37 passed, 0 failed`, exit 0 |
+| `bash tests/test-adopt.sh` | `PASS=21 FAIL=0`, exit 0 |
+| `bash tests/test-config-registry.sh` | `19/19 passed`, exit 0 |
+| `bash tests/test-kit-contract.sh` | `23 passed, 2 failed`, exit 1. BASELINED: pristine `master` at `e7adc2a` fails the SAME two, both `lib/bench` |
+| `shellcheck -S warning lib/cloud/*.sh lib/cloud/tests/smoke.sh hooks/cloud-*.sh bin/cloud` | empty, exit 0 |
+
+### Environment trust (finding 11)
+
+The `CLOUD_<KEY>` env tier is KEPT for operator keys. Removing it was the
+reviewer's stated preference and it was rejected, for one reason:
+`CLOUD_PROVISION`, the master switch for the whole module, is env-only and has
+no config channel. An actor who can set environment variables in a cloud VM
+turns the module on and owns it regardless of where the individual keys resolve,
+so removing the key tier alone closes nothing while costing the operator their
+only per-environment channel (the kit-root `kit.toml` arrives inside the git
+clone).
+
+What was hardened instead, because it was a real second door to the same room:
+the kit-root config path is now PINNED to the kit install `provision.sh` belongs
+to. `kit-config.sh` otherwise reads `KIT_CONFIG_ROOT`/`DWARVES_KIT` from the
+environment, so the operator-owned half of the tier split could have been
+redirected at a `kit.toml` committed inside the repo.
+
+The environment is therefore documented as the trust anchor in `SPEC.md` and in
+the README, not as a convenience.
+
 ## Not proved here
 
 See the "Not covered here" table in `docs/verification/cloud-session-support.md`
 for the full list, including the two installs that only a real cloud VM can
-prove and the CI leg that has not been dispatched.
+prove and the CI leg that has not been dispatched. Added by this round:
+
+| Claim | Status |
+|---|---|
+| a repo-committed `.claude/settings.json` `env` block does NOT reach a hook subprocess in a cloud VM | UNVERIFIED, and it is the load-bearing assumption under the operator tier. If it DOES reach one, a PR can set `CLOUD_PROVISION=1` plus any operator key and the tier split is bypassed. That needs a kit-wide env-hardening pass, not a cloud-local one. Only a real cloud VM answers it |
+| the 90s sibling-clone budget is the right number against the real SessionStart timeout | UNVERIFIED. The platform's hook timeout is not documented; 90s leaves room for the 150s gh install under a 300s assumption. A real VM run calibrates it |
+| the `safe.directory` gate does not break a real cloud session | UNVERIFIED on the platform. The write now needs `CLAUDE_CODE_REMOTE=true` and Linux, which is exactly the context the comment names, but only a VM run confirms root still resolves the repo root there |

--- a/lib/cloud/provision.sh
+++ b/lib/cloud/provision.sh
@@ -22,22 +22,39 @@
 # request can therefore set it.
 #
 #   THE RULE, for whoever adds the next key: a PROJECT key may only name
-#   something INSIDE this repo. Anything that reaches outside the repo, runs
-#   code, or names a credential is an OPERATOR key and skips the project
-#   overlay. When in doubt, take the operator tier.
+#   something INSIDE this repo, and the code must ENFORCE that, not just
+#   promise it. Anything that reaches outside the repo, runs code, or names a
+#   credential is an OPERATOR key and skips the project overlay. When in doubt,
+#   take the operator tier.
 #
 #   key           tier      env override        default
 #   ------------  --------  ------------------  ------------------------------
-#   workspace     project   CLOUD_WORKSPACE     $HOME/workspace
-#   map           project   CLOUD_MAP           (none)
+#   map           project   CLOUD_MAP           (none)          repo-relative
 #   rules         project   CLOUD_RULES         the kit's CLOUD-RULES.md
-#   op_version    project   CLOUD_OP_VERSION    v2.31.1
+#   workspace     operator  CLOUD_WORKSPACE     $HOME/workspace
+#   op_version    operator  CLOUD_OP_VERSION    v2.31.1
 #   repos         operator  CLOUD_REPOS         (none)
 #   repo_owner    operator  CLOUD_REPO_OWNER    (none)
 #   plugins       operator  CLOUD_PLUGINS       (none)
 #   hooks_path    operator  CLOUD_HOOKS_PATH    (none, never auto-detected)
 #   vault         operator  CLOUD_VAULT         (none)
 #   canary_ref    operator  CLOUD_CANARY_REF    op://<vault>/cloud-canary/credential
+#
+# The two project keys are PATHS, so `repo_path` resolves each one against the
+# repo root and refuses anything that escapes it. Naming the tier is not the
+# control; the resolution check is.
+#
+# `workspace` is operator-tier because it names a directory OUTSIDE the repo and
+# the assemble step creates a symlink there. A project-settable value pointed it
+# at `$HOME/.claude/skills`, which turned a PR-authored root `SKILL.md` into a
+# live skill in the same session (reproduced). Constraining it to "under the
+# home" would not have stopped that, because that path IS under the home.
+#
+# `op_version` is operator-tier because it selects a BINARY: the value is
+# interpolated into a download URL, and the download is then chmod +x, prepended
+# to PATH and persisted into CLAUDE_ENV_FILE. It is additionally validated
+# against a version shape, because "operator-tier" is not a reason to skip
+# validating a value that lands in a URL.
 #
 # `repos` and `repo_owner` are operator keys even though a clone runs no code:
 # the clone's AGENTS.md and CLAUDE.md are then NAMED to the model as files to
@@ -82,9 +99,16 @@ if [ -z "$ROOT" ]; then
   # guard, so `git rev-parse` returns empty even inside a clone. Mark it safe,
   # then retry. `.git` is a DIRECTORY in a normal clone and a FILE in a
   # worktree, so test for existence, not for a directory.
+  #
+  # Marking a directory safe writes the operator's GLOBAL ~/.gitconfig, so the
+  # write is gated to the context that needs it. Ungated, a hand-run of this
+  # script on a workstation mutated the operator's own git config. The cloud VM
+  # is the only place root meets someone else's checkout here.
   _cwd="$(pwd -P 2>/dev/null || true)"
   if [ -n "$_cwd" ] && [ -e "$_cwd/.git" ]; then
-    git config --global --add safe.directory "$_cwd" 2>/dev/null || true
+    if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ] && [ "$(uname -s)" = "Linux" ]; then
+      git config --global --add safe.directory "$_cwd" 2>/dev/null || true
+    fi
     ROOT="$(git -C "$_cwd" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$_cwd")"
   else
     ROOT="$_cwd"
@@ -126,12 +150,19 @@ _cfg_env() {
   printf '%s' "${!envname:-}"
 }
 
+#
+# KIT_CONFIG_ROOT is PINNED to the kit install this script belongs to. The
+# resolver otherwise takes that path from the environment, so the kit-root file
+# that is supposed to be the operator-owned half of the split could be
+# redirected at a file inside the repo. Pinning it means the operator tier reads
+# one file whose location no caller chooses.
 cfg() {
   local key="$1" def="${2:-}" v
   v="$(_cfg_env "$key")"
   [ -n "$v" ] && { printf '%s' "$v"; return 0; }
   if [ "$RESOLVER_OK" -eq 1 ]; then
-    v="$(KIT_PROJECT_ROOT="$ROOT" kit_config_get "cloud.$key" "" 2>/dev/null || true)"
+    v="$(KIT_PROJECT_ROOT="$ROOT" KIT_CONFIG_ROOT="$KIT_ROOT" \
+         kit_config_get "cloud.$key" "" 2>/dev/null || true)"
     [ -n "$v" ] && { printf '%s' "$v"; return 0; }
   fi
   printf '%s' "$def"
@@ -142,7 +173,7 @@ cfg_root() {
   v="$(_cfg_env "$key")"
   [ -n "$v" ] && { printf '%s' "$v"; return 0; }
   if [ "$RESOLVER_OK" -eq 1 ]; then
-    v="$(kit_config_get_root "cloud.$key" "" 2>/dev/null || true)"
+    v="$(KIT_CONFIG_ROOT="$KIT_ROOT" kit_config_get_root "cloud.$key" "" 2>/dev/null || true)"
     [ -n "$v" ] && { printf '%s' "$v"; return 0; }
   fi
   printf '%s' "$def"
@@ -176,16 +207,79 @@ expand_home() {  # expand_home <path>
 
 # The tier split, declared ONCE. The suite reads these two lists out of this
 # source and fails if a key is read through the wrong resolver, or belongs to
-# neither list, so the next key cannot silently pick the wrong tier.
+# neither list.
+#
+# That lint checks CONSISTENCY, not CORRECTNESS. It proves each key is read
+# through the resolver its list names; it cannot know whether the list is the
+# right one for that key. Three keys sat in the project list, passed this lint
+# for the whole life of the branch, and each one reached outside the repo. The
+# lint is a spelling check on the tier split, and the enforcement for a
+# project-tier PATH is `repo_path`, below.
 # shellcheck disable=SC2034  # read by lib/cloud/tests/smoke.sh, not by this script
-CLOUD_PROJECT_KEYS="workspace map rules op_version"
+CLOUD_PROJECT_KEYS="map rules"
 # shellcheck disable=SC2034  # same
-CLOUD_OPERATOR_KEYS="repos repo_owner plugins hooks_path vault canary_ref"
+CLOUD_OPERATOR_KEYS="workspace op_version repos repo_owner plugins hooks_path vault canary_ref"
 
-WS="$(expand_home "$(cfg workspace "$_home/workspace")")"
-MAP="$(cfg map "")"
-RULES="$(cfg rules "")"
-OP_VERSION="$(cfg op_version v2.31.1)"
+# ROOT resolved through symlinks: every containment test below compares against
+# this, never against the possibly-symlinked ROOT the caller handed us.
+ROOT_P="$(cd "$ROOT" 2>/dev/null && pwd -P)" || ROOT_P=""
+[ -n "$ROOT_P" ] || ROOT_P="$ROOT"
+
+# repo_path <key> <value> -- resolve a PROJECT-tier path against the repo root.
+# THE rule for a project key is that it may only name something inside this
+# repo, and this is where that rule is enforced. Rejected: an absolute path, a
+# leading `~`, any `..` segment, a path whose directory resolves outside the
+# repo (an intermediate symlink), and a final component that is itself a symlink
+# (a committed `docs/x.md -> /etc/foo` would otherwise be read and printed into
+# model context).
+#
+# The answer comes back in REPO_PATH_OUT, not on stdout, because the refusal
+# reason goes through `note`: a `$( )` call site would swallow that reason INTO
+# the value, leave the value non-empty, and print the note twice (caught in the
+# first run of this guard's own control).
+REPO_PATH_OUT=""
+repo_path() {  # repo_path <key> <value>  -> REPO_PATH_OUT, 1 on refusal
+  local key="$1" val="$2" dir base out
+  REPO_PATH_OUT=""
+  [ -n "$val" ] || return 1
+  case "$val" in
+    /*)  note "$key: '$val' is absolute; a project key may only name a path inside this repo"; return 1 ;;
+    "~"*) note "$key: '$val' starts with ~; a project key may only name a path inside this repo"; return 1 ;;
+  esac
+  case "/$val/" in
+    */../*) note "$key: '$val' contains '..'; a project key may only name a path inside this repo"; return 1 ;;
+  esac
+  dir="$(cd "$ROOT_P/$(dirname "$val")" 2>/dev/null && pwd -P)" || dir=""
+  [ -n "$dir" ] || { note "$key: '$val' does not resolve inside this repo"; return 1; }
+  base="$(basename "$val")"
+  out="$dir/$base"
+  case "$out" in
+    "$ROOT_P"/*) ;;
+    *) note "$key: '$val' resolves outside the repo ($out)"; return 1 ;;
+  esac
+  if [ -L "$out" ]; then
+    note "$key: '$val' is a symlink; a project key may not point out of the repo through one"
+    return 1
+  fi
+  REPO_PATH_OUT="$out"
+}
+
+WS="$(expand_home "$(cfg_root workspace "$_home/workspace")")"
+MAP_RAW="$(cfg map "")"
+RULES_RAW="$(cfg rules "")"
+MAP=""; [ -n "$MAP_RAW" ] && repo_path map   "$MAP_RAW"   && MAP="$REPO_PATH_OUT"
+RULES=""; [ -n "$RULES_RAW" ] && repo_path rules "$RULES_RAW" && RULES="$REPO_PATH_OUT"
+
+# The op pin selects a binary to download, chmod +x and put on PATH, so it is
+# validated as well as operator-tier: a value like `vX/../../../attacker` built
+# a traversal-shaped download URL. A bad pin falls back to the default rather
+# than failing the session, per the exits-0 invariant.
+OP_DEFAULT_VERSION=v2.31.1
+OP_VERSION="$(cfg_root op_version "$OP_DEFAULT_VERSION")"
+if ! printf '%s' "$OP_VERSION" | grep -qE '^v?[0-9]+(\.[0-9]+)*$'; then
+  note "op_version '$OP_VERSION' is not a version string; falling back to $OP_DEFAULT_VERSION"
+  OP_VERSION="$OP_DEFAULT_VERSION"
+fi
 # Operator-owned tier: a branch under review may not set any of these.
 REPOS="$(cfg_root repos "")"
 REPO_OWNER="$(cfg_root repo_owner "")"
@@ -196,10 +290,12 @@ HOOKS_PATH="$(cfg_root hooks_path "")"
 CANARY_VALUE="${CLOUD_CANARY_VALUE:-CLOUD-CANARY-OK}"
 
 # The rules a cloud session follows: the consumer's own file when it names one,
-# else the kit's portable template.
+# else the kit's portable template. RULES is already repo_path-resolved, so a
+# value that pointed outside the repo is empty here and falls back to the kit's
+# own template, which is the safe direction to fail.
 rules_file() {
   if [ -n "$RULES" ]; then
-    case "$RULES" in /*) printf '%s' "$RULES" ;; *) printf '%s' "$ROOT/$RULES" ;; esac
+    printf '%s' "$RULES"
   else
     printf '%s' "$KIT_ROOT/lib/cloud/CLOUD-RULES.md"
   fi
@@ -263,7 +359,7 @@ persist_path() {
 }
 
 install_op() {
-  local arch url tmp
+  local arch url tmp rc=0
   [ "$(uname -s)" = "Linux" ] || { note "secrets: op missing (install it for $(uname -s) by hand)"; return 1; }
   case "$(uname -m)" in
     x86_64|amd64)  arch=amd64 ;;
@@ -274,15 +370,25 @@ install_op() {
   url="https://cache.agilebits.com/dist/1P/op2/pkg/$OP_VERSION/op_linux_${arch}_$OP_VERSION.zip"
   tmp="$(mktemp -d)"
   mkdir -p "$HOME/.local/bin"
-  if curl -fsSL "$url" -o "$tmp/op.zip" && unzip -oq "$tmp/op.zip" op -d "$HOME/.local/bin"; then
+  # --max-time, like both sibling downloads (60 for a clone, 150 for the gh
+  # install): without it a stalled connection holds the SessionStart hook open
+  # until the platform kills the whole hook, which loses every step after this
+  # one instead of just this one.
+  if curl -fsSL --max-time 120 "$url" -o "$tmp/op.zip" \
+     && unzip -oq "$tmp/op.zip" op -d "$HOME/.local/bin"; then
     chmod +x "$HOME/.local/bin/op"
     export PATH="$HOME/.local/bin:$PATH"   # this process only
     persist_path                           # every later Bash command
     say "ok  secrets: installed op $OP_VERSION"
   else
     note "secrets: op install failed ($url)"
-    return 1
+    rc=1
   fi
+  # Explicit, on both paths: the download dir leaked on every call, green or
+  # red. A RETURN trap would be the tidier shape and is not worth the bash
+  # inheritance rules it drags in.
+  rm -rf "$tmp"
+  return "$rc"
 }
 
 # Secrets. A cloud session bootstraps from ONE env var (OP_SERVICE_ACCOUNT_TOKEN,
@@ -363,13 +469,15 @@ plugins() {
 # ---------------------------------------------------------------- verbs
 case "${1:-}" in
   map)
-    if [ -z "$MAP" ]; then
+    if [ -z "$MAP_RAW" ]; then
       say "ok  map: this repo configures no routing map ([cloud] map in .kit.toml)"
       exit 0
     fi
-    case "$MAP" in /*) m="$MAP" ;; *) m="$ROOT/$MAP" ;; esac
-    [ -f "$m" ] || { note "map: $m missing"; exit 0; }
-    cat "$m"
+    # An empty MAP with a non-empty MAP_RAW means repo_path already refused the
+    # value and printed the reason. Printing the file anyway is the whole bug.
+    [ -n "$MAP" ] || exit 0
+    [ -f "$MAP" ] || { note "map: $MAP missing"; exit 0; }
+    cat "$MAP"
     exit 0
     ;;
   rules)
@@ -411,8 +519,20 @@ fi
 # 2. Sibling repos the consumer declared. Cloning depends on the platform's
 #    GitHub proxy covering repos beyond the session repo; when it does not, this
 #    reports and the session keeps working in the repo it has.
+#
+#    The 60s per-clone cap bounds ONE clone, not the loop. Three unreachable
+#    siblings at 60s plus the 150s gh install already exceed the SessionStart
+#    budget, and blowing that budget kills the whole hook, losing every step
+#    after this one. So the loop carries its own deadline and reports the
+#    siblings it skipped, which is the same degradation the per-clone cap gives.
+CLONE_BUDGET=90
+clone_deadline=$(( $(date +%s) + CLONE_BUDGET ))
 for r in $(printf '%s' "$REPOS" | tr ',' ' '); do
   [ -n "$r" ] || continue
+  if [ "$(date +%s)" -ge "$clone_deadline" ]; then
+    note "repos: the ${CLONE_BUDGET}s clone budget is spent; '$r' and any after it were skipped (clone on demand: provision.sh repo $r)"
+    break
+  fi
   case "$r" in
     */*) slug="$r" ;;
     *)   [ -n "$REPO_OWNER" ] || { note "repos: '$r' is a bare name and no repo_owner is set"; continue; }

--- a/lib/cloud/provision.sh
+++ b/lib/cloud/provision.sh
@@ -276,7 +276,20 @@ RULES=""; [ -n "$RULES_RAW" ] && repo_path rules "$RULES_RAW" && RULES="$REPO_PA
 # than failing the session, per the exits-0 invariant.
 OP_DEFAULT_VERSION=v2.31.1
 OP_VERSION="$(cfg_root op_version "$OP_DEFAULT_VERSION")"
-if ! printf '%s' "$OP_VERSION" | grep -qE '^v?[0-9]+(\.[0-9]+)*$'; then
+# `case`, not `grep -qE`: grep matches LINE-wise, so a multi-line value passes
+# when ANY line matches and the rest still reaches the URL. Verified:
+# CLOUD_OP_VERSION=$'v1.0\n../../../../attacker-path' was ACCEPTED by the grep
+# form. A case glob tests the whole string, so a newline cannot hide behind a
+# valid first line. Host stays pinned either way, so this was low severity, but
+# operator tier is not a reason to skip validating a value that lands in a URL.
+case "$OP_VERSION" in
+  v[0-9]*|[0-9]*) _op_shape=ok ;;
+  *) _op_shape=bad ;;
+esac
+case "$OP_VERSION" in
+  *[!v0-9.]*) _op_shape=bad ;;
+esac
+if [ "$_op_shape" != ok ]; then
   note "op_version '$OP_VERSION' is not a version string; falling back to $OP_DEFAULT_VERSION"
   OP_VERSION="$OP_DEFAULT_VERSION"
 fi

--- a/lib/cloud/tests/smoke.sh
+++ b/lib/cloud/tests/smoke.sh
@@ -80,8 +80,16 @@ sha() { if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | cut -c1-
 # Two entry points rather than one with an env prefix: a variable assignment in
 # front of a FUNCTION call leaks into the calling shell in bash, which would
 # leave PATH rewritten for the rest of the run.
+#
+# ON_PATH IS LOAD-BEARING IN THE OFF CASE TOO. Without it the macOS `uname` gate
+# fires first and the hook exits before the cloud gate is ever read, so every
+# OFF assertion passed with the cloud gate DELETED. That was the sixth false
+# green in this subsystem's history: the suite proved at least one of the three
+# gates fires, never which one. With the stub in place the OFF case reaches the
+# cloud gate for real, and neutering that one line turns this suite red.
 guard_off() { printf '{"tool_input":{"file_path":"%s"}}' "$1" \
-    | env -u CLAUDE_CODE_REMOTE CLOUD_DASH_GUARD=1 bash "$H/cloud-dash-guard.sh"; }
+    | PATH="$ON_PATH" env -u CLAUDE_CODE_REMOTE CLOUD_DASH_GUARD=1 \
+      bash "$H/cloud-dash-guard.sh"; }
 guard_on()  { printf '{"tool_input":{"file_path":"%s"}}' "$1" \
     | PATH="$ON_PATH" CLOUD_DASH_GUARD=1 CLAUDE_CODE_REMOTE=true HOME="$W/home" \
       bash "$H/cloud-dash-guard.sh"; }
@@ -94,8 +102,17 @@ guard_noswitch() { printf '{"tool_input":{"file_path":"%s"}}' "$1" \
 echo
 echo "=== 1. STATIC: the gate is the documented variable, not a directory probe ==="
 has() { grep -q "$1" "$2" 2>/dev/null && echo yes || echo no; }
+# has_gate matches the EXECUTABLE gate line, not any occurrence of the name.
+# `has` greps the whole file, and every gate in these hooks has a paragraph of
+# prose above it naming the variable, so `has` reported yes for a hook whose
+# gate had been changed from `|| exit 0` to `|| :`. The static check has to
+# match the line that does the work: the test, the comparison, and the exit.
+has_gate() {  # has_gate <VARNAME> <file>
+  grep -qE "^\[ \"\\\$\{$1:-\}\" = \"[^\"]*\" \] \|\| exit 0" "$2" 2>/dev/null \
+    && echo yes || echo no
+}
 for h in cloud-session-start.sh cloud-dash-guard.sh; do
-  ck "$h gates on CLAUDE_CODE_REMOTE" yes "$(has 'CLAUDE_CODE_REMOTE' "$H/$h")"
+  ck "$h gates on CLAUDE_CODE_REMOTE" yes "$(has_gate CLAUDE_CODE_REMOTE "$H/$h")"
   # The failure this replaces: a gate that tested for a sibling checkout, so
   # cloning that sibling disabled the hook mid-session.
   ck "$h has no '-d \$HOME/...' cloud probe" no \
@@ -109,6 +126,18 @@ ck "NC: the same pattern fires on the historical gate shape" yes \
   "$(grep -qE '^\[ -d "\$HOME/' "$W/old-gate-fixture" && echo yes || echo no)"
 ck "NC: the helper reports absent for a string in no hook" no \
   "$(has 'zzz-not-in-any-hook' "$H/cloud-session-start.sh")"
+# NC for has_gate, the check this suite's sixth false green turned on: a fixture
+# that MENTIONS the variable in prose and neuters the gate must report no, and
+# the intact shape must report yes.
+printf '# gates on CLAUDE_CODE_REMOTE, the documented cloud signal\n[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || :\n' \
+  >"$W/neutered-gate-fixture"
+ck "NC: has_gate rejects a neutered gate whose name survives in a comment" no \
+  "$(has_gate CLAUDE_CODE_REMOTE "$W/neutered-gate-fixture")"
+ck "NC: the plain grep is fooled by that same fixture (why has_gate exists)" yes \
+  "$(has 'CLAUDE_CODE_REMOTE' "$W/neutered-gate-fixture")"
+printf '[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0\n' >"$W/intact-gate-fixture"
+ck "NC: has_gate accepts the intact shape" yes \
+  "$(has_gate CLAUDE_CODE_REMOTE "$W/intact-gate-fixture")"
 
 # The master switch is checked FIRST, before the cloud gate. hooks.json is the
 # plugin manifest and is NOT filtered by the enabled module set, so on the
@@ -125,7 +154,7 @@ gate_order() {  # gate_order <file> <switch-name>
 }
 for pair in "cloud-session-start.sh|CLOUD_PROVISION" "cloud-dash-guard.sh|CLOUD_DASH_GUARD"; do
   h="${pair%%|*}"; sw="${pair##*|}"
-  ck "$h checks $sw" yes "$(has "$sw" "$H/$h")"
+  ck "$h checks $sw" yes "$(has_gate "$sw" "$H/$h")"
   ck "$h checks the switch before CLAUDE_CODE_REMOTE" yes "$(gate_order "$H/$h" "$sw")"
 done
 # NC: the order check reports 'no' on a fixture where the switch comes second.
@@ -134,9 +163,12 @@ printf '[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0\n[ "${CLOUD_PROVISION:-
 ck "NC: the order check catches a switch placed after the cloud gate" no \
   "$(gate_order "$W/order-fixture" CLOUD_PROVISION)"
 
-# The tier split is declared once and read from there, so a new key cannot pick
-# the wrong resolver silently. Every key provision.sh reads must appear in
-# exactly one list, and be read through that list's resolver.
+# The tier split is declared once and read from there. This lint checks
+# CONSISTENCY, never CORRECTNESS: every key provision.sh reads appears in
+# exactly one list and is read through that list's resolver. It cannot know
+# whether the list is the RIGHT one for the key, and three keys that reached
+# outside the repo passed it for the whole life of the branch. The correctness
+# half for a project-tier PATH is the repo_path containment assertions in 5b-3.
 tier_bad=""
 proj="$(grep -oE '^CLOUD_PROJECT_KEYS="[^"]*"' "$L/provision.sh" | sed 's/.*"\(.*\)"/\1/')"
 oper="$(grep -oE '^CLOUD_OPERATOR_KEYS="[^"]*"' "$L/provision.sh" | sed 's/.*"\(.*\)"/\1/')"
@@ -161,7 +193,7 @@ ck "NC: the tier lists are non-empty (the extraction is not vacuous)" yes \
 
 # The op CLI pin lives in two files that run in different contexts (Setup-script
 # time and per-session). A bump that touches one and not the other desyncs them.
-op_pin_a="$(grep -oE 'cfg op_version v[0-9.]+' "$L/provision.sh" | grep -oE 'v[0-9.]+')"
+op_pin_a="$(grep -oE '^OP_DEFAULT_VERSION=v[0-9.]+' "$L/provision.sh" | grep -oE 'v[0-9.]+')"
 op_pin_b="$(grep -oE 'OP_VERSION:-v[0-9.]+' "$L/vm-setup.sh" | grep -oE 'v[0-9.]+')"
 ck "the op version pin matches across provision.sh and vm-setup.sh" "$op_pin_a" "$op_pin_b"
 ck "NC: the op pin extraction is not empty on both sides" yes \
@@ -193,9 +225,17 @@ ck "dash guard OFF exit code" 0 "$rc"
 ck "dash guard OFF is silent" "" "$out"
 ck "dash guard OFF leaves the file byte-identical" "$before" "$(sha "$W/off.md")"
 
-out="$(echo '{}' | env -u CLAUDE_CODE_REMOTE CLOUD_PROVISION=1 bash "$H/cloud-session-start.sh")"; rc=$?
+# Same reason as guard_off: ON_PATH so the uname gate cannot short-circuit the
+# run before the cloud gate. Every side effect is aimed at the workdir, because
+# a NEUTERED cloud gate makes this invocation really provision.
+mkdir -p "$W/off-repo"; git -C "$W/off-repo" init -q 2>/dev/null || true
+out="$(echo '{}' | PATH="$ON_PATH" env -u CLAUDE_CODE_REMOTE CLOUD_PROVISION=1 \
+       HOME="$W/home-off" CLOUD_WORKSPACE="$W/ws-off" CLAUDE_PROJECT_DIR="$W/off-repo" \
+       bash "$H/cloud-session-start.sh")"; rc=$?
 ck "session-start hook OFF exit code" 0 "$rc"
 ck "session-start hook OFF is silent" "" "$out"
+ck "session-start hook OFF assembled nothing" no \
+  "$([ -e "$W/ws-off" ] && echo yes || echo no)"
 
 # The other half of OFF: a real cloud session that never opted in.
 printf '%s\n' "$PROSE_IN" >"$W/noswitch.md"
@@ -222,6 +262,31 @@ mkdir -p "$W/home/workspace/sibling"
 printf '%s\n' "$PROSE_IN" >"$W/sib.md"
 guard_on "$W/sib.md" >/dev/null
 ck "dash guard still fires with a sibling repo cloned" "$PROSE_OUT" "$(cat "$W/sib.md")"
+
+# Each hook has THREE gates: its switch, the cloud signal, and Linux. The suite
+# proved that SOME gate fired, never which one, so any single gate could be
+# deleted and every assertion stayed green. Sections 2 and 3 now pin the switch
+# and the cloud signal; this pins the third, with both other gates ON.
+mkdir -p "$W/darwin"
+printf '#!/bin/sh\n[ "$1" = "-s" ] && { echo Darwin; exit 0; }\nexec /usr/bin/uname "$@"\n' \
+  >"$W/darwin/uname"
+chmod +x "$W/darwin/uname"
+DARWIN_PATH="$W/darwin:$PATH"
+printf '%s\n' "$PROSE_IN" >"$W/darwin.md"
+before="$(sha "$W/darwin.md")"
+out="$(printf '{"tool_input":{"file_path":"%s"}}' "$W/darwin.md" \
+       | PATH="$DARWIN_PATH" CLOUD_DASH_GUARD=1 CLAUDE_CODE_REMOTE=true HOME="$W/home" \
+         bash "$H/cloud-dash-guard.sh")"; rc=$?
+ck "dash guard off Linux exit code" 0 "$rc"
+ck "dash guard off Linux is silent" "" "$out"
+ck "dash guard off Linux leaves the file byte-identical" "$before" "$(sha "$W/darwin.md")"
+out="$(echo '{}' | PATH="$DARWIN_PATH" CLOUD_PROVISION=1 CLAUDE_CODE_REMOTE=true \
+       HOME="$W/home-dar" CLOUD_WORKSPACE="$W/ws-dar" CLAUDE_PROJECT_DIR="$W/off-repo" \
+       bash "$H/cloud-session-start.sh")"; rc=$?
+ck "session-start off Linux exit code" 0 "$rc"
+ck "session-start off Linux is silent" "" "$out"
+ck "session-start off Linux assembled nothing" no \
+  "$([ -e "$W/ws-dar" ] && echo yes || echo no)"
 
 echo
 echo "=== 4. STRUCTURE: no newline consumed, code untouched, prose only ==="
@@ -331,10 +396,22 @@ out="$(PATH="$ON_PATH" HOME="$W/home5" env -u CLOUD_WORKSPACE \
 ck "rules verb reads [cloud] rules from the project .kit.toml" "PROJECT RULES MARKER" "$out"
 out="$(PATH="$ON_PATH" HOME="$W/home5" env -u CLOUD_WORKSPACE \
        bash "$L/provision.sh" --repo-root "$W/cfgrepo" 2>&1)"
-ck "assemble honours [cloud] workspace" yes \
-  "$([ -L "$W/ws-from-toml/cfgrepo" ] && echo yes || echo no)"
+# workspace is OPERATOR-tier: the same project .kit.toml that legitimately sets
+# `rules` must not be able to choose the directory this script creates a symlink
+# in. Set to `$HOME/.claude/skills` from a project file, it made a PR-authored
+# root SKILL.md a live skill in the same session.
+ck "the project .kit.toml did NOT choose the workspace" no \
+  "$([ -e "$W/ws-from-toml" ] && echo yes || echo no)"
+ck "the workspace fell back to the default under HOME" yes \
+  "$([ -L "$W/home5/workspace/cfgrepo" ] && echo yes || echo no)"
 case "$out" in *"docs/MY-RULES.md"*) got=yes ;; *) got=no ;; esac
 ck "assemble names the project rules file" yes "$got"
+# NC: the SAME value from the operator tier does choose the workspace, so the
+# two assertions above are the tier boundary and not a workspace that never works.
+out="$(PATH="$ON_PATH" HOME="$W/home5b" CLOUD_WORKSPACE="$W/ws-from-env" \
+       bash "$L/provision.sh" --repo-root "$W/cfgrepo" 2>&1)"
+ck "NC: the operator tier DOES choose the workspace" yes \
+  "$([ -L "$W/ws-from-env/cfgrepo" ] && echo yes || echo no)"
 # NC: with no project config, the kit's own template is the rules file.
 out="$(PATH="$ON_PATH" HOME="$W/home5" env -u CLOUD_WORKSPACE CLOUD_WORKSPACE="$W/ws3" \
        bash "$L/provision.sh" --repo-root "$W/repo" 2>&1)"
@@ -360,6 +437,69 @@ ck "NC: no literal '~' directory was created under the repo" no \
   "$([ -e "$W/repo/~" ] && echo yes || echo no)"
 
 echo
+echo "=== 5b-3. a project-tier PATH resolves INSIDE the repo, or it is refused ==="
+# Calling a key "project tier" is a comment. This is the enforcement. Both
+# project keys are paths, and each escape shape below printed a file from
+# outside the repo straight into model context before repo_path existed.
+mkdir -p "$W/escape/docs" "$W/curlfail"
+printf 'SECRET OUTSIDE THE REPO\n' >"$W/outside-secret.md"
+printf 'IN-REPO MAP MARKER\n' >"$W/escape/docs/MAP.md"
+printf 'IN-REPO RULES MARKER\n' >"$W/escape/docs/RULES.md"
+ln -sf "$W/outside-secret.md" "$W/escape/docs/link-out.md"
+printf '#!/bin/sh\nexit 1\n' >"$W/curlfail/curl"; chmod +x "$W/curlfail/curl"
+
+esc() {  # esc <verb> <toml-line> -- run one verb with a hostile project value
+  printf '[cloud]\n%s\n' "$2" >"$W/escape/.kit.toml"
+  PATH="$ON_PATH" HOME="$W/home9" CLOUD_WORKSPACE="$W/ws-escape" \
+    env -u CLOUD_MAP -u CLOUD_RULES \
+    bash "$L/provision.sh" --repo-root "$W/escape" "$1" 2>&1
+}
+for k in map rules; do
+  out="$(esc "$k" "$k = \"$W/outside-secret.md\"")"
+  case "$out" in *'SECRET OUTSIDE THE REPO'*) got=leaked ;; *) got=refused ;; esac
+  ck "$k: an absolute path outside the repo is refused" refused "$got"
+  case "$out" in *'!!'*) got=yes ;; *) got=no ;; esac
+  ck "$k: the refusal is explained, not silent" yes "$got"
+  out="$(esc "$k" "$k = \"../outside-secret.md\"")"
+  case "$out" in *'SECRET OUTSIDE THE REPO'*) got=leaked ;; *) got=refused ;; esac
+  ck "$k: a .. traversal out of the repo is refused" refused "$got"
+  out="$(esc "$k" "$k = \"docs/link-out.md\"")"
+  case "$out" in *'SECRET OUTSIDE THE REPO'*) got=leaked ;; *) got=refused ;; esac
+  ck "$k: a committed symlink pointing out of the repo is refused" refused "$got"
+done
+# NC: the legitimate repo-relative use of both keys still works, so the six
+# assertions above are a containment check and not a key that never resolves.
+ck "NC: a repo-relative map is still printed" "IN-REPO MAP MARKER" \
+  "$(esc map 'map = "docs/MAP.md"')"
+ck "NC: a repo-relative rules file is still printed" "IN-REPO RULES MARKER" \
+  "$(esc rules 'rules = "docs/RULES.md"')"
+
+# op_version selects a BINARY: the value lands in a download URL, and the
+# download is chmod +x, prepended to PATH and persisted into CLAUDE_ENV_FILE.
+# The tier is observable because a failed install prints the URL it tried.
+opv() {  # opv <env-assignments...> -- run the secrets step with curl broken
+  PATH="$W/curlfail:$W/nogh" HOME="$W/home-opv" CLOUD_WORKSPACE="$W/ws-opv" \
+    OP_SERVICE_ACCOUNT_TOKEN=stub-value-never-read CLOUD_VAULT=TestVault \
+    env "$@" bash "$L/provision.sh" --repo-root "$W/escape" secrets 2>&1
+}
+printf '[cloud]\nop_version = "v9.9.9"\n' >"$W/escape/.kit.toml"
+out="$(opv -u CLOUD_OP_VERSION)"
+case "$out" in *v9.9.9*) got=used ;; *) got=ignored ;; esac
+ck "op_version: a project .kit.toml value never reaches the download URL" ignored "$got"
+case "$out" in *"$op_pin_a"*) got=yes ;; *) got=no ;; esac
+ck "op_version: the URL carries the operator-tier pin instead" yes "$got"
+# NC: the same value from the operator tier DOES reach the URL.
+out="$(opv CLOUD_OP_VERSION=v9.9.9)"
+case "$out" in *v9.9.9*) got=yes ;; *) got=no ;; esac
+ck "NC: the operator tier DOES set the op pin" yes "$got"
+# Operator tier is not a reason to skip validating a value that lands in a URL.
+out="$(opv 'CLOUD_OP_VERSION=vEVIL/../../../../attacker-path')"
+case "$out" in *"falling back to $op_pin_a"*) got=yes ;; *) got=no ;; esac
+ck "op_version: a traversal-shaped pin is refused at the operator tier too" yes "$got"
+case "$out" in *'attacker-path/op_linux'*) got=yes ;; *) got=no ;; esac
+ck "op_version: the traversal never reaches the download URL" no "$got"
+
+echo
 echo "=== 5b-2. trust boundary: a project .kit.toml cannot set an operator key ==="
 # A .kit.toml rides inside the repo, so a branch under review can edit it. A key
 # whose value SELECTS CODE TO RUN must not be reachable from there. `plugins`
@@ -375,7 +515,14 @@ vault = "AttackerVault"
 canary_ref = "op://AttackerVault/anything/credential"
 repos = "attacker/instructions"
 repo_owner = "attacker"
+workspace = "/dev/null/attacker-ws"
+rules = "docs/OK-RULES.md"
 EOF
+# `/dev/null/...` can never be created, even by root, so an honoured value would
+# surface as a `could not link ... into /dev/null/attacker-ws` line rather than
+# as litter on the test host.
+mkdir -p "$W/evil/docs"
+printf 'PROJECT RULES FROM THE HOSTILE FILE\n' >"$W/evil/docs/OK-RULES.md"
 git -C "$W/evil" init -q 2>/dev/null || true
 printf '#!/bin/sh\ntouch "%s/PWNED"\n' "$W" >"$W/evil/.githooks/pre-commit"
 chmod +x "$W/evil/.githooks/pre-commit"
@@ -396,6 +543,10 @@ ck "the project .kit.toml did NOT reach the secrets step" no "$got"
 # prompt-injection path into every later turn.
 case "$out" in *'attacker/instructions'*) got=yes ;; *) got=no ;; esac
 ck "the project .kit.toml did NOT reach the sibling-clone step" no "$got"
+# workspace joined the operator tier after a project value pointed it at
+# `$HOME/.claude/skills` and made a PR-authored root SKILL.md a live skill.
+case "$out" in *'attacker-ws'*) got=yes ;; *) got=no ;; esac
+ck "the project .kit.toml did NOT choose the workspace" no "$got"
 # NC: the same keys DO take effect from the operator tier (the env override), or
 # the four assertions above would pass for a provision that reads nothing at all.
 out="$(PATH="$ON_PATH" HOME="$W/home6" CLOUD_WORKSPACE="$W/ws-evil2" \
@@ -404,9 +555,13 @@ ck "NC: the operator tier DOES arm core.hooksPath" ".githooks" \
   "$(git -C "$W/evil" config --get core.hooksPath 2>/dev/null || true)"
 git -C "$W/evil" config --unset core.hooksPath 2>/dev/null || true
 # NC: a PROJECT-tier key from the same hostile file still works, so the split is
-# a boundary, not a blanket refusal to read the project file.
-ck "NC: a project-tier key from the same file is still honoured" yes \
-  "$([ -L "$W/ws-evil/evil" ] && echo yes || echo no)"
+# a boundary, not a blanket refusal to read the project file. `rules` is a real
+# project key naming a real in-repo path, unlike the earlier version of this
+# assertion, which checked a workspace symlink the ENV had set.
+out="$(PATH="$ON_PATH" HOME="$W/home6" CLOUD_WORKSPACE="$W/ws-evil" \
+       env -u CLOUD_RULES bash "$L/provision.sh" --repo-root "$W/evil" rules 2>&1)"
+ck "NC: a project-tier key from the same file is still honoured" \
+  "PROJECT RULES FROM THE HOSTILE FILE" "$out"
 
 echo
 echo "=== 5c. provision secrets: CLAUDE_ENV_FILE append-once + canary NC ==="


### PR DESCRIPTION
Stacked on #384 (draft). Base is `feat/cloud-session-support`, not `master`.

## Why stacked

The findings are the point of this branch, so the diff a reviewer opens should
be the FIXES, not the fixes buried in the 3k-line module diff. #384 stays a
draft and is not touched.

## What the review found

An adversarial review demonstrated each finding live. One of them is that the
branch's own proof document was wrong.

| # | Sev | Finding |
|---|---|---|
| 1 | CRITICAL | `workspace` accepted any absolute path from a project `.kit.toml`. `workspace = "$HOME/.claude/skills"` made provisioning create `~/.claude/skills/<repo> -> <repo>`, so a PR-authored root `SKILL.md` became a LIVE skill, loaded in the same session because the hook emits `reloadSkills` |
| 2 | HIGH | `map` accepted any absolute path, so a project value printed a file from outside the repo into model context |
| 3 | HIGH | `rules` same shape |
| 4 | MEDIUM | `op_version` was project-tier and selects a binary that is downloaded, `chmod +x`, prepended to PATH and persisted into `CLAUDE_ENV_FILE`, interpolated unvalidated into the URL |
| 5 | HIGH | the suite passed **118/118 with the `CLAUDE_CODE_REMOTE` gate DEAD in both hooks** |
| 6-9 | MEDIUM | no `--max-time` and a leaked temp dir in `install_op`; no total budget on the sibling-clone loop; a wrong "every verb exits 0" comment; an ungated global `~/.gitconfig` write |
| 10 | overclaim | the tier lint was said to stop the next key picking the wrong tier. It checks CONSISTENCY, not CORRECTNESS, and findings 1 to 4 all passed it |

All three escapes in 1 to 4 are ONE mistake in three places: the rule "a PROJECT
key may only name something INSIDE this repo" was written in a comment and
enforced nowhere.

## What changed

**Tier, per key.** `workspace` and `op_version` move to OPERATOR. `map` and
`rules` are legitimately per-project, so they stay and are CONSTRAINED.

Constraining `workspace` instead of moving it would not have worked:
`$HOME/.claude/skills` is under the resolved home, so a "repo root or home"
containment check accepts the exact demonstrated attack.

**Enforcement in code, not in a comment.** `repo_path` resolves a project-tier
path against the repo root and refuses an absolute path, a leading `~`, a `..`
segment, a directory that resolves outside the repo (an intermediate symlink),
and a final component that is itself a symlink. A refused value is reported as a
`!!` line: `map` prints nothing, `rules` falls back to the kit's own template.
`op_version` is validated against `^v?[0-9]+(\.[0-9]+)*$` before it reaches the
URL.

**The kit-root config path is pinned** to the kit install `provision.sh` belongs
to. `kit-config.sh` otherwise reads it from `KIT_CONFIG_ROOT`, so the
operator-owned half of the split could be redirected at a file inside the repo,
which would have made the whole tier split decorative.

**The gate is now verified, per gate.** Two causes for the false green: the
static check grepped comments, so the prose above each gate satisfied it; and
`guard_off()` plus the OFF session-start invocation ran without `ON_PATH`, so
the macOS `uname` gate short-circuited before the cloud gate was reached.
`has_gate` now matches the executable line, both OFF entry points carry
`ON_PATH`, and a Darwin-stub block pins the third gate on its own.

| Neutered (`\|\| exit 0` to `\|\| :`, name left in place) | Before | After |
|---|---|---|
| nothing | `all 118 passed` | `all 146 passed` |
| `CLAUDE_CODE_REMOTE`, both hooks | `all 118 passed` | `PASS 134  FAIL 6`, exit 1 |
| `CLAUDE_CODE_REMOTE`, session-start only | green | `PASS 136  FAIL 4`, exit 1 |
| `CLAUDE_CODE_REMOTE`, dash-guard only | green | `PASS 137  FAIL 3`, exit 1 |
| the Linux gate, both hooks | green | `PASS 142  FAIL 4`, exit 1 |

**Mediums.** `--max-time 120` on the op download and an explicit temp cleanup on
both paths; a 90s total deadline on the sibling-clone loop, because the 60s cap
bounds ONE clone and three siblings plus the 150s gh install exceed the
SessionStart budget, which kills the whole hook; the `safe.directory` write
gated to a Linux cloud session; the unknown-verb exit-1 exception named in
`cloud.sh` with the README's `|| true` marked load-bearing.

## Per-key control, before and after

Same hostile `.kit.toml` against `0448b56` (unfixed) and `547076e` (fixed).

```
=========== workspace: [cloud] workspace = $HOME/.claude/skills ===========
BEFORE   ~/.claude/skills/repo -> CREATED   <-- the PR SKILL.md is now a live skill
AFTER    ~/.claude/skills/repo -> not created
positive: AFTER the operator tier still sets the workspace (symlink present)

=========== map / rules: an absolute path outside the repo ===========
BEFORE   -> SECRET OUTSIDE THE REPO
AFTER    ->   !! map: '/.../.secret-outside-repo' is absolute; a project key may
              only name a path inside this repo
positive: AFTER a repo-relative value is still printed (IN-REPO MAP MARKER)

=========== op_version: a traversal-shaped pin ===========
BEFORE   URL -> .../pkg/vEVIL/../../../../attacker-path/op_linux_arm64_vEVIL/../../../../attacker-path.zip
AFTER    URL -> .../pkg/v2.31.1/op_linux_arm64_v2.31.1.zip
positive: AFTER CLOUD_OP_VERSION=v2.30.0 -> .../pkg/v2.30.0/op_linux_arm64_v2.30.0.zip
```

The `..` and committed-symlink shapes of the same escapes are asserted in the
suite (section 5b-3), not only in this one run.

## Environment trust: the env tier was KEPT, deliberately

The review preferred removing the `CLOUD_<KEY>` env tier for operator keys. That
was considered and rejected. `CLOUD_PROVISION`, the master switch for the whole
module, is env-only with no config channel, so an actor who can set environment
variables in a cloud VM turns the module on and owns it regardless of where the
individual keys resolve. Removing the key tier alone closes nothing, and it
costs the operator the only per-environment channel that exists in a VM (the
kit-root `kit.toml` arrives inside the git clone).

What was hardened instead is the second door to the same room: the kit-root
config path is pinned, so `KIT_CONFIG_ROOT` cannot redirect the operator half.

The environment is now documented as the TRUST ANCHOR in `lib/cloud/SPEC.md` and
the README, with the open question named: whether a repo-committed
`.claude/settings.json` `env` block reaches a hook subprocess in a cloud VM. If
it does, this needs a kit-wide env-hardening pass, not a cloud-local one. Only a
real cloud VM answers it.

## Verification

```
bash lib/cloud/tests/smoke.sh        -> smoke: all 146 passed          (exit 0)
bash tests/test-meta.sh              -> Passed: 799 / 799              (exit 0)
bash tests/test-hooks.sh             -> Passed: 492 / 492              (exit 0)
bash tests/test-bin-forwarders.sh    -> all 33 passed, 0 skipped       (exit 0)
bash tests/test-install-modules.sh   -> 37 passed, 0 failed            (exit 0)
bash tests/test-adopt.sh             -> PASS=21 FAIL=0                 (exit 0)
bash tests/test-config-registry.sh   -> 19/19 passed                   (exit 0)
bash tests/test-kit-contract.sh      -> 23 passed, 2 failed            (exit 1)
shellcheck -S warning lib/cloud/*.sh lib/cloud/tests/smoke.sh hooks/cloud-*.sh bin/cloud
                                     -> (empty)                        (exit 0)
```

`test-kit-contract`'s 2 offenders are `lib/bench` (no SPEC, no test). BASELINED:
pristine `master` at `e7adc2a` fails the SAME two. Pre-existing debt, not this
branch.

Full record with every control: `lib/cloud/docs/proof-of-done.md`, dated
section at the bottom.

## Still unverified

| Claim | Status |
|---|---|
| a repo-committed `.claude/settings.json` `env` block does NOT reach a hook subprocess in a cloud VM | UNVERIFIED, and it is the load-bearing assumption under the operator tier |
| the 90s clone budget is right against the real SessionStart timeout | UNVERIFIED. The platform's hook timeout is not documented |
| the `safe.directory` gate does not break a real cloud session | UNVERIFIED on the platform |
| everything #384 already lists as unproved (real VM installs, the undispatched CI leg) | unchanged |

**Do not merge.** #384 stays a draft and is untouched.
