### PR TITLE
fix(sync): identity guards stop cross-row title corruption

### DIFF
--- a/docs/verification/sync-identity-guards.md
+++ b/docs/verification/sync-identity-guards.md
@@ -1,0 +1,23 @@
+# Proof of done: sync identity guards (cross-row title corruption)
+
+Root-cause fix for the 2026-09-01 dfoundation board scramble: DF-310/311/312 titles rotated against their notes, identically on two machines syncing one Reminders list. Mechanism: `build_state`'s prefix adoption lacked the `titles_agree` check the link path has, so a mispaired spoke item was adopted with the board's title as snap-truth; the next sync read the spoke text as a retitle and `board_edit_item` overwrote the board row. A 2026-08-16 worktree sync's 180-row cross-board fossil state map seeded the poisoned pairings.
+
+## Green run
+
+| # | Command | Exit | Verdict |
+|---|---|---|---|
+| 1 | `uv run --with pytest pytest lib/sync/tests/` | 0 | PASS 248/248 (4 new: mispaired adoption refused; rotation guard board-wins; genuine retitle still flows; worktree fence refusal) |
+
+## Negative control
+
+Fault injected: removed the `titles_agree` gate from `build_state`'s adoption loop. Result: `FAILED test_core.py::test_build_state_refuses_mispaired_prefix_adoption` (1 failed, 37 passed in test_core.py). Restored; full suite green (run #1).
+
+## Reproduce
+
+```bash
+uv run --with pytest pytest lib/sync/tests/
+```
+
+## Remediation note (estate-side, not this repo)
+
+The poisoned artifacts remain outside this repo: the dfoundation Reminders list still holds mispaired titles, and both machines' `~/.cache/backlog-sync/.../reminders.state.json` snapshots recorded them. With these guards a re-sync no longer writes them to the board (id-collision notes surface instead); healing = re-title the reminders from board truth (the engine's board-wins conflict path does this once linked) and quarantine the 2026-08-16 worktree fossil state dir. Tracked as ops-toolkit ID-639.

--- a/lib/sync/backlog_sync.py
+++ b/lib/sync/backlog_sync.py
@@ -396,6 +396,20 @@ def main(argv=None):
         sys.exit(f"no backlog at {args.backlog}; pass --backlog or run via "
                  "`board sync` from an adopted repo")
 
+    # worktree fence: spokes (a Reminders list, a Notion db) are shared per
+    # BOARD, not per checkout. A sync run from a git worktree pairs the
+    # spoke's items against that branch's divergent row set and poisons the
+    # shared state for every other checkout (a 180-row cross-board fossil
+    # map from exactly this, 2026-08-16, fed the 2026-09-01 dfoundation
+    # title scramble). Only the canonical checkout may sync.
+    if "/.claude/worktrees/" in str(args.backlog.resolve()) \
+            and not os.environ.get("KIT_SYNC_ALLOW_WORKTREE"):
+        sys.exit("board sync: refusing to sync a worktree checkout "
+                 f"({args.backlog}); spokes are shared per board, and a "
+                 "worktree's divergent rows poison them for every checkout. "
+                 "Run from the canonical checkout, or set "
+                 "KIT_SYNC_ALLOW_WORKTREE=1 if you truly know better.")
+
     state_dir = board_state_dir(args.state_root, args.backlog)
     # single-writer lock: overlapping runs would hand out colliding IDs and
     # clobber each other's board writes

--- a/lib/sync/sync_core.py
+++ b/lib/sync/sync_core.py
@@ -333,7 +333,17 @@ def plan_sync(rows: dict, items: list, state: dict,
                                f"(board={row.item!r} spoke={it_title!r})")
             p.src_set_title.append((it["rid"], want_title))
         elif src_t_changed and not board_t_changed:
-            p.board_edit_item.append((bid, it_title))
+            # rotation guard: a spoke "retitle" that lands exactly on ANOTHER
+            # row's current item is the cross-row mispairing signature (the
+            # 2026-09-01 scramble), never a real edit; board wins.
+            others = {r.item for b2, r in rows.items() if b2 != bid}
+            if it_title in others:
+                p.conflicts.append(
+                    f"{bid}: spoke title duplicates another row's item; "
+                    f"mispairing suspected, board wins (spoke={it_title!r})")
+                p.src_set_title.append((it["rid"], want_title))
+            else:
+                p.board_edit_item.append((bid, it_title))
         elif it["title"] != want_title:
             p.src_set_title.append((it["rid"], want_title))
         if snapd.get("notes") != row.notes:
