### PR TITLE
fix(board): translate the shim's --backlog-file for promote

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to dwarves-kit are documented here.
 - agents: new devops-triage subagent, on-demand production error-alert triage (evidence-first, read-only, bounded verdict); ambient twin lives in ops-toolkit tools/alert-triage/
 
 ### Fixed
+- `board promote` now translates the consumer shim's `--backlog-file` instead of forwarding it
+  verbatim (#443). Numeric selection (`promote <n>`, `promote reject <n>`) always failed with a
+  usage error, leaving `promote all` as the only working path and reducing the documented human
+  review gate to all-or-nothing. The flag was also discarded outright, so promote resolved its
+  write target from cwd and could land rows on a DIFFERENT repo's board than the shim addressed.
 - **Queue launcher pre-flights the `/goal` 4000-char cap.** Interactive `/goal` refuses
   anything over 4000 chars, but the launcher never checked before typing, so an over-budget
   pointer opened a real window, typed a silently-rejected goal, and sat idle forever with no

--- a/docs/verification/board-promote-backlog-file.md
+++ b/docs/verification/board-promote-backlog-file.md
@@ -1,0 +1,86 @@
+# board promote: --backlog-file translation (issue #443)
+
+Date: 2026-08-27
+Class: behavioral (changes what `board promote` does, and where it writes)
+
+## Restated claim
+
+`board promote` is correct when, invoked through the shim `board init` scaffolds:
+(a) **numeric selection works** — `promote <n>` promotes exactly candidate n, measured by the
+promoted row landing on the board while the unselected candidate stays staged; and
+(b) **the addressed board is the one written** — measured by running repoA's shim from inside
+repoB and checking repoA's BACKLOG.md gains the row while repoB's gains nothing.
+
+Both were false before this change.
+
+## Defect
+
+The shim always appends `--backlog-file <path>`. `lib/board/board.sh` forwarded argv to
+`lib/board/bin/add-backlog` verbatim, and that engine takes no flags at all — it resolves its
+targets from `BACKLOG_STAGE_BACKLOG` / `BACKLOG_STAGE_STAGING` with a cwd-derived fallback. Two
+consequences compounded:
+
+1. The flag reached the selection parse, `int("--backlog-file")` raised, and every
+   `promote <n>` / `promote reject <n>` failed with a usage message about candidate numbers.
+   `list` returns before that parse and `all` short-circuits past it, so those two kept working
+   — which is the worst possible failure shape here: the only surviving promote path is the one
+   that promotes *everything*, reducing a documented human review gate to all-or-nothing.
+2. The operator's explicit target was discarded, so promote resolved its write target from cwd.
+   In the cross-repo cockpit this kit exists to provide, that means promoting into the wrong
+   repo's board with no warning.
+
+`cmd_sync` already documents and handles exactly this shim behaviour
+(`lib/board/board.sh`: "Consumer shims append `--backlog-file`; translate it to the engine's
+`--backlog`"). `promote` never got the same treatment.
+
+## Run
+
+```
+Command: bash tests/test-board.sh
+Exit: 0
+Output (excerpt):
+
+  === AC7: promote translates --backlog-file (issue #443) ===
+    PASS AC7a: numeric selection works through the shim's --backlog-file (was: usage error)
+    PASS AC7b: the addressed repo is written, not the cwd repo
+    PASS AC7c: promoted the SELECTED candidate (A-first), not all of them
+    PASS AC7d: unselected candidate stays staged -- the review gate is not all-or-nothing
+    PASS NC-f: unrecognised flag is named explicitly, not reported as a bad candidate number
+
+  TOTAL: 42   PASS: 41   FAIL: 0   SKIP: 1
+```
+
+The single SKIP is the pre-existing NC-e ops-toolkit render comparison, absent on this machine.
+
+## Negative control
+
+Fix stashed, same suite re-run against unmodified sources:
+
+```
+Command: git stash push lib/board/board.sh lib/board/bin/add-backlog && bash tests/test-board.sh
+Exit: 1
+Output (excerpt):
+    FAIL AC7a: numeric selection works through the shim's --backlog-file (was: usage error)
+    PASS AC7b: the addressed repo is written, not the cwd repo
+    FAIL AC7c: promoted the SELECTED candidate (A-first), not all of them
+    PASS AC7d: unselected candidate stays staged -- the review gate is not all-or-nothing
+    FAIL NC-f: unrecognised flag is named explicitly, not reported as a bad candidate number
+
+  TOTAL: 42   PASS: 38   FAIL: 3   SKIP: 1
+```
+Verdict: RED-as-expected. Sources restored and byte-compared afterwards.
+
+**Honest limit on two of the five.** AC7b and AC7d pass on the *unfixed* code too, because when
+`promote <n>` dies at the usage error nothing is written anywhere — so "repoB gained no rows" and
+"A-second is still staged" are vacuously true. They do not discriminate this particular defect.
+They are kept because they DO discriminate a plausible wrong fix: one that makes numeric
+selection work but still resolves the target from cwd, or that promotes the whole staging file.
+AC7a, AC7c and NC-f are the three that actually go red.
+
+## Rollback
+
+Revert the commit. The change is confined to a dispatch branch in `lib/board/board.sh`, a new
+`cmd_promote`, and a flag guard in `lib/board/bin/add-backlog`; no state, no migration, no
+on-disk format change. Consumer shims are untouched and need no regeneration — the fix is
+deliberately on the kit side so existing scaffolded shims are fixed without the consumer
+doing anything.

--- a/lib/board/bin/add-backlog
+++ b/lib/board/bin/add-backlog
@@ -132,6 +132,22 @@ def main(argv):
         print(f"\npromote with: board promote <n>...  |  board promote all  |  board promote reject <n>")
         return 0
 
+    # This engine takes no flags -- it resolves its targets from
+    # BACKLOG_STAGE_BACKLOG / BACKLOG_STAGE_STAGING. Say so plainly instead of
+    # feeding an unrecognised flag to int() below and reporting it as a usage
+    # error about the SELECTION, which is what made #443 hard to read: consumer
+    # shims append --backlog-file, and every `promote <n>` failed with a message
+    # about candidate numbers. board.sh translates the flag before we are
+    # reached; anything still flag-shaped here is genuinely unhandled.
+    flags = [a for a in argv if a.startswith("-")]
+    if flags:
+        print(f"add-backlog: unrecognised option(s): {' '.join(flags)}", file=sys.stderr)
+        print("  this engine takes no flags; set BACKLOG_STAGE_BACKLOG / "
+              "BACKLOG_STAGE_STAGING instead.", file=sys.stderr)
+        print("  (invoked via `board promote`? board.sh translates "
+              "--backlog-file for you -- reaching here means it did not.)", file=sys.stderr)
+        return 2
+
     reject = argv[0] == "reject"
     sel = argv[1:] if reject else argv
     if (not reject) and argv[0] == "all":

--- a/lib/board/board.sh
+++ b/lib/board/board.sh
@@ -944,6 +944,34 @@ _legacy_bridge_note() {
   echo "      folded into the sync module; port tracked as kit ID-290." >&2
 }
 
+# board promote [list | <n>... | all | reject <n>...] [--backlog-file <path>]
+# -- the human gate. Consumer shims scaffolded by `cmd_init` ALWAYS append
+# `--backlog-file`, and `bin/add-backlog` understands no flags at all: it reads
+# BACKLOG_STAGE_BACKLOG / BACKLOG_STAGE_STAGING with a cwd-derived fallback.
+# Forwarding argv verbatim therefore broke twice over -- the flag reached
+# add-backlog's `int(x)` selection parse (so `promote <n>` and `promote reject
+# <n>` always failed usage, leaving `all` as the only working path and reducing
+# the review gate to all-or-nothing), and the operator's explicit target was
+# silently dropped, so promote resolved its write target from cwd and could land
+# rows in a DIFFERENT repo's board than the shim addressed. Translate here, the
+# same way cmd_sync already does for its engine. Fixes #443.
+cmd_promote() {
+  local backlog="" args=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --backlog-file) backlog="${2:-}"; shift 2 ;;
+      *) args+=("$1"); shift ;;
+    esac
+  done
+  if [ -n "$backlog" ]; then
+    export BACKLOG_STAGE_BACKLOG="$backlog"
+    # staging is the board's sibling by construction (cmd_init scaffolds both
+    # into _meta/), so derive rather than adding a second flag to every shim.
+    export BACKLOG_STAGE_STAGING="${BACKLOG_STAGE_STAGING:-$(dirname "$backlog")/backlog-staging.md}"
+  fi
+  exec "$BOARD_DIR/bin/add-backlog" ${args+"${args[@]}"}
+}
+
 usage() { sed -n '2,166p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 main() {
@@ -957,7 +985,7 @@ main() {
     sync) shift; cmd_sync "$@" ;;
     init) shift; cmd_init "$@" ;;
     capture) shift; cmd_capture "$@" ;;
