### PR TITLE
fix(stats): memory-sweep no longer crashes on unreadable path refs

### DIFF
--- a/docs/verification/memsweep-oserror.md
+++ b/docs/verification/memsweep-oserror.md
@@ -1,0 +1,27 @@
+# Proof of done: memsweep-oserror
+
+Scope: `memory_lens._classify_and_test` crashed the whole `stats memory-sweep` with `PermissionError: [Errno 13] Permission denied: '/var/root/Library/Application'` when any note's inline code span named a path whose parent dir is unreadable on the host. Guard both path branches: OSError = untestable-here, token skipped (never reported dead).
+
+## Green run
+
+Command: bash tests/test-memory-lens.sh   (from lib/stats, with the fix + new regression fixture)
+Exit: 0
+Verdict: PASS, 40 passed, 0 failed; includes the new `unreadable-abs-path-note` fixture (inline span under /var/root/...) asserted NOT flagged dead and not crashing.
+
+Command: uv run stats memory-sweep --json   (live, against the ops-toolkit real corpus that originally crashed)
+Exit: 0
+Verdict: PASS, sweep completes, 368 rows returned (pre-fix: PermissionError traceback at memory_lens.py `_classify_and_test` via `Path.exists()`).
+
+## Negative control
+
+Command: revert the abs-path OSError guard (restore bare `Path(token).exists()`), rerun bash tests/test-memory-lens.sh
+Exit: 1
+Verdict: RED as expected, 25 of 40 fail (the crash cascades through every sweep-dependent assertion).
+
+Command: restore the guard, rerun bash tests/test-memory-lens.sh
+Exit: 0
+Verdict: PASS, 40/40 green again.
+
+## Rationale
+
+The module's own rule is that a false dead-ref costs trust more than a missed one; an unreadable-parent path is untestable on this host, not dead, so the token is skipped (`None`) rather than flagged. The `~user` branch already caught `RuntimeError` for unresolvable users; this adds the missing `OSError` shape on both branches.

--- a/lib/stats/src/stats/memory_lens.py
+++ b/lib/stats/src/stats/memory_lens.py
@@ -128,10 +128,19 @@ def _classify_and_test(token: str) -> tuple[str, bool] | None:
             return ("path", Path(token).expanduser().exists())
         except RuntimeError:
             return ("path", False)
+        except OSError:
+            # exists() can RAISE instead of returning False when a parent dir is
+            # unreadable on this host (e.g. a note quoting /var/root/...): that is
+            # "untestable here", not "dead", so skip rather than report a false
+            # dead-ref or crash the sweep.
+            return None
     if token.startswith("/"):
         if not token.startswith(_REAL_PATH_PREFIXES):
             return None
-        return ("path", Path(token).exists())
+        try:
+            return ("path", Path(token).exists())
+        except OSError:
+            return None
     return None
 
 