@@ -533,13 +543,21 @@ def build_state(rows: dict, items: list, plan: Plan, created: dict,
     for rid, _t, _b, _kw in plan.board_add:
         if rid in assigned and assigned[rid] in rows:
             m[assigned[rid]] = entry_for(assigned[rid], rid)
-    # adopt prefix-matched items that weren't in the old map
+    # adopt prefix-matched items that weren't in the old map. titles_agree is
+    # load-bearing here exactly as in plan_sync's link path: without it, a
+    # mispaired spoke item ("DF-311 · <some other row's text>") is adopted
+    # with the BOARD's title stored as snap-truth, and the next sync reads
+    # the spoke's text as a retitle and overwrites the board row (the
+    # 2026-09-01 dfoundation DF-310/311/312 scramble, identical on two
+    # machines syncing the same poisoned list).
     known_rids = {e["rid"] for e in m.values()}
     for it in items:
         if it["rid"] in known_rids:
             continue
-        bid, _ = parse_title(it["title"])
+        bid, it_title = parse_title(it["title"])
         if bid and bid in rows and bid not in m:
+            if not titles_agree(it_title, rows[bid].item):
+                continue  # id collision: plan_sync notes it next run
             m[bid] = entry_for(bid, it["rid"])
     # scope flags: set on exit, cleared on re-entry, carried while frozen
     exited = {bid for bid, _ in plan.src_scope_exit}

--- a/lib/sync/tests/test_core.py
+++ b/lib/sync/tests/test_core.py
@@ -439,3 +439,60 @@ def test_board_add_marks_intake_notes_untrusted():
     assert "2% only" in row.notes
     assert row.notes.endswith("#inbox")
     assert row.item == "buy milk"  # title deliberately not tagged
+
+
+def test_build_state_refuses_mispaired_prefix_adoption():
+    """A spoke item whose embedded id points at a board row with DIFFERENT
+    text must not be adopted into the snapshot map: adoption stores the
+    BOARD's title as snap-truth, so the very next sync reads the spoke's
+    text as a retitle and overwrites the board row (the 2026-09-01
+    dfoundation DF-310/311/312 scramble, reproduced on two machines)."""
+    rows = parse_board(BOARD)
+    poisoned = item("r-poison", "ID-10 · Ship the widget")  # ID-11's text
+    honest = item("r-ok", "ID-11 · Ship the widget")
+    state = build_state(rows, [poisoned, honest], Plan(), {}, {}, {})
+    assert "ID-10" not in state["map"]
+    assert state["map"]["ID-11"]["rid"] == "r-ok"
+
+
+def test_rotation_guard_board_wins_on_cross_row_title():
+    """A linked spoke item 'retitled' to exactly ANOTHER row's current item
+    is the cross-row mispairing signature: the board must win (spoke gets
+    re-titled back), never a board_edit_item."""
+    rows = parse_board(BOARD)
+    state = {"map": snap("ID-10", "r1", "Fix the frobnicator")}
+    it = item("r1", "ID-10 · Ship the widget")  # ID-11's exact item text
+    p = plan_sync(rows, [it], state)
+    assert p.board_edit_item == []
+    assert any("mispairing" in c for c in p.conflicts)
+    assert ("r1", title_for("ID-10", "Fix the frobnicator")) in p.src_set_title
+
+
+def test_rotation_guard_still_allows_real_retitle():
+    """A genuine spoke retitle (text not matching any other row) still flows
+    to the board."""
+    rows = parse_board(BOARD)
+    state = {"map": snap("ID-10", "r1", "Fix the frobnicator")}
+    it = item("r1", "ID-10 · Fix the frobnicator properly")
+    p = plan_sync(rows, [it], state)
+    assert ("ID-10", "Fix the frobnicator properly") in p.board_edit_item
+    assert p.conflicts == []
+
+
+def test_worktree_fence_refuses_sync(tmp_path):
+    """Spokes are shared per board; a worktree checkout's divergent rows
+    poison them for every other checkout. The engine refuses the path
+    outright (KIT_SYNC_ALLOW_WORKTREE=1 is the explicit override)."""
+    import os
+    import subprocess
+    wt = tmp_path / "repo" / ".claude" / "worktrees" / "x" / "_meta"
+    wt.mkdir(parents=True)
+    (wt / "BACKLOG.md").write_text(BOARD)
+    engine = Path(__file__).resolve().parents[1] / "backlog_sync.py"
+    env = {k: v for k, v in os.environ.items() if k != "KIT_SYNC_ALLOW_WORKTREE"}
+    r = subprocess.run(
+        [sys.executable, str(engine), "--backlog", str(wt / "BACKLOG.md"),
+         "--apps", "reminders", "--dry-run"],
+        capture_output=True, text=True, env=env)
+    assert r.returncode != 0
+    assert "refusing to sync a worktree" in (r.stderr + r.stdout)


### PR DESCRIPTION
Root-cause fix for the 2026-09-01 dfoundation board scramble (DF-310/311/312 titles rotated identically on two machines syncing one Reminders list; no commit ever contained those pairings).

Mechanism (two-sync deterministic corruption): (1) build_state's prefix adoption had no titles_agree check, so a mispaired item was adopted with the BOARD's title stored as snap-truth; (2) the next sync judged the spoke text a retitle and board_edit_item overwrote the board row.

Guards: adoption requires titles_agree (mirrors the link path); rotation guard in plan_sync (a spoke retitle equal to another row's item = mispairing, board wins); worktree fence in backlog_sync (spokes are shared per board, KIT_SYNC_ALLOW_WORKTREE=1 overrides). A 2026-08-16 worktree sync's 180-row cross-board fossil state seeded the poison.

Green run: uv run --with pytest pytest lib/sync/tests/ -> 248 passed (4 new). Negative control: dropping guard 1 fails test_build_state_refuses_mispaired_prefix_adoption (verified, restored). Proof: docs/verification/sync-identity-guards.md. Estate pointer: ops-toolkit ID-639.