### PR TITLE
fix(install): symlink hooks in compat mode, harden non-empty-dir case

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -341,19 +341,36 @@ KIT_REQUESTED_MODULES="$(echo "$KIT_REQUESTED_MODULES" | xargs)"
 # "don't run both paths" hazard the README warns about.
 #
 # So on a plugin machine we do a COMPAT-ONLY install: symlink the legacy
-# ~/.claude/dwarves-kit paths (lib, WORKFLOW.md, AGENTS.md) that docs still call
-# as plain bash (`bash ~/.claude/dwarves-kit/lib/<x>.sh`, where CLAUDE_PLUGIN_ROOT
-# is not set). No settings.json hooks, no flat commands. The symlinks track this
-# checkout (KIT_DIR), which is also the marketplace source, so a `git pull`
-# updates them. Force the full bash install with KIT_FORCE_FULL=1.
+# ~/.claude/dwarves-kit paths (lib, hooks, WORKFLOW.md, AGENTS.md) that docs still
+# call as plain bash (`bash ~/.claude/dwarves-kit/lib/<x>.sh`, where
+# CLAUDE_PLUGIN_ROOT is not set). No settings.json hooks, no flat commands. The
+# symlinks track this checkout (KIT_DIR), which is also the marketplace source,
+# so a `git pull` updates them. Force the full bash install with KIT_FORCE_FULL=1.
+#
+# kit_symlink_hardened <target> <linkname> -- `ln -sfn` silently no-ops on macOS
+# when LINKNAME already exists as a REAL (non-symlink) directory: -n only guards
+# against LINKNAME being a symlink-to-dir, so ln instead treats LINKNAME as a
+# directory and links TARGET's basename INSIDE it, leaving LINKNAME itself
+# unchanged (observed: a stale real ~/.claude/dwarves-kit/hooks/ dir that never
+# auto-updated). Move a real non-empty dir aside first, loudly, before linking.
+kit_symlink_hardened() {
+  local target="$1" linkname="$2"
+  if [ -e "$linkname" ] && [ ! -L "$linkname" ] && [ -d "$linkname" ] && [ -n "$(ls -A "$linkname" 2>/dev/null)" ]; then
+    local bak="${linkname}.pre-symlink.bak.$(date +%Y%m%d-%H%M%S)"
+    echo "[warn] $linkname is a real non-empty directory (ln -sfn would silently no-op); moving it to $bak"
+    mv "$linkname" "$bak"
+  fi
+  mkdir -p "$(dirname "$linkname")"
+  ln -sfn "$target" "$linkname"
+}
 PLUGIN_LIB="$(ls -d "$CLAUDE_DIR"/plugins/cache/dwarves-marketplace/kit/*/lib 2>/dev/null | sort -V | tail -1 || true)"
 if [ -n "${PLUGIN_LIB:-}" ] && [ -z "${KIT_FORCE_FULL:-}" ]; then
   echo "[plugin detected] kit@dwarves-marketplace is installed; runtime comes from the plugin."
   echo "Doing a COMPAT-ONLY install (legacy path shims), not the full bash install,"
   echo "to avoid double-registering hooks."
   mkdir -p "$CLAUDE_DIR/dwarves-kit/docs"
-  for f in bin lib WORKFLOW.md AGENTS.md docs/WORKFLOW.md docs/impl-playbook; do
-    ln -sfn "$KIT_DIR/$f" "$CLAUDE_DIR/dwarves-kit/$f"
+  for f in bin lib hooks WORKFLOW.md AGENTS.md docs/WORKFLOW.md docs/impl-playbook; do
+    kit_symlink_hardened "$KIT_DIR/$f" "$CLAUDE_DIR/dwarves-kit/$f"
     echo "[ok] compat symlink ~/.claude/dwarves-kit/$f -> $KIT_DIR/$f"
   done
   # CLI shims too: a plugin/compat machine is a dev machine, so expose every


### PR DESCRIPTION
## Summary
- Compat-only install (plugin detected) symlinks `bin`, `lib`, `AGENTS.md`, `WORKFLOW.md`, `docs/WORKFLOW.md`, `docs/impl-playbook` into `~/.claude/dwarves-kit/`, but never `hooks`, leaving a stale real `hooks/` dir that never tracks the checkout after a plugin-source move.
- `ln -sfn` silently no-ops on macOS when the link target is already a real (non-symlink) non-empty directory: `-n` only guards a symlink-to-dir, so `ln` instead links the target's basename INSIDE the existing directory, leaving the directory itself untouched with no error.
- Added `kit_symlink_hardened()`: moves a real non-empty target aside to `<name>.pre-symlink.bak.<timestamp>` with a loud `[warn]`, then symlinks normally. Applied to every entry in the compat loop, including the new `hooks`.

## Test plan
Ran the modified `install.sh` against a throwaway `CLAUDE_DIR` (`mktemp -d`), simulating both preconditions:
- Faked a plugin-cache dir (`plugins/cache/dwarves-marketplace/kit/1.2.3/lib`) so the script takes the compat-only branch.
- Pre-seeded a REAL non-empty `dwarves-kit/hooks/` dir (the stale-dir precondition) before running.

Result:
```
[warn] .../dwarves-kit/hooks is a real non-empty directory (ln -sfn would silently no-op); moving it to .../dwarves-kit/hooks.pre-symlink.bak.20260818-215045
[ok] compat symlink ~/.claude/dwarves-kit/hooks -> <checkout>/hooks
```
Post-run: `hooks` is now a real symlink into the checkout; the old real dir's content survived intact under `hooks.pre-symlink.bak.20260818-215045/old-safety-gate.sh`.

Also re-ran a normal (non-plugin) full install against a second throwaway `CLAUDE_DIR` (exit 0, unaffected), plus the repo's existing install test suite, all green:
```
tests/test-install-compat.sh   -> PASS: install compat (exit 0)
tests/test-install-modules.sh  -> 37 passed, 0 failed
tests/test-install-contract.sh -> PASS=4 FAIL=0
tests/test-install-clis.sh     -> all 20 passed
```

https://claude.ai/code/session_014Zk52wJiVWahkVvagTh54U