### PR TITLE
feat(hooks): add session-age cache-hygiene nudge to context-hints

### DIFF
--- a/docs/verification/session-age-clear-nudge.md
+++ b/docs/verification/session-age-clear-nudge.md
@@ -1,0 +1,93 @@
+# Proof of done: session-age cache-hygiene nudge (context-hints)
+Profile: feature   Proof class: behavioral
+
+## 1. Acceptance criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | When session elapsed time is under 6h, `context-hints.sh` prints the existing temporal line and no nudge line | PASS | R1 |
+| 2 | When session elapsed time exceeds 6h, `context-hints.sh` prints one extra line: `consider /clear or a handoff split (cache-hygiene rule)` | PASS | R1 |
+| 3 | No new hook, no new state file, no new data collection: the nudge reuses `temporal_line`'s existing elapsed computation | PASS | R1 (code inspection: `hooks/context-hints.py` diff touches only `temporal_line`) |
+| 4 | Existing `tests/test-kit-foldin-hooks.sh` suite stays green | PASS | R1 |
+
+## 2. Implementation
+
+| Aspect | Detail |
+|---|---|
+| What | `hooks/context-hints.py`'s `temporal_line()` gained a `NUDGE_THRESHOLD_SECONDS = 6 * 3600` module constant and a conditional append: when `elapsed > NUDGE_THRESHOLD_SECONDS`, the returned line grows a second line, `consider /clear or a handoff split (cache-hygiene rule)`. |
+| Where | `hooks/context-hints.py` only. `hooks/context-hints.sh` is an unmodified thin exec shim (`exec python3 context-hints.py "$@"`); the UserPromptSubmit logic lives entirely in the `.py`, so no `.sh` edit was needed. |
+| How it runs | Invoked by the UserPromptSubmit hook on every prompt; `temporal_line` already ran per prompt to print "Session time: ... elapsed", so the nudge check is free (no new I/O, no new state file, reuses the already-computed `elapsed` local). |
+| Compaction-count leg | Not implemented. The source row asked for elapsed>6h OR compaction-count>=2. `context-hints.py`'s only inputs are the UserPromptSubmit stdin payload (`prompt`, `session_id`) and its own per-session `{start,last}` state file; neither carries a compaction counter. The repo's only compaction signal, `hooks/pre-compact-backup.sh`'s per-repo numbered backup-file count, is not session-keyed and reading it from `context-hints.py` would be new cross-hook data collection, which the row explicitly ruled out ("do not add new data collection"). Elapsed-time threshold only, as the row's fallback instruction allows. |
+| Reversibility | `git revert` the commit; no persistent state schema changed (same `{start, last}` JSON shape as before). |
+
+## 3. Confirmation (runs)
+
+| Run | When | Command | Exit | Verdict |
+|---|---|---|---|---|
+| R1 | 2026-08-11 | `bash tests/test-kit-foldin-hooks.sh` | 0 | PASS (94/94, incl. 3 new rows 5a/5b/5c) |
+| R2 | 2026-08-11 | `git checkout HEAD~1 -- hooks/context-hints.py && bash tests/test-kit-foldin-hooks.sh` (then `git checkout HEAD -- hooks/context-hints.py` to restore) | 1 | RED-as-expected |
+
+## 4. Run detail
+
+### R1 GREEN
+- Command: `bash tests/test-kit-foldin-hooks.sh`
+- Exit: 0
+- Output (excerpt):
+  ```
+  === context-hints.sh (UserPromptSubmit) ===
+    PASS row 1: skill hint fires on keyword match (exit 0)
+    PASS row 1: hint names the mapped skill
+    PASS NC: empty stdin exits 0 (exit 0)
+    PASS NC: malformed JSON exits 0 (exit 0)
+    PASS row 5a: far under threshold (100s elapsed), no nudge (negative control)
+    PASS row 5b: 5s under threshold, no nudge
+    PASS row 5c: 5s over threshold, nudge fires
+  ...
+  === Results ===
+  Passed: 94 / 94
+  All kit-foldin hooks tests passed.
+  ```
+- Verdict: PASS
+- Note: covers AC1-AC4. Row 5a is a far-under-threshold negative control, 5b/5c straddle the 21600s boundary by 5s each side.
+
+### R2 NEGATIVE CONTROL
+- Command: `git checkout HEAD~1 -- hooks/context-hints.py` (reverts only the fix, keeps the new tests), then `bash tests/test-kit-foldin-hooks.sh`, then `git checkout HEAD -- hooks/context-hints.py` to restore.
+- Exit: 1
+- Output (excerpt):
+  ```
+    PASS row 5a: far under threshold (100s elapsed), no nudge (negative control)
+    PASS row 5b: 5s under threshold, no nudge
+    FAIL row 5c: 5s over threshold, nudge fires (missing 'consider /clear or a handoff split (cache-hygiene rule)')
+  ...
+  === Results ===
+  Passed: 93 / 94
+  1 test(s) failed.
+  ```
+- Verdict: RED-as-expected
+- Note: rows 5a/5b still pass under the reverted code because "no nudge under threshold" trivially holds when the feature does not exist at all; row 5c is the one row that actually exercises the fix, and it fails without it, confirming the test is load-bearing. Restore verified byte-identical via `git diff --stat HEAD` (empty output) after `git checkout HEAD -- hooks/context-hints.py`.
+
+## 5. Reproduce
+
+```
+bash tests/test-kit-foldin-hooks.sh
+```
+
+## Before/after
+
+**Before** (`temporal_line` returned only the elapsed/idle line, no threshold check):
+```python
+if elapsed < 1:
+    return None  # first prompt of the session: nothing useful yet
+return f"Session time: {humanize(elapsed)} elapsed, {humanize(idle)} since your last prompt."
+```
+
+**After** (elapsed reused for a second, conditional line):
+```python
+if elapsed < 1:
+    return None  # first prompt of the session: nothing useful yet
+line = f"Session time: {humanize(elapsed)} elapsed, {humanize(idle)} since your last prompt."
+if elapsed > NUDGE_THRESHOLD_SECONDS:
+    line += "\nconsider /clear or a handoff split (cache-hygiene rule)"
+return line
+```
+A session past 6h elapsed now gets a second line in its UserPromptSubmit context injection nudging `/clear` or a handoff split; a session under threshold is unchanged.

