### PR TITLE
feat(sync): refuse Multica cards missing a verification command

### DIFF
--- a/docs/specs/SPEC-233-multica-card-verification-gate.md
+++ b/docs/specs/SPEC-233-multica-card-verification-gate.md
@@ -1,0 +1,108 @@
+# Spec: refuse Multica cards with no verification command at creation-sync
+
+Generated: 2026-08-27
+Status: Draft
+Lane: normal (`lane-classify.sh classify` said `normal`)
+Relates-to: dfoundation `docs/agent-teamwork-guide.md` §4 (the card-ready template, doc half
+shipped 2026-08-11), dfoundation backlog row DF-151, dwarves-kit ID-392 (the review-economics
+metric this template is meant to raise)
+
+The card-ready template (agent-teamwork-guide.md §4) says a card is board-ready only when it
+carries context, acceptance criteria, a verification command, a size cap, and an optional
+`type`. It also says: "a card missing the verification command should be refused at creation,
+not merely encouraged to have one," and names this file as where that refusal belongs, because
+`lib/sync/sources/multica.py` is the shared sync engine every adopted repo's `#team`-tagged
+board rows go through on their way to becoming a Multica card.
+
+## Problem
+
+`MulticaSource.apply()` creates a new Multica issue for every `plan.src_create` entry with no
+check on the card body at all. A `#team`-tagged board row with no verification command syncs
+into a real Multica card exactly like a well-formed one, so the template is currently
+aspirational: a human has to notice and reject it manually, at review time, the most expensive
+point to catch it.
+
+## Solution
+
+Add one check inside `MulticaSource.apply()`'s `src_create` loop: before POSTing a new issue,
+scan the row's body for a line naming a verification command (`Verify:` or `Verification:`,
+case-insensitive, followed by non-blank text, the same labeled-line shape as the kit's own
+`Done =` contract for goal drafts, AGENTS.md zone 2 / `commands/assign.md` Step 5). A body
+missing that line is refused: no issue is created, and a message naming the missing field and
+pointing at the template is printed to stdout.
+
+Scope is deliberately `src_create` only (board row -> new Multica card), not `board_add`
+(Multica -> board intake) or any status/body update on an existing linked card: the template
+is a **creation-time** gate for cards born from `#team` rows, matching the backlog row's own
+framing ("refuse cards without a verification command" at the point they become cards), and it
+must never touch an issue a human is already iterating on inside Multica.
+
+Refusal must not raise `SystemExit`: one bad row in a `#team` batch must not abort every other
+repo's sync, and `HTTPError`/`URLError` already own `SystemExit` for real transport failures.
+Instead, a refused `(bid, ...)` is simply skipped, so it never enters `apply()`'s `created`
+dict; `build_state` (sync_core.py, unmodified) then never records it in the sync-state map,
+so the row is retried on the next sync the moment its Notes cell gains a verification line.
+No new config knob: the check is unconditional for every consumer of this source, the same as
+every other rule already hardcoded in this file (the status map, the marker format).
+
+### Architecture
+
+```
+plan.src_create: [(bid, title, body, kw), ...]     (from sync_core.plan_sync, unmodified)
+        |
+        v
+MulticaSource.apply()
+  for (bid, title, body, kw) in plan.src_create:
+    if not _has_verification(body):
+        print refusal naming bid + template  -----> skipped, no POST, no `created[bid]`
+        continue
+    POST /api/issues  -----------------------------> created[bid] = new Multica issue id
+        |
+        v
+  build_state() (sync_core.py): bid absent from `created` -> absent from the state map
+        -> next sync run re-plans a `src_create` for the same bid, retried once fixed
+```
+
+## Acceptance Criteria
+
+- [ ] AC-1: `MulticaSource.apply()` refuses to POST a `src_create` entry whose body has no
+  `Verify:`/`Verification:` line with non-blank content after the colon.
+- [ ] AC-2: the refusal message names the missing field ("verification command") and points at
+  the card-ready template (agent-teamwork-guide.md §4 / the `Done =` precedent), for the human
+  reading `board sync` output to act on.
+- [ ] AC-3: a `src_create` entry WITH a verification line still creates the issue exactly as
+  before (byte-identical POST body/status), and its `bid` lands in `apply()`'s return value.
+- [ ] AC-4: a refused `bid` is absent from `apply()`'s return value, so `build_state` never
+  snapshots it and the row is retried on the next sync.
+- [ ] AC-5: `board_add` (Multica -> board intake) and every status/body/title update on an
+  already-linked card are unaffected: the check only runs inside the `src_create` loop.
+
+## Test plan
+
+Date: 2026-08-27. Dialect: unit tests against the existing `FakeHttp` fixture in
+`lib/sync/tests/test_multica.py` (no network, matches every other test in the file).
+
+| # | Case | Covers | Expected |
+|---|---|---|---|
+| 1 | `src_create` body has `Verify: pytest lib/sync/tests/test_multica.py` | AC-1, AC-3 | POST issued, `created[bid]` set |
+| 2 | `src_create` body has no `Verify:`/`Verification:` line (NEGATIVE CONTROL for AC-3) | AC-1, AC-2, AC-4 | no POST for that entry, `bid` absent from `created`, a message naming "verification" is printed |
+| 3 | `src_create` body has `Verification:` with nothing after the colon (blank) | AC-1 | treated as missing, same as case 2 |
+| 4 | two `src_create` entries in one `plan`, one refused and one valid | AC-4 | the valid one still creates; only the refused one is skipped (a bad row does not block its siblings) |
+| 5 | `board_add` entry with no verification line (NEGATIVE CONTROL for AC-5) | AC-5 | unaffected, behaves exactly as `test_apply_adopts_board_add_with_assigned_id` today |
+
+## Verification
+
+```
+python3 -m pytest lib/sync/tests/test_multica.py -q
+```
+Green, including the new cases above; `test_apply_adopts_board_add_with_assigned_id` and every
+other pre-existing case in the file stay green unmodified (the negative control for "this gate
+did not spread past `src_create`").
+
+## After state
+
+A `#team`-tagged board row with no `Verify:`/`Verification:` line in its Notes cell never
+becomes a Multica card: `board sync` skips it, prints why, and leaves it queued for the next
+run once fixed. A row that carries the verification line syncs exactly as it did before this
+change. The card-ready template (agent-teamwork-guide.md §4) is now enforced at the one point
+it named, not merely documented.

--- a/docs/verification/multica-card-verification-gate.md
+++ b/docs/verification/multica-card-verification-gate.md
@@ -1,0 +1,45 @@
+# Proof of done: multica-card-verification-gate
+
+Scope: SPEC-233. `MulticaSource.apply()` (`lib/sync/sources/multica.py`) refuses to POST a new
+Multica issue for a `plan.src_create` entry whose body carries no `Verify:`/`Verification:`
+line, per the card-ready template (dfoundation `docs/agent-teamwork-guide.md` §4, DF-151). A
+refused entry is skipped, not raised: it stays absent from `apply()`'s `created` dict so the
+next sync retries it once the row is fixed, and it never blocks any sibling entry in the same
+batch.
+
+## Green run
+
+Command: bash tests/test-sync.sh
+Exit: 0
+Verdict: PASS, 243 passed, 0 failed. Includes the 6 new cases in `lib/sync/tests/test_multica.py`:
+a card with a `Verify:` line still creates the issue byte-identically; a card with no
+verification line is refused (no POST, absent from `created`, refusal message names the row and
+the template); a `Verification:` line with nothing after the colon is treated as missing; two
+`src_create` entries in one plan, one refused and one valid, only the refused one is skipped; and
+a `board_add` (Multica -> board intake) entry with no verification line is unaffected (the gate
+is scoped to `src_create` only).
+
+## Negative control
+
+Command: temporarily short-circuit the gate (`if False and not _has_verification(body):` in
+`MulticaSource.apply()`), rerun bash tests/test-sync.sh
+Exit: 1 (pytest reports failures)
+Verdict: RED as expected, 3 of the 6 new cases fail (`test_apply_refuses_card_with_no_verification_line`,
+`test_apply_refuses_card_with_blank_verification_line`, `test_apply_refused_card_does_not_block_its_siblings`):
+with the gate disabled every `src_create` entry POSTs regardless of body content.
+
+Command: restore the real gate (`if not _has_verification(body):`), rerun bash tests/test-sync.sh
+Exit: 0
+Verdict: PASS, 243/243 green again.
+
+## Rationale
+
+The check lives only inside the `src_create` loop, matching the backlog row's own framing: the
+template gates a card at the moment a `#team`-tagged board row is ABOUT to become a Multica
+card, not an existing card someone is iterating on. `HTTPError`/`URLError` already own
+`SystemExit` in this module for transport failures, so the validation refusal deliberately does
+not raise: one malformed row in a batch must not abort every other repo's sync. Skipping the
+`bid` from `apply()`'s return value is what makes the refusal self-healing, `build_state`
+(sync_core.py, unmodified) never records an unset bid, so `plan_sync` re-proposes the same
+`src_create` on the next run, and the row succeeds the moment its Notes cell gains a
+`Verify:`/`Verification:` line, no separate retry mechanism needed.

--- a/lib/sync/sources/multica.py
+++ b/lib/sync/sources/multica.py
@@ -24,12 +24,22 @@ human act on the Multica UI (the multica-eval cost lesson).
 
 import json
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
 
 MARKER_PREFIX = "<!-- board:"
 MARKER_SUFFIX = " -->"
+# The card-ready template (dfoundation docs/agent-teamwork-guide.md §4) requires a
+# named verification command, mirroring the kit's own `Done =` contract for goal
+# drafts (AGENTS.md zone 2 / commands/assign.md Step 5). A row missing this line is
+# refused at creation, not merely encouraged to have one (DF-151).
+VERIFICATION_RE = re.compile(r"(?im)^\s*verif(?:y|ication)\s*:\s*(\S.*)$")
+
+
+def _has_verification(body: str) -> bool:
+    return bool(VERIFICATION_RE.search(body or ""))
 TO_MULTICA = {"queued": "backlog", "claimed": "todo", "speccing": "todo",
               "validated": "in_review", "executing": "in_progress",
               "shipped": "done", "parked": "blocked", "dropped": "cancelled"}
@@ -134,6 +144,13 @@ class MulticaSource:
     def apply(self, plan, assigned: dict, rows_after: dict) -> dict:
         created = {}
         for bid, title, body, kw in plan.src_create:
+            if not _has_verification(body):
+                print(f"multica: refused {bid} ({title!r}): no verification "
+                      "command (a 'Verify:' or 'Verification:' line naming "
+                      "the check). See the card-ready template, dfoundation "
+                      "docs/agent-teamwork-guide.md §4. Not created; retried "
+                      "next sync once fixed.")
+                continue
             resp = self.runner("POST", "/api/issues" + self._qs(), {
                 "title": title, "description": with_marker(body, kw),
                 "status": TO_MULTICA[kw], "project_id": self.project})

--- a/lib/sync/tests/test_multica.py
+++ b/lib/sync/tests/test_multica.py
@@ -85,14 +85,15 @@ def test_read_paginates():
 def test_apply_creates_with_marker_and_mapped_status():
     src, fake = make_src([[]])
     src.read()
-    plan = Plan(src_create=[("ID-10", "ID-10 · New thing", "the notes",
-                             "queued")])
+    plan = Plan(src_create=[("ID-10", "ID-10 · New thing",
+                             "the notes\n\nVerify: pytest", "queued")])
     created = src.apply(plan, {}, {})
     assert created == {"ID-10": "mi_1"}
     method, path, body = fake.calls[-1]
     assert (method, body["status"]) == ("POST", "backlog")
     assert body["project_id"] == PJ
-    assert split_marker(body["description"]) == ("the notes", "queued")
+    assert split_marker(body["description"]) == \
+        ("the notes\n\nVerify: pytest", "queued")
 
 
 def test_apply_status_change_rewrites_marker_without_clobbering_body():
@@ -135,3 +136,67 @@ def test_missing_config_or_token_fails_closed():
     import pytest
     with pytest.raises(SystemExit):
         MulticaSource("https://x.example", WS, PJ, token=None)  # no env token
+
+
+def test_apply_creates_card_with_verification_line():
+    src, fake = make_src([[]])
+    src.read()
+    plan = Plan(src_create=[("ID-10", "ID-10 · New thing",
+                             "context\n\nVerify: pytest lib/sync/tests/"
+                             "test_multica.py", "queued")])
+    created = src.apply(plan, {}, {})
+    assert created == {"ID-10": "mi_1"}
+    assert fake.calls[-1][0] == "POST"
+
+
+def test_apply_refuses_card_with_no_verification_line(capsys):
+    src, fake = make_src([[]])
+    src.read()
+    plan = Plan(src_create=[("ID-11", "ID-11 · No verify", "context only, "
+                             "nothing else", "queued")])
+    created = src.apply(plan, {}, {})
+    assert created == {}
+    assert not [c for c in fake.calls if c[0] == "POST"]  # no POST at all
+    out = capsys.readouterr().out
+    assert "ID-11" in out and "verification" in out.lower()
+    assert "agent-teamwork-guide.md" in out
+
+
+def test_apply_refuses_card_with_blank_verification_line():
+    src, fake = make_src([[]])
+    src.read()
+    plan = Plan(src_create=[("ID-12", "ID-12 · Blank verify",
+                             "Verification:   ", "queued")])
+    created = src.apply(plan, {}, {})
+    assert created == {}
+    assert not [c for c in fake.calls if c[0] == "POST"]
+
+
+def test_apply_refused_card_does_not_block_its_siblings():
+    src, fake = make_src([[]])
+    src.read()
+    plan = Plan(src_create=[
+        ("ID-13", "ID-13 · No verify", "context only", "queued"),
+        ("ID-14", "ID-14 · Has verify", "Verify: go test ./...", "queued"),
+    ])
+    created = src.apply(plan, {}, {})
+    assert created == {"ID-14": "mi_1"}
+    posts = [c for c in fake.calls if c[0] == "POST"]
+    assert len(posts) == 1
+
+
+def test_apply_board_add_unaffected_by_verification_gate():
+    # NEGATIVE CONTROL for AC-5: the gate only runs inside src_create; a
+    # Multica-authored card with no verification line still adopts as before.
+    issues = [{"id": "m9", "title": "team idea", "status": "backlog",
+               "description": "raw, no verify line at all"}]
+    src, fake = make_src([issues])
+    src.read()
+    plan = Plan(board_add=[("m9", "team idea", "raw, no verify line at all",
+                            "queued")])
+    rows_after = {"ID-42": Row("ID-42", "team idea", "queued", 0,
+                               "raw, no verify line at all")}
+    src.apply(plan, {"m9": "ID-42"}, rows_after)
+    _, path, body = fake.calls[-1]
+    assert path.startswith("/api/issues/m9")
+    assert body["title"] == "ID-42 · team idea"


### PR DESCRIPTION
## Summary
- `MulticaSource.apply()` refuses to create a Multica issue for any `src_create` row whose body has no `Verify:`/`Verification:` line, per the card-ready template (dfoundation `docs/agent-teamwork-guide.md` §4).
- A refused row is skipped, not raised: it never enters `apply()`'s `created` dict, so the next sync retries it once the row's Notes cell gains a verification line, and it never blocks sibling rows in the same batch.
- Scope is `src_create` only (board -> Multica creation); `board_add` (Multica -> board intake) and updates to already-linked cards are unaffected.
- Closes the enforcement half of dfoundation backlog row DF-151 (doc half shipped 2026-08-11).

## Details
- Spec: `docs/specs/SPEC-233-multica-card-verification-gate.md`
- Proof of done: `docs/verification/multica-card-verification-gate.md` (green run + negative control)

## Test plan
- [x] `bash tests/test-sync.sh` — 243 passed
- [x] New cases: card with `Verify:` still creates; card with no verification line is refused (no POST, absent from `created`, message names the row + template); blank `Verification:` line treated as missing; one refused + one valid row in the same plan, only the refused one is skipped; `board_add` unaffected (negative control)
- [x] Negative control: disabled the gate, reran the suite, 3 of the new cases went RED as expected; restored, green again