### PR TITLE
fix(docs): resolve lib/ paths via DWARVES_KIT fallback in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,11 @@ How to do one unit of work. The smallest verifiable increment, verified, committ
    executing), then pull them one at a time.** Work that never touches the board is
    invisible to the board's state machine even when its runs are ledgered, the gap an
    operator caught live on 2026-06-10 (SPEC-064). Not handed one: pull the board's top queued item,
-   `bash lib/board/backlog.sh next`, claim it (goal-registry) and flip it to `claimed` (the
+   `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/board/backlog.sh" next`, claim it (goal-registry) and flip it to `claimed` (the
    `/kit:assign --next` flow). The BACKLOG is the board; its Status column is the state
    machine (`queued -> claimed -> speccing -> validated -> executing -> shipped`, + parked/
    dropped). Operator-named work is unchanged; pull is an additional trigger, never a daemon.
-1. **Classify the type, then size the lane.** `bash lib/classify/task-type-classify.sh classify "<task>"`
+1. **Classify the type, then size the lane.** `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/classify/task-type-classify.sh" classify "<task>"`
    first: `spec-feature` picks a lane below; any other type (incident / reconcile / operate /
    planning / learning / eval / research / review / doc / migration / data-tool) runs its TYPE LOOP per
    `WORKFLOW.md ## Type loops`, with its executor from the registry's `agent` column. The lane
@@ -59,11 +59,11 @@ How to do one unit of work. The smallest verifiable increment, verified, committ
    understood, type-shaped questions, recommended answers, contradictions checked against the
    repo, answers WRITTEN as they resolve (glossary / sparse ADR / the goal draft's Context).
    Tiny lane exempt. **Record the grill's disposition either way** (SPEC-063):
-   `bash lib/gate/gate-ledger.sh record <rid> grill ran "<N> branches resolved"`, or, when the
+   `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" record <rid> grill ran "<N> branches resolved"`, or, when the
    conversation already resolved the banks, `... record <rid> grill skipped "<why>"`; a
    skip without a reason is invisible to telemetry, which defeats the point.
    **Then phase 0: define the done scenario**
-   (`bash lib/gate/proof-gate.sh contract "<task>"` + the type's test-design dialect,
+   (`bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/proof-gate.sh" contract "<task>"` + the type's test-design dialect,
    test-design-standard §5b) BEFORE any work runs; the grill's answers are the done's raw
    material, and the goal draft carries the `Done =` line.
 2. **Read the spec and its acceptance criteria.** For a spec-driven task: the active spec's task row, its AC, its `## Verification`, and its `## After state`. No spec (tiny lane): the one obvious edit.
@@ -73,20 +73,20 @@ How to do one unit of work. The smallest verifiable increment, verified, committ
 
 If you cannot make progress, see zone 4 (Pause if) and stop with a named blocker note. Do not churn.
 
-**One rid per run, derived from the branch (SPEC-070).** `<rid>` everywhere below is `$(bash lib/gate/gate-ledger.sh rid)`: the branch slug (`type/` prefix stripped), the same key `hooks/ship-gate.sh` checks at push, so assign-time records and ship-time enforcement meet with no mirror re-records. Derive it AFTER the work branch exists; the verb refuses master/main/detached.
+**One rid per run, derived from the branch (SPEC-070).** `<rid>` everywhere below is `$(bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" rid)`: the branch slug (`type/` prefix stripped), the same key `hooks/ship-gate.sh` checks at push, so assign-time records and ship-time enforcement meet with no mirror re-records. Derive it AFTER the work branch exists; the verb refuses master/main/detached.
 
 **Show the road, then your position on it (SPEC-063).** Right after a lane is committed,
-print the checklist the run will walk: `bash lib/gate/gate-ledger.sh plan <lane>`. At each phase
-entry, print where the run stands: `bash lib/gate/gate-ledger.sh progress <rid> <lane>`
+print the checklist the run will walk: `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" plan <lane>`. At each phase
+entry, print where the run stands: `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" progress <rid> <lane>`
 (one status line: `<rid> · <lane> · step k/n (<phase>)` + the ✓/▶/· checklist). For the
-full story of a past or in-flight run: `bash lib/telemetry/lane-telemetry.sh trace <rid>`.
+full story of a past or in-flight run: `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/telemetry/lane-telemetry.sh" trace <rid>`.
 
 **Escalate the review for enforcement surfaces (SPEC-069).** A run touching `lib/` or
 `hooks/` uses `/kit:review-team` (multi-lens), not a single reviewer.
 
-**Record your gates (ADR-0024).** When you run a phase gate (`/kit:spec`, `/kit:spec-validate`, `/kit:execute`, `/kit:review`, `/kit:docs`, `/kit:ship`, ...), record it so the run is auditable: `bash lib/gate/gate-ledger.sh record <rid> <Phase> ran`; record a deliberate skip as `skipped "<why>"`. The `ship-gate` hook refuses a push whose lane has a required gate with no `ran`/`override` entry. Phase ORDER matters too: the lane plan is the V-model descent order; `bash lib/gate/gate-ledger.sh descent <rid> <lane>` names out-of-order records, surfaced at ship as an advisory (SPEC-076). Full convention + the logged-override path: WORKFLOW.md "## Gate ledger and ship enforcement".
+**Record your gates (ADR-0024).** When you run a phase gate (`/kit:spec`, `/kit:spec-validate`, `/kit:execute`, `/kit:review`, `/kit:docs`, `/kit:ship`, ...), record it so the run is auditable: `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" record <rid> <Phase> ran`; record a deliberate skip as `skipped "<why>"`. The `ship-gate` hook refuses a push whose lane has a required gate with no `ran`/`override` entry. Phase ORDER matters too: the lane plan is the V-model descent order; `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" descent <rid> <lane>` names out-of-order records, surfaced at ship as an advisory (SPEC-076). Full convention + the logged-override path: WORKFLOW.md "## Gate ledger and ship enforcement".
 
-**Gates are also MEASURED, not just recorded (SPEC-129).** Beside `ran`/`skipped`, `bash lib/gate/gate-ledger.sh outcome <rid> <phase> start|end [caught=<bool>]` brackets a gate with a duration and whether it caught a defect, on the same additive marker convention (a fourth `| OUTCOME |` line beside `| GATE | / | DEBT | / | TOKENS |`; existing readers ignore it). The only live emitter today is `hooks/ship-gate.sh` at the ship boundary, HOOK-ENFORCED but ship-boundary-only, not yet per-phase; read it back with `outcome-read`. **A parallel wave closes the SPEC-number race at dispatch, not at spec-time (SPEC-128).** `lib/queue/orchestrate.sh`'s own wavefront dispatch atomically reserves a number per sub-goal via `bash lib/spec/spec-next.sh reserve` (a portable mkdir-mutex over an append-only reservations ledger) before any worker can race `spec-next.sh next`; a standalone session still calls `spec-next.sh next` directly, unaffected. **Generate the confirmation table, never hand-author it (SPEC-132).** `bash lib/gate/proof-table-gen.sh <rid>` renders `docs/verification/generated/<rid>.md` from the same gate/run ledger (surfacing the OUTCOME column above when present); see `docs/verification/README.md` "Generators write run ledgers, never the canonical." Full detail on all three, plus the two advisory measurement gates (coverage-delta, mutation-smoke): WORKFLOW.md "## Gate ledger and ship enforcement" and "## Advisory measurement gates".
+**Gates are also MEASURED, not just recorded (SPEC-129).** Beside `ran`/`skipped`, `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" outcome <rid> <phase> start|end [caught=<bool>]` brackets a gate with a duration and whether it caught a defect, on the same additive marker convention (a fourth `| OUTCOME |` line beside `| GATE | / | DEBT | / | TOKENS |`; existing readers ignore it). The only live emitter today is `hooks/ship-gate.sh` at the ship boundary, HOOK-ENFORCED but ship-boundary-only, not yet per-phase; read it back with `outcome-read`. **A parallel wave closes the SPEC-number race at dispatch, not at spec-time (SPEC-128).** `lib/queue/orchestrate.sh`'s own wavefront dispatch atomically reserves a number per sub-goal via `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/spec/spec-next.sh" reserve` (a portable mkdir-mutex over an append-only reservations ledger) before any worker can race `spec-next.sh next`; a standalone session still calls `spec-next.sh next` directly, unaffected. **Generate the confirmation table, never hand-author it (SPEC-132).** `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/proof-table-gen.sh" <rid>` renders `docs/verification/generated/<rid>.md` from the same gate/run ledger (surfacing the OUTCOME column above when present); see `docs/verification/README.md` "Generators write run ledgers, never the canonical." Full detail on all three, plus the two advisory measurement gates (coverage-delta, mutation-smoke): WORKFLOW.md "## Gate ledger and ship enforcement" and "## Advisory measurement gates".
 
 ## 3. Done means
 
@@ -153,7 +153,7 @@ describes a module's SURFACE (leaf/human vs internal-helper), not its location; 
 separate `tools/` tree. Each multi-verb subsystem exposes a **standalone `<subsystem> <verb>`
 command** (`board next`, `gate ledger ...`, `classify ...`, `spec ...`, `goal ...`,
 `session ...`) that forwards to the script owning that verb; the internal
-`bash lib/<subsystem>/<file>.sh` form used throughout the task loop still works unchanged.
+`bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/<subsystem>/<file>.sh"` form used throughout the task loop still works unchanged.
 There is no `kit` uber-dispatcher, each command's own `--help` is the discovery surface. The
 read plane is **`stats`**: a stateless projection recomputed on demand from the append-only
 ledger, never a persisted second source of truth.

--- a/docs/verification/agents-md-lib-path-fallback.md
+++ b/docs/verification/agents-md-lib-path-fallback.md
@@ -1,0 +1,48 @@
+# Proof of done: AGENTS.md lib/ path fallback (fixes #401)
+
+## Claim
+
+`AGENTS.md`'s command snippets (`bash lib/...`) resolve correctly in a
+consumer repo that was scaffolded WITHOUT a full `/kit:adopt` (kit run
+as a global Claude Code plugin only, no local `lib/` copied in), by
+falling back to `${DWARVES_KIT:-$HOME/.claude/dwarves-kit}`.
+
+## Test repo
+
+`/Users/hieutieutu/workspace/prohome/projects` — has `AGENTS.md`
+(copied verbatim from this kit) but no local `lib/`, `hooks/`, or
+`bin/` (plugin-only scaffold, adopt intentionally skipped).
+
+## Negative control (RED — before fix, bare repo-relative form)
+
+```
+$ cd /Users/hieutieutu/workspace/prohome/projects
+$ bash lib/gate/gate-ledger.sh rid
+bash: lib/gate/gate-ledger.sh: No such file or directory
+Exit: 127
+```
+
+Confirms the pre-fix snippet form is broken in this environment —
+exactly the bug reported in #401.
+
+## Green run (after fix — DWARVES_KIT fallback form)
+
+```
+$ cd /Users/hieutieutu/workspace/prohome/projects
+$ bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" rid
+construction-project-tracking
+Exit: 0
+```
+
+Same command, same repo, same missing local `lib/` — resolves via the
+global kit install and returns the correct rid.
+
+## Verdict: PASS
+
+Command: `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/gate/gate-ledger.sh" rid`
+Exit: 0
+Rollback: revert `AGENTS.md` to the pre-fix commit; bare `bash lib/gate/gate-ledger.sh rid` reproduces the RED case above.
+
+All 11 patched snippets in `AGENTS.md` follow the identical
+substitution (`bash lib/X.sh` → `bash "${DWARVES_KIT:-$HOME/.claude/dwarves-kit}/lib/X.sh"`),
+verified by `grep -c 'bash lib/' AGENTS.md` returning 0 post-patch.


### PR DESCRIPTION
## Summary
- `lib/adopt.sh` copies `AGENTS.md` byte-for-byte into every consumer repo (`cp "$src_agents" "$agents"`, never rewritten)
- Its `bash lib/...` command snippets (11 spots) are repo-relative — only correct inside this repo, or after a full `/kit:adopt` that also wires `lib/` locally
- A project scaffolded in plugin-only mode (adopt skipped, kit run purely as a global Claude Code plugin) never gets a local `lib/`, so every `gate-ledger`/`classify`/`proof-gate` snippet in its copied `AGENTS.md` fails with `No such file or directory`
- `_meta/board` already handles this correctly via `${DWARVES_KIT:-$HOME/.claude/dwarves-kit}` fallback — this PR applies the same pattern to `AGENTS.md`'s 11 command snippets

Fixes #401

## Test plan
- [x] `grep -c 'bash lib/' AGENTS.md` returns 0 post-patch
- [x] Proof-of-done in `docs/verification/agents-md-lib-path-fallback.md`: negative control (bare `bash lib/gate/gate-ledger.sh rid` → exit 127 in a plugin-only repo with no local `lib/`) followed by green run (`DWARVES_KIT` fallback form → exit 0, correct rid)