-    promote) shift; exec "$BOARD_DIR/bin/add-backlog" "$@" ;;
+    promote) shift; cmd_promote "$@" ;;
     -h|--help|help) usage ;;
     *) cmd_board_single "$@" ;;
   esac

--- a/tests/test-board.sh
+++ b/tests/test-board.sh
@@ -258,6 +258,59 @@ else
 fi
 
 echo ""
+echo "=== AC7: promote translates --backlog-file (issue #443) ==="
+# Consumer shims scaffolded by `board init` ALWAYS append --backlog-file, and
+# bin/add-backlog takes no flags. Forwarding argv verbatim broke twice: the flag
+# reached add-backlog's int() selection parse (so `promote <n>` always failed
+# usage, leaving `all` as the only working path), and the operator's explicit
+# target was dropped, so promote wrote to a cwd-derived board -- possibly a
+# DIFFERENT repo's than the shim addressed.
+PROMO_A="$TMPDIR_T/promoA"; PROMO_B="$TMPDIR_T/promoB"
+for r in "$PROMO_A" "$PROMO_B"; do
+  mkdir -p "$r/_meta"
+  printf '# BACKLOG\n\n| ID | Item | Notes & source | Status |\n|---|---|---|---|\n' > "$r/_meta/BACKLOG.md"
+done
+cat > "$PROMO_A/_meta/backlog-staging.md" <<'STAGE'
+# staging
+
+## [staged] A-first
+- Intent: selected by number
+- Tags: #u-lo #f-lo
+
+## [staged] A-second
+- Intent: must stay staged
+- Tags: #u-lo #f-lo
+STAGE
+cat > "$PROMO_B/_meta/backlog-staging.md" <<'STAGE'
+# staging
+
+## [staged] B-own
+- Intent: must never be touched by repoA's shim
+- Tags: #u-lo #f-lo
+STAGE
+
+# Run from INSIDE promoB while addressing promoA's board -- the cross-repo case.
+( cd "$PROMO_B" && bash "$BOARD" promote 1 --backlog-file "$PROMO_A/_meta/BACKLOG.md" ) >/dev/null 2>&1
+A_ROWS="$(grep -c '^| ID-' "$PROMO_A/_meta/BACKLOG.md" || true)"
+B_ROWS="$(grep -c '^| ID-' "$PROMO_B/_meta/BACKLOG.md" || true)"
+
+assert "AC7a: numeric selection works through the shim's --backlog-file (was: usage error)" \
+  "$([ "$A_ROWS" -eq 1 ] && echo 0 || echo 1)"
+assert "AC7b: the addressed repo is written, not the cwd repo" \
+  "$([ "$B_ROWS" -eq 0 ] && echo 0 || echo 1)"
+assert "AC7c: promoted the SELECTED candidate (A-first), not all of them" \
+  "$(grep -q 'A-first' "$PROMO_A/_meta/BACKLOG.md" && echo 0 || echo 1)"
+assert "AC7d: unselected candidate stays staged -- the review gate is not all-or-nothing" \
+  "$(grep -q '^## \[staged\] A-second' "$PROMO_A/_meta/backlog-staging.md" && echo 0 || echo 1)"
+
+# NC-f: the engine no longer misreports an unknown flag as a selection error.
+NCF_OUT="$(BACKLOG_STAGE_BACKLOG="$PROMO_A/_meta/BACKLOG.md" \
+  BACKLOG_STAGE_STAGING="$PROMO_A/_meta/backlog-staging.md" \
+  python3 "$KIT_DIR/lib/board/bin/add-backlog" 1 --bogus 2>&1 || true)"
+assert "NC-f: unrecognised flag is named explicitly, not reported as a bad candidate number" \
+  "$(echo "$NCF_OUT" | grep -q 'unrecognised option' && echo 0 || echo 1)"
+
+echo ""
 echo "=== Coverage delta ==="
 BEFORE_COUNT=0   # no lib/board/board.sh, no lib/board/parse-board.sh, no tests/test-board.sh before SPEC-146
 AFTER_COUNT="$TOTAL"


