### PR TITLE
docs(fleet): commit the fleet design set and two playbook additions

### DIFF
--- a/docs/fleet/CONTRIBUTING.md
+++ b/docs/fleet/CONTRIBUTING.md
@@ -1,0 +1,167 @@
+# Contributing to the skill fleet
+
+This doc is for contributors: people adding a skill to the registry, editing
+the schema, or changing how sync generates loaders. For day-to-day operation see
+[SYNC.md](SYNC.md); for the format spec see [SCHEMA.md](SCHEMA.md).
+
+The fleet's golden rule, repeated from the schema: **one body, many loaders.**
+You author exactly one `SKILL.md` per skill plus one `[[skills]]` row in
+`fleet.toml`. Everything a harness consumes is *generated* from that pair. You
+never hand-author a `cc` directory copy, a `codex` `openai.yaml`, or an
+`opencode` copy.
+
+## Adding a new skill (the happy path)
+
+### 1. Author the canonical `SKILL.md`
+
+One file per skill. Frontmatter is the machine contract (routing/versioning);
+the body is the human contract.
+
+```markdown
+---
+name: github-pr-workflow
+description: "Carry a GitHub PR from branch to merge with CI gating."
+version: 1.4.0
+author: Tieubao (tieubao), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [github, pr, ci]
+---
+
+# GitHub PR Workflow
+
+One-shot lifecycle for shipping a change through GitHub. Does not merge for you;
+it gates and hands you the merge decision. Depends on `gh` and `git`.
+
+## When to Use
+...
+```
+
+Rules (full list in [SCHEMA.md §4](SCHEMA.md)):
+
+- `name` matches `^[a-z0-9][a-z0-9-]{0,63}$` and **equals** the `fleet.toml` `id`.
+- `description` is ≤ 60 chars, one sentence, ends with `.`.
+- `version` is SemVer and **equals** the `fleet.toml` `version`.
+- `author` credits a human first, then `Hermes Agent`. Never `author: Hermes Agent` alone.
+- `license` is an SPDX id. `platforms` is a subset of `[linux, macos, windows]`.
+
+### 2. Register it in `fleet.toml`
+
+```toml
+[[skills]]
+id = "github-pr-workflow"
+source = "skills/devops/github-pr-workflow/SKILL.md"
+version = "1.4.0"
+tier = "core"
+dependencies = ["gh", "git"]
+metadata = { category = "devops", tags = ["github", "pr"], license = "MIT" }
+```
+
+- `id`, `source`, `version` are required (V3).
+- `id` is unique and well-formed (V4).
+- `harnesses` is optional; it defaults to `[fleet].default_harnesses`.
+- `category` (in `metadata`) sets the output subdirectory; if omitted, sync
+  falls back to the top-level directory of `source`.
+
+### 3. Validate before committing
+
+```bash
+fleet sync --check
+```
+
+`--check` validates the whole registry and reports `new` / `up-to-date` /
+`update` / `drift` per harness without writing. Green means safe to commit the
+`fleet.toml` change (the generated loaders are produced at sync time, not
+committed to the registry source).
+
+### 4. Generate the loaders
+
+```bash
+fleet sync
+```
+
+Confirm the loaders appear under the configured output roots
+(`skills/`, `codex/`, `opencode/` by default; see
+[SCHEMA.md §3.2](SCHEMA.md)).
+
+## Adding a Craft skill (stream-backed)
+
+A Craft skill is declared with `tier = "craft"` and a `private://` or `url:`
+source instead of a relative path. You do **not** author the `SKILL.md` in the
+registry repo — it lives on the private stream. See
+[PRIVATE-STREAM.md](PRIVATE-STREAM.md) for the full flow.
+
+```toml
+[[skills]]
+id = "internal-deploy-runbook"
+source = "private://skills/deploy/SKILL.md"
+version = "0.9.0"
+tier = "craft"
+```
+
+The cross-file contract (V8/V9) still applies: the stream's `SKILL.md` `name`
+and `version` must match `fleet.toml`.
+
+## Core-tier constraints (do not bypass)
+
+If `tier` is omitted or `"core"` (the default), these hard constraints hold
+([SCHEMA.md §3.5](SCHEMA.md), validation V10/V11):
+
+- `source` **must** be a plain relative repo path. Forbidden prefixes:
+  `url:`, `private://`, `http://`, `https://`.
+- `source` must resolve to a file inside the repo (under `skills_root`).
+- `dependencies` must name local CLIs/runtimes already on a standard dev
+  machine (`gh`, `git`, `yt-dlp`). They must **not** name packages requiring a
+  network install to consume the skill.
+- The generated loaders must be plain files (`.md` / `.yaml`) — no embedded
+  remote fetch, no wrapper that phones home.
+
+If your skill needs a remote source or a network install, it is a **Craft**
+skill, not core. Set `tier = "craft"`. Core exists to be the N4 adoption
+driver: plain files, no external dependency at consume time.
+
+## Versioning
+
+- **Skill version** (`SKILL.md` `version` and `fleet.toml` `[[skills]].version`)
+  is SemVer 2.0.0. `MAJOR` = breaking change, `MINOR` = backward-compatible
+  addition, `PATCH` = fix/clarification. New skills start at `0.1.0`. The two
+  values **must stay equal** (V8/V9).
+- **Harness version constraint** (`harnesses[].min_version` / `max_version`)
+  constrains the *harness runtime*, not the skill. Inclusive bounds.
+- **Registry schema version** (`[fleet].version`) is the file-shape version.
+  Pinned at `1.0.0` for the canonical release. Bump MAJOR only on a breaking
+  change to the `fleet.toml` shape. It is distinct from every skill version.
+
+## Changing the schema
+
+The schema is the contract; changes ripple to the validator, the generator, and
+this documentation. When you change `fleet.toml` or `SKILL.md` semantics:
+
+1. Update [SCHEMA.md](SCHEMA.md) first — it is the canonical spec. Add a
+   validation rule row (V1–V13 and beyond) with severity and location.
+2. Add a valid example and, where the change introduces a new rejection, an
+   invalid example in §8/§9.
+3. Keep `fleet.schema.json` (the machine-readable JSON Schema, Draft 2020-12)
+   in sync with the prose. It is the artifact CI can check a `fleet.toml`
+   against directly.
+4. Update the relevant operator doc ([SYNC.md](SYNC.md) for behavior,
+   [PRIVATE-STREAM.md](PRIVATE-STREAM.md) for Craft, this file for the
+   contributor path).
+5. Bump `[fleet].version` only on a breaking file-shape change.
+
+The acceptance-criteria traceability table at the bottom of SCHEMA.md maps each
+criterion to where it is satisfied — extend it when you add a rule.
+
+## Reference artifacts in this directory
+
+| File | What it is |
+|---|---|
+| `SCHEMA.md` | Canonical `fleet.toml` + `SKILL.md` schema spec (v1.0.0). |
+| `fleet.schema.json` | Machine-readable JSON Schema (Draft 2020-12) for `fleet.toml`. |
+| `fleet.toml` | Reference registry exercising all three harnesses and both tiers. |
+| `README.md` | Index into this doc set. |
+| `SYNC.md` | `fleet sync` usage, `--check`, drift, troubleshooting. |
+| `PRIVATE-STREAM.md` | Craft private-stream integration. |
+| `CONTRIBUTING.md` | This file. |

