### PR TITLE
fix(board): battery hardening for publish + sync collision hold

### DIFF
--- a/docs/verification/battery-publish-hardening.md
+++ b/docs/verification/battery-publish-hardening.md
@@ -1,0 +1,24 @@
+# Proof of done: battery hardening for publish + sync collision hold
+
+Fixes from the 2026-09-01 verification battery on the board-publish batch (infra CRITICAL: autostash-conflict could commit conflict markers or wedge the checkout; security M3-M6: unpinned push, logical-path fence, glob pathspec, swallowed rebase; review H1/M4/M8: same conflict class, interactive-prompt hang, refused-adoption duplicate loop).
+
+Changes: `cmd_publish` is commit-first (a rebase conflict can never stage markers into the board file); push pinned to `origin HEAD:refs/heads/<branch>` with detached-HEAD refusal; `:(literal)` pathspecs; physical-path worktree fence; non-interactive git (`GIT_TERMINAL_PROMPT=0`, `core.askPass=true`, BatchMode ssh); rc 3 = committed-but-not-on-remote (monitoring signal); `rebase --abort` guarantees a clean checkout. `plan_sync` holds `src_create` for a bid whose existing spoke item title-mismatches, so a refused adoption cannot mint duplicates forever.
+
+## Green run
+
+| # | Command | Exit | Verdict |
+|---|---|---|---|
+| 1 | `bash tests/test-board-publish.sh` | 0 | PASS 19/19 (new AC5 diverged+rebase, AC6 real same-line conflict -> no markers + clean index + rc 3, AC7 detached HEAD) |
+| 2 | `uv run --with pytest pytest lib/sync/tests/` | 0 | PASS 249/249 (new collision-hold test) |
+| 3 | `bash -n lib/board/board.sh` | 0 | PASS |
+
+## Negative control
+
+Fault injected: the `rebase --abort` recovery replaced with a no-op. Result: `FAIL CONFLICT MARKERS in the working board file` + `FAIL unmerged index left behind` (17/19). This is the exact bug the AC6 fixture caught during development (`rebase --abort --quiet` is not a valid flag combination, so the original abort never ran). Restored; 19/19 (run #1).
+
+## Reproduce
+
+```bash
+bash tests/test-board-publish.sh
+uv run --with pytest pytest lib/sync/tests/
+```

--- a/lib/board/board.sh
+++ b/lib/board/board.sh
@@ -942,8 +942,13 @@ cmd_sync() {
 # runner (the estate's hourly sweeper) leaves every checkout permanently
 # dirty, spoke writes invisible off-host and every ff-pull blocked
 # (ops-toolkit ID-638). Stages ONLY the board file; other dirt is untouched.
-# Rebase-first so the checkout stays fast-forwardable; a failed push keeps
-# the commit local and warns (the next publish rebases over it).
+#
+# COMMIT-FIRST by design (battery 2026-09-01): committing before any pull
+# means a rebase conflict can never stage conflict markers into the board
+# file, and a failed rebase aborts back to the committed state instead of
+# wedging the checkout. Exit codes: 0 published or clean no-op; 2 usage or
+# fence refusal; 3 committed locally but NOT on the remote (push/rebase
+# failure) -- callers treat 3 as a monitoring signal, the commit is safe.
 cmd_publish() {
   local backlog="" push=1
   while [ $# -gt 0 ]; do case "$1" in
@@ -953,7 +958,9 @@ cmd_publish() {
   esac; done
   backlog="${backlog:-$PWD/_meta/BACKLOG.md}"
   [ -f "$backlog" ] || { echo "board publish: no backlog at $backlog" >&2; return 2; }
-  local absdir; absdir="$(cd "$(dirname "$backlog")" && pwd)"
+  # physical path (pwd -P): the worktree fence must not be evadable through
+  # a symlinked path, matching the sync engine's resolve() fence
+  local absdir; absdir="$(cd "$(dirname "$backlog")" && pwd -P)"
   case "$absdir" in
     */.claude/worktrees/*)
       echo "board publish: refusing a worktree checkout ($backlog); publish" >&2
@@ -962,27 +969,47 @@ cmd_publish() {
   esac
   local root; root="$(git -C "$absdir" rev-parse --show-toplevel 2>/dev/null)" \
     || { echo "board publish: $backlog is not in a git repo" >&2; return 2; }
+  local branch; branch="$(git -C "$root" symbolic-ref --quiet --short HEAD)" \
+    || { echo "board publish: detached HEAD; refusing to publish" >&2; return 2; }
   local rel="${absdir}/$(basename "$backlog")"; rel="${rel#"$root"/}"
-  if git -C "$root" diff --quiet -- "$rel" 2>/dev/null; then
+  # :(literal) everywhere: a board path with glob characters must never
+  # widen the pathspec to unrelated files in an auto-pushed commit
+  local spec=":(literal)$rel"
+  if git -C "$root" diff --quiet -- "$spec" 2>/dev/null; then
     echo "board publish: no board changes in $rel"
     return 0
   fi
-  # never rebase away a concurrent writer: autostash covers other dirt
-  git -C "$root" pull --rebase --autostash --quiet 2>/dev/null || true
-  git -C "$root" diff --quiet -- "$rel" 2>/dev/null && { echo "board publish: changes were upstream already"; return 0; }
-  git -C "$root" add -- "$rel"
-  if ! git -C "$root" commit --quiet -m "chore(board): publish spoke updates" -- "$rel"; then
+  # a scheduled runner must never hang on a credential or hostkey prompt
+  local -a G=(git -c core.askPass=true -C "$root")
+  export GIT_TERMINAL_PROMPT=0
+  export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -o BatchMode=yes}"
+  "${G[@]}" add -- "$spec"
+  if ! "${G[@]}" commit --quiet -m "chore(board): publish spoke updates" -- "$spec"; then
     echo "board publish: commit failed for $rel" >&2
     return 1
   fi
   echo "board publish: committed $rel"
-  if [ "$push" -eq 1 ]; then
-    if git -C "$root" push --quiet 2>/dev/null; then
-      echo "board publish: pushed"
-    else
-      echo "board publish: WARN push failed (auth?); commit is local, next publish rebases" >&2
-    fi
+  [ "$push" -eq 1 ] || return 0
+  # pinned refspec: only ever the current branch, never a surprise target
+  if "${G[@]}" push --quiet origin "HEAD:refs/heads/$branch" 2>/dev/null; then
+    echo "board publish: pushed"
+    return 0
   fi
+  # non-ff or auth failure: try one rebase, abort hard on any conflict so
+  # the checkout is never left mid-rebase (the commit survives either way)
+  if ! "${G[@]}" pull --rebase --autostash --quiet origin "$branch" 2>/dev/null \
+      || [ -n "$("${G[@]}" ls-files -u -- "$spec" 2>/dev/null)" ]; then
+    "${G[@]}" rebase --abort >/dev/null 2>&1 || true
+    echo "board publish: WARN remote diverged and rebase did not apply cleanly;" >&2
+    echo "  commit is local, checkout restored, will retry next publish" >&2
+    return 3
+  fi
+  if "${G[@]}" push --quiet origin "HEAD:refs/heads/$branch" 2>/dev/null; then
+    echo "board publish: pushed (after rebase)"
+    return 0
+  fi
+  echo "board publish: WARN push failed (auth?); commit is local, next publish retries" >&2
+  return 3
 }
 
 # bridge was folded into the sync module 2026-07-16; these verbs are the

--- a/lib/sync/sync_core.py
+++ b/lib/sync/sync_core.py
@@ -223,6 +223,7 @@ def plan_sync(rows: dict, items: list, state: dict,
 
     # link spoke items to board ids: snapshot map first, then title prefix
     linked: dict[str, dict] = {}
+    collided: set[str] = set()  # bids with a title-mismatched spoke item
     for bid, entry in smap.items():
         it = by_rid.get(entry.get("rid", ""))
         if it is not None:
@@ -242,6 +243,7 @@ def plan_sync(rows: dict, items: list, state: dict,
                 p.notes.append(
                     f"id collision: {bid} title mismatch, not linked "
                     f"(board={rows[bid].item!r} spoke={it_title!r})")
+                collided.add(bid)
                 continue
             linked[bid] = it
             claimed_rids.add(it["rid"])
@@ -267,6 +269,14 @@ def plan_sync(rows: dict, items: list, state: dict,
                 continue
             if not row_in:
                 continue  # filtered off this app: never created here
+            if bid in collided:
+                # a mismatched spoke item already carries this id: creating a
+                # second one would duplicate forever (battery 2026-09-01, MED
+                # finding). Surface the stall instead; the operator fixes or
+                # deletes the stale spoke item and the next sync creates.
+                p.notes.append(f"{bid}: create held, a title-mismatched spoke "
+                               "item already carries this id (fix or remove it)")
+                continue
             p.src_create.append((bid, title_for(bid, row.item), row.notes,
                                  row.status_kw))
             continue

--- a/lib/sync/tests/test_core.py
+++ b/lib/sync/tests/test_core.py
@@ -496,3 +496,16 @@ def test_worktree_fence_refuses_sync(tmp_path):
         capture_output=True, text=True, env=env)
     assert r.returncode != 0
     assert "refusing to sync a worktree" in (r.stderr + r.stdout)
+
+
+def test_collided_bid_holds_create_instead_of_duplicating():
+    """After an id-collision refusal (title-mismatched spoke item), the row
+    must NOT src_create a second spoke item; that would duplicate forever
+    while the stale item lingers (battery 2026-09-01)."""
+    rows = parse_board(BOARD)
+    stale = item("r-stale", "ID-10 · Ship the widget")  # wrong text for ID-10
+    p = plan_sync(rows, [stale], {})
+    assert all(bid != "ID-10" for bid, *_ in p.src_create)
+    assert any("create held" in n for n in p.notes)
+    # other rows still create normally
+    assert any(bid == "ID-11" for bid, *_ in p.src_create)

--- a/tests/test-board-publish.sh
+++ b/tests/test-board-publish.sh
@@ -7,7 +7,10 @@
 #        pushed to the remote; ONLY the board file is staged (other dirt stays)
 #   AC2  no board changes -> no commit, exit 0
 #   AC3  a worktree checkout path is refused (same fence as sync)
-#   AC4  push failure (no remote) keeps the local commit and warns, exit 0
+#   AC4  push failure (no remote) keeps the local commit, warns, exit 3
+#   AC5  diverged remote, non-conflicting upstream edit -> rebase + push
+#   AC6  diverged remote, conflicting board edit -> no markers, abort, rc 3
+#   AC7  detached HEAD refused (exit 2)
 set -u
 HERE="$(cd "$(dirname "$0")" && pwd)"
 BOARD_SH="$HERE/../lib/board/board.sh"
@@ -57,16 +60,55 @@ out="$(bash "$BOARD_SH" publish --backlog-file "$WORK/r2/.claude/worktrees/x/_me
 [ "$rc" -ne 0 ] && ok "nonzero exit" || bad "worktree path accepted (rc=0)"
 echo "$out" | grep -q "refusing a worktree" && ok "refusal names the fence" || bad "no refusal message: $out"
 
-echo "case AC4 (push failure -> commit kept, warn, exit 0):"
+echo "case AC4 (push failure -> commit kept, warn, exit 3):"
 mkrepo "$WORK/r3"
 command rm -rf "$WORK/r3.remote"   # kill the remote so push fails
 printf '| ID-3 | another row | x | queued |\n' >> "$WORK/r3/_meta/BACKLOG.md"
 out="$(cd "$WORK/r3" && GIT_AUTHOR_EMAIL=t@t GIT_AUTHOR_NAME=t GIT_COMMITTER_EMAIL=t@t GIT_COMMITTER_NAME=t \
   bash "$BOARD_SH" publish --backlog-file "$WORK/r3/_meta/BACKLOG.md" 2>&1)"; rc=$?
-[ "$rc" -eq 0 ] && ok "exit 0 on push failure (commit preserved)" || bad "nonzero exit: $rc"
+[ "$rc" -eq 3 ] && ok "exit 3 on push failure (monitoring signal, commit preserved)" || bad "expected rc 3, got: $rc"
 git -C "$WORK/r3" log -1 --format=%s | grep -q "chore(board)" \
   && ok "local commit kept" || bad "no local commit after push failure"
-echo "$out" | grep -q "WARN push failed" && ok "push failure warns honestly" || bad "no push warning: $out"
+echo "$out" | grep -q "WARN" && ok "push failure warns honestly" || bad "no push warning: $out"
+
+echo "case AC5 (diverged remote, NON-conflicting upstream edit -> rebase + push):"
+mkrepo "$WORK/r4"
+git clone -q -b main "$WORK/r4.remote" "$WORK/r4b" && cd "$WORK/r4b" || bad "clone failed"
+printf 'upstream note\n' >> "$WORK/r4b/README.md" 2>/dev/null || printf 'upstream note\n' > "$WORK/r4b/README.md"
+git -C "$WORK/r4b" -c user.email=t@t -c user.name=t add -A
+git -C "$WORK/r4b" -c user.email=t@t -c user.name=t commit -qm "upstream: unrelated"
+git -C "$WORK/r4b" push -q origin main
+printf '| ID-4 | diverge row | x | queued |\n' >> "$WORK/r4/_meta/BACKLOG.md"
+out="$(cd "$WORK/r4" && GIT_AUTHOR_EMAIL=t@t GIT_AUTHOR_NAME=t GIT_COMMITTER_EMAIL=t@t GIT_COMMITTER_NAME=t \
+  bash "$BOARD_SH" publish --backlog-file "$WORK/r4/_meta/BACKLOG.md" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 after rebase+push" || bad "rc=$rc: $out"
+git -C "$WORK/r4.remote" log --format=%s main | grep -q "chore(board)" \
+  && ok "publish commit reached the diverged remote" || bad "remote missing publish commit after rebase"
+
+echo "case AC6 (diverged remote, CONFLICTING board edit -> no markers, abort, rc 3):"
+mkrepo "$WORK/r5"
+git clone -q -b main "$WORK/r5.remote" "$WORK/r5b"
+# same line edited differently on both sides = guaranteed rebase conflict
+sed -i '' 's/| ID-1 | thing | notes | queued |/| ID-1 | thing | notes | executing |/' "$WORK/r5b/_meta/BACKLOG.md"
+git -C "$WORK/r5b" -c user.email=t@t -c user.name=t add -A
+git -C "$WORK/r5b" -c user.email=t@t -c user.name=t commit -qm "upstream: conflicting board edit"
+git -C "$WORK/r5b" push -q origin main
+sed -i '' 's/| ID-1 | thing | notes | queued |/| ID-1 | thing | notes | parked |/' "$WORK/r5/_meta/BACKLOG.md"
+out="$(cd "$WORK/r5" && GIT_AUTHOR_EMAIL=t@t GIT_AUTHOR_NAME=t GIT_COMMITTER_EMAIL=t@t GIT_COMMITTER_NAME=t \
+  bash "$BOARD_SH" publish --backlog-file "$WORK/r5/_meta/BACKLOG.md" 2>&1)"; rc=$?
+[ "$rc" -eq 3 ] && ok "conflicting divergence exits 3" || bad "rc=$rc (want 3): $out"
+grep -q '<<<<<<<' "$WORK/r5/_meta/BACKLOG.md" \
+  && bad "CONFLICT MARKERS in the working board file" || ok "no conflict markers in the board file"
+git -C "$WORK/r5" log -1 --format=%s | grep -qE "chore\(board\)|upstream" \
+  && ok "checkout not wedged (HEAD readable, commit intact)" || bad "checkout in a broken state"
+[ -z "$(git -C "$WORK/r5" ls-files -u)" ] && ok "no unmerged index entries" || bad "unmerged index left behind"
+
+echo "case AC7 (detached HEAD refused):"
+git -C "$WORK/r1" checkout -q --detach HEAD
+printf '| ID-5 | detached row | x | queued |\n' >> "$WORK/r1/_meta/BACKLOG.md"
+out="$(bash "$BOARD_SH" publish --backlog-file "$WORK/r1/_meta/BACKLOG.md" 2>&1)"; rc=$?
+[ "$rc" -eq 2 ] && ok "detached HEAD exits 2" || bad "rc=$rc (want 2)"
+echo "$out" | grep -q "detached HEAD" && ok "refusal names detached HEAD" || bad "no detached-HEAD message: $out"
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"


### PR DESCRIPTION
Applies the 2026-09-01 verification battery's blocking findings on the board-publish batch:

| Arm | Finding | Fix |
|---|---|---|
| infra CRITICAL | autostash-conflict path could commit conflict markers or wedge the checkout forever | commit-first design; rebase only after a rejected push; `rebase --abort` on any failure (the abort itself had a latent bug: `--quiet` is invalid on abort, caught by the new AC6 fixture) |
| security M3 | unpinned `git push` from an hourly agent | pinned `origin HEAD:refs/heads/<branch>` + detached-HEAD refusal |
| security M4 | logical-path worktree fence bypassable via symlink | `pwd -P` |
| security M5 | glob-interpreted pathspec could stage unrelated files | `:(literal)` everywhere |
| review M4 | credential prompt hangs launchd | `GIT_TERMINAL_PROMPT=0`, `core.askPass=true`, BatchMode ssh |
| infra HIGH (rc) | push failure invisible to monitoring | rc 3 = committed-but-not-on-remote, consumed by the sweeper |
| review M8 | refused adoption mints spoke duplicates forever | `plan_sync` holds src_create for collided bids with an honest note |

Green: publish 19/19 (AC5 diverged+rebase, AC6 real same-line conflict -> no markers/clean index/rc 3, AC7 detached HEAD), pytest 249/249. Negative control: abort no-op'd -> 2 asserts red (the exact wedge class), restored. Proof: docs/verification/battery-publish-hardening.md.