### PR TITLE
feat(board): publish verb, the git leg of intake-publish-relay

### DIFF
--- a/docs/verification/board-publish.md
+++ b/docs/verification/board-publish.md
@@ -1,0 +1,24 @@
+# Proof of done: `board publish` (the git leg of intake -> publish -> relay)
+
+`board sync` mutates the board file in place; the estate's hourly sweeper had no publish leg, so every Mini checkout stayed permanently dirty: spoke writes invisible off-host and every ff-pull blocked (ops-toolkit ID-638; bit two deploys on 2026-09-01). `cmd_publish` stages only the board file, pulls rebase-first with autostash, commits `chore(board): publish spoke updates`, and pushes; a failed push keeps the commit local with an honest warn. Worktree checkouts are refused, the same fence as sync.
+
+## Green run
+
+| # | Command | Exit | Verdict |
+|---|---|---|---|
+| 1 | `bash tests/test-board-publish.sh` | 0 | PASS 11/11 (commit+push; other dirt untouched; clean no-op; worktree refusal; push-failure keeps commit + warns) |
+| 2 | `bash -n lib/board/board.sh` | 0 | PASS |
+
+## Negative control
+
+Fault injected: commit subject changed away from `chore(board): publish spoke updates`. Result: 3/11 FAIL (`no publish commit`, `remote missing the publish commit`, `no local commit after push failure`). Restored from the commit; suite green (run #1).
+
+## Reproduce
+
+```bash
+bash tests/test-board-publish.sh
+```
+
+## Consumer wiring (separate PR, ops-toolkit)
+
+`_meta/board-sync-all` calls `board publish --backlog-file <path>` per repo after its sync leg; push auth under launchd rides the sweeper's existing env (GH_TOKEN / askpass), with the warn path covering hosts that lack it.

--- a/lib/board/board.sh
+++ b/lib/board/board.sh
@@ -937,6 +937,54 @@ cmd_sync() {
   exec python3 "$BOARD_DIR/../sync/backlog_sync.py" "${args[@]}" ${fwd[@]+"${fwd[@]}"}
 }
 
+# publish: the git leg of SPEC-002's intake -> publish -> relay sequencing.
+# `board sync` mutates the board file in place; without this leg a scheduled
+# runner (the estate's hourly sweeper) leaves every checkout permanently
+# dirty, spoke writes invisible off-host and every ff-pull blocked
+# (ops-toolkit ID-638). Stages ONLY the board file; other dirt is untouched.
+# Rebase-first so the checkout stays fast-forwardable; a failed push keeps
+# the commit local and warns (the next publish rebases over it).
+cmd_publish() {
+  local backlog="" push=1
+  while [ $# -gt 0 ]; do case "$1" in
+    --backlog-file) backlog="${2:-}"; shift 2 ;;
+    --no-push) push=0; shift ;;
+    *) echo "publish: unknown arg: $1" >&2; return 64 ;;
+  esac; done
+  backlog="${backlog:-$PWD/_meta/BACKLOG.md}"
+  [ -f "$backlog" ] || { echo "board publish: no backlog at $backlog" >&2; return 2; }
+  local absdir; absdir="$(cd "$(dirname "$backlog")" && pwd)"
+  case "$absdir" in
+    */.claude/worktrees/*)
+      echo "board publish: refusing a worktree checkout ($backlog); publish" >&2
+      echo "  runs from the canonical checkout only (same fence as sync)." >&2
+      return 2 ;;
+  esac
+  local root; root="$(git -C "$absdir" rev-parse --show-toplevel 2>/dev/null)" \
+    || { echo "board publish: $backlog is not in a git repo" >&2; return 2; }
+  local rel="${absdir}/$(basename "$backlog")"; rel="${rel#"$root"/}"
+  if git -C "$root" diff --quiet -- "$rel" 2>/dev/null; then
+    echo "board publish: no board changes in $rel"
+    return 0
+  fi
+  # never rebase away a concurrent writer: autostash covers other dirt
+  git -C "$root" pull --rebase --autostash --quiet 2>/dev/null || true
+  git -C "$root" diff --quiet -- "$rel" 2>/dev/null && { echo "board publish: changes were upstream already"; return 0; }
+  git -C "$root" add -- "$rel"
+  if ! git -C "$root" commit --quiet -m "chore(board): publish spoke updates" -- "$rel"; then
+    echo "board publish: commit failed for $rel" >&2
+    return 1
+  fi
+  echo "board publish: committed $rel"
+  if [ "$push" -eq 1 ]; then
+    if git -C "$root" push --quiet 2>/dev/null; then
+      echo "board publish: pushed"
+    else
+      echo "board publish: WARN push failed (auth?); commit is local, next publish rebases" >&2
+    fi
+  fi
+}
+
 # bridge was folded into the sync module 2026-07-16; these verbs are the
 # legacy cockpit engine until the SPEC-002 P2 port (kit board ID-290).
 _legacy_bridge_note() {
@@ -955,6 +1003,7 @@ main() {
     status) shift; cmd_status "$@" ;;
     writeback) shift; cmd_writeback "$@" ;;
     sync) shift; cmd_sync "$@" ;;
+    publish) shift; cmd_publish "$@" ;;
     init) shift; cmd_init "$@" ;;
     capture) shift; cmd_capture "$@" ;;
     promote) shift; exec "$BOARD_DIR/bin/add-backlog" "$@" ;;

--- a/tests/test-board-publish.sh
+++ b/tests/test-board-publish.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# test-board-publish.sh -- `board publish`, the git leg of SPEC-002's
+# intake -> publish -> relay sequencing (ops-toolkit ID-638).
+#
+# Proves:
+#   AC1  a spoke-dirtied board file is committed (chore(board) subject) and
+#        pushed to the remote; ONLY the board file is staged (other dirt stays)
+#   AC2  no board changes -> no commit, exit 0
+#   AC3  a worktree checkout path is refused (same fence as sync)
+#   AC4  push failure (no remote) keeps the local commit and warns, exit 0
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BOARD_SH="$HERE/../lib/board/board.sh"
+WORK="$(mktemp -d)"
+trap 'command rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok   $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+
+mkrepo() {  # <dir> ; creates repo with _meta/BACKLOG.md + a bare origin
+  local d="$1"
+  git init -q -b main "$d"
+  mkdir -p "$d/_meta"
+  printf '| ID | Item | Notes & source | Status |\n|---|---|---|---|\n| ID-1 | thing | notes | queued |\n' > "$d/_meta/BACKLOG.md"
+  git -C "$d" -c user.email=t@t -c user.name=t add -A
+  git -C "$d" -c user.email=t@t -c user.name=t commit -qm init
+  git init -q --bare "$d.remote"
+  git -C "$d" remote add origin "$d.remote"
+  git -C "$d" push -q -u origin main
+}
+
+echo "case AC1 (dirty board -> committed + pushed; other dirt untouched):"
+mkrepo "$WORK/r1"
+printf '| ID-2 | new row | from spoke | queued |\n' >> "$WORK/r1/_meta/BACKLOG.md"
+echo scratch > "$WORK/r1/other.txt"
+out="$(cd "$WORK/r1" && GIT_AUTHOR_EMAIL=t@t GIT_AUTHOR_NAME=t GIT_COMMITTER_EMAIL=t@t GIT_COMMITTER_NAME=t \
+  bash "$BOARD_SH" publish --backlog-file "$WORK/r1/_meta/BACKLOG.md" 2>&1)"
+git -C "$WORK/r1" log -1 --format=%s | grep -q "chore(board): publish spoke updates" \
+  && ok "board commit created" || bad "no publish commit: $(git -C "$WORK/r1" log -1 --format=%s)"
+git -C "$WORK/r1.remote" log -1 --format=%s main 2>/dev/null | grep -q "chore(board)" \
+  && ok "pushed to origin" || bad "remote missing the publish commit"
+git -C "$WORK/r1" status --porcelain | grep -q "other.txt" \
+  && ok "unrelated dirt left untouched" || bad "unrelated file was swept into the commit"
+echo "$out" | grep -q "pushed" && ok "reports pushed" || bad "no pushed report: $out"
+
+echo "case AC2 (clean board -> no commit):"
+before="$(git -C "$WORK/r1" rev-parse HEAD)"
+out="$(cd "$WORK/r1" && bash "$BOARD_SH" publish --backlog-file "$WORK/r1/_meta/BACKLOG.md" 2>&1)"
+[ "$(git -C "$WORK/r1" rev-parse HEAD)" = "$before" ] \
+  && ok "HEAD unchanged" || bad "a commit appeared with no board changes"
+echo "$out" | grep -q "no board changes" && ok "honest no-op report" || bad "no no-op report: $out"
+
+echo "case AC3 (worktree path refused):"
+mkdir -p "$WORK/r2/.claude/worktrees/x/_meta"
+printf '| ID | Item | Notes & source | Status |\n|---|---|---|---|\n' > "$WORK/r2/.claude/worktrees/x/_meta/BACKLOG.md"
+out="$(bash "$BOARD_SH" publish --backlog-file "$WORK/r2/.claude/worktrees/x/_meta/BACKLOG.md" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "nonzero exit" || bad "worktree path accepted (rc=0)"
+echo "$out" | grep -q "refusing a worktree" && ok "refusal names the fence" || bad "no refusal message: $out"
+
+echo "case AC4 (push failure -> commit kept, warn, exit 0):"
+mkrepo "$WORK/r3"
+command rm -rf "$WORK/r3.remote"   # kill the remote so push fails
+printf '| ID-3 | another row | x | queued |\n' >> "$WORK/r3/_meta/BACKLOG.md"
+out="$(cd "$WORK/r3" && GIT_AUTHOR_EMAIL=t@t GIT_AUTHOR_NAME=t GIT_COMMITTER_EMAIL=t@t GIT_COMMITTER_NAME=t \
+  bash "$BOARD_SH" publish --backlog-file "$WORK/r3/_meta/BACKLOG.md" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 on push failure (commit preserved)" || bad "nonzero exit: $rc"
+git -C "$WORK/r3" log -1 --format=%s | grep -q "chore(board)" \
+  && ok "local commit kept" || bad "no local commit after push failure"
+echo "$out" | grep -q "WARN push failed" && ok "push failure warns honestly" || bad "no push warning: $out"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
board sync mutates the board file in place; without a publish leg a scheduled runner leaves every checkout permanently dirty: spoke writes invisible off-host and every ff-pull blocked (ops-toolkit ID-638, bit two Mini deploys 2026-09-01).

`board publish [--backlog-file F] [--no-push]`: stages ONLY the board file, pulls rebase-first (autostash covers other dirt), commits `chore(board): publish spoke updates`, pushes. Push failure keeps the commit local and warns (next publish rebases). Worktree checkouts refused, same fence as the sync engine's new worktree fence (#467).

Follows the engine's own documented sequencing (SPEC-002/004: intake, publish, relay as separate invocations; the taskboard-pull runner is the precedent). Consumer wiring (the estate sweeper calling it per repo) is a separate ops-toolkit PR.

Green run: tests/test-board-publish.sh 11/11. Negative control: commit-subject fault fails 3 asserts (verified, restored). Proof: docs/verification/board-publish.md.