### PR TITLE
fix(gate): match docs/verification at any depth

### DIFF
--- a/docs/verification/proof-path-experiments.md
+++ b/docs/verification/proof-path-experiments.md
@@ -1,0 +1,102 @@
+# Verification: proof path matching is location-agnostic
+
+Scope: `_fresh_proof_files()` and the set-wise group regex in
+`lib/gate/proof-ledger.sh`. The claim under test is that a proof at
+`docs/verification/` nested under ANY owner directory now satisfies the gate,
+that the pre-fix code did not accept it, and that nothing previously accepted
+or rejected changes.
+
+## Problem
+
+The matcher enumerated owner directories: repo-root `docs/verification/`,
+`tools/<name>/docs/verification/`, and any `/proof-of-done.md`. ops-toolkit's
+co-location rule also puts an experiment's proof at
+`experiments/<slug>/docs/verification/<feature>.md`, which matched none of
+them. The gate then read a branch that HAD a proof as unproven, fell through
+to the override branch, and refused the source change with "no proof of done".
+
+This is the second occurrence. ID-478 fixed the same class for `tools/` by
+adding one more alternative. Enumeration is the defect: each new co-location
+home needs another alternative, and the failure is silent.
+
+## Change
+
+Two regexes collapse into location-agnostic forms.
+
+```
+-'^docs/verification/.+\.md$|^tools/[^/]+/docs/verification/.+\.md$|(^|/)proof-of-done\.md$'
++'(^|/)docs/verification/.+\.md$|(^|/)proof-of-done\.md$'
+
+-'s#^(docs/verification/[^/]+/).*#\1#p;s#^(tools/[^/]+/docs/verification/[^/]+/).*#\1#p'
++'s#^(.*docs/verification/[^/]+/).*#\1#p'
+```
+
+This grants nothing the already-anywhere `/proof-of-done.md` rule did not.
+The `grep -v '/README\.md$'` exclusion is untouched.
+
+## Green run
+
+```
+bash tests/test-proof-experiment-verification-path.sh
+```
+
+| Case | Result |
+|---|---|
+| `experiments/<slug>/docs/verification/<feature>.md` accepted | PASS |
+| `experiments/<slug>/docs/verification/<feature>/run.md` accepted (set-wise grouping) | PASS |
+| An unenumerated owner dir (`learning/<topic>/docs/verification/...`) accepted | PASS |
+| `docs/verification/README.md` still excluded | PASS |
+
+- Command: `bash tests/test-proof-experiment-verification-path.sh`
+- Exit: 0
+- Verdict: PASS
+
+## NEGATIVE CONTROL
+
+The same fixture was run against `origin/master`'s copy of the lib, obtained
+with `git show origin/master:lib/gate/proof-ledger.sh`, and then against the
+patched copy.
+
+```
+--- PRE-FIX lib (expect BLOCK) ---
+pre-fix lib BLOCKED as expected
+--- POST-FIX lib (expect ACCEPT) ---
+post-fix lib ACCEPTED as expected
+```
+
+- Command: pre-fix `check` on an `experiments/.../docs/verification/*.md` proof
+- Exit: non-zero (BLOCKED)
+- Verdict: RED-as-expected
+
+The fixture is identical across both runs, so the accept is attributable to the
+regex change and nothing else. The README case above is the second control: it
+proves the loosened pattern did not become accept-everything.
+
+## Regression
+
+Every sibling proof test re-run against the patched lib.
+
+| Test | Result |
+|---|---|
+| test-proof-dir-layout.sh | ALL PASS (3/3) |
+| test-proof-tool-verification-path.sh | ALL PASS (1/1) |
+| test-proof-visual-evidence.sh | ALL PASS (4/4) |
+| test-proof-table-gen.sh | green |
+| proof-loop-09-scenario-b.sh | every transcript claim reproduced |
+| test-proof-override-order.sh | FAILS 1, pre-existing, see below |
+
+`test-proof-override-order.sh` fails on pristine `master` as well, with no
+change of mine present. Its negative control reverts "the fix" by stashing an
+UNCOMMITTED working-tree diff to `lib/gate/proof-ledger.sh`. That fix has been
+committed for some time, so on master the file has no diff to stash and the
+test takes its own `[NO EXECUTABLE CHECK]` branch and counts a failure. On this
+branch it stashes MY unrelated edit instead, reverts to committed master, which
+still contains the override-order fix, and so the case stays PASS and again
+counts a failure. The test can no longer pass either way. Reverting to
+`git show <fix-sha>^:lib/gate/proof-ledger.sh` would repair it. Out of scope
+here, filed separately.
+
+## Rollback
+
+`git revert`. The gate returns to enumerating owner directories, and an
+experiment's co-located proof goes invisible again.

