### PR TITLE
fix(orchestrate): dispatch gate sub-goals, count merged-PR flips

### DIFF
--- a/commands/mega.md
+++ b/commands/mega.md
@@ -78,6 +78,14 @@ task outside the mega-goal entirely (`lib/classify/lane-classify.sh classify` wi
 `tiny` on its own merits). Reserve dedicated sub-goals for work substantial enough to
 need its own PR, proof, and merge gate.
 
+**A port-then-delete chain owes a re-diff (mirrors the skill's decompose rule).** When one
+sub-goal PORTS code out of a location and a later sub-goal DELETES that source, the deleting
+sub-goal's `Done =` MUST include: "every ported file re-diffed against the source's FINAL state
+(`git diff <port-base> <head> -- <source-dir>` is empty, or the delta re-applied)". The port
+branch froze the source at the moment it was cut; anything that landed in the source afterwards
+is invisible to the port and dies with the delete. Field case: two fixes merged into the source
+between the port branch and the delete, and both were lost until a post-close audit found them.
+
 **Deployable terminus (mirrors the skill's "definition of done extends past
 built").** Once real diffs exist, check `lib/gate/proof-ledger.sh deployable <root>
 <base>` (SG-07's classifier, reused verbatim, never a second one). When it prints
@@ -253,6 +261,12 @@ mark):
 gh pr create --draft ...                      # open held: draft is the GitHub-intrinsic block
 bash lib/goal/mega-merge.sh mark <pr> [repo]        # ensure the do-not-merge label + draft + add label (idempotent)
 ```
+
+`lib/queue/orchestrate.sh` enforces this half of the contract directly: a `gate` / `gate!` sub-goal
+is DISPATCHED like an `auto` one, its prompt carries the held-PR instruction above, and the loop
+holds AFTER the session, grounded on the PR existing (a gate sub-goal never flips its own box, so a
+missing PR is the same no-self-claim halt an unflipped box gets). `MEGA_GATE_DISPATCH=0` restores
+the older stop-before-running posture.
 
 `mega-merge.sh mark` ensures the `do-not-merge` label exists (so `--label` never fails),
 converts the PR to a draft, and adds the label -- exactly the state `_merge_exclusion`

--- a/docs/verification/orchestrate-gate-dispatch.md
+++ b/docs/verification/orchestrate-gate-dispatch.md
@@ -1,0 +1,77 @@
+# Proof of done: orchestrate.sh gate dispatch + merged-PR box reconciliation
+
+Two defects observed on a real 5-sub-goal mega-goal run (foundation-workers
+`_meta/megagoals/retire-apps/`, its `RUN_REPORT.md` "Incidents" holds the field record), plus one
+decompose rule the same run needed.
+
+## Acceptance criteria
+
+| # | Criterion | Met |
+|---|---|---|
+| AC1 | A box flipped inside a sub-goal's now-merged PR counts: the driver reconciles against `origin/<default>` before the no-self-claim halt | yes (A1) |
+| AC2 | No-self-claim is unchanged: a remote box counts only when its line carries a real `PR #<n>` | yes (A2, negative control) |
+| AC3 | A dirty tree is never force-pulled; the remote copy is read for the check only | yes (A3, negative control) |
+| AC4 | Outside a git repo the guardrail halt is byte-identical | yes (A4, negative control) |
+| AC5 | A `gate` sub-goal is DISPATCHED, its prompt carries the held-PR contract, and the loop holds afterwards on its PR URL | yes (B1, B1b) |
+| AC6 | A gate session that opened no PR halts the loop, exactly like an unflipped box | yes (B2, negative control) |
+| AC7 | `MEGA_GATE_DISPATCH=0` restores the stop-before-running behavior | yes (B3, B6 negative control, plus the legacy blocks in the three existing orchestrate test files) |
+| AC8 | `gate!` is dispatched too, then halts the whole loop, on the serial path and under a wave | yes (B4, B5) |
+| AC9 | `--dry-run` names the dispatch-then-hold plan | yes (B6) |
+| AC10 | `commands/mega.md` Step 1 carries the port-then-delete re-diff rule, mirrored into the never-diverge skill copy | yes (`commands/mega.md`, `dotfiles` PR) |
+
+## What changed
+
+`lib/queue/orchestrate.sh`:
+
+- `_default_branch` / `_roadmap_remote_view` / `_sg_pr_url` (new helpers).
+- The grounded-completion check consults `origin/<default>` before halting. Clean tree on the
+  default branch: `git fetch` + `merge --ff-only`. Dirty tree: `git show origin/<default>:<path>`
+  into a temp file, read-only, plus a locked `flip` of the one box line the remote already carries
+  so `_next` cannot re-pick the same sub-goal forever.
+- `MEGA_GATE_DISPATCH` (default 1): a `gate` / `gate!` sub-goal runs through the same dispatch body
+  an `auto` one does. `_build_prompt` takes an optional policy argument that injects the held-PR
+  contract (draft PR, `mega-merge.sh mark`, never merge, never flip the box). The hold happens after
+  the session and is grounded on `_sg_pr_url`. `gate!` forces itself as the cycle's pick under a
+  wave, so the wave still quiesces around it.
+- `GH_CMD` mock seam for the PR lookup.
+
+`commands/mega.md`: the port-then-delete re-diff rule in Step 1; the driver's gate-dispatch behavior
+named in Step 5.
+
+## Confirmation run-table
+
+| Command | Exit | Result |
+|---|---|---|
+| `bash tests/test-orchestrate-gate-dispatch.sh` | 0 | 23/23 PASS (`ALL PASS`), 6 of them negative controls |
+| `bash tests/test-orchestrate.sh` | 1 | 61 PASS; the 2 failures (`dry-run SG-02 inherit`, `SG-02 got an unexpected --model`) are PRE-EXISTING on `origin/master`, byte-identical to the baseline capture |
+| `bash tests/test-orchestrate-hardening.sh` | 0 | 12/12 PASS |
+| `bash tests/test-orchestrate-wavefront.sh` | 0 | 103/103 PASS |
+| `bash tests/test-meta.sh` | 1 | 806/813; the 7 failures are PRE-EXISTING and the failure set is identical to the baseline capture (verified by set-diff) |
+
+Verdict: PASS. Every new assertion is green; no test that passed before regressed.
+
+## Negative controls (RED-by-design)
+
+| Control | What it poisons | Observed |
+|---|---|---|
+| A2 | remote box flipped WITHOUT a `PR #<n>` | run halts nonzero, "did not check its ROADMAP box" |
+| A3 | dirty working tree | HEAD unmoved, staged work intact, remote read for the check only |
+| A4 | megagoal outside any git repo | halt message and exit code unchanged |
+| B1b | the `auto` sub-goal's prompt | carries no `HELD SUB-GOAL` block |
+| B2 | gate session opens no PR | run halts nonzero, "opened no PR" |
+| B3 / B6 | `MEGA_GATE_DISPATCH=0` | gate sub-goal never dispatched; old stop message and plain `(gate)` plan label return |
+
+## Reproduce
+
+```bash
+bash tests/test-orchestrate-gate-dispatch.sh
+bash tests/test-orchestrate.sh
+bash tests/test-orchestrate-hardening.sh
+bash tests/test-orchestrate-wavefront.sh
+bash tests/test-meta.sh
+```
+
+The A-block fixtures build a real bare remote plus a clone, and the mock session pushes the box flip
+to the remote without touching the driver's checkout, so the merged-PR shape is reproduced for real
+rather than simulated. The B-block fixtures mock `gh` through `GH_CMD`, so no network and no GitHub
+auth are involved.

--- a/lib/queue/orchestrate.sh
+++ b/lib/queue/orchestrate.sh
@@ -27,8 +27,14 @@
 # <megagoal-dir> holds: ROADMAP.md (sub-goal lines `- [ ] SG-NN ... , auto|gate , ...`),
 # POINTER_PROMPT.md (static resume prompt), HANDOFF.md (feed-forward, written by each sub-goal).
 # Grounded completion: a sub-goal session MUST flip its ROADMAP checkbox to [x]; the
-# orchestrator advances only then (no self-claim). It STOPS at the first `gate` sub-goal
-# (shared-repo review needs a human).
+# orchestrator advances only then (no self-claim). When the local box is unchecked it reconciles
+# against `origin/<default>` first, so a box flipped inside a now-merged PR still counts (a remote
+# box counts only when its line also carries a real `PR #<n>`).
+#
+# Gate sub-goals (env MEGA_GATE_DISPATCH=1 default): a `gate` / `gate!` sub-goal is DISPATCHED like
+# an `auto` one, its prompt carries the held-PR contract (open the PR as a DRAFT, `mega-merge.sh
+# mark` it, never merge it, never flip the box), and the loop HOLDS afterwards for the human merge,
+# grounded on the PR existing. MEGA_GATE_DISPATCH=0 restores the old stop-before-running behavior.
 #
 # TIER-4 mega-close (SPEC-118/ID-093, env TIER4_CLOSE=1 default): when EVERY box is checked, the run
 # does a real mega-level close over the ASSEMBLED WAVE -- a mechanical no-orphan sweep (a dispatchable
@@ -215,6 +221,20 @@ PANE_VIEWER_ALLOWED="auto cmux kitty wezterm ghostty iterm terminal none"
 # else on (1).
 TIER4_CLOSE="${TIER4_CLOSE:-$(_kit_bool01 "$(kit_config_get mega.tier4_close)" 1)}"
 
+# Gate-sub-goal DISPATCH (default 1). The documented contract (commands/mega.md Step 5, the
+# plan-for-mega-goal skill) is that a `gate` sub-goal's worker DOES the work, opens its PR as a
+# DRAFT, marks it via `mega-merge.sh mark`, and the loop then stops for a HUMAN MERGE. The driver
+# used to stop BEFORE running it ("open/await its PR for review"), so a gate sub-goal was never
+# dispatched and its work never happened -- the loop asked a human to review a PR nobody had
+# opened. With this on, a `gate`/`gate!` sub-goal is dispatched exactly like an `auto` one, its
+# prompt carries the held-PR contract, and the hold happens AFTER the session, keyed on the PR
+# existing. MEGA_GATE_DISPATCH=0 restores the old stop-before-running behavior.
+MEGA_GATE_DISPATCH="${MEGA_GATE_DISPATCH:-1}"
+
+# `gh` seam for the gate hold's PR lookup, mirroring CLAUDE_CMD's mock seam so tests need no
+# network and no GitHub auth.
+GH_CMD="${GH_CMD:-gh}"
+
 _say() { printf '%s\n' "$*"; }
 
 # Portable file mtime (epoch secs). GNU `stat -c` FIRST: it errors cleanly on BSD/macOS, so the
@@ -325,6 +345,73 @@ _ready_set() {
     line=$(_sg_line "$roadmap" "$id")
     [ -z "$(_sg_deps_blocked "$roadmap" "$line")" ] && printf '%s\t%s\n' "$id" "$policy"
   done < <(_subgoals "$roadmap")
+}
+
+# ---- Merged-PR box reconciliation + gate-hold PR lookup ---------------------------------------
+# The repo's default branch, from `origin/HEAD` when the remote HEAD ref is present, else whichever
+# of main/master the remote actually carries. Empty when neither resolves (no remote, bare checkout).
+_default_branch() {  # repo
+  local repo="$1" d
+  d=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)
+  [ -n "$d" ] && { printf '%s' "${d#origin/}"; return 0; }
+  for d in main master; do
+    git -C "$repo" show-ref --verify --quiet "refs/remotes/origin/$d" && { printf '%s' "$d"; return 0; }
+  done
+}
+
+# A view of ROADMAP.md that reflects `origin/<default>`, for the grounded-completion box check.
+# A sub-goal worker commonly flips its own box INSIDE its PR; once that PR merges, the box is
+# checked on the remote while this driver's local checkout is still behind, and the box check below
+# called a healthy session a liar (observed on a real 5-sub-goal run). Prints the path to READ:
+#   * the LOCAL roadmap, after a `git fetch` + `--ff-only` merge, when the megagoal sits in a repo
+#     whose checkout is ON the default branch with a CLEAN tree (never force-pull a dirty tree);
+#   * a TEMP copy read out of `origin/<default>` when the tree is dirty (check only, no mutation);
+#   * nothing at all when there is no repo / no remote / the checkout is on a feature branch.
+# The caller deletes a temp path; a returned path equal to $roadmap is the live file. STDOUT carries
+# the path and NOTHING else (the caller reads it through a command substitution), so the two log
+# lines below go to stderr.
+_roadmap_remote_view() {  # dir roadmap
+  local dir="$1" roadmap="$2" repo branch def rel tmp
+  repo=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || return 0
+  [ -n "$repo" ] || return 0
+  def=$(_default_branch "$repo"); [ -n "$def" ] || return 0
+  branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  [ "$branch" = "$def" ] || return 0
+  git -C "$repo" fetch --quiet origin "$def" 2>/dev/null || return 0
+  # Repo-relative path of the ROADMAP, derived by prefix-stripping PHYSICAL paths rather than by
+  # `git ls-files <abspath>`: on macOS the megadir often arrives via the /var -> /private/var symlink,
+  # which git rejects as "outside repository" even though it is not.
+  rel=$(cd "$(dirname "$roadmap")" 2>/dev/null && pwd -P)/$(basename "$roadmap")
+  rel="${rel#"$repo"/}"
+  case "$rel" in /*) return 0 ;; esac   # not under the repo root: nothing to reconcile against
+  # Untracked files are EXCLUDED from the dirty test: the driver itself writes BOARD.md and
+  # .orchestrate/ into the megagoal dir, so `--porcelain` alone would call every run dirty and the
+  # fast-forward would never happen. `merge --ff-only` still refuses on its own if the fast-forward
+  # would clobber an untracked file, and the `git show` path below catches that refusal.
+  if [ -z "$(git -C "$repo" status --porcelain --untracked-files=no 2>/dev/null)" ] \
+     && git -C "$repo" merge --ff-only "origin/$def" >/dev/null 2>&1; then
+    echo "[orchestrate] [reconcile] fast-forwarded $def to origin/$def before the box check." >&2
+    printf '%s' "$roadmap"; return 0
+  fi
+  tmp=$(mktemp) || return 0
+  if git -C "$repo" show "origin/$def:$rel" > "$tmp" 2>/dev/null; then
+    echo "[orchestrate] [reconcile] tree not fast-forwardable; reading ROADMAP.md from origin/$def for the box check only." >&2
+    printf '%s' "$tmp"; return 0
+  fi
+  rm -f "$tmp"
+}
+
+# The PR URL for a sub-goal's declared branch, or empty. This is how a GATE sub-goal's completion is
+# grounded: it must NOT flip its own box (a human merges its PR), so the evidence that its session
+# actually finished is that a PR exists. Mockable via GH_CMD; any failure (no gh, no auth, no PR)
+# yields empty, which the caller treats exactly like an unflipped box.
+_sg_pr_url() {  # dir id
+  local dir="$1" id="$2" branch url
+  branch=$(_sg_branch "$(_goalfile "$dir" "$id")" "$id")
+  [ -n "$branch" ] || return 0
+  # shellcheck disable=SC2086 # GH_CMD is operator config; word-splitting is intended (mirrors CLAUDE_FLAGS).
+  url=$($GH_CMD pr view "$branch" --json url -q .url 2>/dev/null | head -1)
+  case "$url" in http*) printf '%s' "$url" ;; esac
 }
 
 # ---- SG-10 board-view / event-sourced status -----------------------------------------------
@@ -714,9 +801,19 @@ _emit_start() {  # dir id
 }
 
 _build_prompt() {
-  local dir="$1" id="$2"
+  local dir="$1" id="$2" gate_policy="${3:-}"
   cat "$dir/POINTER_PROMPT.md" 2>/dev/null
   printf '\n\nNEXT SUB-GOAL: %s\n' "$id"
+  # Held-PR contract for a `gate` / `gate!` sub-goal (MEGA_GATE_DISPATCH). The worker does the work
+  # like any other sub-goal; what differs is the ending. Absent third arg -> nothing is printed and
+  # an `auto` sub-goal's prompt stays byte-identical.
+  if [ -n "$gate_policy" ]; then
+    printf '\nHELD SUB-GOAL (%s): this sub-goal ends at a HUMAN MERGE, not at a merge you perform.\n' "$gate_policy"
+    printf -- '- Do the work and verify it exactly as any other sub-goal.\n'
+    printf -- '- Open the PR as a DRAFT (`gh pr create --draft ...`), then run `bash lib/goal/mega-merge.sh mark <pr>` so the do-not-merge label and the draft state are both set.\n'
+    printf -- '- Do NOT merge the PR. Do NOT flip this sub-goal ROADMAP box. A human merges, and the merge is what checks the box.\n'
+    printf -- '- The orchestrator grounds your completion on the PR EXISTING, so the PR is the deliverable.\n'
+  fi
   # Inject the goal file's CONTENT (not just a path), so the session has the contract and
   # re-discovery is actually eliminated (SPEC-087 "Session invocation").
   local gf; gf=$(_goalfile "$dir" "$id")
@@ -1955,7 +2052,7 @@ _tier4_close() {  # dir roadmap
 # -----------------------------------------------------------------------------------------------
 
 cmd_run() {
-  local dir="" dry=0 step=0 stream=0 board_arg=""
+  local dir="" dry=0 step=0 stream=0 board_arg="" forced_pick=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --dry-run)  dry=1 ;;
@@ -2008,9 +2105,17 @@ cmd_run() {
     local any=0
     while IFS=$'\t' read -r sg ppolicy; do
       any=1
-      local rmodel reffort
+      local rmodel reffort plabel="$ppolicy"
       IFS=$'\t' read -r rmodel reffort < <(_route "$(_goalfile "$dir" "$sg")")
-      _say "  -> $sg ($ppolicy)  [model: ${rmodel:-inherit}, effort: ${reffort:-inherit}]  [prompt: POINTER_PROMPT + goal-file + $([ -s "$dir/HANDOFF.md" ] && echo HANDOFF || echo no-handoff)]"
+      # Under MEGA_GATE_DISPATCH a gate sub-goal is RUN and only then held, so the plan must not
+      # read as "skipped": name the dispatch and the hold in the same breath.
+      if [ "$MEGA_GATE_DISPATCH" = 1 ]; then
+        case "$ppolicy" in
+          gate)    plabel="gate, dispatch then hold for human merge" ;;
+          'gate!') plabel="gate!, dispatch then halt the whole loop for human merge" ;;
+        esac
+      fi
+      _say "  -> $sg ($plabel)  [model: ${rmodel:-inherit}, effort: ${reffort:-inherit}]  [prompt: POINTER_PROMPT + goal-file + $([ -s "$dir/HANDOFF.md" ] && echo HANDOFF || echo no-handoff)]"
       [ "$ppolicy" = "gate!" ] && { _say "  == STOP at $sg (gate!: global halt for human review) =="; break; }
       [ "$ppolicy" = gate ] && { _say "  == STOP at $sg (gate: human review) =="; break; }
       [ "$step" = 1 ] && _say "     [--step] pause here for the operator before the next sub-goal"
@@ -2051,11 +2156,24 @@ cmd_run() {
       local gbang
       gbang=$(_ready_set "$roadmap" | awk -F'\t' '$2=="gate!"{print $1; exit}')
       if [ -n "$gbang" ]; then
-        _emit_event "$dir" "$gbang" blocked "gate!: global halt for human review"
-        [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
-        _say "[orchestrate] STOP (gate!): global halt for human review; $gbang is a gate! sub-goal. Resolve, then re-run."
-        return 0
+        if [ "$MEGA_GATE_DISPATCH" = 1 ]; then
+          # A gate! sub-goal is DISPATCHED (it does the work and opens the held PR) and only THEN
+          # halts the loop. Force it as this cycle's serial pick so the wave still quiesces around
+          # it -- nothing else is admitted alongside it, exactly as before; the only change is that
+          # the gate! sub-goal's own work now happens instead of being skipped.
+          forced_pick="$gbang"
+        else
+          _emit_event "$dir" "$gbang" blocked "gate!: global halt for human review"
+          [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
+          _say "[orchestrate] STOP (gate!): global halt for human review; $gbang is a gate! sub-goal. Resolve, then re-run."
+          return 0
+        fi
       fi
+    fi
+
+    # Wave admission. Skipped when a gate! sub-goal was forced as this cycle's pick above: the wave
+    # quiesces around it, so nothing may be admitted alongside it.
+    if [ "$WAVE_CAP" -ge 2 ] && [ -z "$forced_pick" ]; then
       local admitted_n
       admitted_n=$(_wave_gate "$dir" "$roadmap" | awk -F'\t' '$1=="run"{n++} END{print n+0}')
       if [ "$admitted_n" -ge 2 ]; then
@@ -2115,7 +2233,12 @@ cmd_run() {
     fi
 
     local nx id policy
-    nx=$(_next "$roadmap")
+    if [ -n "$forced_pick" ]; then
+      nx=$(_subgoals "$roadmap" | awk -F'\t' -v i="$forced_pick" '$1==i && $3==0 {print $1"\t"$2}')
+      forced_pick=""
+    else
+      nx=$(_next "$roadmap")
+    fi
     if [ -z "$nx" ]; then
       # All boxes checked. TIER-4 mega-close (SPEC-118) replaces the bare "done"-and-return: verify
       # the assembled wave (no-orphan sweep + integration-verifier + review-team + advisor) THEN HOLD
@@ -2130,23 +2253,30 @@ cmd_run() {
     # exactly (blocked event + message + return 0). Checked BEFORE plain `gate` since they are
     # distinct policy values. On WAVE_CAP=1 this is the ONLY gate! stop (the wave-block twin above
     # is skipped), and it is also the catch-all when the wave path falls through to `_next`.
-    if [ "$policy" = "gate!" ]; then
-      _emit_event "$dir" "$id" blocked "gate!: global halt for human review"
-      [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
-      _say "[orchestrate] STOP (gate!): global halt for human review; $id is a gate! sub-goal. Resolve, then re-run."
-      return 0
-    fi
-
-    if [ "$policy" = gate ]; then
-      _emit_event "$dir" "$id" blocked "gate: human review"
-      [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
-      _say "[orchestrate] STOP: $id is a gate sub-goal; open/await its PR for review, then re-run."
-      # Advisory (ID-090 default flip): under the concurrent default (WAVE_CAP>=2) a `gate` holds only
-      # its OWN dependent chain , independent branches with disjoint `## Touches` keep running in the
-      # wave. If you meant "quiesce EVERYTHING for review", use `gate!` (global stop-all) instead. (On
-      # a Touches-less mega-goal there is no concurrency, so this `gate` still stopped the whole loop.)
-      [ "$WAVE_CAP" -ge 2 ] && echo "[orchestrate] [advisory] '$id' is a chain-stop \`gate\`; under WAVE_CAP=$WAVE_CAP independent Touches-disjoint branches keep running. Use \`gate!\` for a global stop-all." >&2
-      return 0
+    # A gate / gate! sub-goal is DISPATCHED like an auto one and HELD afterwards (MEGA_GATE_DISPATCH,
+    # the default): its worker does the work, opens a DRAFT PR, marks it, and does NOT flip its box.
+    # `gate_hold` carries the policy through the shared dispatch body below to the post-session hold.
+    # MEGA_GATE_DISPATCH=0 restores the old stop-BEFORE-running behavior verbatim.
+    local gate_hold=""
+    if [ "$policy" = "gate!" ] || [ "$policy" = gate ]; then
+      if [ "$MEGA_GATE_DISPATCH" = 1 ]; then
+        gate_hold="$policy"
+      elif [ "$policy" = "gate!" ]; then
+        _emit_event "$dir" "$id" blocked "gate!: global halt for human review"
+        [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
+        _say "[orchestrate] STOP (gate!): global halt for human review; $id is a gate! sub-goal. Resolve, then re-run."
+        return 0
+      else
+        _emit_event "$dir" "$id" blocked "gate: human review"
+        [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
+        _say "[orchestrate] STOP: $id is a gate sub-goal; open/await its PR for review, then re-run."
+        # Advisory (ID-090 default flip): under the concurrent default (WAVE_CAP>=2) a `gate` holds only
+        # its OWN dependent chain , independent branches with disjoint `## Touches` keep running in the
+        # wave. If you meant "quiesce EVERYTHING for review", use `gate!` (global stop-all) instead. (On
+        # a Touches-less mega-goal there is no concurrency, so this `gate` still stopped the whole loop.)
+        [ "$WAVE_CAP" -ge 2 ] && echo "[orchestrate] [advisory] '$id' is a chain-stop \`gate\`; under WAVE_CAP=$WAVE_CAP independent Touches-disjoint branches keep running. Use \`gate!\` for a global stop-all." >&2
+        return 0
+      fi
     fi
 
     # Per-sub-goal model/effort routing (SPEC-087): read the goal file's hints and pass them as
@@ -2196,7 +2326,7 @@ cmd_run() {
     # below covers the happy path; this trap covers an interrupt. Cheap to reset every cycle (only
     # EXIT trap this script sets on the serial path).
     trap 'rm -f "$pfile"' EXIT
-    _build_prompt "$dir" "$id" > "$pfile"
+    _build_prompt "$dir" "$id" "$gate_hold" > "$pfile"
     # Run the session via the extracted helper (TASK-000): it picks the correct run-path
     # (watchdog / --stream|det-handoff stream-json / plain) and returns the session exit code.
     # slog (the stream-log path, "" when no capture happened) comes back via _ROS_SLOG for the
@@ -2213,8 +2343,57 @@ cmd_run() {
       return 1
     fi
 
+    # Gate hold: the session ran; a human now merges. A gate sub-goal must NOT flip its own box, so
+    # its completion is grounded on the PR EXISTING instead. No PR -> the same no-self-claim halt an
+    # unflipped box gets: the session did not produce the one artifact the hold is about.
+    if [ -n "$gate_hold" ]; then
+      local prurl; prurl=$(_sg_pr_url "$dir" "$id")
+      if [ -z "$prurl" ]; then
+        _emit_event "$dir" "$id" blocked "$gate_hold: no PR opened (no self-claim)"
+        [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
+        echo "[orchestrate] [guardrail] $id is a $gate_hold sub-goal but opened no PR for its branch; halting (no self-claim, no advance on a dead/incomplete session)." >&2
+        return 1
+      fi
+      _record_tokens "$dir" "$id" "$slog"
+      _emit_event "$dir" "$id" blocked "$gate_hold: awaiting human merge ($prurl)"
+      [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null
+      if [ "$gate_hold" = "gate!" ]; then
+        _say "[orchestrate] STOP (gate!): global halt for human review; $id ran and opened $prurl. Merge it, then re-run."
+      else
+        _say "[orchestrate] STOP: $id is a gate sub-goal; it ran and opened $prurl for human review. Merge it, then re-run."
+        [ "$WAVE_CAP" -ge 2 ] && echo "[orchestrate] [advisory] '$id' is a chain-stop \`gate\`; under WAVE_CAP=$WAVE_CAP independent Touches-disjoint branches keep running. Use \`gate!\` for a global stop-all." >&2
+      fi
+      return 0
+    fi
+
     # grounded completion: advance only if the box actually flipped.
     local checked; checked=$(_subgoals "$roadmap" | awk -F'\t' -v i="$id" '$1==i {print $3}')
+    if [ "$checked" != 1 ]; then
+      # Merged-PR reconciliation before the halt (the false-halt fix). A worker commonly flips its box
+      # INSIDE its PR; the PR merges, and this checkout is still behind, so the local box reads
+      # unchecked and a healthy run halted. Consult the remote default branch. No-self-claim is
+      # UNCHANGED: a remote box counts only when its line also carries a real `PR #<n>`, so a bare
+      # checked box never advances the loop, on either side.
+      local rview rline
+      rview=$(_roadmap_remote_view "$dir" "$roadmap")
+      if [ -n "$rview" ]; then
+        rline=$(_sg_line "$rview" "$id")
+        case "$rline" in
+          '- ['[xX]']'*)
+            if printf '%s' "$rline" | grep -qE 'PR #[0-9]+'; then
+              checked=1
+              _say "[orchestrate] [reconcile] $id box is checked on origin with $(printf '%s' "$rline" | grep -oE 'PR #[0-9]+' | head -1); accepting the merged-PR flip."
+              # Mirror the merged flip into the LOCAL ROADMAP when the fast-forward could not run
+              # (dirty tree). Without it `_next` re-picks this same sub-goal every cycle and the loop
+              # spins forever. This writes the ONE box line the remote already carries, through the
+              # same locked idempotent flip the loop uses -- it is a reconcile, never a claim, and it
+              # never force-pulls anything else out of the operator's working tree.
+              [ "$rview" = "$roadmap" ] || cmd_flip "$dir" "$id" >/dev/null 2>&1 || true
+            fi ;;
+        esac
+        [ "$rview" = "$roadmap" ] || rm -f "$rview"
+      fi
+    fi
     if [ "$checked" != 1 ]; then
       _emit_event "$dir" "$id" blocked "box not flipped (no self-claim)"
       [ "$board_mode" != roadmap ] && _render_board "$dir" "$roadmap" "$board_mode" >/dev/null

--- a/tests/test-orchestrate-gate-dispatch.sh
+++ b/tests/test-orchestrate-gate-dispatch.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# test-orchestrate-gate-dispatch.sh
+# Pins the two orchestrate.sh defects a real 5-sub-goal run surfaced:
+#   A. Merged-PR box reconciliation. A worker flips its ROADMAP box INSIDE its PR; the PR merges;
+#      the driver read the LOCAL (behind) checkout and halted a healthy run with "did not check its
+#      ROADMAP box". The driver must reconcile against origin/<default> before halting -- and only
+#      accept a remote box whose line also carries a real `PR #<n>` (no-self-claim unchanged).
+#   B. Gate sub-goal DISPATCH. The documented contract is that a `gate` sub-goal's worker DOES the
+#      work, opens a DRAFT PR, marks it, and the loop holds for a HUMAN MERGE. The driver stopped
+#      BEFORE running it, so the work never happened. MEGA_GATE_DISPATCH=0 restores the old posture.
+# Follows the existing fixture pattern: a mega-goal dir + a fake `claude` on PATH via CLAUDE_CMD.
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORCH="$KIT/lib/queue/orchestrate.sh"
+fails=0
+pass() { echo "PASS $*"; }
+fail() { echo "FAIL $*"; fails=$((fails + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export CLAUDE_FLAGS=""
+
+# A mega-goal dir: SG-01 auto, SG-02 gate. Goal files declare a Branch: so _sg_pr_url has one.
+mk_megagoal() {  # dir
+  local d="$1"
+  mkdir -p "$d/goals"
+  cat > "$d/ROADMAP.md" <<'EOF'
+# Mega-goal: gate-dispatch fixture
+## Sub-goals
+- [ ] SG-01 build the thing , auto , PR #__
+- [ ] SG-02 wire the deploy , gate , PR #__
+EOF
+  echo "POINTER: resume from ROADMAP" > "$d/POINTER_PROMPT.md"
+  printf '**Branch:** feat/sg-one\nDone = the thing builds\n' > "$d/goals/01-build.md"
+  printf '**Branch:** feat/sg-two\nDone = the deploy is wired\n' > "$d/goals/02-wire.md"
+}
+
+# A fake `gh` whose `pr view <branch> --json url` answers from $GH_PRS ("<branch> <url>" per line).
+mk_mock_gh() {
+  cat > "$TMP/gh" <<'EOF'
+#!/usr/bin/env bash
+# args: pr view <branch> --json url -q .url
+[ "${1:-}" = pr ] && [ "${2:-}" = view ] || exit 1
+awk -v b="${3:-}" '$1==b {print $2; found=1} END{exit !found}' "$GH_PRS" 2>/dev/null
+EOF
+  chmod +x "$TMP/gh"
+}
+
+# ===================== A. merged-PR box reconciliation =====================
+# A real two-repo fixture: `upstream` is the remote; `local` is the driver's checkout on master.
+# The mock session commits + pushes the box flip (with `-- PR #629`) to the remote WITHOUT touching
+# the local checkout -- exactly the merged-PR shape. The local box therefore reads unchecked.
+mk_repo_pair() {  # base
+  local base="$1"
+  git init -q --bare "$base/upstream.git"
+  git init -q "$base/seed"
+  git -C "$base/seed" config user.email t@t.t; git -C "$base/seed" config user.name t
+  mkdir -p "$base/seed/mega/goals"
+  cat > "$base/seed/mega/ROADMAP.md" <<'EOF'
+# Mega-goal: reconcile fixture
+## Sub-goals
+- [ ] SG-01 ported thing , auto , PR #__
+EOF
+  echo "POINTER: resume from ROADMAP" > "$base/seed/mega/POINTER_PROMPT.md"
+  printf '**Branch:** feat/sg-one\nDone = ported\n' > "$base/seed/mega/goals/01-port.md"
+  git -C "$base/seed" add -A >/dev/null
+  git -C "$base/seed" commit -qm init
+  git -C "$base/seed" branch -M master
+  git -C "$base/seed" remote add origin "$base/upstream.git"
+  git -C "$base/seed" push -q origin master
+  git clone -q "$base/upstream.git" "$base/local"
+  git -C "$base/local" config user.email t@t.t; git -C "$base/local" config user.name t
+}
+
+# The mock: pushes the flipped box to the remote, leaves the driver's checkout untouched.
+# $FLIP_TAIL is what follows the id on the flipped line (with or without a PR #).
+mk_mock_merge_pr() {
+  cat > "$TMP/claude-mergepr" <<'EOF'
+#!/usr/bin/env bash
+# env: PAIR (fixture base), FLIP_TAIL
+prompt=$(cat)
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+wt="$PAIR/pusher"
+rm -rf "$wt"
+git clone -q "$PAIR/upstream.git" "$wt"
+git -C "$wt" config user.email t@t.t; git -C "$wt" config user.name t
+awk -v id="$id" -v tail="$FLIP_TAIL" \
+  '{ if ($0 ~ ("^- \\[ \\] " id " ")) print "- [x] " id " " tail; else print }' \
+  "$wt/mega/ROADMAP.md" > "$wt/mega/ROADMAP.md.tmp" && mv "$wt/mega/ROADMAP.md.tmp" "$wt/mega/ROADMAP.md"
+git -C "$wt" commit -qam "flip $id"
+git -C "$wt" push -q origin master
+EOF
+  chmod +x "$TMP/claude-mergepr"
+}
+mk_mock_merge_pr
+
+# --- A1: a remote box carrying `-- PR #629` is ACCEPTED (the false halt is gone) ---
+P1="$TMP/pair1"; mkdir -p "$P1"; mk_repo_pair "$P1"
+rc=0
+( export PAIR="$P1" FLIP_TAIL="ported thing , auto , PR #__ -- PR #629"
+  TIER4_CLOSE=0 CLAUDE_CMD="$TMP/claude-mergepr" bash "$ORCH" run "$P1/local/mega" ) \
+  > "$TMP/rec1.out" 2>&1 || rc=$?
+[ "$rc" = 0 ] && pass "A1: merged-PR box flip accepted; run exits 0 (no false halt)" \
+  || { fail "A1: run exited $rc"; cat "$TMP/rec1.out"; }
+grep -q 'reconcile' "$TMP/rec1.out" \
+  && pass "A1: driver logs what it reconciled" || { fail "A1: no reconcile log line"; cat "$TMP/rec1.out"; }
+grep -q 'did not check its ROADMAP box' "$TMP/rec1.out" \
+  && { fail "A1: still halted on the stale local box"; cat "$TMP/rec1.out"; } \
+  || pass "A1: no stale-box guardrail halt"
+grep -q '^- \[x\] SG-01' "$P1/local/mega/ROADMAP.md" \
+  && pass "A1: clean checkout was fast-forwarded to origin/master" \
+  || { fail "A1: local checkout not fast-forwarded"; cat "$P1/local/mega/ROADMAP.md"; }
+
+# --- A2 [NEGATIVE CONTROL]: a remote box with NO `PR #N` is REJECTED (no self-claim kept) ---
+P2="$TMP/pair2"; mkdir -p "$P2"; mk_repo_pair "$P2"
+rc=0
+( export PAIR="$P2" FLIP_TAIL="ported thing , auto"
+  TIER4_CLOSE=0 CLAUDE_CMD="$TMP/claude-mergepr" bash "$ORCH" run "$P2/local/mega" ) \
+  > "$TMP/rec2.out" 2>&1 || rc=$?
+{ [ "$rc" != 0 ] && grep -q 'did not check its ROADMAP box' "$TMP/rec2.out"; } \
+  && pass "A2 (neg control): a bare remote box (no PR #N) still halts the loop" \
+  || { fail "A2: bare remote box wrongly accepted (rc=$rc)"; cat "$TMP/rec2.out"; }
+
+# --- A3 [NEGATIVE CONTROL]: a DIRTY tree is never force-pulled ---
+P3="$TMP/pair3"; mkdir -p "$P3"; mk_repo_pair "$P3"
+echo "operator work in progress" > "$P3/local/dirty.txt"
+git -C "$P3/local" add dirty.txt
+head_before=$(git -C "$P3/local" rev-parse HEAD)
+rc=0
+( export PAIR="$P3" FLIP_TAIL="ported thing , auto , PR #__ -- PR #700"
+  TIER4_CLOSE=0 CLAUDE_CMD="$TMP/claude-mergepr" bash "$ORCH" run "$P3/local/mega" ) \
+  > "$TMP/rec3.out" 2>&1 || rc=$?
+{ [ "$rc" = 0 ] && grep -q 'not fast-forwardable' "$TMP/rec3.out" \
+  && grep -q '^- \[x\] SG-01' "$P3/local/mega/ROADMAP.md"; } \
+  && pass "A3: dirty tree read from origin; only the merged box line is mirrored locally" \
+  || { fail "A3: dirty tree handling wrong (rc=$rc)"; cat "$TMP/rec3.out"; git -C "$P3/local" status --porcelain; }
+# The point of the dirty path: the driver never force-pulls the operator's work away.
+git -C "$P3/local" diff --cached --name-only | grep -q dirty.txt \
+  && pass "A3 (neg control): the operator's staged work survives (no force-pull)" || fail "A3: staged work lost"
+[ "$(git -C "$P3/local" rev-parse HEAD)" = "$head_before" ] \
+  && pass "A3 (neg control): HEAD was NOT fast-forwarded over the dirty tree" \
+  || fail "A3: dirty tree was force-pulled (HEAD moved)"
+
+# --- A4 [NEGATIVE CONTROL]: no git repo at all -> the halt is unchanged ---
+NG="$TMP/mg-nogit"; mk_megagoal "$NG"
+cat > "$TMP/claude-noflip" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+echo "did work, forgot the box"
+EOF
+chmod +x "$TMP/claude-noflip"
+rc=0
+CLAUDE_CMD="$TMP/claude-noflip" bash "$ORCH" run "$NG" > "$TMP/rec4.out" 2>&1 || rc=$?
+{ [ "$rc" != 0 ] && grep -q 'did not check its ROADMAP box' "$TMP/rec4.out"; } \
+  && pass "A4 (neg control): outside a git repo the no-self-claim halt is byte-identical" \
+  || { fail "A4: non-repo halt changed (rc=$rc)"; cat "$TMP/rec4.out"; }
+
+# ===================== B. gate sub-goal dispatch =====================
+mk_mock_gh
+# The mock records every id it was handed and flips ONLY auto boxes (a gate worker must not flip).
+cat > "$TMP/claude-gate" <<'EOF'
+#!/usr/bin/env bash
+# env: RUNLOG, GATE_RM, PROMPTDIR
+prompt=$(cat)
+id=$(printf '%s' "$prompt" | grep -oE 'SG-[0-9]+' | head -1)
+echo "INVOKED $id" >> "$RUNLOG"
+printf '%s' "$prompt" > "$PROMPTDIR/$id.prompt"
+case "$id" in
+  SG-02) : ;;   # gate sub-goal: opens a PR, never flips its own box
+  *) awk -v id="$id" '{ if ($0 ~ ("^- \\[ \\] " id " ")) sub(/\[ \]/, "[x]"); print }' \
+       "$GATE_RM" > "$GATE_RM.tmp" && mv "$GATE_RM.tmp" "$GATE_RM" ;;
+esac
+EOF
+chmod +x "$TMP/claude-gate"
+
+run_gate_fixture() {  # dir outfile [extra-env...]
+  local d="$1" out="$2"; shift 2
+  : > "$TMP/runlog"; mkdir -p "$TMP/prompts"
+  RUNLOG="$TMP/runlog" GATE_RM="$d/ROADMAP.md" PROMPTDIR="$TMP/prompts" \
+    GH_CMD="$TMP/gh" GH_PRS="$TMP/prs" TIER4_CLOSE=0 CLAUDE_CMD="$TMP/claude-gate" \
+    env "$@" bash "$ORCH" run "$d" > "$out" 2>&1
+}
+
+# --- B1: default -> the gate sub-goal IS dispatched, then the loop holds on its PR ---
+printf 'feat/sg-two https://github.com/o/r/pull/42\n' > "$TMP/prs"
+DG="$TMP/mg-gate"; mk_megagoal "$DG"
+rc=0; run_gate_fixture "$DG" "$TMP/b1.out" || rc=$?
+[ "$rc" = 0 ] && pass "B1: gate dispatch exits 0 (clean human-hold)" \
+  || { fail "B1: rc=$rc"; cat "$TMP/b1.out"; }
+grep -q 'INVOKED SG-02' "$TMP/runlog" \
+  && pass "B1: the gate sub-goal actually ran" || { fail "B1: gate sub-goal never dispatched"; cat "$TMP/runlog"; }
+grep -q 'https://github.com/o/r/pull/42' "$TMP/b1.out" \
+  && pass "B1: the STOP-for-human line carries the PR URL" || { fail "B1: no PR URL in the stop line"; cat "$TMP/b1.out"; }
+grep -q 'STOP: SG-02 is a gate sub-goal' "$TMP/b1.out" \
+  && pass "B1: STOP-for-human line present" || { fail "B1: no STOP line"; cat "$TMP/b1.out"; }
+grep -q '^- \[ \] SG-02' "$DG/ROADMAP.md" \
+  && pass "B1: the gate sub-goal's box is left for the human merge to check" || fail "B1: gate box flipped"
+
+# --- B1b: the gate sub-goal's PROMPT carries the held-PR contract ---
+{ grep -q 'HELD SUB-GOAL (gate)' "$TMP/prompts/SG-02.prompt" \
+  && grep -qi 'draft' "$TMP/prompts/SG-02.prompt" \
+  && grep -q 'mega-merge.sh mark' "$TMP/prompts/SG-02.prompt" \
+  && grep -q 'Do NOT merge' "$TMP/prompts/SG-02.prompt"; } \
+  && pass "B1b: gate prompt injects draft-PR + mark + do-not-merge + do-not-flip" \
+  || { fail "B1b: gate prompt contract missing"; cat "$TMP/prompts/SG-02.prompt"; }
+grep -q 'HELD SUB-GOAL' "$TMP/prompts/SG-01.prompt" \
+  && fail "B1b (neg control): the auto sub-goal's prompt was polluted with the held contract" \
+  || pass "B1b (neg control): the auto sub-goal's prompt is unchanged"
+
+# --- B2 [NEGATIVE CONTROL]: gate session opened NO PR -> guardrail halt, same as an unflipped box ---
+: > "$TMP/prs"
+DG2="$TMP/mg-gate-nopr"; mk_megagoal "$DG2"
+rc=0; run_gate_fixture "$DG2" "$TMP/b2.out" || rc=$?
+{ [ "$rc" != 0 ] && grep -q 'opened no PR' "$TMP/b2.out"; } \
+  && pass "B2 (neg control): a gate session with no PR halts the loop (no self-claim)" \
+  || { fail "B2: no-PR case did not halt (rc=$rc)"; cat "$TMP/b2.out"; }
+
+# --- B3: MEGA_GATE_DISPATCH=0 restores the stop-BEFORE-running behavior ---
+printf 'feat/sg-two https://github.com/o/r/pull/42\n' > "$TMP/prs"
+DG3="$TMP/mg-gate-off"; mk_megagoal "$DG3"
+rc=0; run_gate_fixture "$DG3" "$TMP/b3.out" MEGA_GATE_DISPATCH=0 || rc=$?
+{ [ "$rc" = 0 ] && grep -q 'open/await its PR for review' "$TMP/b3.out" \
+  && ! grep -q 'INVOKED SG-02' "$TMP/runlog"; } \
+  && pass "B3: MEGA_GATE_DISPATCH=0 stops before running the gate sub-goal (escape hatch)" \
+  || { fail "B3: escape hatch wrong (rc=$rc)"; cat "$TMP/b3.out"; cat "$TMP/runlog"; }
+
+# --- B4: gate! is dispatched too, then halts the whole loop ---
+printf 'feat/sg-two https://github.com/o/r/pull/77\n' > "$TMP/prs"
+DG4="$TMP/mg-gatebang"; mk_megagoal "$DG4"
+sed -i.bak 's/, gate ,/, gate! ,/' "$DG4/ROADMAP.md"
+rc=0; run_gate_fixture "$DG4" "$TMP/b4.out" || rc=$?
+{ [ "$rc" = 0 ] && grep -q 'INVOKED SG-02' "$TMP/runlog" \
+  && grep -q 'STOP (gate!)' "$TMP/b4.out" && grep -q 'pull/77' "$TMP/b4.out"; } \
+  && pass "B4: gate! is dispatched, then halts the whole loop with its PR URL" \
+  || { fail "B4: gate! dispatch wrong (rc=$rc)"; cat "$TMP/b4.out"; }
+grep -q 'HELD SUB-GOAL (gate!)' "$TMP/prompts/SG-02.prompt" \
+  && pass "B4: gate! prompt carries the held-PR contract" || fail "B4: gate! prompt contract missing"
+
+# --- B5: gate! under WAVE_CAP=2 is dispatched first and nothing waves alongside it ---
+printf 'feat/sg-one https://github.com/o/r/pull/88\n' > "$TMP/prs"
+DG5="$TMP/mg-gatebang-wave"; mk_megagoal "$DG5"
+cat > "$DG5/ROADMAP.md" <<'EOF'
+# Mega-goal: gate! under a wave
+## Sub-goals
+- [ ] SG-01 halt-all , gate! , PR #__
+- [ ] SG-02 wire the deploy , auto , PR #__
+EOF
+printf '**Branch:** feat/sg-one\nDone = halt\n\n## Touches\nlib/a/**\n' > "$DG5/goals/01-build.md"
+printf '**Branch:** feat/sg-two\nDone = wired\n\n## Touches\nlib/b/**\n' > "$DG5/goals/02-wire.md"
+rc=0; run_gate_fixture "$DG5" "$TMP/b5.out" WAVE_CAP=2 || rc=$?
+{ [ "$rc" = 0 ] && grep -q 'INVOKED SG-01' "$TMP/runlog" && ! grep -q 'INVOKED SG-02' "$TMP/runlog" \
+  && grep -q 'STOP (gate!)' "$TMP/b5.out"; } \
+  && pass "B5: under WAVE_CAP=2 the gate! sub-goal runs and the wave quiesces around it" \
+  || { fail "B5: gate! wave handling wrong (rc=$rc)"; cat "$TMP/b5.out"; cat "$TMP/runlog"; }
+
+# --- B6: --dry-run names the dispatch-then-hold plan ---
+DG6="$TMP/mg-gate-dry"; mk_megagoal "$DG6"
+out=$(bash "$ORCH" run "$DG6" --dry-run 2>&1)
+printf '%s' "$out" | grep -q 'SG-02 (gate, dispatch then hold for human merge)' \
+  && pass "B6: dry-run plan says 'gate, dispatch then hold for human merge'" \
+  || { fail "B6: dry-run plan wrong"; printf '%s\n' "$out"; }
+out=$(MEGA_GATE_DISPATCH=0 bash "$ORCH" run "$DG6" --dry-run 2>&1)
+printf '%s' "$out" | grep -q 'SG-02 (gate)' \
+  && pass "B6 (neg control): MEGA_GATE_DISPATCH=0 dry-run keeps the plain '(gate)' label" \
+  || { fail "B6 neg control wrong"; printf '%s\n' "$out"; }
+
+echo
+if [ "$fails" = 0 ]; then echo "ALL PASS"; else echo "$fails FAILED"; fi
+exit "$fails"

--- a/tests/test-orchestrate-wavefront.sh
+++ b/tests/test-orchestrate-wavefront.sh
@@ -959,7 +959,7 @@ bash "$ORCH" flip "$MEGADIR" "$id" >/dev/null 2>&1
 MOCK
 chmod +x "$TMP/claude-resume"
 # Run 1: flips SG-01+SG-02, stops at the gate SG-03 (partway; the kill boundary).
-( export ORCH="$ORCH" MEGADIR="$RES" RESLOG="$RESLOG" CLAUDE_FLAGS="" CLAUDE_CMD="$TMP/claude-resume"
+( export ORCH="$ORCH" MEGADIR="$RES" RESLOG="$RESLOG" CLAUDE_FLAGS="" MEGA_GATE_DISPATCH=0 CLAUDE_CMD="$TMP/claude-resume"
   bash "$ORCH" run "$RES" ) > "$TMP/resume1.out" 2>&1
 c1_r1=$(wc -l < "$RESLOG/SG-01.runs" 2>/dev/null | tr -d ' '); c2_r1=$(wc -l < "$RESLOG/SG-02.runs" 2>/dev/null | tr -d ' ')
 { grep -q '^- \[x\] SG-01' "$RES/ROADMAP.md" && grep -q '^- \[x\] SG-02' "$RES/ROADMAP.md" \
@@ -967,7 +967,7 @@ c1_r1=$(wc -l < "$RESLOG/SG-01.runs" 2>/dev/null | tr -d ' '); c2_r1=$(wc -l < "
   && pass "resume: run 1 flips SG-01+SG-02, stops at gate (each ran once)" \
   || { fail "resume: run 1 partial-progress wrong (c1=$c1_r1 c2=$c2_r1)"; cat "$TMP/resume1.out"; }
 # Run 2 (the restart): re-derive from ROADMAP; already-checked boxes must NOT be re-run.
-( export ORCH="$ORCH" MEGADIR="$RES" RESLOG="$RESLOG" CLAUDE_FLAGS="" CLAUDE_CMD="$TMP/claude-resume"
+( export ORCH="$ORCH" MEGADIR="$RES" RESLOG="$RESLOG" CLAUDE_FLAGS="" MEGA_GATE_DISPATCH=0 CLAUDE_CMD="$TMP/claude-resume"
   bash "$ORCH" run "$RES" ) > "$TMP/resume2.out" 2>&1
 c1_r2=$(wc -l < "$RESLOG/SG-01.runs" 2>/dev/null | tr -d ' '); c2_r2=$(wc -l < "$RESLOG/SG-02.runs" 2>/dev/null | tr -d ' ')
 { [ "$c1_r2" = 1 ] && [ "$c2_r2" = 1 ]; } \
@@ -1138,6 +1138,10 @@ grep -q 'blocked: SG-01 is dep-blocked (not in ready set)' "$TMP/dep-fallthrough
 # V-CRIT-7). Driven OUT-OF-PROCESS (`bash "$ORCH" run`) so the real WAVE_CAP env is exercised.
 
 # ---- (m) gate! GLOBAL-STOP at WAVE_CAP=2 halts everything even with other ready sub-goals ----
+# These blocks pin the SCHEDULER contract (what quiesces, what holds), so they run with
+# MEGA_GATE_DISPATCH=0: the escape hatch keeps the stop-BEFORE-running posture they were written
+# for, and gets real coverage in the process. The default (dispatch the gate sub-goal, then hold
+# for the human merge) is covered by tests/test-orchestrate-gate-dispatch.sh.
 # SG-01 is `gate!` and independent; SG-02/SG-03 are independent, Touches-declaring, disjoint -> absent
 # the gate! stop they would form a 2-wide wave. The gate! scan runs BEFORE admission, so the loop must
 # STOP (rc 0, clear message) and run NOTHING. No git repo needed: the stop precedes any worktree.
@@ -1169,7 +1173,7 @@ bash "$ORCH" flip "$MEGADIR" "$id" >/dev/null 2>&1
 MOCK
 chmod +x "$TMP/claude-gatebang"
 gbrc=0
-( export ORCH="$ORCH" MEGADIR="$GBM" GBLOG="$GBLOG" CLAUDE_FLAGS="" WAVE_CAP=2 CLAUDE_CMD="$TMP/claude-gatebang"
+( export ORCH="$ORCH" MEGADIR="$GBM" GBLOG="$GBLOG" CLAUDE_FLAGS="" WAVE_CAP=2 MEGA_GATE_DISPATCH=0 CLAUDE_CMD="$TMP/claude-gatebang"
   bash "$ORCH" run "$GBM" ) > "$TMP/gatebang.out" 2>&1 || gbrc=$?
 # (1) clean human-stop: rc 0, no false-complete
 { [ "$gbrc" = 0 ] && ! grep -q 'all sub-goals checked; done' "$TMP/gatebang.out"; } \
@@ -1228,7 +1232,7 @@ bash "$ORCH" flip "$MEGADIR" "$id" >/dev/null 2>&1
 MOCK
 chmod +x "$TMP/claude-chainhold"
 chrc=0
-( export ORCH="$ORCH" MEGADIR="$CPM" CHLOG="$CHLOG" CLAUDE_FLAGS="" WAVE_CAP=2 CLAUDE_CMD="$TMP/claude-chainhold"
+( export ORCH="$ORCH" MEGADIR="$CPM" CHLOG="$CHLOG" CLAUDE_FLAGS="" WAVE_CAP=2 MEGA_GATE_DISPATCH=0 CLAUDE_CMD="$TMP/claude-chainhold"
   bash "$ORCH" run "$CPM" ) > "$TMP/chainhold.out" 2>&1 || chrc=$?
 # (1) the loop stops cleanly at the gate (rc 0, gate chain-stop message)
 { [ "$chrc" = 0 ] && grep -q 'STOP: SG-01 is a gate sub-goal' "$TMP/chainhold.out"; } \

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -70,7 +70,10 @@ grep -q '^- \[ \] SG-01' "$D/ROADMAP.md" && [ ! -f "$D/HANDOFF.md" ] \
 # ============================ TEST 3: real run via good mock ============================
 D2="$TMP/mg2"; mk_megagoal "$D2"; mk_mock_good
 export MOCK_ROADMAP="$D2/ROADMAP.md" MOCK_DIR="$D2"
-CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$D2" > "$TMP/run.out" 2>&1
+# MEGA_GATE_DISPATCH=0 pins the LEGACY stop-BEFORE-running posture this test was written for; the
+# default (dispatch the gate sub-goal, then hold for the human merge) is covered by
+# tests/test-orchestrate-gate-dispatch.sh.
+MEGA_GATE_DISPATCH=0 CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$D2" > "$TMP/run.out" 2>&1
 rc=$?
 [ "$rc" = 0 ] && pass "run exited 0" || { fail "run exited $rc"; cat "$TMP/run.out"; }
 grep -q '^- \[x\] SG-01' "$D2/ROADMAP.md" && grep -q '^- \[x\] SG-02' "$D2/ROADMAP.md" \
@@ -236,7 +239,7 @@ grep -q '^- \[ \] SG-01' "$DS/ROADMAP.md" && pass "--step --dry-run did not exec
 # 9b: --step real run, operator resumes (Enter) -> chain completes, stops at gate.
 D9="$TMP/mg9"; mk_megagoal "$D9"; mk_mock_good
 export MOCK_ROADMAP="$D9/ROADMAP.md" MOCK_DIR="$D9"
-printf '\n\n' | CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$D9" --step > "$TMP/step.out" 2>&1
+printf '\n\n' | MEGA_GATE_DISPATCH=0 CLAUDE_CMD="$TMP/claude-good" bash "$ORCH" run "$D9" --step > "$TMP/step.out" 2>&1
 { grep -q '^- \[x\] SG-01' "$D9/ROADMAP.md" && grep -q '^- \[x\] SG-02' "$D9/ROADMAP.md" \
   && grep -q '^- \[ \] SG-03' "$D9/ROADMAP.md"; } \
   && pass "--step resume: SG-01+SG-02 ran, gate SG-03 untouched" || { fail "--step resume wrong"; cat "$TMP/step.out"; }


### PR DESCRIPTION
Two defects a real 5-sub-goal mega-goal run surfaced in `lib/queue/orchestrate.sh`, plus the decompose rule the same run needed.

## 1. False halt after a merged-PR box flip

A sub-goal worker commonly flips its ROADMAP box inside its own PR. Once that PR merged, the driver still read the local (behind) checkout, saw an unchecked box, and halted a healthy run with `[guardrail] SG-NN did not check its ROADMAP box`.

The grounded-completion check now reconciles against `origin/<default>` before it halts:

- clean tree on the default branch: `git fetch` + `merge --ff-only`;
- dirty tree: read the remote copy with `git show origin/<default>:<path>` for the check only, then mirror just that one box line locally through the existing locked `flip` so `_next` cannot re-pick the same sub-goal forever;
- no repo / no remote / on a feature branch: no-op, the halt is byte-identical.

No-self-claim is unchanged: a remote box counts only when its line also carries a real `PR #<n>`.

## 2. `gate` sub-goals were never dispatched

`run` stopped BEFORE a `gate` sub-goal with "open/await its PR for review", so the work never happened and the loop asked a human to review a PR nobody had opened. That contradicts `commands/mega.md` Step 5 and the `plan-for-mega-goal` skill, both of which say a gate sub-goal's worker DOES the work, opens the PR as a draft, runs `mega-merge.sh mark`, and the loop stops for a human MERGE.

A `gate` / `gate!` sub-goal now runs through the same dispatch body an `auto` one does:

- `_build_prompt` takes an optional policy argument that injects the held-PR contract (draft PR, `mega-merge.sh mark`, never merge, never flip the box); an `auto` prompt is byte-identical;
- the hold happens AFTER the session and is grounded on the PR existing (`_sg_pr_url`, mockable via `GH_CMD`), since a gate sub-goal must not flip its own box. No PR is the same no-self-claim halt an unflipped box gets;
- `gate!` forces itself as the cycle's pick under a wave, so the wave still quiesces around it, and it halts the whole loop after its session;
- `--dry-run` prints `-> SG-NN (gate, dispatch then hold for human merge)`;
- `MEGA_GATE_DISPATCH=0` restores the old stop-before-running posture.

## 3. Port-then-delete re-diff rule

`commands/mega.md` Step 1: when a chain ports code out of a location and a later sub-goal deletes the source, the deleting sub-goal's `Done =` must include a re-diff of every ported file against the source's FINAL state. The field case lost two fixes that merged into the source between the port branch and the delete. Mirrored into the `plan-for-mega-goal` skill (canonical copy in `tieubao/dotfiles`, PR linked below) per the never-diverge rule.

## Tests

`tests/test-orchestrate-gate-dispatch.sh` (new, 23 assertions, 6 of them negative controls). The reconcile fixtures build a real bare remote plus a clone and push the box flip to the remote without touching the driver's checkout, so the merged-PR shape is reproduced rather than simulated; the gate fixtures mock `gh` via `GH_CMD`.

| Command | Exit | Result |
|---|---|---|
| `bash tests/test-orchestrate-gate-dispatch.sh` | 0 | 23/23 PASS |
| `bash tests/test-orchestrate.sh` | 1 | 61 PASS; 2 failures PRE-EXISTING on `origin/master` |
| `bash tests/test-orchestrate-hardening.sh` | 0 | 12/12 PASS |
| `bash tests/test-orchestrate-wavefront.sh` | 0 | 103/103 PASS |
| `bash tests/test-meta.sh` | 1 | 806/813; the 7 failures are PRE-EXISTING, failure set identical before and after (set-diff verified) |

The three existing orchestrate test files pin their scheduler assertions (SPEC-106 exit criteria 3 and 4, the gate-stop blocks) through `MEGA_GATE_DISPATCH=0`, which preserves exactly the behavior they were written for and gives the escape hatch real coverage. Nothing was deleted or weakened.

Proof of done: `docs/verification/orchestrate-gate-dispatch.md`.
