### PR TITLE
fix(sync): chunk Notion rich_text by UTF-16 units, not codepoints

### DIFF
--- a/docs/verification/notion-rich-utf16.md
+++ b/docs/verification/notion-rich-utf16.md
@@ -1,0 +1,30 @@
+# notion sync: rich_text chunking by UTF-16 units
+
+Claim: `_rich` chunks never exceed 2000 UTF-16 code units, so a Notes
+body holding an emoji no longer 400s the Notion `v1/pages` request.
+Incident: the dfoundation hourly board-sync exited rc=1 on every run
+(2026-08-18) with `validation_error ... length should be <= 2000,
+instead was 2001`; the board carried Notes cells with one astral char
+inside their first 2000 codepoints.
+
+## Green run
+
+| Command | Exit | Verdict |
+|---|---|---|
+| `uv run --with pytest pytest tests/test_notion.py tests/test_notion_taskboard.py -q` (lib/sync) | 0 | PASS: 40 passed, including the two new `test_rich_chunks_by_utf16_units_not_codepoints` |
+| `uv run --with pytest pytest tests/ -q` (lib/sync) | 0 | PASS: 175 passed, full sync suite |
+
+## Negative control (revert -> RED -> restore)
+
+| Command | Exit | Verdict |
+|---|---|---|
+| `git stash push -- lib/sync/sources/notion.py lib/sync/sources/notion_taskboard.py`, then run the two new tests | 1 | RED: both fail on the old `len()`-based slicing (`2 failed`) |
+| `git stash pop` | 0 | fix restored; suite green again |
+
+## Reproduce
+
+```bash
+cd lib/sync && uv run --with pytest pytest \
+  tests/test_notion.py::test_rich_chunks_by_utf16_units_not_codepoints \
+  tests/test_notion_taskboard.py::test_rich_chunks_by_utf16_units_not_codepoints -q
+```

