### PR TITLE
docs: close SPEC-231 audit gaps (changelog, label, backrefs)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,14 @@ All notable changes to dwarves-kit are documented here.
   tree byte-identical (checksummed before/after, plus an independent negative control).
 
 ### Added
+- **Auto review-fix loop on the full lane (SPEC-231).** The multi-lens review now runs by
+  default, not on request: `/kit:execute` drives `/kit:review-team` (the three specialist
+  lenses plus the kit-default advisor, in one pass) after build on the full lane, and the
+  spec stage runs a default design-time critique plus advisor over-suggest before validate.
+  Findings sort convergent-first (a defect two or more lenses agree on outranks single-lens
+  taste), and the review re-runs over each fix batch up to two rounds, because a fix batch
+  can reopen the bug it fixed. The verdict stays advisory (auto-run, not auto-block), and a
+  lane gate keeps the cost on the full lane only. Foundation: `docs/patterns/review-fix-loop.md`.
 - **`slop-stripper` agent: the behavior-preserving AI-slop strip pass (kit ID-402).** Resolves the
   deslop absorption contradiction (2026-06-11 pinned-kits called it a duplicate of the simplify +
   maintainability-lens surfaces; the 2026-07-25 absorption survey scored it ABSORB). Both were

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -384,7 +384,7 @@ the V-model lens above. Every cell is one of:
 |---|---|---|---|---|---|
 | Think | skip | run-lite | measure-twice | skip | run-lite |
 | Design (opt-in) | skip | skip | measure-twice | skip | skip |
-| Design critique (opt-in) | skip | skip | measure-twice | skip | skip |
+| Design critique (default full, opt-in normal) | skip | skip | measure-twice | skip | skip |
 | UI design (opt-in) | skip | skip | run-lite | skip | skip |
 | Spec | skip | measure-twice | measure-twice | skip | run-lite |
 | Validate | skip | skip | measure-twice | skip | skip |

--- a/docs/briefs/DECISION-BRIEF-auto-review-loop.md
+++ b/docs/briefs/DECISION-BRIEF-auto-review-loop.md
@@ -1,5 +1,7 @@
 # Decision Brief: auto review-fix loop as a default spine phase
 
+> Realized by SPEC-231 (`docs/specs/SPEC-231-auto-review-loop.md`).
+
 The design was discussed with the operator across prior conversation turns; this
 brief records the accepted shape. The operator raised the pain directly and
 approved the recommendation before this brief was written.

--- a/docs/implementation-notes/SPEC-231-auto-review-loop.md
+++ b/docs/implementation-notes/SPEC-231-auto-review-loop.md
@@ -1,0 +1,15 @@
+# Implementation notes: SPEC-231 auto review-fix loop
+
+Delta from the spec. The wiring itself is recorded in the spec; this note holds only what the spec did not.
+
+## 2026-08-12 Post-merge audit follow-up
+
+Context: a fresh-context Opus verifier audited the merged wiring (PRs #397, #398) against SPEC-231's own claims. The auto-run held end to end (lenses plus advisor in one review-team pass, execute default-run, ship-gate backstop, bounded two-round loop, design-time over-suggest, model tiers intact). It found four gaps; this follow-up resolves three.
+
+Decision: fixed a, b, c; left d.
+
+- a. CHANGELOG had no entry for a user-facing behavior change. Added an `[Unreleased]` Added entry. `/kit:ship` normally writes this; the spec landed as a direct wiring PR, so the entry was missed.
+- b. The V-model lane-matrix row header still read "Design critique (opt-in)" while the spec's after-state requires "default (full lane)". The cell value (measure-twice on the full column) was already correct, so this was a stale label the staleness sweep missed, not a behavioral bug. Corrected the header.
+- c. SPEC-231 claimed the pattern doc and the brief cross-reference the spec, but neither carried a backref. Added a one-line SPEC-231 backref to both, which is cleaner than softening the spec's verification claim.
+
+Open question left for the operator (gap d, not fixed): `docs/WORKFLOW.md` counts "3 bounded loops (the engines)". The new review-fix loop is a bounded in-session loop but is not an engine (the engines are goal, debug, execute). Leaving the count at three treats "engine" as the spine-loop sense, consistent with the pre-existing uncounted test-plan revise loop. Revisit only if "bounded loops" starts to mean every in-session loop.

--- a/docs/patterns/review-fix-loop.md
+++ b/docs/patterns/review-fix-loop.md
@@ -1,5 +1,7 @@
 # Pattern: the review-fix loop
 
+> Wired into the spine by SPEC-231 (`docs/specs/SPEC-231-auto-review-loop.md`).
+
 A multi-lens review is not a one-shot gate. A fix batch that resolves review
 findings can introduce new ones, so the review must run again on the fix, until
 the findings that matter stop appearing. This pattern names the three moves that


### PR DESCRIPTION
Follow-up after a fresh-context verifier audited the merged auto-review-loop wiring (PRs #397, #398). The auto-run held end to end: the three specialist lenses plus the kit-default advisor fire in one review-team pass, execute commands it as default-run on the full lane, the ship-gate lists review as required, the bounded two-round convergence-ranked loop is defined, and the design-time over-suggest arm fires at the spec stage. Model tiers intact (sonnet everywhere, security-only session-model override).

Three doc gaps closed:
- CHANGELOG [Unreleased] entry for the auto-run-review behavior (the direct wiring PR missed it; /kit:ship normally writes it).
- V-model lane-matrix row header corrected from Design critique (opt-in) to name the full-lane default (stale label the sweep missed; the cell value was already correct).
- SPEC-231 backref added to the pattern doc and the brief.

Left for the operator (gap d): whether the review-fix loop counts among WORKFLOW's 3 bounded engines; left at 3 since the engines are goal/debug/execute. Recorded in docs/implementation-notes/SPEC-231-auto-review-loop.md.

https://claude.ai/code/session_019RigzJh7XP4CwTCa2Tp6dL