--- a/docs/fleet/PRIVATE-STREAM.md
+++ b/docs/fleet/PRIVATE-STREAM.md
@@ -1,0 +1,109 @@
+# Craft private stream integration for synced skills
+
+Core-tier skills live as plain files in a repo and sync from a local
+`SKILL.md` (see [SYNC.md](SYNC.md) and [SCHEMA.md §3.5](SCHEMA.md)). Craft-tier
+skills are different: their single source lives on the **private update
+stream** — the same perpetual-update channel that delivers other Craft features
+(ladders, persona packs, the private update channel per
+`docs/tiers.md`). A Craft skill's maintained updates propagate to every
+harness in one pull.
+
+This doc covers how a Craft skill references the stream, what sync does with it,
+and how to operate it.
+
+## Why Craft rides the stream
+
+The Craft tier's value is *maintained, kept-current* skills. If a Craft skill's
+source were a hand-cloned repo file, it would drift from upstream the moment
+the maintainer shipped a fix. Riding the private stream means a single
+`fleet sync` (or the stream's own pull) brings every harness up to the
+maintained version at once — the literal "fleet skills ride the stream" line in
+`docs/tiers.md`.
+
+> Honesty boundary (from the design brief): the sync engine generates loaders
+> **everywhere**; enforcement of anything beyond generation stays where the
+> harness supports it. A Craft skill synced from the stream is still a generated
+> loader on each harness — the stream only changes *where the source comes
+> from*.
+
+## Declaring a Craft skill on the stream
+
+A Craft skill differs from a core skill in two `fleet.toml` fields:
+
+- `tier = "craft"` (omits the core plain-file constraints V10/V11).
+- `source` uses the `private://` or `url:` scheme instead of a relative repo
+  path.
+
+```toml
+[[skills]]
+id = "internal-deploy-runbook"
+source = "private://skills/deploy/SKILL.md"   # resolves via the private stream
+version = "0.9.0"
+tier = "craft"
+harnesses = ["cc", "codex", "opencode"]
+metadata = { category = "devops", stream = "skills" }
+```
+
+| Source form | Meaning | When to use |
+|---|---|---|
+| `private://<stream>/<path>` | Resolve `<path>` from the private update stream named `<stream>`. | The canonical Craft form; the source is maintained upstream and pulled, not cloned. |
+| `url:<https-url>` | Fetch the `SKILL.md` from a `https` URL at sync time. | A hosted source you control; less preferred than `private://` because it has no stream identity or version provenance. |
+
+`core` skills **may not** use either scheme — that is a V10 validation error
+(see [SYNC.md Troubleshooting](SYNC.md)).
+
+## What sync does with a stream source
+
+For a Craft skill, `fleet sync`:
+
+1. Authenticates to the private stream using the operator's Craft entitlement
+   (the same credential the update channel uses).
+2. Resolves `source` to a concrete `SKILL.md` revision on the stream.
+3. Validates that `SKILL.md` (V7) and the cross-file contract (V8/V9) against
+   `fleet.toml`, exactly as for a core skill.
+4. Generates each harness loader from the resolved source.
+5. Records the resolved stream revision in the checksum so a later upstream
+   change shows as `update` (not `drift`) — sync knows the source moved, so it
+   regenerates rather than flagging a conflict.
+
+The loaders written to `cc`/`codex`/`opencode` are byte-identical in shape to
+core loaders; only the *origin* of the bytes differs.
+
+## Pulling updates
+
+When the upstream maintainer ships a new version of a stream-hosted skill:
+
+1. Refresh the stream (the same step that updates ladders/packs):
+   ```bash
+   fleet stream pull          # or the update-channel's own pull command
+   ```
+2. Re-run sync. Craft skills whose stream revision changed show as `update`;
+   `fleet sync` regenerates their loaders.
+3. Run `fleet sync --check` in CI to confirm every Craft skill still resolves
+   and validates against the refreshed stream.
+
+Because the source is upstream-owned, **never** edit a stream-hosted `SKILL.md`
+locally and expect it to survive — a stream pull will replace it. Local
+corrections go back to the maintainer (open a change against the stream source),
+not into a local copy.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `skill X: core source must be a plain path (V10)` | A `core` skill used `private://`/`url:`. | Set `tier = "craft"`, or move the content into the repo as a relative path. |
+| `skill X: stream auth failed` | No Craft entitlement / stale stream token. | Re-authenticate the update channel; confirm the Craft license is active. |
+| `skill X: source 'private://...' not found on stream` | Wrong stream name or path, or the skill isn't published to that stream. | Check `metadata.stream` and the path; confirm the skill is published upstream. |
+| `skill X: stream revision unresolved` | The stream returned no revision for the pinned `version`. | Bump `version` to a published one, or pin `version` to match the stream's current tag. |
+| `skill X: url: fetch failed` | The `https` source is unreachable or returns non-200. | Verify the URL and network access; prefer `private://` for maintained sources. |
+| Loaders never update after a stream pull | Sync ran before the pull, or with a stale cache. | Pull the stream, then re-run `fleet sync`; check the recorded revision moved. |
+
+## Relationship to other tiers
+
+- **Core** (`docs/tiers.md`): free forever, plain files, N4 adoption driver.
+  Synced from a local `SKILL.md`. No stream dependency.
+- **Craft** (this doc): perpetual license + update stream. Synced skills ride
+  the private stream.
+- **Crew** (`docs/tiers.md`): org-shared packs + the fleet dashboard panel; the
+  org's routing map becomes policy-as-code the gateway checks. The dashboard
+  render of a Craft skill labels it as stream-backed.

--- a/docs/fleet/README.md
+++ b/docs/fleet/README.md
@@ -1,0 +1,65 @@
+# Skill Fleet
+
+One skill body, every harness. The skill fleet keeps a single canonical
+`SKILL.md` per skill and generates each runtime's loader from it, so you edit
+one file instead of maintaining a hand-copied duplicate in Claude Code, Codex,
+and opencode/pi.
+
+The fleet has three moving parts:
+
+1. **Registry** — `fleet.toml` declares which skills go to which harnesses, at
+   what version, from what single source. It is declarative; it never stores the
+   generated loaders.
+2. **Sync/adapt engine** — `fleet sync` generates each harness's loader format
+   from the one body and detects drift (a generated copy that diverged from
+   source) without silently overwriting it.
+3. **Render** — `fleet render` prints a runtime-by-purpose grid (skills live
+   where, versions, drift flags). See the design brief
+   `../briefs/DECISION-BRIEF-skill-fleet.md` for the visual.
+
+This directory holds the operator and contributor docs:
+
+| Doc | Audience | What it covers |
+|---|---|---|
+| [SCHEMA.md](SCHEMA.md) | contributor / author | `fleet.toml` and `SKILL.md` format rules, valid + invalid examples, versioning, the V1–V13 validation ruleset. |
+| [SYNC.md](SYNC.md) | user / operator | `fleet sync` usage, the `--check` flag, drift detection behavior, and troubleshooting. |
+| [PRIVATE-STREAM.md](PRIVATE-STREAM.md) | user (Craft tier) | How Craft-tier synced skills ride the private update stream. |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | contributor | How to add a new skill to the registry, the core-tier constraints, and the path from schema change to shipped loaders. |
+
+## Why this exists
+
+Without a fleet, an agent estate fragments: skills installed in Claude Code, a
+different set under Codex, another under pi — drifting versions, duplicated
+bodies, no view of what lives where. The ecosystem's answer today is
+superpowers-style per-harness reinstall: hand-maintained duplicates. That is a
+recorded AVOID in this kit (the packaging doctrine, ID-396). The fleet makes the
+antidote a product feature: one source, generated adapters. That generalizes
+[mattpocock's dual-harness pattern](../briefs/DECISION-BRIEF-skill-fleet.md)
+to three harnesses.
+
+Two hard properties the design protects:
+
+- **Core tier is plain files only (N4).** A `tier = "core"` skill's `source`
+  must be a relative repo path — no `url:`, no `private://`, no runtime fetch.
+  Its dependencies must be local CLIs already on a standard dev machine. No
+  network dependency at consume time.
+- **Craft skills ride the private stream.** Craft-tier skills may reference the
+  private update channel; maintained skill updates propagate to every harness
+  in one pull. See [PRIVATE-STREAM.md](PRIVATE-STREAM.md).
+
+## Supported harnesses
+
+| `harness` id | Full name | Generated loader |
+|---|---|---|
+| `cc` | Claude Code / CC dir | `<out>/<category>/<id>/SKILL.md` (directory skill) |
+| `codex` | OpenAI Codex | `<out>/<id>.openai.yaml` + sibling `<id>.md` |
+| `opencode` | pi / opencode | `<out>/<category>/<id>/SKILL.md` |
+
+## Status
+
+The fleet is a **designed, queued** subsystem (board IDs ID-431 and ID-432).
+The schema in this directory is the canonical contract (registry schema version
+`1.0.0`). The `fleet sync`, `fleet render`, and private-stream integration are
+documented here as the behavior they will implement; the docs track the schema
+as the source of truth and will be reconciled against the implementation when
+the engine lands.

--- a/docs/fleet/SCHEMA.md
+++ b/docs/fleet/SCHEMA.md
@@ -1,0 +1,345 @@
+# Skill Fleet Schema Specification
+
+*Canonical schema reference for the skill fleet. This is the format spec;
+[README.md](README.md) is the index, [SYNC.md](SYNC.md) covers `fleet sync`,
+[PRIVATE-STREAM.md](PRIVATE-STREAM.md) covers the Craft private stream, and
+[CONTRIBUTING.md](CONTRIBUTING.md) covers adding skills.*
+
+**Schema version: `1.0.0`** · **Status: canonical** ·
+**Owner: t_3dd38adf** (root of the fleet decomposition)
+
+This document is the single source of truth for two formats:
+
+1. **`fleet.toml`** — the registry that says *which* skills go to *which*
+   harnesses, at *what* version, from *what* single source.
+2. **`SKILL.md`** — the canonical per-skill body. Exactly **one** of these exists
+   per skill. Every harness loader is *generated* from it.
+
+Design goal (from the brief): generalize mattpocock's dual-harness pattern to
+**all** listed harnesses from a single source. No per-harness packaging. The
+**core tier is plain files only** (N4 adoption driver) — no external install, no
+network dependency at consume time. "Craft" skills may ride the private stream.
+
+---
+
+## 1. Guiding principles
+
+- **One body, many loaders.** Author a skill once (`SKILL.md`). `fleet sync`
+  emits the CC directory copy, the Codex `openai.yaml` sidecar, and the
+  opencode skill directory. Editing the skill means editing one file.
+- **Registry is declarative, not imperative.** `fleet.toml` declares intent;
+  the engine generates. It never stores generated content.
+- **Drift is detected, never silent.** Generated files are checksummed against
+  the source. A changed source that disagrees with an on-disk generated loader
+  is reported before any overwrite (see `t_ce555189`).
+- **Core = plain files, N4.** A `tier = "core"` skill's `source` MUST be a
+  plain relative repo path. No `url:`, no `private://`, no runtime package
+  fetch. Core `dependencies` MUST be local CLIs, not `pip install` targets.
+
+---
+
+## 2. Supported harnesses
+
+| `harness` id | Full name            | Generated loader format                              |
+|--------------|----------------------|-----------------------------------------------------|
+| `cc`        | Claude Code / CC dir | `<cc>/<category>/<id>/SKILL.md` (directory skill)   |
+| `codex`     | OpenAI Codex         | `<codex>/<id>.openai.yaml` (+ sibling `.md`)        |
+| `opencode`  | pi / opencode        | `<opencode>/<category>/<id>/SKILL.md`               |
+
+---
+
+## 3. `fleet.toml` schema
+
+### 3.1 `[fleet]` table (registry-global)
+
+| Key                | Type            | Required | Default                       | Rules |
+|--------------------|-----------------|----------|-------------------------------|-------|
+| `version`          | `string` (semver) | yes    | —                             | Registry schema version. **Pin `1.0.0`.** Bump MAJOR on a breaking file-shape change. This is *not* a skill version. |
+| `registry_name`    | `string` (1–128)  | yes    | —                             | Human label used in drift/catalog output. |
+| `default_harnesses`| `array<string>`   | no     | `["cc","codex","opencode"]`   | Harness ids applied to any `[[skills]]` that omits `harnesses`. Entries must be unique and drawn from §2. |
+| `skills_root`      | `string`          | no     | `"."`                         | Base dir (relative to `fleet.toml`) for resolving `source` and writing loaders. |
+
+### 3.2 `[fleet.outputs]` table (optional)
+
+Maps each harness id to a relative output directory. Defaults shown.
+
+| Key        | Default     | Meaning |
+|------------|-------------|---------|
+| `cc`       | `"skills"`  | CC skills root. |
+| `codex`    | `"codex"`   | Codex sidecars root. |
+| `opencode` | `"opencode"`| opencode skills root. |
+
+### 3.3 `[[skills]]` array (one entry per skill)
+
+| Key            | Type                  | Required | Default           | Rules |
+|----------------|-----------------------|----------|-------------------|-------|
+| `id`           | `string`              | yes      | —                 | Unique skill id. **MUST equal** the `name` in the source `SKILL.md` frontmatter. Pattern: `^[a-z0-9][a-z0-9-]{0,63}$`. |
+| `source`       | `string`              | yes      | —                 | Resolves the canonical `SKILL.md`. Core tier: a plain relative repo path. Craft tier: may use `private://<stream>/...` or `url:<https>`. |
+| `version`      | `string` (semver)     | yes      | —                 | Pinned skill version. **MUST equal** `source` `SKILL.md` `version`. |
+| `harnesses`    | `array`               | no       | `default_harnesses` | Non-empty list of harness targets. Each element is either a bare id (`"cc"`) or a table `{ name, min_version?, max_version? }`. Unique ids. |
+| `tier`         | `"core" \| "craft"`   | no       | `"core"`          | `core` ⇒ plain-file / N4 rules (§3.5) enforced. |
+| `dependencies` | `array<string>`       | no       | `[]`              | Local CLIs/runtimes the skill needs (informational + drift-checked). Core: no remote-install targets. |
+| `metadata`     | `table`               | no       | `{}`              | Free-form. Recommended keys: `category`, `tags`, `maintainers`, `license`. |
+
+### 3.4 `harnesses` element forms
+
+```toml
+# bare id — any version
+harnesses = ["cc", "codex", "opencode"]
+
+# table form — adds a version constraint
+harnesses = [
+  "cc",
+  { name = "codex", min_version = "0.30.0" },
+  { name = "opencode", min_version = "1.0.0", max_version = "1.9.9" },
+]
+```
+
+- `name` ∈ {`cc`, `codex`, `opencode`}.
+- `min_version` / `max_version` are semver strings (inclusive).
+- A harness must appear **at most once** across the array.
+
+### 3.5 Core-tier (N4) hard constraints
+
+If `tier` is omitted or `"core"`:
+
+- `source` MUST be a relative repo path (no scheme). Forbidden prefixes:
+  `url:`, `private://`, `http://`, `https://`.
+- `source` MUST resolve to a file inside the repo (under `skills_root`).
+- `dependencies` entries MUST name local CLIs / runtimes already present on a
+  standard dev machine (e.g. `gh`, `git`, `yt-dlp`). They MUST NOT name
+  packages that require a network install to consume the skill.
+- The generated loaders MUST be plain files (`.md` / `.yaml`), no embedded
+  remote fetch, no wrapper that phones home.
+
+`craft` tier is exempt and may reference the private stream.
+
+---
+
+## 4. `SKILL.md` canonical format (single source)
+
+One file per skill. Frontmatter is the **machine contract**; the body is the
+**human contract**. `fleet sync` reads frontmatter for routing/versioning and
+copies the whole file (frontmatter + body) into each loader.
+
+### 4.1 Required frontmatter
+
+```yaml
+---
+name: <id>                 # lowercase, hyphens, ≤64 chars; MUST equal fleet.toml `id`
+description: "One sentence, ≤60 chars, ends with a period."
+version: <semver>          # MUST equal fleet.toml `version` for this skill
+author: Real Name (handle), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Short, Tags]
+    related_skills: [other-skill]
+---
+```
+
+| Field        | Required | Rules |
+|--------------|----------|-------|
+| `name`       | yes      | `^[a-z0-9][a-z0-9-]{0,63}$`. **Equals `fleet.toml` `id`.** |
+| `description`| yes      | ≤ 60 chars, one sentence, ends with `.`. No marketing words. Wrap in quotes if it contains `:`. |
+| `version`    | yes      | Semver. **Equals `fleet.toml` `version`.** |
+| `author`     | yes      | Credit a human first, then `Hermes Agent`. Never `author: Hermes Agent` alone. |
+| `license`    | yes      | SPDX id (`MIT`, `Apache-2.0`, `UNLICENSED`, …). |
+| `platforms`  | yes      | Subset of `[linux, macos, windows]`, audited from the script/tool use. |
+| `metadata.hermes.tags`      | no | Informational tags for the catalog. |
+| `metadata.hermes.related_skills` | no | In-repo skill ids only. |
+
+### 4.2 Body structure (recommended order)
+
+```
+# <Skill> Skill
+2–3 sentence intro: what it does, what it doesn't do, dependency stance.
+
+## When to Use          - triggers (+ "Don't use for:" counter-triggers)
+## Prerequisites        - exact env vars, installs, API key sourcing
+## How to Run           - canonical invocation
+## Pitfalls             - version traps, gotchas, don'ts
+## References           - pointers to references/ templates/ scripts/ (optional)
+```
+
+### 4.3 Global validation rules (all tiers)
+
+1. File starts with `---` as the first bytes (no leading blank line) and closes
+   with `\n---\n` before the body.
+2. Frontmatter parses as a YAML mapping.
+3. `name`, `description`, `version`, `author`, `license`, `platforms` present.
+4. `description` ≤ 60 chars; ends with `.`.
+5. Non-empty body after the closing `---`.
+6. Full file ≤ 100,000 chars (target ~100 lines simple / ~200 complex).
+7. Cross-file: `SKILL.md` `name` == `fleet.toml` `id`; `SKILL.md` `version` ==
+   `fleet.toml` `version`. Mismatch ⇒ registry is invalid (rejected by `fleet sync`).
+
+---
+
+## 5. How `fleet sync` maps one source → three loaders
+
+For a `[[skills]]` entry with `category` taken from `metadata.category`
+(fallback: top-level dir of `source`):
+
+| Harness  | Output path                                            | What is written |
+|----------|--------------------------------------------------------|-----------------|
+| `cc`     | `<cc>/<category>/<id>/SKILL.md`                        | Verbatim copy of source `SKILL.md`. |
+| `codex`  | `<codex>/<id>.openai.yaml` (+ `<id>.md` sibling)       | `openai.yaml` sidecar (name, version, description, file ref) + the `.md` copy. |
+| `opencode`| `<opencode>/<category>/<id>/SKILL.md`                 | Verbatim copy of source `SKILL.md`. |
+
+Because the loaders are generated, **none** of them is hand-authored — that is
+what eliminates per-harness packaging. See `examples/` for a concrete run.
+
+---
+
+## 6. Versioning scheme
+
+- **Skill version** (`SKILL.md` `version` and `fleet.toml` `[[skills]].version`):
+  **SemVer 2.0.0** (`MAJOR.MINOR.PATCH`).
+  - `MAJOR`: breaking change to the skill's behavior or interface.
+  - `MINOR`: backward-compatible addition.
+  - `PATCH`: fixes/clarifications.
+  - New skills start at `0.1.0`.
+- **Harness version constraint** (`harnesses[].min_version` / `max_version`):
+  SemVer, interpreted against the *harness runtime* version
+  (`cc`, `codex`, `opencode`), not the skill version. Inclusive bounds.
+- **Registry schema version** (`[fleet].version`): SemVer of this file shape.
+  Pinned at `1.0.0` for the canonical release.
+
+---
+
+## 7. Validation rules summary (engine MUST enforce)
+
+| # | Rule | Severity | Where |
+|---|------|----------|-------|
+| V1 | `fleet.toml` parses as TOML | error | fleet |
+| V2 | `[fleet].version` present, valid semver | error | fleet |
+| V3 | every `[[skills]]` has `id`, `source`, `version` | error | fleet |
+| V4 | `id` matches `^[a-z0-9][a-z0-9-]{0,63}$` and is unique | error | fleet |
+| V5 | every `harnesses` entry ∈ {cc,codex,opencode}, unique | error | fleet |
+| V6 | `source` file exists & is readable | error | fleet→source |
+| V7 | `SKILL.md` frontmatter has required keys (§4.3) | error | source |
+| V8 | `SKILL.md` `name` == `fleet` `id` | error | cross-file |
+| V9 | `SKILL.md` `version` == `fleet` `version` | error | cross-file |
+| V10 | core tier: `source` is plain relative path (no scheme) | error | fleet |
+| V11 | core tier: `dependencies` are local CLIs (no remote-install) | warn | fleet |
+| V12 | harness runtime satisfies `min_version`/`max_version` at sync time | skip/ warn | engine×runtime |
+| V13 | generated loader checksum matches source after sync (drift) | report | drift (t_ce555189) |
+
+---
+
+## 8. Valid examples
+
+### 8.1 `fleet.toml` — valid
+
+```toml
+[fleet]
+version = "1.0.0"
+registry_name = "dwarves-kit-fleet"
+default_harnesses = ["cc", "codex", "opencode"]
+
+[[skills]]
+id = "github-pr-workflow"
+source = "skills/devops/github-pr-workflow/SKILL.md"
+version = "1.4.0"
+tier = "core"
+dependencies = ["gh", "git"]
+metadata = { category = "devops", tags = ["github", "pr"], license = "MIT" }
+```
+
+### 8.2 `SKILL.md` — valid (canonical)
+
+```markdown
+---
+name: github-pr-workflow
+description: "Carry a GitHub PR from branch to merge with CI gating."
+version: 1.4.0
+author: Tieubao (tieubao), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [github, pr, ci]
+---
+
+# GitHub PR Workflow
+
+One-shot lifecycle for shipping a change through GitHub.
+...
+```
+
+See `examples/skills/devops/github-pr-workflow/SKILL.md` for the full body and
+`examples/generated/{cc,codex,opencode}/...` for the three loader outputs.
+
+---
+
+## 9. Invalid examples (rejected by the engine)
+
+### 9.1 `fleet.toml` — invalid (V4: bad id; V3: missing version)
+
+```toml
+[[skills]]
+id = "GitHub PR Workflow"     # V4: space + caps, not ^[a-z0-9][a-z0-9-]{0,63}$
+source = "skills/devops/github-pr-workflow/SKILL.md"
+# V3: `version` missing
+```
+
+### 9.2 `fleet.toml` — invalid (V5: duplicate + unknown harness)
+
+```toml
+[[skills]]
+id = "youtube-content"
+source = "skills/research/youtube-content/SKILL.md"
+version = "2.1.0"
+harnesses = ["cc", "cc", "gemini"]   # V5: "cc" duplicated, "gemini" not a known harness
+```
+
+### 9.3 `fleet.toml` — invalid (V10: core tier with remote source)
+
+```toml
+[[skills]]
+id = "internal-deploy-runbook"
+source = "https://example.com/skills/deploy/SKILL.md"  # V10: core tier forbids url:
+version = "0.9.0"
+tier = "core"
+```
+
+### 9.4 `SKILL.md` — invalid (V8/V9: name+version mismatch with registry)
+
+```markdown
+---
+name: gh-pr                      # V8: must equal fleet id "github-pr-workflow"
+description: "Carry a GitHub PR from branch to merge with CI gating."
+version: 1.5.0                   # V9: must equal fleet version 1.4.0
+author: Tieubao (tieubao), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+---
+```
+
+### 9.5 `SKILL.md` — invalid (§4.3: description too long, no closing `---`)
+
+```markdown
+---
+name: spike
+description: "Use this skill when the user wants to feel out an idea before committing to a real build by validating feasibility, comparing approaches, and surfacing unknowns."  # > 60 chars
+version: 1.0.0
+author: Hermes Agent              # no human credited
+license: MIT
+platforms: [linux, macos, windows]
+# missing closing --- before body
+```
+
+---
+
+## 10. Acceptance-criteria traceability
+
+| Criterion | Where satisfied |
+|-----------|-----------------|
+| Schema documentation complete | §1–§7 |
+| Valid + invalid examples | §8, §9 |
+| Validation rules unambiguous | §3.5, §4.3, §7 |
+| All harnesses have example entries | `fleet.toml` ex1 (all 3), ex2 (cc+codex), ex3; `examples/generated/` |
+| Eliminates per-harness packaging | §1, §5 (single source, generated loaders) |
+| Core tier plain files, no external deps | §3.5 (V10/V11), ex1 |

--- a/docs/fleet/SYNC.md
+++ b/docs/fleet/SYNC.md
@@ -1,0 +1,196 @@
+# `fleet sync`: syncing skills to every harness
+
+`fleet sync` reads `fleet.toml`, finds each skill's single-source `SKILL.md`,
+validates it, and **generates** each target harness's loader from that one body.
+It never hand-copies and it never silently overwrites a loader that someone has
+edited by hand.
+
+This doc covers how to run sync, the `--check` dry-run, what drift detection
+does, and how to recover from the common failures. For the file formats
+themselves see [SCHEMA.md](SCHEMA.md).
+
+## Setup
+
+`fleet sync` is a Core-tier, plain-file tool. It needs no network access and no
+remote install — it reads and writes repositories on local disk.
+
+1. **Have a `fleet.toml` at your registry root.** A minimal one:
+
+   ```toml
+   [fleet]
+   version = "1.0.0"
+   registry_name = "my-fleet"
+   default_harnesses = ["cc", "codex", "opencode"]
+
+   [[skills]]
+   id = "github-pr-workflow"
+   source = "skills/devops/github-pr-workflow/SKILL.md"
+   version = "1.4.0"
+   tier = "core"
+   dependencies = ["gh", "git"]
+   metadata = { category = "devops" }
+   ```
+
+   See [SCHEMA.md §3](SCHEMA.md) for every key, and the reference
+   `fleet.toml` shipped at `fleet.toml` in this directory.
+
+2. **Point `source` at a real `SKILL.md`.** The `source` path is resolved
+   relative to `[fleet].skills_root` (default `.`, i.e. the directory containing
+   `fleet.toml`). For a `core` skill, `source` must be a plain relative repo
+   path — no `url:`, `private://`, or `http(s)://` (that is a V10 error). Craft
+   skills may use `private://<stream>/...` or `url:<https>`; see
+   [PRIVATE-STREAM.md](PRIVATE-STREAM.md).
+
+3. **Run sync.** From the registry root:
+
+   ```bash
+   fleet sync
+   ```
+
+   With no arguments, sync validates every `[[skills]]` entry and writes the
+   loaders for each skill's `harnesses`.
+
+## Invocation
+
+```bash
+fleet sync [--check] [--registry PATH] [--only ID,...] [--harness cc,codex]
+```
+
+| Flag | Meaning |
+|---|---|
+| `--check` | Validate and report what *would* change, write nothing. See below. |
+| `--registry PATH` | Use a `fleet.toml` at `PATH` instead of the one in the current directory. |
+| `--only ID,...` | Restrict the run to the named skill ids (comma-separated). |
+| `--harness cc,codex` | Override the harness set for this run (subset of the skill's declared harnesses). |
+
+> Invocation note: the command is shown as `fleet sync`. When wired into an
+> adopted repo it runs as the kit's `fleet` entrypoint; the bare form is used in
+> this doc for readability.
+
+## What a normal sync does
+
+For each valid `[[skills]]` entry, sync:
+
+1. Parses `fleet.toml` (V1) and checks `[fleet].version` (V2).
+2. Validates the entry has `id`/`source`/`version` (V3), a well-formed unique
+   `id` (V4), and known unique harnesses (V5).
+3. Reads and validates the source `SKILL.md` (V6, V7) and checks the cross-file
+   contract: `SKILL.md` `name` == `fleet` `id` (V8) and `version` == `fleet`
+   `version` (V9). For `core` skills it also enforces the plain-file source
+   constraint (V10) and local-CLI dependency rule (V11).
+4. For each target harness, generates the loader (see the output map below).
+5. Computes a checksum of each generated loader against the source and records
+   it for next-run drift detection (V13).
+
+### Output map
+
+| Harness | Output path | Written content |
+|---|---|---|
+| `cc` | `<cc>/<category>/<id>/SKILL.md` | Verbatim copy of source `SKILL.md`. |
+| `codex` | `<codex>/<id>.openai.yaml` (+ `<id>.md` sibling) | `openai.yaml` sidecar (name, version, description, file ref) + the `.md` copy. |
+| `opencode` | `<opencode>/<category>/<id>/SKILL.md` | Verbatim copy of source `SKILL.md`. |
+
+`<category>` is taken from `metadata.category`, falling back to the top-level
+directory of `source`. The output roots (`cc`, `codex`, `opencode`) default to
+`skills`, `codex`, `opencode` respectively and are configurable via
+`[fleet.outputs]` (see [SCHEMA.md §3.2](SCHEMA.md)).
+
+Because the loaders are generated, **none** of them is hand-authored — that is
+what eliminates per-harness packaging.
+
+## The `--check` flag (dry run)
+
+`fleet sync --check` validates the registry and every source, and reports what
+it *would* write, **without writing anything**. It is the safe way to verify a
+`fleet.toml` change before committing loaders, and the form CI runs.
+
+```bash
+fleet sync --check
+```
+
+It reports, per skill:
+
+- validation status (pass, or the failing rule id such as `V8`);
+- for each harness, one of:
+  - `new` — no loader exists yet; sync would create it;
+  - `up-to-date` — an identical loader already exists;
+  - `update` — a loader exists and would be regenerated (source changed);
+  - `drift` — a loader exists, differs from source, and has local edits (see
+    drift below); `--check` never resolves drift, it surfaces it.
+
+Exit code: `0` if every entry is valid and every in-sync-or-new loader would be
+written cleanly; **non-zero** if any entry fails validation (so CI can fail the
+build) or if any skill is in `drift` (so a human looks before an overwrite).
+`--check` still exits `0` when loaders would be freshly created — that is a
+normal, non-destructive action.
+
+Use it in a pre-push hook:
+
+```bash
+# .github/workflows/fleet.yml (illustrative)
+- run: fleet sync --check
+```
+
+## Drift detection
+
+"Drift" means a generated loader on disk no longer matches the source it was
+generated from. There are two causes, and sync tells them apart because the
+recovery is different:
+
+| State | Cause | sync's behavior |
+|---|---|---|
+| **Stale** (`update`) | The source `SKILL.md` changed; the loader is behind. | Safe to regenerate. `fleet sync` overwrites it (no local edits were made to the loader). |
+| **Drifted** (`drift`) | Someone edited the *generated loader* by hand, diverging from source. | **Never silently overwritten.** sync reports the conflict and stops touching that file. |
+
+Detection is checksum-based (V13): when sync writes a loader it records a
+checksum of the source-committed content. On the next run it compares the
+on-disk loader's checksum against the source. A mismatch that is *not* explained
+by a newer source is drift.
+
+### What to do on drift
+
+1. Read the report: sync prints which harness loader drifted and the path.
+2. Decide the intent:
+   - **The hand-edit was a fix** that belongs in the source: move the change
+     into the canonical `SKILL.md`, then `fleet sync` regenerates cleanly.
+   - **The hand-edit was a harness-specific tweak** that should not be in the
+     shared body: that is a sign the skill needs a harness-specific override
+     (out of scope for v1; tracked in the design brief) — for now, treat
+     hand-edits to generated loaders as unsupported and revert them.
+   - **The source is wrong** and the hand-edit is the real version: pull the
+     change back into `SKILL.md`, bump `version`, and re-sync.
+3. After reconciling, edit only `SKILL.md`, never the generated loader, then
+   re-run `fleet sync`.
+
+The principle: **generated files are not yours to edit.** They are disposable
+outputs. The only authored artifact is `SKILL.md` + `fleet.toml`.
+
+## Troubleshooting
+
+| Symptom | Rule | Cause | Fix |
+|---|---|---|---|
+| `fleet.toml: parse error` | V1 | TOML syntax error (stray quote, bad array). | Run `fleet sync --check`; the parser points at the line. |
+| `fleet[version]: missing or invalid` | V2 | `[fleet].version` absent or not semver. | Set `version = "1.0.0"`. |
+| `skill X: missing id/source/version` | V3 | A `[[skills]]` entry lacks a required field. | Add the missing field. |
+| `skill X: id 'GitHub PR' invalid` | V4 | `id` has spaces/caps or is too long. | Use `^[a-z0-9][a-z0-9-]{0,63}$`, e.g. `github-pr-workflow`. |
+| `skill X: duplicate/unknown harness 'gemini'` | V5 | A harness appears twice or is not `cc`/`codex`/`opencode`. | Dedupe and use only the three known ids. |
+| `skill X: source not found: <path>` | V6 | `source` does not resolve under `skills_root`. | Fix the path, or `skills_root`. |
+| `skill X: SKILL.md missing required key` | V7 | Frontmatter lacks `name`/`description`/`version`/`author`/`license`/`platforms`. | Add the missing frontmatter keys (see [SCHEMA.md §4.1](SCHEMA.md)). |
+| `skill X: name 'gh-pr' != fleet id 'github-pr-workflow'` | V8 | `SKILL.md` `name` and `fleet.toml` `id` disagree. | Make them identical. |
+| `skill X: version 1.5.0 != fleet version 1.4.0` | V9 | `SKILL.md` `version` and `fleet.toml` `version` disagree. | Bump both to the same semver. |
+| `skill X: core source must be a plain path` | V10 | A `core` skill uses `url:`/`private://`/`http(s)://`. | Move the content into the repo as a relative path, or set `tier = "craft"`. |
+| `skill X: dependency 'pip-pkg' is a remote install` | V11 (warn) | A `core` skill depends on a package that needs a network install. | Use a local CLI (`gh`, `git`, `yt-dlp`), or set `tier = "craft"`. |
+| `skill X: harness 'codex' runtime < min_version 0.30.0` | V12 | The installed harness runtime is older than the constraint. | Upgrade the harness, or relax `min_version`. (Reported/skipped, not fatal in v1.) |
+| `skill X: drift in <harness> loader` | V13 | A generated loader was edited by hand. | Reconcile into `SKILL.md` (see Drift above); never edit the loader. |
+
+### Common confusion
+
+- **"I changed `SKILL.md` but the harness still shows the old text."** The
+  loader is not live-linked to the source; you must run `fleet sync` to
+  regenerate it. `fleet sync --check` first to confirm what will change.
+- **"Sync overwrote my tweak!"** If it did, the loader was *stale*, not drifted
+  — sync only overwrites when the source changed and the loader had no local
+  edits. If you want a change to survive, put it in `SKILL.md`.
+- **"My craft skill won't sync from `private://`."** Craft sources resolve
+  through the private stream, not the local repo. See
+  [PRIVATE-STREAM.md](PRIVATE-STREAM.md).

--- a/docs/impl-playbook/ci-cd-pipeline.md
+++ b/docs/impl-playbook/ci-cd-pipeline.md
@@ -1,0 +1,33 @@
+# CI/CD pipeline: the deploy-pipeline formula
+
+Distills the foundation-workers memo publish pipeline (measured 110s to 78s, 2026-08-19) plus the expand/contract migration rule and GitHub's Actions hardening guide. Each pattern earned its place by a real failure or a measured win; the source column names the proof.
+
+## The formula, in build order
+
+1. **Path-filter the trigger.** A run that starts is the most expensive no-op. Filter at the `on:` block so an irrelevant push never boots a runner.
+2. **Guard before work.** Fail on missing env vars first (`require_env`). Read secrets capture-first into variables, mask each value, export once. An auth failure then fails in seconds, not after the build.
+3. **Gate sub-deploys on the push range.** In a monorepo, diff `event.before..sha` against each deployable's paths plus its deps. Skip the deploy whose inputs did not change. Every uncertain answer (force push, missing base sha, manual dispatch) must fall back to deploying. The skip can then only ever be a correct no-op.
+4. **Order generators as a staged DAG, parallel inside each stage.** Write the dependency reason as a comment on the stage list. An unstated dependency becomes a silent ENOENT that ships bad output (the directory-tree bug shipped for weeks).
+5. **Carry caches on the runner, not the cloud.** On a self-hosted runner, a persistent local dir for the compiler cache and the package store beats a cloud-cache tarball round trip (~40s saved per run).
+6. **Parallelize the deploy tail.** Independent jobs (static assets, object storage, data plane) run as background jobs with collected exit codes. The tail costs max(job) instead of sum(job).
+7. **Migrations apply before code deploys.** Fail-closed code that needs a new table must never reach production before the table exists. Expand/contract is the general form.
+8. **Write deltas, not snapshots.** Hash-gate data-plane writes (seed only changed rows). Content-hash asset uploads come free from the platform (wrangler manifests); do not rebuild that layer.
+9. **Retry only idempotent network calls.** Three attempts with backoff on puts and deploys. Never retry a step whose repeat changes state.
+10. **Sweep hazards by property, not by name.** Oversize files get dropped by a size test. A filename list rots on the next addition.
+
+## Cross-cutting rules
+
+- **The script is runner-agnostic.** Every knob is an env var. No CI expressions inside the script. Any machine with the toolchain can run it by hand, which is also how you debug it.
+- **Heuristic guards fail open, correctness guards fail closed.** A "previous run was green" check proceeds when the API errors. A migrations check never does.
+- **Under `set -euo pipefail`, a `grep` with no matches kills the pipeline it sits in.** Wrap classification greps as `{ grep ... || true; }`. This exact bug failed six reaper runs before its message could print.
+- **Cleanup jobs race their producers.** A close-triggered reaper can run while the preview job it cleans up after is still uploading. Design the periodic sweep as the recovery path, and make raced orphans inert (no crons, no bindings) so the race costs nothing.
+- **`gh pr merge --auto` merges the head armed at that moment.** Commits pushed after arming orphan silently. Verify landed changes by content in `origin/main`, not by PR state.
+
+## Sources
+
+- `foundation-workers/docs/verification/memo-deploy-dag.md` and `preview-cron-guard.md` (the measured runs, the negative controls, the reaper race evidence)
+- `foundation-workers/apps/memo/scripts/build-and-deploy.sh` (the reference implementation of 1, 2, 5, 6, 7, 8, 9, 10)
+- [ParallelChange / expand-contract (Martin Fowler site)](https://martinfowler.com/bliki/ParallelChange.html)
+- [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) (untrusted input via env vars, least-privilege permissions)
+
+Verified: 2026-08-19.

--- a/docs/impl-playbook/exploratory-testing.md
+++ b/docs/impl-playbook/exploratory-testing.md
@@ -17,6 +17,10 @@ Unscripted testing without structure produces no record of what was actually cov
 
 After the scripted cases from `test-case-design.md` pass, not instead of them. Scripted cases check the shapes you already thought of; a short exploratory pass catches the shape you didn't. Reach for it on anything with real integration points, a UI/CLI flow, or a feature whose actual runtime behavior might drift from what the spec describes, exactly the gap the router intro's "floor, not ceiling" line points at, applied specifically to testing.
 
+## Probing live systems safely
+
+- **Mutation-safe auth probes**: exploit the route's check ORDER to test auth against production without side effects. Pick inputs that pass the gate under test but are guaranteed to fail a LATER gate (a real resource id plus a bogus actor, so authz returns 403 before any mutation runs). The probe proves the auth layer live while the doomed final check guarantees nothing changes. Judge the response BODY, not the status code alone: platform errors hide inside ordinary statuses (a dead Cloudflare Worker returns its 1042 error wrapped in an HTTP 404, indistinguishable by status from an app-level not-found).
+
 ## At personal scale
 
 Skip the formal session report and metrics tracking, that overhead is for an auditable QA team, not a solo maintainer. Keep the three ideas in lightweight form: state the one-line charter before you start poking, time-box it (15-30 minutes is plenty for a personal-scale tool, not 90), and if a session turns out to be mostly Setup time, that is itself a finding, the thing was not ready to explore.

--- a/docs/tiers.md
+++ b/docs/tiers.md
@@ -41,7 +41,7 @@ INTERPRETATION layer: "your data is free forever; our reading of it is the produ
 | Upstream absorb machinery + seed watch | absorb | shipped (+ID-403) |
 | Tool-selection ladders, BASIC set (browser use, memory, computer use, rendering, model routing: which tool when) | ladders (new) | queued ID-418 |
 | North-star alignment lens (proposals state the criterion they serve) | advisor | queued ID-397 |
-| Skill fleet: cross-runtime registry + `fleet sync` (one skill body -> every harness) + `fleet render` | fleet (new) | queued ID-431/432 |
+| Skill fleet: cross-runtime registry + `fleet sync` (one skill body -> every harness) + `fleet render` | fleet (new) | queued ID-431/432 · [docs/fleet/](fleet/) |
 
 ## Craft (perpetual license + update stream)
 
@@ -53,7 +53,7 @@ INTERPRETATION layer: "your data is free forever; our reading of it is the produ
 | Tool-selection ladders, MAINTAINED library (updated as the ecosystem moves; part of the stream) | ladders | queued ID-418 |
 | Private update channel + pack marketplace access | install | queued ID-410 |
 | Ambient module self-suggest | onboard | queued ID-405 |
-| Fleet skills ride the stream (maintained skills propagate to every harness in one pull) | fleet | queued ID-431 |
+| Fleet skills ride the stream (maintained skills propagate to every harness in one pull) | fleet | queued ID-431 · [docs/fleet/PRIVATE-STREAM.md](fleet/PRIVATE-STREAM.md) |
 
 ## Crew (per-seat, annual, flat)
 


### PR DESCRIPTION
Found untracked in the working copy and committed as-is. No content of mine beyond this description.

## Why it matters that they were untracked

`docs/tiers.md` already links to `docs/fleet/` and `docs/fleet/PRIVATE-STREAM.md` in two rows. Those files existed only on one machine, so both links were broken for anyone reading the repo from git. Same story for `docs/impl-playbook/ci-cd-pipeline.md`: the always-loaded playbook router lists it as a trigger reference and it did not exist in git.

## What lands

| Path | What |
|---|---|
| `docs/fleet/README.md` | front door for the cross-runtime skill fleet (ID-431/432) |
| `docs/fleet/SCHEMA.md` | registry shape |
| `docs/fleet/SYNC.md` | the one-body-to-every-harness sync engine |
| `docs/fleet/CONTRIBUTING.md` | authoring rules |
| `docs/fleet/PRIVATE-STREAM.md` | how Craft-tier skills ride the update channel |
| `docs/impl-playbook/ci-cd-pipeline.md` | the missing router reference |
| `docs/impl-playbook/exploratory-testing.md` | new section: probing live systems safely |
| `docs/tiers.md` | the two links above |

The exploratory-testing addition is worth reading on its own: order a probe so it passes the gate under test and is guaranteed to fail a later one, so auth can be verified against production with no mutation, and judge the response body rather than the status, since a dead Cloudflare Worker hides its 1042 inside an ordinary 404.

Scanned for credentials before staging, none present. Docs only, no behavior change.