### PR TITLE
Gauntlet: scrub the room before persist, harden watch + campaign paths

### DIFF
--- a/docs/guides/gauntlet-tutorial.md
+++ b/docs/guides/gauntlet-tutorial.md
@@ -223,8 +223,12 @@ Three rules this recipe cost real rounds to learn:
    hangs until the timeout.
 3. The room has exactly one credential slot, `ANTHROPIC_API_KEY`, regardless of which
    provider it actually authenticates; put the NeuralWatt (or other endpoint) key
-   there. The config file that holds it, `~/.omp/agent/models.yml`, exists only
-   inside the disposable container and is gone when the room tears down.
+   there. The config file that holds it lives under the container-only HOME and dies
+   with the room, BUT anything the probe or its tools ECHO into `/work` (transcripts,
+   stderr, install logs) is persisted, on failing rounds too. run.sh redacts every
+   literal occurrence of the key before persisting and refuses the persist if
+   redaction cannot clean it; treat that as a backstop, not a license, the record
+   still gets an eyeball before commit (rule 8).
 
 `bg-run` (ops-toolkit) is a convenient launcher for the round itself (tmux session +
 a status dir); it is an operator convenience, not a kit dependency.

--- a/docs/verification/gauntlet-room-scrub.md
+++ b/docs/verification/gauntlet-room-scrub.md
@@ -1,0 +1,21 @@
+# Proof of done: gauntlet room scrub + watch/campaign hardening
+
+Date: 2026-08-31. Branch: fix/gauntlet-room-scrub. Source: retroactive security lens on #456 (1 HIGH, 2 MEDIUM).
+
+## Recorded run
+
+- Command: `bash tests/gauntlet/cleanroom/persist-check.sh`
+- Exit: 0
+- Output: `PASS leg A (exit=7, CARD.md persisted)` / `PASS leg B` / `PASS leg C (key scrubbed to <REDACTED-KEY>)` / `PERSIST-CHECK: GREEN`
+- Command: `bash tests/gauntlet/tier1.sh`
+- Exit: 0
+- Output: `TIER1: GREEN` (lint glob covers all four touched scripts)
+- Verdict: PASS
+
+## Negative control
+
+Leg C IS the measured red arm: its probe (`echo "$ANTHROPIC_API_KEY" > /work/leak.txt`) run against the pre-fix runner persists the literal canary into the record tree (the HIGH's exact exploitation path, public repo); post-fix the persisted file carries `<REDACTED-KEY>` and a repo-wide grep for the canary is empty. Additional checks in the same pass: committed run records grep-verified clean for the live key (twice, tonight); the campaign containment `case` refuses a `campaign-current` symlink resolving outside the gauntlet tree; every watch.sh render path now routes through the control-byte `sanitize` filter.
+
+## Rollback
+
+Single squash commit revert; no state. The scrub is additive on the persist path; reverting restores the eyeball-only scrub of the run-record contract.

--- a/tests/gauntlet/cleanroom/persist-check.sh
+++ b/tests/gauntlet/cleanroom/persist-check.sh
@@ -50,6 +50,29 @@ echo "== persist-check: RUN_OUT persists on every docker exit code, rc propagate
 run_leg "leg A (PROBE_CMD='exit 7')" "exit 7" 7
 run_leg "leg B (PROBE_CMD='exit 0')" "exit 0" 0
 
+# Leg C: the automated key scrub. A probe that echoes the room key into /work
+# must persist as <REDACTED-KEY>, never the literal value.
+leg_c() {
+  local stage_dir out_dir log rc ok=1
+  stage_dir="$(mktemp -d "${HOME}/.cache/gauntlet-persist-check/stage.XXXXXX")"
+  out_dir="$(mktemp -d "${HOME}/.cache/gauntlet-persist-check/out.XXXXXX")"
+  log="$(mktemp "${HOME}/.cache/gauntlet-persist-check/log.XXXXXX")"
+  rc=0
+  ANTHROPIC_API_KEY="dummy-scrub-canary-0451" \
+    GAUNTLET_STAGE_DIR="${stage_dir}" RUN_OUT="${out_dir}/room" \
+    PROBE_CMD='echo "$ANTHROPIC_API_KEY" > /work/leak.txt; exit 0' \
+    bash tests/gauntlet/cleanroom/run.sh user > "${log}" 2>&1 || rc=$?
+  [ "${rc}" -eq 0 ] || { echo "  leg C: exit ${rc}, expected 0 (see ${log})"; ok=0; }
+  if grep -rqF "dummy-scrub-canary-0451" "${out_dir}" 2>/dev/null; then
+    echo "  leg C: literal key survived into the persisted room"; ok=0
+  fi
+  grep -qF "<REDACTED-KEY>" "${out_dir}/room/leak.txt" 2>/dev/null \
+    || { echo "  leg C: redaction marker missing from leak.txt"; ok=0; }
+  if [ "${ok}" -eq 1 ]; then echo "PASS  leg C (key scrubbed to <REDACTED-KEY>)"; rm -f "${log}"; else echo "FAIL  leg C (log kept at ${log})"; fail=1; fi
+  rm -rf "${stage_dir}" "${out_dir}"
+}
+leg_c
+
 echo
 if [ "${fail}" -eq 0 ]; then echo "PERSIST-CHECK: GREEN"; else echo "PERSIST-CHECK: RED"; fi
 exit "${fail}"

--- a/tests/gauntlet/cleanroom/run.sh
+++ b/tests/gauntlet/cleanroom/run.sh
@@ -230,8 +230,27 @@ PROBE_EOF
   # failure (disk full, bad path) is reported but never overrides the probe's
   # own exit code, the round's outcome is the probe's outcome, not the cp's.
   if [ -n "${RUN_OUT:-}" ]; then
+    # Automated scrub (rule 8; security review of #456): the room env carried the
+    # probe key, and probe/tool output is untrusted text, so redact every literal
+    # occurrence BEFORE anything leaves the stage. Bash ${var//pat/rep} with a
+    # quoted pattern is a literal replace, immune to key metacharacters.
+    if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+      grep -rlIF "${ANTHROPIC_API_KEY}" "${STAGE}/work" 2>/dev/null | while IFS= read -r f; do
+        _c="$(cat "$f")"
+        printf '%s\n' "${_c//"${ANTHROPIC_API_KEY}"/<REDACTED-KEY>}" > "$f"
+      done
+      if grep -rqIF "${ANTHROPIC_API_KEY}" "${STAGE}/work" 2>/dev/null; then
+        echo "SCRUB FAILED: key still present after redaction; refusing to persist the room" >&2
+        mkdir -p "${RUN_OUT}"
+        echo "Room persist REFUSED: automated key redaction could not clean the contents; the stage was discarded with the room." > "${RUN_OUT}/SCRUB-REFUSED.md"
+        exit "${rc}"
+      fi
+    fi
     mkdir -p "${RUN_OUT}"
     if cp -R "${STAGE}/work/." "${RUN_OUT}/"; then
+      # A probe-created symlink persisted into the repo could point at a host
+      # path; records carry copies, never links.
+      find "${RUN_OUT}" -type l -delete 2>/dev/null || true
       echo "room contents persisted to ${RUN_OUT}"
     else
       echo "persist failed: cp -R ${STAGE}/work/. -> ${RUN_OUT}/" >&2

--- a/tests/gauntlet/cleanroom/watch.sh
+++ b/tests/gauntlet/cleanroom/watch.sh
@@ -35,9 +35,15 @@ else
   TAIL_ARGS=(-n 200 -f -- "${TRANSCRIPT}")
 fi
 
+# Every render path routes through this: transcript text is probe-controlled,
+# so strip terminal control bytes (ANSI/OSC escapes) before it reaches the
+# operator's terminal. Newline and tab survive.
+sanitize() { LC_ALL=C tr -d '\000-\010\013\014\016-\037\177'; }
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "watch.sh: jq not found, plain tail" >&2
-  exec tail "${TAIL_ARGS[@]}"
+  tail "${TAIL_ARGS[@]}" | sanitize
+  exit 0
 fi
 
 FIRST_LINE="$(head -n 1 "${TRANSCRIPT}")"
@@ -55,13 +61,13 @@ if printf '%s' "${FIRST_LINE}" | grep -qF '"type":"session"' \
     elif .type == "tool_execution_start" then "-> " + .toolName
     elif .type == "tool_execution_end" and (.isError // false) then "<- ERROR " + .toolName
     else empty end
-  '
+  ' | sanitize
 elif printf '%s' "${FIRST_LINE}" | grep -qF '"subtype":"init"' \
   || printf '%s' "${FIRST_LINE}" | grep -qF '"type":"assistant"'; then
   # Real claude --output-format stream-json sessions open with
   # {"type":"system","subtype":"init",...}; assistant-first covers partial logs.
-  tail "${TAIL_ARGS[@]}" | jq -R -r --unbuffered -f "${PANE_TAIL_JQ}"
+  tail "${TAIL_ARGS[@]}" | jq -R -r --unbuffered -f "${PANE_TAIL_JQ}" | sanitize
 else
   echo "watch.sh: unrecognized transcript format, plain tail" >&2
-  tail "${TAIL_ARGS[@]}"
+  tail "${TAIL_ARGS[@]}" | sanitize
 fi

--- a/tests/gauntlet/deploy/gauntlet-campaign
+++ b/tests/gauntlet/deploy/gauntlet-campaign
@@ -63,6 +63,12 @@ next_row_in() {
 
 PASS_DIR="$(resolve_pass_dir)"
 mkdir -p "${PASS_DIR}"
+# Containment (security review of #456): a tampered campaign-current symlink must
+# not steer record writes outside the gauntlet tree.
+case "$(cd "${PASS_DIR}" 2>/dev/null && pwd -P)" in
+  "$(cd "${GAUNTLET_DIR}" && pwd -P)"/*) ;;
+  *) echo "campaign-current resolves outside ${GAUNTLET_DIR}; refusing" >&2; exit 1;;
+esac
 next_row="$(next_row_in "${PASS_DIR}")"
 
 if [ -z "${next_row}" ]; then


### PR DESCRIPTION
Retroactive security lens (Opus) on #456 found what the earlier panel, review, and verifier all missed, because it looked from a different threat model: **persisting failed rounds also persists probe-controlled text from a room whose env holds the live provider key, into a PUBLIC repo**, with only an operator eyeball between (HIGH). Committed records grep-verified clean twice tonight, so nothing leaked, but the class was live.

Fixes, per the lens's own remediations: run.sh literal-redacts every key occurrence across the staged room before any copy and **refuses the persist** when redaction cannot clean it (persist-check leg C proves it live with a canary: pre-fix the canary persists verbatim, post-fix only `<REDACTED-KEY>`); persisted records drop probe-created symlinks; gauntlet-campaign refuses a `campaign-current` resolving outside the gauntlet tree; every watch.sh render path routes through a control-byte sanitize (ANSI/OSC injection); tutorial rule 3 reworded to name the persisted-echo risk.

Proof: docs/verification/gauntlet-room-scrub.md — PERSIST-CHECK GREEN (3 legs incl. the scrub canary), TIER1 GREEN.