### PR TITLE
test(emit-sweep): refresh stale command-count and exemption-table pins

### DIFF
--- a/docs/verification/emit-sweep-pins.md
+++ b/docs/verification/emit-sweep-pins.md
@@ -1,0 +1,42 @@
+# Proof of done: refresh stale command-emit-sweep pins (ID-475)
+
+## What changed
+
+`tests/test-command-emit-sweep.sh` had two stale manual tripwire pins: the
+command-count (32) and the exemption-table expected set (10, missing
+`feature-map`). The repo had drifted to 36 commands and an 11-entry table, so
+the test was RED on master. Updated both pins plus the AC2 header comment.
+Test-only change; no production/library code touched.
+
+## Recorded run
+
+```
+Command: bash tests/test-command-emit-sweep.sh
+Exit: 0
+Passed: 19 / 19
+```
+
+## Confirmation + negative control
+
+| Run | Command | Result |
+|---|---|---|
+| green | `bash tests/test-command-emit-sweep.sh` | 19/19, Exit 0 |
+| independent count | `ls commands/*.md \| wc -l` | 36 (matches the new pin) |
+| NEGATIVE CONTROL | revert the count pin to `32` | AC1 fails (expected 32, got 36); restore -> 19/19 green |
+
+Verdict: PASS (claim: the pins match the live repo and the tripwire still
+fires; metric: the test suite; threshold: 19/19 with the reverted pin flipping
+RED).
+
+## Rollback
+
+Test-only, no state. `git revert` the branch commits to restore the old pins
+(the test goes RED again against the current repo, which is the pre-fix state).
+No cleanup.
+
+## Reproduce
+
+```
+bash tests/test-command-emit-sweep.sh   # 19/19
+ls commands/*.md | wc -l                # 36, must equal the count pin
+```

--- a/tests/test-command-emit-sweep.sh
+++ b/tests/test-command-emit-sweep.sh
@@ -19,7 +19,7 @@
 # later when RUN_REPORT quietly under-counts it.
 #
 #   AC1  every command in commands/ (a) mentions gate-ledger, or (b) is in the exemption table
-#   AC2  the exemption table names exactly the 9 expected utility commands (no silent drift)
+#   AC2  the exemption table names exactly the 11 expected utility commands (no silent drift)
 #   AC3  each of the 9 newly-wired commands genuinely contains a gate-ledger record call
 #        (not just present-by-coincidence in the loose AC1 check)
 #   AC4  NEGATIVE CONTROL: a fixture command with NEITHER an emit NOR an exemption entry IS

--- a/tests/test-command-emit-sweep.sh
+++ b/tests/test-command-emit-sweep.sh
@@ -83,15 +83,16 @@ if [ "$ORPHAN_RC" -eq 0 ]; then RC=0; else RC=1; fi
 assert "every command in commands/ mentions gate-ledger OR is exempted (0 orphans)" $RC
 
 TOTAL_COMMANDS=$(find "$COMMANDS_DIR" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')
-assert_eq "commands/ has 32 command files (2026-07-04 count +1 pitch.md/SPEC-140 +1 onboard.md/SPEC-199 +1 test-write.md/SPEC-203; update this pin if it legitimately changes)" "$TOTAL_COMMANDS" "32"
+assert_eq "commands/ has 36 command files (was 32 on 2026-07-04, +4 since; every command still classifies as emit-or-exempt per AC1's sweep, so update this pin when it legitimately changes)" "$TOTAL_COMMANDS" "36"
 
 echo ""
-echo "=== AC2: the exemption table names exactly the 10 expected utility commands ==="
+echo "=== AC2: the exemption table names exactly the 11 expected utility commands ==="
 
 EXPECTED_EXEMPT="absorb
 adopt
 dispatch
 draft-agent
+feature-map
 kit-health
 mega
 next
@@ -101,7 +102,7 @@ visual-team"
 
 SORTED_EXPECTED="$(printf '%s\n' "$EXPECTED_EXEMPT" | sort)"
 SORTED_ACTUAL="$(printf '%s\n' "$EXEMPT" | sort)"
-assert_eq "exemption table = {absorb,adopt,dispatch,draft-agent,kit-health,mega,next,onboard,start,visual-team}, no more no less" "$SORTED_ACTUAL" "$SORTED_EXPECTED"
+assert_eq "exemption table = {absorb,adopt,dispatch,draft-agent,feature-map,kit-health,mega,next,onboard,start,visual-team}, no more no less" "$SORTED_ACTUAL" "$SORTED_EXPECTED"
 
 echo ""
 echo "=== AC3: each of the 9 newly-wired commands genuinely records its own phase ==="


### PR DESCRIPTION
The command-emit-sweep test was red on master: two manual tripwire pins had gone stale.

- `commands/` count pin: 32 -> 36
- exemption-table expected set: added `feature-map` (10 -> 11)

AC1's orphan sweep and AC4's negative control both stay green, confirming every command still classifies as emit-or-exempt. Only the pins were behind. Test now 19/19.

Clears ops-toolkit board ID-475.