--- a/hooks/context-hints.py
+++ b/hooks/context-hints.py
@@ -5,7 +5,15 @@ Ported from ops-toolkit's cc-context-hooks (function-named per the kit-foldin de
 note: no host-agent prefix). Two small, pure-string additions, both sub-millisecond:
 
   temporal   how long this session has run + how long since the last prompt
-             (helps time/deadline reasoning)
+             (helps time/deadline reasoning); past NUDGE_THRESHOLD_SECONDS elapsed,
+             adds a cache-hygiene nudge (suggest /clear or a handoff split) reusing
+             the same elapsed value, no extra data collection. A compaction-count
+             leg was in-scope per the source row but is not implemented: this hook's
+             inputs (stdin payload + its own per-session {start, last} state) carry
+             no compaction counter, and the only compaction signal in the repo
+             (hooks/pre-compact-backup.sh's per-repo backup-file count) is not
+             session-keyed, so wiring it in would be new cross-hook data collection,
+             which the row explicitly ruled out.
   skill-hint keyword -> skill nudges from a small map, so a relevant skill/command is
              surfaced even if its description did not auto-fire (JIT activation)
 
@@ -35,6 +43,7 @@ import time
 HERE = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_MAP = os.path.join(HERE, "context-hints-skills-map.json")
 DEFAULT_STATE = os.path.expanduser("~/.claude/dwarves-kit/state/context-hints")
+NUDGE_THRESHOLD_SECONDS = 6 * 3600  # ~6h elapsed: cache-hygiene rule (ID-269)
 
 
 def now():
@@ -73,7 +82,10 @@ def temporal_line(session_id):
         pass
     if elapsed < 1:
         return None  # first prompt of the session: nothing useful yet
-    return f"Session time: {humanize(elapsed)} elapsed, {humanize(idle)} since your last prompt."
+    line = f"Session time: {humanize(elapsed)} elapsed, {humanize(idle)} since your last prompt."
+    if elapsed > NUDGE_THRESHOLD_SECONDS:
+        line += "\nconsider /clear or a handoff split (cache-hygiene rule)"
+    return line
 
 
 def skill_hints(prompt):

--- a/tests/test-kit-foldin-hooks.sh
+++ b/tests/test-kit-foldin-hooks.sh
@@ -56,6 +56,18 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local NAME="$1" NEEDLE="$2" HAY="$3"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$HAY" | grep -qF "$NEEDLE"; then
+    echo -e "  ${RED}FAIL${NC} $NAME (unexpectedly found '$NEEDLE')"
+    FAIL=$((FAIL + 1))
+  else
+    echo -e "  ${GREEN}PASS${NC} $NAME"
+    PASS=$((PASS + 1))
+  fi
+}
+
 # Detached work lands asynchronously: poll a file for a needle instead of asserting
 # right after the hook returns (the hook is expected to return before the write happens).
 wait_for_file_contains() {
@@ -94,6 +106,36 @@ assert_exit "NC: empty stdin exits 0" 0 $RC
 # NC: malformed JSON never crashes / never blocks.
 RC=0; echo 'not json' | bash "$KIT_DIR/hooks/context-hints.sh" >/dev/null 2>&1 || RC=$?
 assert_exit "NC: malformed JSON exits 0" 0 $RC
+
+# ID-269: session-age cache-hygiene nudge. Threshold is NUDGE_THRESHOLD_SECONDS in
+# context-hints.py (6h = 21600s). Each row primes a session's "start" at t=BASE via a
+# first hook call, then re-invokes at t=BASE+ELAPSED to control the elapsed value the
+# hook computes (same CONTEXT_HINTS_NOW seam the row-1 test above already relies on).
+NUDGE_STATE="$TD/ch-nudge-state"
+NUDGE_THRESHOLD=21600
+
+# row 5a (negative control, well under threshold): no nudge line at all.
+CONTEXT_HINTS_STATE="$NUDGE_STATE" CONTEXT_HINTS_NOW=1000 \
+  bash -c "echo '{\"prompt\":\"hi\",\"session_id\":\"nudge-far-under\"}' | bash '$KIT_DIR/hooks/context-hints.sh'" >/dev/null
+OUT=$(CONTEXT_HINTS_STATE="$NUDGE_STATE" CONTEXT_HINTS_NOW=$((1000 + 100)) \
+  bash -c "echo '{\"prompt\":\"hi\",\"session_id\":\"nudge-far-under\"}' | bash '$KIT_DIR/hooks/context-hints.sh'")
+assert_not_contains "row 5a: far under threshold (100s elapsed), no nudge (negative control)" \
+  "cache-hygiene rule" "$OUT"
+
+# row 5b: just under threshold (threshold - 5s elapsed), still no nudge.
+CONTEXT_HINTS_STATE="$NUDGE_STATE" CONTEXT_HINTS_NOW=2000 \
+  bash -c "echo '{\"prompt\":\"hi\",\"session_id\":\"nudge-just-under\"}' | bash '$KIT_DIR/hooks/context-hints.sh'" >/dev/null
+OUT=$(CONTEXT_HINTS_STATE="$NUDGE_STATE" CONTEXT_HINTS_NOW=$((2000 + NUDGE_THRESHOLD - 5)) \
+  bash -c "echo '{\"prompt\":\"hi\",\"session_id\":\"nudge-just-under\"}' | bash '$KIT_DIR/hooks/context-hints.sh'")
+assert_not_contains "row 5b: 5s under threshold, no nudge" "cache-hygiene rule" "$OUT"
+
+# row 5c: just over threshold (threshold + 5s elapsed), nudge fires with the exact line.
+CONTEXT_HINTS_STATE="$NUDGE_STATE" CONTEXT_HINTS_NOW=3000 \
+  bash -c "echo '{\"prompt\":\"hi\",\"session_id\":\"nudge-just-over\"}' | bash '$KIT_DIR/hooks/context-hints.sh'" >/dev/null
+OUT=$(CONTEXT_HINTS_STATE="$NUDGE_STATE" CONTEXT_HINTS_NOW=$((3000 + NUDGE_THRESHOLD + 5)) \
+  bash -c "echo '{\"prompt\":\"hi\",\"session_id\":\"nudge-just-over\"}' | bash '$KIT_DIR/hooks/context-hints.sh'")
+assert_contains "row 5c: 5s over threshold, nudge fires" \
+  "consider /clear or a handoff split (cache-hygiene rule)" "$OUT"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary
- `hooks/context-hints.py`'s `temporal_line()` reuses its existing elapsed-time computation: past 6h elapsed, appends one line, `consider /clear or a handoff split (cache-hygiene rule)`, to the UserPromptSubmit context injection.
- No new hook, no new state file, no new data collection.
- Compaction-count leg (elapsed>6h OR compaction-count>=2) is NOT implemented: `context-hints.py`'s inputs (stdin payload + its own per-session state) carry no compaction counter, and the repo's only compaction signal (`hooks/pre-compact-backup.sh`'s per-repo backup-file count) is not session-keyed, so wiring it in would be new cross-hook data collection. Elapsed-time threshold only, per the fallback the source row allows.

## Test plan
- [x] `bash tests/test-kit-foldin-hooks.sh` green, 94/94 (3 new rows: 5a far-under negative control, 5b just-under, 5c just-over threshold, nudge fires)
- [x] Negative control: revert the fix only (`git checkout HEAD~1 -- hooks/context-hints.py`), suite goes RED (row 5c fails, 93/94), restore (`git checkout HEAD -- hooks/context-hints.py`), verified byte-identical
- [x] Proof-of-done doc: `docs/verification/session-age-clear-nudge.md`

https://claude.ai/code/session_01U56mQYb3QKwP6Tx5ZEAsSA