### PR DESCRIPTION
Fixes #443.

## What was broken

Consumer shims scaffolded by `board init` always append `--backlog-file`, and `bin/add-backlog` understands no flags at all — it resolves its targets from `BACKLOG_STAGE_BACKLOG` / `BACKLOG_STAGE_STAGING` with a cwd-derived fallback. `promote` forwarded argv verbatim, and that broke twice over.

**1. Numeric selection always failed.** The flag reached the engine's `int(x)` selection parse, so `int("--backlog-file")` raised and every `promote <n>` / `promote reject <n>` exited 2 with a usage message about *candidate numbers* — pointing the operator at the wrong thing entirely.

`list` returns before that parse and `all` short-circuits past it, so exactly those two kept working. That is the worst shape this failure could take: the only surviving path is the one that promotes **everything**, and `promote` is documented as *"the human gate"*. Someone wanting 2 of 5 candidates had no working way to say so, and the obvious workaround promotes the three they meant to leave staged.

**2. The addressed board was ignored.** The operator's explicit `--backlog-file` was discarded, so promote resolved its write target from cwd:

```
$ cd repoB && bash /abs/path/repoA/_meta/board promote all
promoted ID-001: repoB own candidate

$ grep -c '^| ID-' repoA/_meta/BACKLOG.md    # unchanged
$ grep -c '^| ID-' repoB/_meta/BACKLOG.md    # repoB's candidate landed here
```

