### PR TITLE
feat(grill): facts-vs-decisions split + shared-understanding gate

### DIFF
--- a/commands/grill.md
+++ b/commands/grill.md
@@ -90,12 +90,18 @@ expensive to get wrong first:
 Rules (absorbed from grill-with-docs, see Source):
 
 - **ONE question per turn.** Wait for the answer before the next.
+- **Facts vs decisions**: facts about the codebase come from exploration (read the code, run
+  the commands), never from the operator; only a genuine decision is put to the operator as a
+  question. A fact the repo can answer is not a question.
 - **Every question carries a recommended answer** with one line of reasoning, so the operator
   corrects instead of composing from scratch.
 - **Challenge vague or overloaded terms** against the glossary; surface contradictions with the
   actual code/records IMMEDIATELY, not at the end.
 - **Walk the dependency tree**: when an answer opens a branch (a named system, an implied
   constraint), follow it before moving on.
+- **Shared-understanding gate**: before the grill proceeds past a resolved question, and again
+  before exit, the operator must confirm the shared understanding is real; without that
+  confirmation the grill holds where it is.
 - **Stop when** every branch is resolved or the operator says enough. Do not pad; five sharp
   questions beat twenty generic ones.
 


### PR DESCRIPTION
Closes kit ID-404 (absorb mattpocock grilling's July refinement).

## What changed
Two new rule bullets in the Step 2 Rules block of `commands/grill.md`, in the command's existing voice and structure:

1. **Facts vs decisions**: facts about the codebase are gathered by exploration (read the code, run the commands), never asked of the operator; only a genuine decision becomes a question. A fact the repo can answer is not a question.
2. **Shared-understanding gate**: before the grill proceeds past a resolved question, and again before exit, the operator must confirm the shared understanding is real; without that confirmation the grill holds where it is.

## Why
Per the absorption source (docs/research/2026-07-25-skills-repos-onboarding-absorption.md §1), mattpocock's grill-with-docs gained exactly these two mechanisms: the facts/decisions split and the confirmation gate. The kit took this skill from the same source (ID-049), so this is a delta catch-up, tiny lane, one command-body edit.

## Scope
- 6 insertions, 0 deletions, single file (`commands/grill.md`). No restructure, no other commands touched.
- Board row status not updated (orchestrator-owned).