### PR TITLE
docs: correct stale rosters and dead references across living docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ dwarves-kit/
   install.sh / settings.json    Bash install path
   .claude-plugin/               Plugin install path (plugin.json, marketplace.json)
   .github/workflows/test.yml    CI: macOS + Ubuntu test matrix
-  bin/                          STABLE consumer entrypoints (SPEC-184, one `<subsystem> <verb>` grammar per ADR-0034): `board`/`classify`/`gate`/`goal`/`learn`/`mega`/`queue`/`session`/`spec`/`stats` thin forwarders to `lib/<subsystem>/`, plus the two module CLIs (`prose-rag`, `worktree-provision`) that keep their module names. A consumer (an adopted repo's board shim, the adopt-injected CLAUDE.md block) references `$DWARVES_KIT/bin/<name>`, NEVER a deep lib path, so an internal lib reorg cannot silently break it (the board-shim class of bug). Deployed by install.sh next to lib/.
+  bin/                          STABLE consumer entrypoints (SPEC-184, one `<subsystem> <verb>` grammar per ADR-0034): `board`/`classify`/`gate`/`goal`/`learn`/`mega`/`queue`/`session`/`spec`/`stats`/`config`/`plugin-check` thin forwarders to `lib/<subsystem>/`, plus the module CLIs (`prose-rag`, `worktree-provision`, `skill-improve`, `skill-review`) that keep their own names, and two standalone maintainer tools outside the forwarder pattern (`activate`, `release`, licensing and release cutting). A consumer (an adopted repo's board shim, the adopt-injected CLAUDE.md block) references `$DWARVES_KIT/bin/<name>`, NEVER a deep lib path, so an internal lib reorg cannot silently break it (the board-shim class of bug). Deployed by install.sh next to lib/.
   agents/                       Subagents dispatched by commands
   commands/                     Markdown command prompts
   hooks/                        Hook scripts + hooks.json plugin manifest

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -515,7 +515,8 @@ The gate-ledger's `RUN_REPORT.md` (`/kit:mega`'s per-sub-goal gate matrix) can o
 as covered if SOME command actually calls `gate-ledger.sh` for it. A 2026-07-04 audit of every
 file under `commands/` found 11 of 29 commands with a real `bash lib/gate/gate-ledger.sh <verb>` call
 and 18 dark, with no distinction between "this phase genuinely has no ledger concern" and "nobody
-wired it yet" -- the RUN_REPORT under-counts silently either way. This section is the single
+wired it yet" -- the RUN_REPORT under-counts silently either way (`commands/` has since grown to
+36 files; 26 now match `gate-ledger.sh`). This section is the single
 source of truth for that distinction (parsed by `tests/test-command-emit-sweep.sh`, no second
 copy): every command in `commands/` either contains a `gate-ledger` call, or is listed below with
 a reason it legitimately does not need one.
@@ -529,12 +530,13 @@ pure RUN_REPORT observability, never a new required gate; `think` / `design` / `
 `validate` / `reflect` (the phase `retro.md` records) already ARE matrix rows and this closes
 their record-side gap.
 
-**10 utility commands, exempted (no direct emit by design):**
+**11 utility commands, exempted (no direct emit by design):**
 
 | Command | Why no direct emit |
 |---|---|
 | `absorb.md` | Maintainer-only external-source absorption audit (SPEC-004); propose-only, approves/merges nothing itself, and runs outside any spec's rid/lane lifecycle. |
 | `adopt.md` | One-time repo-bootstrap into a NEW consumer repo (injects AGENTS.md/CLAUDE.md/WORKFLOW pointer); runs BEFORE any rid or lane exists in that repo. |
+| `feature-map.md` | Standalone source-cited feature-inventory generator for ANY target project (this kit's own or an external one); not a `Lane x phase depth matrix` row (no lane requires it, the same carve-out as `verify.md`/`explain.md` above), so it has no phase to record against. |
 | `onboard.md` | Interactive first-run orchestrator (SPEC-199); CALLS start/adopt/config (each of which emits or is itself exempt) but owns no V-model phase and runs before any rid or lane exists in a fresh consumer, exactly like `adopt.md`. |
 | `next.md` | Pure read-only task dispatcher, own text says "Do NOT execute anything. Just detect and recommend."; hands off to `/kit:execute`, which is the one that emits. |
 | `start.md` | Pure read-only session entry-point detector, own text says "Do NOT execute anything."; same shape as `next.md`. |
@@ -1052,7 +1054,7 @@ operator detail read `MANUAL.md`; for component fit and the SDLC state machine r
 the cycle, V-model, and type loops) lives at [`docs/workflow-map.md`](workflow-map.md).
 
 At a glance: **1** backbone (the spine, above), **5** primary intake lanes (the lane
-table, above), **3** bounded loops (the engines, below), **10** opt-in side-flows,
+table, above), **3** bounded loops (the engines, below), **11** opt-in side-flows,
 **7** alternate/branch flows, and **4** hard stops (the only blockers). Everything
 except the four hard stops **suggests and routes; it does not block**.
 
@@ -1282,7 +1284,7 @@ mistake is irreversible:
 | `/kit:dispatch <specs>` | disjointness gate -> N background worktree workers -> lead-owned convergence | all workers READY + drift-clean, converged via `/kit:ship` | disjointness gate + drift guard (`lib/gate/dispatch-gate.sh`); no auto-merge; no DAG (ADR-0019) |
 | `/kit:think` | decision brief | brief written (if BUILD) | advisory |
 | `/kit:spec` | spec scaffold | spec exists, `Status: DRAFT` | spec-drift-guard hook |
-| `/kit:spec-validate` | 5-lens adversarial review | `Status: VALIDATED` | advisory (full lane) |
+| `/kit:spec-validate` | 6-lens adversarial review (5 advisory, 1 blocking) | `Status: VALIDATED` | advisory (full lane) |
 | `/kit:execute` | verification pipeline | all tasks + integration PASS | verification pipeline (hard) |
 | `/kit:debug` | feedback-loop-first debug loop (Phase 0 + 4 phases) | root cause + fix verified + human-confirmed | iron law + guess-fix guard |
 | `/kit:review[-team]` | review | verdict recorded in the spec's `## Review` | advisory |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,7 @@ Every command and agent mapped to its V-model arm, grouped so the left side (BUI
 | `/kit:spec-validate` | command | Spec review | gate | Adversarial pre-build gate; 6 lenses attack the spec (5 advisory, 1 blocking on the design record); sets Status: VALIDATED |
 | `/kit:devs-team` | command | Design critique | gate | Opt-in; 5 engineering lenses stress-test the solution design before the spec hardens |
 | `/kit:review` | command | Code review | gate | Single-pass paranoid review; security, architecture, regressions, edge cases |
