### PR TITLE
Gauntlet: clean-room scrub no longer kills the persist

### DIFF
--- a/docs/verification/scrub-clean-room.md
+++ b/docs/verification/scrub-clean-room.md
@@ -1,0 +1,18 @@
+# Proof of done: clean-room scrub no-match fix
+
+Date: 2026-09-01. Branch: fix/scrub-clean-room.
+
+## Recorded run
+
+- Command: `bash tests/gauntlet/cleanroom/persist-check.sh`
+- Exit: 0
+- Output: `PASS leg A` / `PASS leg B` / `PASS leg C (key scrubbed to <REDACTED-KEY>)` / `PASS leg D (clean room persists with key set)` / `PERSIST-CHECK: GREEN`
+- Verdict: PASS
+
+## Negative control
+
+The red arm is the live 2026-09-01 campaign log (`bg-runs/gauntlet-campaign/run.log`, ticks 1-2): with the key set and a clean room, the scrub's `grep | while` pipeline exited 1 under `pipefail`, run.sh died before the persist, the row record never landed, and the campaign re-ran J1 on every tick. Leg D reproduces that condition (`ANTHROPIC_API_KEY` set, `PROBE_CMD='exit 0'`, nothing to redact) and fails against the pre-fix runner, passes post-fix.
+
+## Rollback
+
+Single-hunk revert; no state.

--- a/tests/gauntlet/cleanroom/persist-check.sh
+++ b/tests/gauntlet/cleanroom/persist-check.sh
@@ -73,6 +73,26 @@ leg_c() {
 }
 leg_c
 
+# Leg D: key SET but the room is CLEAN (no occurrence anywhere). The scrub's
+# no-match path must not kill the persist (the 2026-09-01 campaign regression:
+# grep|while under pipefail exited 1 and run.sh died before RUN_OUT).
+leg_d() {
+  local stage_dir out_dir log rc ok=1
+  stage_dir="$(mktemp -d "${HOME}/.cache/gauntlet-persist-check/stage.XXXXXX")"
+  out_dir="$(mktemp -d "${HOME}/.cache/gauntlet-persist-check/out.XXXXXX")"
+  log="$(mktemp "${HOME}/.cache/gauntlet-persist-check/log.XXXXXX")"
+  rc=0
+  ANTHROPIC_API_KEY="dummy-clean-room-canary" \
+    GAUNTLET_STAGE_DIR="${stage_dir}" RUN_OUT="${out_dir}/room" \
+    PROBE_CMD='exit 0' \
+    bash tests/gauntlet/cleanroom/run.sh user > "${log}" 2>&1 || rc=$?
+  [ "${rc}" -eq 0 ] || { echo "  leg D: exit ${rc}, expected 0 (see ${log})"; ok=0; }
+  [ -f "${out_dir}/room/CARD.md" ] || { echo "  leg D: CARD.md missing, clean-room scrub killed the persist"; ok=0; }
+  if [ "${ok}" -eq 1 ]; then echo "PASS  leg D (clean room persists with key set)"; rm -f "${log}"; else echo "FAIL  leg D (log kept at ${log})"; fail=1; fi
+  rm -rf "${stage_dir}" "${out_dir}"
+}
+leg_d
+
 echo
 if [ "${fail}" -eq 0 ]; then echo "PERSIST-CHECK: GREEN"; else echo "PERSIST-CHECK: RED"; fi
 exit "${fail}"

--- a/tests/gauntlet/cleanroom/run.sh
+++ b/tests/gauntlet/cleanroom/run.sh
@@ -235,10 +235,13 @@ PROBE_EOF
     # occurrence BEFORE anything leaves the stage. Bash ${var//pat/rep} with a
     # quoted pattern is a literal replace, immune to key metacharacters.
     if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-      grep -rlIF "${ANTHROPIC_API_KEY}" "${STAGE}/work" 2>/dev/null | while IFS= read -r f; do
+      # Process substitution + `|| true`: a CLEAN room means grep matches nothing
+      # and exits 1, which must not kill the persist under pipefail (the exact
+      # regression that re-ran campaign row J1 forever on 2026-09-01).
+      while IFS= read -r f; do
         _c="$(cat "$f")"
         printf '%s\n' "${_c//"${ANTHROPIC_API_KEY}"/<REDACTED-KEY>}" > "$f"
-      done
+      done < <(grep -rlIF "${ANTHROPIC_API_KEY}" "${STAGE}/work" 2>/dev/null || true)
       if grep -rqIF "${ANTHROPIC_API_KEY}" "${STAGE}/work" 2>/dev/null; then
         echo "SCRUB FAILED: key still present after redaction; refusing to persist the room" >&2
         mkdir -p "${RUN_OUT}"


### PR DESCRIPTION
Live campaign tick 1 caught it: with the key set and a CLEAN room, the scrub's `grep | while` pipeline exits 1 under pipefail and run.sh dies before the RUN_OUT persist, so the row record never lands and the campaign re-runs J1 forever. Process substitution + `|| true` fixes it; persist-check gains **leg D** (key set + clean room), the exact condition none of the prior three legs combined, which is how the bug shipped. Proof: docs/verification/scrub-clean-room.md, red arm = the live campaign log.