### PR TITLE
fix(gate): widen proof-ledger to accept tool-verification proofs

### DIFF
--- a/docs/verification/proof-scan-tool-paths.md
+++ b/docs/verification/proof-scan-tool-paths.md
@@ -1,0 +1,82 @@
+# Proof of done: proof-scan-tool-paths (ID-478)
+
+Class: behavioral. Widens `lib/gate/proof-ledger.sh` `_fresh_proof_files()` and the
+set-wise directory-grouping in `check()` to also accept a proof co-located at
+`tools/<name>/docs/verification/<slug>.md` (a monorepo's per-tool convention),
+alongside the existing repo-root `docs/verification/<slug>.md` and
+`.../proof-of-done.md` shapes.
+
+## GREEN (real run)
+
+New regression test, `tests/test-proof-tool-verification-path.sh`, against a
+fixture with a fresh proof at `tools/x/docs/verification/vf-tool.md`:
+
+Command: `bash tests/test-proof-tool-verification-path.sh`
+Exit: 0
+Verdict: PASS
+Output:
+
+```
+PASS tools/<name>/docs/verification/<slug>.md proof satisfies the gate
+ALL PASS (1/1)
+```
+
+Full gate-related suite (every `tests/test-proof-*.sh` plus adjacent proof-ledger
+consumers), all green except two pre-existing failures confirmed unrelated to
+this change (see NEGATIVE CONTROL below):
+
+Command: `bash tests/test-proof-dir-layout.sh && bash tests/test-proof-visual-evidence.sh && bash tests/test-deployable-done.sh && bash tests/test-delivery-ratio.sh`
+Exit: 0
+Verdict: PASS (3/3, 4/4, 17/17, 8/8 respectively)
+
+The full hook regression suite also passes clean:
+
+Command: `bash tests/test-hooks.sh`
+Exit: 0
+Verdict: PASS
+Output tail:
+
+```
+=== Results ===
+Passed: 492 / 492
+All tests passed.
+```
+
+## NEGATIVE CONTROL
+
+Reverted `lib/gate/proof-ledger.sh` to its pre-fix content (`git show HEAD^:...`)
+and re-ran the new test: it goes RED (the co-located tool-path proof is invisible
+to the pre-fix scan, reproducing the bug), then the fix was restored
+(`git checkout -- lib/gate/proof-ledger.sh`) and the test goes GREEN again.
+
+Command: `bash tests/test-proof-tool-verification-path.sh` (pre-fix lib)
+Exit: 1
+Output: `FAIL co-located tool verification proof should ACCEPT but the gate BLOCKED`
+
+Command: `bash tests/test-proof-tool-verification-path.sh` (fix restored)
+Exit: 0
+Output: `PASS tools/<name>/docs/verification/<slug>.md proof satisfies the gate`
+
+## Pre-existing unrelated failures (documented, not caused by this change)
+
+Two tests fail identically on a pristine checkout with NO uncommitted diff to
+`lib/gate/proof-ledger.sh` (verified by stashing this branch's diff and re-running
+each in isolation), so neither is a regression from this fix:
+
+- `tests/test-proof-override-order.sh`: its own negative-control step (step 6)
+  assumes the SOLE uncommitted diff to `lib/gate/proof-ledger.sh` is the
+  override-order fix it guards, and stashes whatever diff is present to simulate
+  reverting it. With this branch's unrelated diff present, stashing it reverts to
+  `HEAD` (which already carries the override-order fix, committed separately), so
+  the expected re-block never reproduces. On a clean checkout it instead prints
+  `[NO EXECUTABLE CHECK: ... no uncommitted diff to revert]` and still counts as a
+  fail. Confirmed failing the same way with this branch's diff stashed away.
+- `tests/test-classify-md-inert.sh`: its "strip lib" construction resolves a
+  relative path (`//telemetry/kit-log-dir.sh`) that does not exist from the
+  temp file's location, independent of any content in `proof-ledger.sh`.
+  Confirmed failing identically with this branch's diff stashed away.
+
+## Reproducibility
+
+Command: `bash tests/test-proof-tool-verification-path.sh`
+Rerun twice, same result both times: `ALL PASS (1/1)`, exit 0.

--- a/lib/gate/proof-ledger.sh
+++ b/lib/gate/proof-ledger.sh
@@ -147,17 +147,19 @@ delivery_ratio() {
 }
 
 # the verification-log files this branch added/modified (excludes the convention README).
-# Two accepted shapes: the repo-root convention (docs/verification/<slug>.md) AND a proof
+# Three accepted shapes: the repo-root convention (docs/verification/<slug>.md), a proof
 # co-located with its subject anywhere in the tree (any path ending /proof-of-done.md, e.g.
-# a monorepo's tools/<name>/docs/proof-of-done.md). The content check in check() validates
-# either the same way; location is just where the proof lives.
+# a monorepo's tools/<name>/docs/proof-of-done.md), and a monorepo tool's own verification
+# dir (tools/<name>/docs/verification/<slug>.md, per ops-toolkit's per-tool co-location
+# convention). The content check in check() validates all three the same way; location is
+# just where the proof lives.
 _fresh_proof_files() {
   local root="$1" base="$2"
   { git -C "$root" diff --name-only "$base"..HEAD 2>/dev/null
     git -C "$root" diff --name-only HEAD 2>/dev/null
     git -C "$root" diff --name-only --cached 2>/dev/null
     git -C "$root" ls-files --others --exclude-standard 2>/dev/null
-  } | sort -u | grep -E '^docs/verification/.+\.md$|(^|/)proof-of-done\.md$' | grep -v '/README\.md$' || true
+  } | sort -u | grep -E '^docs/verification/.+\.md$|^tools/[^/]+/docs/verification/.+\.md$|(^|/)proof-of-done\.md$' | grep -v '/README\.md$' || true
 }
 
 # Repo identity for override scoping (ID-299). The override log is machine-local and now