--- a/lib/sync/sources/notion.py
+++ b/lib/sync/sources/notion.py
@@ -21,7 +21,7 @@ from sync_core import (ACTIVE_STATUSES, BOARD_STATES, extract_tags,
 STATE_COLORS = {"queued": "gray", "claimed": "yellow", "speccing": "orange",
                 "validated": "purple", "executing": "blue", "shipped": "green",
                 "parked": "brown", "dropped": "red"}
-RICH_LIMIT = 2000  # Notion rich_text element content cap
+RICH_LIMIT = 2000  # Notion rich_text element content cap, in UTF-16 code units
 
 
 def _run_ntn(args: list, data: dict | None = None):
@@ -38,7 +38,19 @@ def _run_ntn(args: list, data: dict | None = None):
 
 
 def _rich(text: str) -> list:
-    chunks = [text[i:i + RICH_LIMIT] for i in range(0, len(text), RICH_LIMIT)]
+    # Notion measures the cap in UTF-16 code units, not codepoints: an astral
+    # char (emoji) counts as 2, so len()-based 2000-char slices can weigh 2001
+    # and 400 the whole request (validation_error, board-sync rc=1 every run).
+    chunks, buf, units = [], [], 0
+    for ch in text:
+        u = 2 if ord(ch) > 0xFFFF else 1
+        if units + u > RICH_LIMIT:
+            chunks.append("".join(buf))
+            buf, units = [], 0
+        buf.append(ch)
+        units += u
+    if buf:
+        chunks.append("".join(buf))
     return [{"type": "text", "text": {"content": c}} for c in chunks[:100]] \
         or [{"type": "text", "text": {"content": ""}}]
 

--- a/lib/sync/sources/notion_taskboard.py
+++ b/lib/sync/sources/notion_taskboard.py
@@ -19,7 +19,7 @@ import subprocess
 
 from sync_core import extract_tags, strip_tags
 
-RICH_LIMIT = 2000  # Notion rich_text element content cap
+RICH_LIMIT = 2000  # Notion rich_text element content cap, in UTF-16 code units
 
 
 def _run_ntn(args: list, data: dict | None = None):
@@ -37,7 +37,19 @@ def _run_ntn(args: list, data: dict | None = None):
 
 
 def _rich(text: str) -> list:
-    chunks = [text[i:i + RICH_LIMIT] for i in range(0, len(text), RICH_LIMIT)]
+    # Notion measures the cap in UTF-16 code units, not codepoints: an astral
+    # char (emoji) counts as 2, so len()-based 2000-char slices can weigh 2001
+    # and 400 the whole request (validation_error, board-sync rc=1 every run).
+    chunks, buf, units = [], [], 0
+    for ch in text:
+        u = 2 if ord(ch) > 0xFFFF else 1
+        if units + u > RICH_LIMIT:
+            chunks.append("".join(buf))
+            buf, units = [], 0
+        buf.append(ch)
+        units += u
+    if buf:
+        chunks.append("".join(buf))
     return [{"type": "text", "text": {"content": c}} for c in chunks[:100]] \
         or [{"type": "text", "text": {"content": ""}}]
 

--- a/lib/sync/tests/test_notion.py
+++ b/lib/sync/tests/test_notion.py
@@ -184,6 +184,19 @@ def test_rich_never_empty_and_json_safe():
     json.dumps(_rich("a" * 5000))
 
 
+def test_rich_chunks_by_utf16_units_not_codepoints():
+    # 1999 ASCII + one astral char = 2000 codepoints but 2001 UTF-16 units;
+    # a len()-based chunk ships it whole and Notion 400s the request.
+    text = "a" * 1999 + "\U0001F4CA"
+    chunks = _rich(text)
+    utf16 = [sum(2 if ord(c) > 0xFFFF else 1 for c in ch["text"]["content"])
+             for ch in chunks]
+    assert all(u <= 2000 for u in utf16)
+    assert "".join(ch["text"]["content"] for ch in chunks) == text
+    # plain ASCII still packs a full 2000 per chunk
+    assert _rich("a" * 2000)[0]["text"]["content"] == "a" * 2000
+
+
 def test_unbound_without_flags_exits_with_guidance():
     src = NotionSource(runner=FakeNtn())
     with pytest.raises(SystemExit, match="notion-db"):

--- a/lib/sync/tests/test_notion_taskboard.py
+++ b/lib/sync/tests/test_notion_taskboard.py
@@ -9,7 +9,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from sources.notion_taskboard import NotionTaskBoardSource, parse_map  # noqa: E402
+from sources.notion_taskboard import (NotionTaskBoardSource, _rich,  # noqa: E402
+                                      parse_map)
 from sync_core import Plan, Row, plan_create_only  # noqa: E402
 
 
@@ -443,6 +444,18 @@ def test_partial_batch_failure_checkpoints_and_never_duplicates(tmp_path):
     backlog_sync.sync_create_only(src2, board, state, dry_run=False)
     assert len(fake2.page_bodies()) == 1
     assert sorted(json.loads(state.read_text())["map"]) == ["DF-1", "DF-2"]
+
+
+def test_rich_chunks_by_utf16_units_not_codepoints():
+    # The dfoundation board carried a Notes cell with one emoji inside its
+    # first 2000 codepoints: 2001 UTF-16 units, Notion 400'd every hourly
+    # sync (2026-08-18). Chunks must weigh <= 2000 UTF-16 units.
+    text = "a" * 1999 + "\U0001F4CA" + "b" * 50
+    chunks = _rich(text)
+    utf16 = [sum(2 if ord(c) > 0xFFFF else 1 for c in ch["text"]["content"])
+             for ch in chunks]
+    assert all(u <= 2000 for u in utf16)
+    assert "".join(ch["text"]["content"] for ch in chunks) == text
 
 
 def test_warn_duplicate_ids_general_prefix():


### PR DESCRIPTION
Notion measures the 2000-char rich_text cap in UTF-16 code units. `_rich` sliced by Python `len()`, so a 2000-codepoint chunk holding one astral char (emoji) weighed 2001 units and the whole `v1/pages` request 400'd with `validation_error`. The dfoundation hourly board-sync hit exactly this (a Notes cell with an emoji inside its first 2000 codepoints) and exited rc=1 on every run.

Fix: both duplicated helpers (`notion.py`, `notion_taskboard.py`) pack chunks by UTF-16 weight, never splitting an astral char.

Proof: `docs/verification/notion-rich-utf16.md` (green run 175 passed, stash-revert RED on the two new tests, restore).