--- a/lib/gate/proof-ledger.sh
+++ b/lib/gate/proof-ledger.sh
@@ -147,19 +147,26 @@ delivery_ratio() {
 }
 
 # the verification-log files this branch added/modified (excludes the convention README).
-# Three accepted shapes: the repo-root convention (docs/verification/<slug>.md), a proof
-# co-located with its subject anywhere in the tree (any path ending /proof-of-done.md, e.g.
-# a monorepo's tools/<name>/docs/proof-of-done.md), and a monorepo tool's own verification
-# dir (tools/<name>/docs/verification/<slug>.md, per ops-toolkit's per-tool co-location
-# convention). The content check in check() validates all three the same way; location is
-# just where the proof lives.
+# Two accepted shapes, both location-agnostic: any `docs/verification/<slug>.md` (at the
+# repo root or nested under whatever owns it) and any path ending `/proof-of-done.md`. The
+# content check in check() validates both the same way; location is just where the proof
+# lives.
+#
+# The nested case used to be spelled out as `tools/<name>/docs/verification/`, which only
+# covered a monorepo TOOL. ops-toolkit's co-location rule also puts an experiment's proof at
+# `experiments/<slug>/docs/verification/<feature>.md`, and that matched nothing, so a real
+# proof was invisible and the gate fell through to the override branch and refused the source
+# change (hit 2026-08-25). Enumerating owner directories is the bug: every new co-location
+# home needs another alternative, and the failure is silent. Matching `docs/verification/` at
+# any depth is both smaller and closed over future owners, and it grants nothing the
+# already-anywhere `/proof-of-done.md` rule did not.
 _fresh_proof_files() {
   local root="$1" base="$2"
   { git -C "$root" diff --name-only "$base"..HEAD 2>/dev/null
     git -C "$root" diff --name-only HEAD 2>/dev/null
     git -C "$root" diff --name-only --cached 2>/dev/null
     git -C "$root" ls-files --others --exclude-standard 2>/dev/null
-  } | sort -u | grep -E '^docs/verification/.+\.md$|^tools/[^/]+/docs/verification/.+\.md$|(^|/)proof-of-done\.md$' | grep -v '/README\.md$' || true
+  } | sort -u | grep -E '(^|/)docs/verification/.+\.md$|(^|/)proof-of-done\.md$' | grep -v '/README\.md$' || true
 }
 
 # Repo identity for override scoping (ID-299). The override log is machine-local and now