--- a/lib/stats/tests/test-memory-lens.sh
+++ b/lib/stats/tests/test-memory-lens.sh
@@ -105,6 +105,17 @@ RuntimeError, a real bug found via the first real-corpus run against `~server/..
 notes).
 EOF
 
+cat > "$GITREPO/.claude/memory/unreadable-abs-path-note.md" <<'EOF'
+---
+name: unreadable-abs-path-note
+---
+
+See `/var/root/Library/Application Support/fixture-file` for context; an absolute path whose
+parent dir is unreadable on this host makes Path.exists() RAISE PermissionError instead of
+returning False. That is untestable-here, not dead: the sweep must skip it (no ref, no crash),
+found via the first ops-toolkit real-corpus run.
+EOF
+
 cat > "$GITREPO/.claude/memory/MEMORY.md" <<'EOF'
 # fixture memory index
 
@@ -218,7 +229,7 @@ PY
 SCAN_OUT="$(cat "$FIX/scan.out")"
 echo "$SCAN_OUT"
 
-has "M-total 13 units (8 repo + 4 builtin + 1 prose-store MEMORY.md)" "TOTAL=13" "$SCAN_OUT"
+has "M-total 14 units (9 repo + 4 builtin + 1 prose-store MEMORY.md)" "TOTAL=14" "$SCAN_OUT"
 has "M-dead-path-note dead=1, not stale" "|dead-path-note|note|dead=1|stale=False" "$SCAN_OUT"
 has "M-live-path-note dead=0 (absolute path under a real root, live)" "|live-path-note|note|dead=0|stale=False" "$SCAN_OUT"
 has "M-old-note dead=0, STALE=True (git-commit path)" "|old-note|note|dead=0|stale=True" "$SCAN_OUT"
@@ -226,6 +237,7 @@ has "M-flag-fence-note dead=0 (flag skipped, no crash)" "|flag-fence-note|note|d
 has "M-prose-path-note dead=0 (no backticks, not extracted)" "|prose-path-note|note|dead=0|stale=False" "$SCAN_OUT"
 has "M-repo-relative-skip-note dead=0 (bare relative path SKIPPED, repo store)" "|repo-relative-skip-note|note|dead=0|stale=False" "$SCAN_OUT"
 has "M-unresolvable-tilde-user-note dead=2 (two unresolvable ~user refs, RuntimeError caught, flagged dead, no crash)" "|unresolvable-tilde-user-note|note|dead=2|stale=False" "$SCAN_OUT"
+hasnt "M-unreadable-abs-path-note not flagged dead (PermissionError path skipped as untestable, no crash)" "|unreadable-abs-path-note|note|dead=1" "$SCAN_OUT"
 REPO_NAME="$(basename "$GITREPO")"
 has "M-repo MEMORY.md dead=2 (missing-note link + orphan tombstone)" "repo:${REPO_NAME}|MEMORY|index|dead=2" "$SCAN_OUT"
 has "M-builtin-abs-note dead=0 (absolute path under a real root, live)" "|builtin-abs-note|note|dead=0|stale=False" "$SCAN_OUT"
@@ -245,12 +257,12 @@ has "M-cli orphan index entries surface as index-link" "index-link:(no linked fi
 echo
 echo "== M-lens: ledger rebuild + ledger show memories materializes the compact 5-column table =="
 REBUILD_OUT="$(R rebuild)"
-has "M-lens memories=13 in rebuild counts" '"memories": 13' "$REBUILD_OUT"
+has "M-lens memories=14 in rebuild counts" '"memories": 14' "$REBUILD_OUT"
 SHOW_OUT="$(R show memories --json)"
 has "M-lens show memories has store/slug/written/last_verified/dead_ref_count columns" '"store":' "$SHOW_OUT"
 has "M-lens show memories dead-path-note row present" '"slug": "dead-path-note",' "$SHOW_OUT"
 N_ROWS="$(printf '%s' "$SHOW_OUT" | grep -c '"slug":' || true)"
-if [ "$N_ROWS" -eq 13 ]; then ok "M-lens exactly 13 rows in memories table"; else bad "M-lens want 13 rows, got $N_ROWS"; fi
+if [ "$N_ROWS" -eq 14 ]; then ok "M-lens exactly 14 rows in memories table"; else bad "M-lens want 14 rows, got $N_ROWS"; fi
 
 echo
 echo "== M-anomaly: _detect_memory_hygiene fires (fixture dead-ref rate over the 15% threshold + min-sample) =="


### PR DESCRIPTION
Path.exists() raises PermissionError (an OSError) when a ref's parent dir is unreadable on the host (e.g. a memory note quoting /var/root/...). The whole memory-sweep died on the first such note; found on the ops-toolkit real corpus, where the sweep now completes (368 rows).

Fix: guard both the ~user and absolute-path branches; OSError = untestable-here, token skipped (None), never reported dead, per the module's false-dead-ref-costs-trust rule.

Proof: docs/verification/memsweep-oserror.md — green 40/40 + live 368-row sweep; NC guard-reverted 25/40 RED, restored 40/40.

https://claude.ai/code/session_01B8YvgeMCZxG1rjJDfRLN14