-| `/kit:review-team` | command | Code review | gate | Parallel variant; dispatches the `code-reviewer` agent x3 (security / architecture / test-coverage lenses) |
+| `/kit:review-team` | command | Code review | gate | Parallel variant; dispatches `security-reviewer` (security) plus the `code-reviewer` agent x2 (architecture / test-coverage lenses) |
 | `/kit:visual-team` | command | Visual critique | gate | Opt-in; 5 design lenses critique UI output; mirrors review-team for visual work |
 | `/kit:docs` | command | Doc sync | gate | Diffs code vs docs and patches drift; dispatches doc-verifier before committing |
 | `/kit:explain` | command | Understanding (AFTER gate) | gate | ADR-0031 §2; emits a literate-diff explainer (background -> goal+intuition -> prose-ordered diff -> diagram) via `lib/explain.sh`, composing narrate-log + svg-knowledge-diagram; grounded in the diff + test results, advisory |
@@ -561,7 +561,7 @@ Two paths, do not run both. See ADR-0009.
 The "## State model" above is the *data* state (the three stores). This is the *process*
 state: the states a single unit of work moves through, and the guarded transitions
 between them. It is the formal model behind `WORKFLOW.md`'s cycle/lanes (the rules) and
-`MANUAL.md`'s "## Operator scenarios" (the operator-facing projection). The point of
+`docs/MANUAL.md`'s "## Operator scenarios" (the operator-facing projection). The point of
 declaring it is that at any moment Claude (and the operator) can answer four questions
 without guessing: where am I, where can I go, what does each transition cost/require (the
 guard), and how do I trigger it.
@@ -646,8 +646,8 @@ guard), and how do I trigger it.
 
 ### Sub-machines
 
-- **BUILDING** expands to: `worker -> task-verifier -> {PASS | FAIL:fixable -> fix-agent (<=2) | FAIL:escalate} -> integration-verifier`. The diagram is in `WORKFLOW.md` "## Flow and loop reference" (the execute pipeline), and the read-only contract is in "## Verification pipeline" above.
-- **DEBUGGING** expands to: `Phase 1 Root cause -> Phase 2 Pattern -> Phase 3 Hypothesis -> Phase 4 Implementation`, under the iron law (no fix without a recorded root cause), guarded by the guess-fix guard. The diagram is in `WORKFLOW.md` "## Flow and loop reference" (the debug loop).
+- **BUILDING** expands to: `worker -> task-verifier -> {PASS | FAIL:fixable -> fix-agent (<=2) | FAIL:escalate} -> integration-verifier`. The diagram is in `docs/WORKFLOW.md` "## Flow and loop reference" (the execute pipeline), and the read-only contract is in "## Verification pipeline" above.
+- **DEBUGGING** expands to: `Phase 1 Root cause -> Phase 2 Pattern -> Phase 3 Hypothesis -> Phase 4 Implementation`, under the iron law (no fix without a recorded root cause), guarded by the guess-fix guard. The diagram is in `docs/WORKFLOW.md` "## Flow and loop reference" (the debug loop).
 
 ### Hard stops as guards (the only blockers)
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -163,7 +163,7 @@ Who calls whom. An arrow is a real invocation (shell-out, source, or import).
               │                           ├─► intel ──► (calls observe)           │
               │                           ├─► audit ──► triage ────────────────┐  │
               │                           └─► recall                           │  │
-              │                  bridge ──► board mirror (to Hermes cockpit)   │  │
+              │                  sync   ──► board mirror (to Hermes cockpit)   │  │
               │                                                                ▼  ▼
               └──────────────────────────────────────────────────── board (staging/promote)
                                           the loop closes here


### PR DESCRIPTION
Staleness sweep over the kit's living docs (README, docs/architecture, docs/data-flow, docs/WORKFLOW). Dated records (specs, briefs, retros, ADRs) untouched. Each fix cites code evidence:

- README bin/ roster: 12 -> 18 entrypoints (config, plugin-check, skill-improve, skill-review, activate, release).
- architecture.md: review-team dispatches security-reviewer + code-reviewer x2 (not code-reviewer x3); MANUAL.md/WORKFLOW.md section citations repointed to docs/ post-SPEC-185 root-slim.
- data-flow.md: bridge module map repointed to sync (bridge absorbed 2026-07-16).
- WORKFLOW.md: 10 -> 11 side-flows; spec-validate 5-lens -> 6-lens (5 advisory, 1 blocking); command emit-coverage counts refreshed, feature-map.md added to the exemption table.

Left unfixed (out of scope, code/test): tests/test-command-emit-sweep.sh has a stale hardcoded 32-command pin (now 36) and already fails on master independent of this branch.

https://claude.ai/code/session_019RigzJh7XP4CwTCa2Tp6dL