@@ -281,7 +288,7 @@ check() {
   # satisfy when the UNION of a group's files carries both markers.
   if [ "$ok" -ne 0 ] && [ -n "$files" ]; then
     local groups g content grp_img
-    groups="$(printf '%s\n' "$files" | sed -nE 's#^(docs/verification/[^/]+/).*#\1#p;s#^(tools/[^/]+/docs/verification/[^/]+/).*#\1#p' | sort -u)"
+    groups="$(printf '%s\n' "$files" | sed -nE 's#^(.*docs/verification/[^/]+/).*#\1#p' | sort -u)"
     while IFS= read -r g; do
       [ -n "$g" ] || continue
       content=""; grp_img=1     # grp_img=0 iff some file in the group embeds a REAL image

--- a/tests/test-proof-experiment-verification-path.sh
+++ b/tests/test-proof-experiment-verification-path.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# test-proof-experiment-verification-path.sh
+# Guards the co-located verification path for owners OTHER than tools/ (ID-553): a fresh
+# proof at experiments/<slug>/docs/verification/<feature>.md must satisfy check(), the same
+# as the repo-root and tools/<name>/ conventions.
+#
+# This is the second time the same bug landed. ID-478 fixed it for tools/ by adding one more
+# alternative to the grep; enumerating owner directories left every other co-location home
+# still invisible, and the failure is silent (the gate reports "no proof of done" for a
+# branch that has one). The fix matches docs/verification/ at ANY depth, so case 3 below is
+# the one that stops the next recurrence.
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$KIT/lib/gate/proof-ledger.sh"
+fails=0
+pass(){ echo "PASS $*"; }
+fail(){ echo "FAIL $*"; fails=$((fails+1)); }
+
+# $1 = dir, $2 = path of the proof file relative to the repo root
+make_fixture() {
+  local d="$1" rel="$2" proof
+  rm -rf "$d"; mkdir -p "$d/$(dirname "$rel")" "$d/lib"
+  git -C "$d" init -q; git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  echo baseline > "$d/lib/thing.sh"
+  git -C "$d" add -A; git -C "$d" commit -qm base
+  echo "changed behavior" >> "$d/lib/thing.sh"                                  # behavioral diff
+  proof="$d/$rel"
+  {
+    echo "# Verification"
+    echo "## NEGATIVE CONTROL"
+    echo "reverting the change turns this RED."
+    echo '- Command: `bash lib/thing.sh`'
+    echo '- Exit: 0'
+    echo '- Verdict: PASS'
+  } > "$proof"
+  git -C "$d" add -A
+}
+base(){ git -C "$1" rev-parse HEAD; }
+
+check_accepts() {  # $1 = label, $2 = proof path relative to repo root
+  local d=/tmp/vf-exp-path-gate
+  make_fixture "$d" "$2"
+  if bash "$LIB" check "$d" "$(base "$d")" vf-exp >/dev/null 2>&1; then
+    pass "$1"
+  else
+    fail "$1 , proof exists but the gate BLOCKED"
+  fi
+  rm -rf "$d"
+}
+
+check_accepts "experiments/<slug>/docs/verification/<feature>.md accepted" \
+  "experiments/webnovel-dl/docs/verification/repair-outliers.md"
+
+# set-wise layout: the green run and the negative control may live in separate files under
+# a per-feature directory. Grouping must key on the nested prefix too, not only a root one.
+check_accepts "experiments/<slug>/docs/verification/<feature>/run.md accepted" \
+  "experiments/webnovel-dl/docs/verification/repair-outliers/run.md"
+
+# The generalization's real payload: an owner directory nobody has enumerated yet.
+check_accepts "an unenumerated owner dir under docs/verification/ accepted" \
+  "learning/social-stratification/docs/verification/claim-teardown.md"
+
+# Guard the other direction: a README under docs/verification/ is documentation about
+# proofs, not a proof, and must stay excluded or every repo self-satisfies the gate.
+D=/tmp/vf-exp-path-gate-neg
+make_fixture "$D" "experiments/e/docs/verification/README.md"
+if bash "$LIB" check "$D" "$(base "$D")" vf-exp >/dev/null 2>&1; then
+  fail "a docs/verification/README.md must NOT satisfy the gate, but it did"
+else
+  pass "docs/verification/README.md still excluded"
+fi
+rm -rf "$D"
+
+[ "$fails" -eq 0 ] && { echo "ALL PASS (4/4)"; exit 0; } || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
The proof matcher enumerated owner directories: repo-root `docs/verification/`, `tools/<name>/docs/verification/`, and any `/proof-of-done.md`. ops-toolkit's co-location rule also puts an experiment's proof at `experiments/<slug>/docs/verification/<feature>.md`, which matched none of them. The gate then read a branch that HAD a proof as unproven, fell through to the override branch, and refused the source change with "no proof of done".

Hit live on 2026-08-25 in ops-toolkit. The workaround there was renaming the file to `docs/verification/<feature>/proof-of-done.md`, which is a filename trick, not a fix.

## Why generalize instead of adding a fourth alternative

This is the second occurrence of the same class. ID-478 fixed it for `tools/` by adding one more alternative. Enumeration is the defect: each new co-location home needs another alternative, and the failure mode is silent, the gate reports "no proof of done" for a branch that has one.

```
-'^docs/verification/.+\.md$|^tools/[^/]+/docs/verification/.+\.md$|(^|/)proof-of-done\.md$'
+'(^|/)docs/verification/.+\.md$|(^|/)proof-of-done\.md$'

-'s#^(docs/verification/[^/]+/).*#\1#p;s#^(tools/[^/]+/docs/verification/[^/]+/).*#\1#p'
+'s#^(.*docs/verification/[^/]+/).*#\1#p'
```

Two alternatives instead of three, covering more. It grants nothing the already-anywhere `/proof-of-done.md` rule did not. The `grep -v /README.md$` exclusion is untouched and now tested.

## Proof

`docs/verification/proof-path-experiments.md`. New test `tests/test-proof-experiment-verification-path.sh`, 4/4 PASS: the flat experiment path, the set-wise per-feature directory, an owner directory nobody has enumerated yet, and the README case that must stay excluded.

Negative control ran the same fixture against `origin/master`'s copy of the lib via `git show`: it BLOCKED, and the patched copy ACCEPTED. Same fixture both runs, so the accept is attributable to the regex and nothing else.

Regression: `test-proof-dir-layout` 3/3, `test-proof-tool-verification-path` 1/1, `test-proof-visual-evidence` 4/4, `test-proof-table-gen` green, `proof-loop-09-scenario-b` reproduced.

## One pre-existing failure, not from this change

`test-proof-override-order.sh` fails, and it fails on pristine `master` too. Its negative control reverts "the fix" by stashing an UNCOMMITTED working-tree diff to `lib/gate/proof-ledger.sh`. That fix has been committed for a while, so on master there is no diff to stash and the test takes its own `[NO EXECUTABLE CHECK]` branch and counts a failure. On any other branch it stashes an unrelated edit, reverts to committed master which still contains the override-order fix, and the case stays PASS, counting a failure again. It cannot pass either way. Pinning it to `git show <fix-sha>^:lib/gate/proof-ledger.sh` would repair it. Left out of this PR deliberately.