@@ -279,7 +281,7 @@ check() {
   # satisfy when the UNION of a group's files carries both markers.
   if [ "$ok" -ne 0 ] && [ -n "$files" ]; then
     local groups g content grp_img
-    groups="$(printf '%s\n' "$files" | sed -nE 's#^(docs/verification/[^/]+/).*#\1#p' | sort -u)"
+    groups="$(printf '%s\n' "$files" | sed -nE 's#^(docs/verification/[^/]+/).*#\1#p;s#^(tools/[^/]+/docs/verification/[^/]+/).*#\1#p' | sort -u)"
     while IFS= read -r g; do
       [ -n "$g" ] || continue
       content=""; grp_img=1     # grp_img=0 iff some file in the group embeds a REAL image

--- a/tests/test-proof-tool-verification-path.sh
+++ b/tests/test-proof-tool-verification-path.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# test-proof-tool-verification-path.sh
+# Guards the monorepo tool-co-located verification path (ID-478): a fresh proof at
+# tools/<name>/docs/verification/<slug>.md must satisfy check(), the same as the
+# repo-root docs/verification/<slug>.md convention. Before the fix, _fresh_proof_files()
+# anchored its grep at the repo root and this file was invisible to the gate.
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$KIT/lib/gate/proof-ledger.sh"
+fails=0
+pass(){ echo "PASS $*"; }
+fail(){ echo "FAIL $*"; fails=$((fails+1)); }
+
+make_fixture() {  # $1 = dir
+  local d="$1" proof
+  rm -rf "$d"; mkdir -p "$d/tools/x/docs/verification" "$d/lib"
+  git -C "$d" init -q; git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  echo baseline > "$d/lib/thing.sh"
+  git -C "$d" add -A; git -C "$d" commit -qm base
+  echo "changed behavior" >> "$d/lib/thing.sh"                                  # behavioral diff
+  proof="$d/tools/x/docs/verification/vf-tool.md"
+  {
+    echo "# Verification , vf-tool"
+    echo "## NEGATIVE CONTROL"
+    echo "reverting the change turns this RED."
+    echo '- Command: `bash lib/thing.sh`'
+    echo '- Exit: 0'
+    echo '- Verdict: PASS'
+  } > "$proof"
+  git -C "$d" add -A
+}
+base(){ git -C "$1" rev-parse HEAD; }
+
+F=/tmp/vf-tool-path-gate
+make_fixture "$F"
+if bash "$LIB" check "$F" "$(base "$F")" vf-tool >/dev/null 2>&1; then
+  pass "tools/<name>/docs/verification/<slug>.md proof satisfies the gate"
+else
+  fail "co-located tool verification proof should ACCEPT but the gate BLOCKED"
+fi
+rm -rf "$F"
+
+[ "$fails" -eq 0 ] && { echo "ALL PASS (1/1)"; exit 0; } || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## Summary

`_fresh_proof_files()` in `lib/gate/proof-ledger.sh` anchored its grep at the
repo root (`^docs/verification/.+\.md$`), so a proof co-located per a
monorepo's per-tool convention at `tools/<name>/docs/verification/<slug>.md`
was invisible to the ship-gate. The set-wise directory-grouping in `check()`
had the same repo-root-only anchor (`^(docs/verification/[^/]+/).*`), so a
directory-layout proof under `tools/<name>/docs/verification/<slug>/` had the
same gap.

- Widen the `_fresh_proof_files()` grep to also match
  `^tools/[^/]+/docs/verification/.+\.md$`.
- Widen the set-wise `sed` group capture to also match
  `tools/[^/]+/docs/verification/[^/]+/` prefixes. The group key is the full
  prefix (`tools/<name>/docs/verification/<slug>/`), so two tools' slugs
  never merge into one group.
- Updated the comment above `_fresh_proof_files` to name the third accepted
  shape.

## Test plan

- Added `tests/test-proof-tool-verification-path.sh`: a fresh proof at
  `tools/x/docs/verification/vf-tool.md` now satisfies `check()`.
- Ran the full `tests/test-proof-*.sh` set plus `tests/test-deployable-done.sh`
  and `tests/test-delivery-ratio.sh`: all green except two pre-existing
  failures (`test-proof-override-order.sh`, `test-classify-md-inert.sh`)
  confirmed unrelated by reproducing them identically on a pristine checkout
  with no diff to `proof-ledger.sh` (see `docs/verification/proof-scan-tool-paths.md`).
- `tests/test-hooks.sh`: 492/492 passed.
- Negative control: reverted the fix, new test goes RED; restored, goes GREEN.

Full proof-of-done: `docs/verification/proof-scan-tool-paths.md`.
