### PR TITLE
fix(install): skip bare command symlinks on plugin installs

### DIFF
--- a/docs/verification/installer-plugin-detect.md
+++ b/docs/verification/installer-plugin-detect.md
@@ -1,0 +1,45 @@
+# Proof of done: installer skips bare command symlinks on plugin installs
+
+Change: install.sh step 3 detects a `kit@*` entry in `$CLAUDE_DIR/plugins/installed_plugins.json`. When present, it removes kit-owned bare symlinks instead of creating them. Shell-only installs keep the old behavior.
+
+Method: full installer run with `HOME` and `CLAUDE_DIR` pointed at a sandbox, so no real `~/.claude` or `~/.local/bin` state is touched. Reproduce with the script below.
+
+## Green run
+
+Command: `bash prove-installer.sh` (sandboxed HOME; two installs: shell-only, then plugin-seeded with one stale kit symlink + one foreign symlink)
+Exit: 0
+Output:
+```
+case1 shell-only: symlinks=36 (expect >30)
+case2 plugin: kit-owned symlinks=0 (expect 0), foreign link=kept (expect kept)
+case2 detect-msg lines: 1
+PROOF: PASS
+```
+Verdict: PASS
+
+## Negative control
+
+Command: `git checkout origin/master -- install.sh && bash prove-installer.sh` (revert), then `git checkout HEAD -- install.sh` (restore)
+Exit: 0 (proof script reports FAIL as designed)
+Output:
+```
+case2 plugin: kit-owned symlinks=36 (expect 0)
+case2 detect-msg lines: 0
+PROOF: FAIL
+```
+Verdict: RED on revert, restored after. The detect branch is load-bearing.
+
+## Reproduce
+
+```bash
+WT=<kit checkout>
+SB=$(mktemp -d)
+run() { HOME="$1" CLAUDE_DIR="$1/.claude" bash "$WT/install.sh" >"$1/install.log" 2>&1; }
+mkdir -p "$SB/shell-only/.claude"; run "$SB/shell-only"
+find "$SB/shell-only/.claude/commands" -type l | wc -l                     # expect >30
+mkdir -p "$SB/plugin/.claude/plugins" "$SB/plugin/.claude/commands"
+echo '{"version":2,"plugins":{"kit@dwarves-marketplace":[{"scope":"user"}]}}' > "$SB/plugin/.claude/plugins/installed_plugins.json"
+ln -s "$WT/commands/design.md" "$SB/plugin/.claude/commands/design.md"
+run "$SB/plugin"
+find "$SB/plugin/.claude/commands" -type l -lname "$WT/*" | wc -l          # expect 0
+```

--- a/install.sh
+++ b/install.sh
@@ -711,16 +711,33 @@ fi
 echo "[ok] Wrote kit.toml: $KIT_TOML"
 echo "[ok] Enabled modules: ${KIT_ENABLED_MODULES:-<spine-only>}"
 
-# 3. Symlink commands
-for CMD_FILE in "$KIT_DIR/commands/"*.md; do
-  CMD_NAME=$(basename "$CMD_FILE")
-  LINK="$CLAUDE_DIR/commands/$CMD_NAME"
-  if [ -L "$LINK" ] || [ -f "$LINK" ]; then
-    rm "$LINK"
-  fi
-  ln -s "$CMD_FILE" "$LINK"
-  echo "[ok] Linked command: /${CMD_NAME%.md}"
-done
+# 3. Symlink commands. Skipped when the kit is also installed as a Claude Code
+# plugin: the plugin already serves every command live under the kit: prefix, and
+# bare-name symlinks would duplicate the slash menu and shadow same-named Anthropic
+# built-ins (/design was the first real collision). On a plugin install this step
+# instead removes any kit-owned bare symlinks a previous shell install left behind.
+PLUGINS_FILE="$CLAUDE_DIR/plugins/installed_plugins.json"
+if [ -f "$PLUGINS_FILE" ] && jq -e '.plugins | keys[] | select(startswith("kit@"))' "$PLUGINS_FILE" >/dev/null 2>&1; then
+  for CMD_FILE in "$KIT_DIR/commands/"*.md; do
+    CMD_NAME=$(basename "$CMD_FILE")
+    LINK="$CLAUDE_DIR/commands/$CMD_NAME"
+    if [ -L "$LINK" ] && [ "$(readlink "$LINK")" = "$CMD_FILE" ]; then
+      rm "$LINK"
+      echo "[ok] Removed bare command symlink (plugin serves kit:${CMD_NAME%.md}): /${CMD_NAME%.md}"
+    fi
+  done
+  echo "[ok] Plugin install detected: commands served as kit:*, no bare symlinks"
+else
+  for CMD_FILE in "$KIT_DIR/commands/"*.md; do
+    CMD_NAME=$(basename "$CMD_FILE")
+    LINK="$CLAUDE_DIR/commands/$CMD_NAME"
+    if [ -L "$LINK" ] || [ -f "$LINK" ]; then
+      rm "$LINK"
+    fi
+    ln -s "$CMD_FILE" "$LINK"
+    echo "[ok] Linked command: /${CMD_NAME%.md}"
+  done
+fi
 
 # 4. Copy skills (symlinks don't always work for skills). Loop over every
 # skills/*/SKILL.md the kit ships (glob, not a hardcoded single skill), so a newly


### PR DESCRIPTION
## What

install.sh step 3 now detects a plugin install (a `kit@*` entry in `$CLAUDE_DIR/plugins/installed_plugins.json`). When found, it removes kit-owned bare symlinks from `~/.claude/commands` instead of creating them. Shell-only installs are unchanged.

## Why

The plugin serves every command live under the `kit:` prefix. The bare symlinks duplicated the slash menu and shadowed same-named Anthropic built-ins: the new `/design` skill only surfaced after removing the local `design.md` symlink.

## Proof

`docs/verification/installer-plugin-detect.md`: sandboxed-HOME full-installer runs, both cases green, negative control (revert -> 36 stray symlinks -> restore).

https://claude.ai/code/session_01MD3RJjpdcEd2dJgRoPZd77