repoA's shim, repoA's flag, repoB's board. In the cross-repo cockpit this kit exists to provide (`boards.txt`, `board all`, `board mirror`), that is a silent write to the wrong repo.

## The fix

`cmd_sync` already documents and handles this exact shim behaviour — *"Consumer shims append `--backlog-file`; translate it to the engine's `--backlog`"*. `promote` now gets the same treatment: a `cmd_promote` that parses the flag out, exports `BACKLOG_STAGE_BACKLOG`, derives `BACKLOG_STAGE_STAGING` as its sibling (both are scaffolded into `_meta/` by `cmd_init`, so deriving beats adding a second flag to every shim), and execs the engine with the remaining args.

Defence in depth: `add-backlog` now names an unrecognised flag explicitly instead of feeding it to `int()` and reporting a selection error. That misdirection is most of why #443 was hard to read.

**Kit-side on purpose.** Shims already scaffolded in consumer repos are fixed without those repos regenerating anything.

## Verification

`bash tests/test-board.sh` → **TOTAL 42, PASS 41, FAIL 0, SKIP 1**. The skip is the pre-existing NC-e ops-toolkit render comparison, absent on this machine.

Five new assertions, run from inside repoB while addressing repoA's board:

```
AC7a  numeric selection works through the shim's --backlog-file (was: usage error)
AC7b  the addressed repo is written, not the cwd repo
AC7c  promoted the SELECTED candidate, not all of them
AC7d  unselected candidate stays staged -- the review gate is not all-or-nothing
NC-f  unrecognised flag is named explicitly, not reported as a bad candidate number
```

**Negative control:** fix stashed, same suite re-run → **FAIL 3**, sources restored and byte-compared.

**Honest limit, worth a reviewer's attention:** AC7b and AC7d pass on the *unfixed* code too. When `promote <n>` dies at the usage error nothing is written anywhere, so "repoB gained no rows" and "A-second is still staged" are vacuously true. They do not discriminate this defect. They are kept because they do discriminate a plausible *wrong* fix — one that makes selection work but still resolves the target from cwd, or that promotes the whole staging file. **AC7a, AC7c and NC-f are the three that actually go red.**

Proof-of-done with both runs: `docs/verification/board-promote-backlog-file.md`.

## Rollback

Revert the commit. Confined to a dispatch branch, a new `cmd_promote`, and a flag guard — no state, no migration, no on-disk format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnGEYYtrsV3iTY1VXc7tvW