### PR TITLE
Exempt docs/verification from operating-surface scans

### DIFF
--- a/docs/verification/scan-exempt-verification.md
+++ b/docs/verification/scan-exempt-verification.md
@@ -1,0 +1,31 @@
+# Proof of done: exempt docs/verification from the operating-surface scans
+
+Follow-up to ID-640 (#476). That fix scoped the stale-phases scan to `git ls-files`, which then correctly saw its OWN proof doc (`docs/verification/test-meta-scan-scope.md`, now tracked), and that proof quotes the "8 phases" string it documents fixing. Same class bit the earlier drift-repair proof (a `/user:` literal). Root cause: `docs/verification/` is a point-in-time proof-record dir that legitimately quotes the strings under discussion, exactly like `docs/retro/` and `docs/handoff/`, but neither the stale-phases scan nor the SPEC-029 dead-prefix scan exempted it. Fix: add `docs/verification/` to both exclusion lists.
+
+## Recorded run
+
+```
+Command: bash tests/test-meta.sh   (tracked proof doc with 3x "8 phases" present)
+Exit: 0
+Verdict: PASS   # 823 / 823, All meta tests passed
+```
+
+## NEGATIVE CONTROL
+
+A TRACKED live-surface doc outside docs/verification/ carrying the string must still fail (the scan keeps its teeth):
+
+```
+Command: printf 'the kit has 8 phases now\n' > docs/CONTROL-live-surface.md ; git add ; bash tests/test-meta.sh
+Exit: 1
+Verdict: PASS   # exactly 1 "stale '8 phases' string found" FAIL, on the live-surface doc; docs/verification/ stayed exempt
+```
+
+So docs/verification/ is exempt (the proof doc no longer trips it) while a real operating-surface doc under docs/ still fails. Both the stale-phases scan and the dead-prefix (/user:) scan gained the exemption, so a future proof may quote either forbidden string.
+
+Rollback: two single-token additions to grep exclusion lists in `tests/test-meta.sh`; `git revert`.
+
+## Reproduce
+
+```
+bash tests/test-meta.sh
+```

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -71,7 +71,7 @@ echo "=== Invocation namespace guard (SPEC-029, SPEC-030) ==="
 # automatically. tests/ is NOT scanned: this file names /user: to describe the
 # guard. Enforces /user: ABSENCE only (DEC-005); bare-/cmd is not auto-checked.
 USER_NS_HITS=$(cd "$KIT_DIR" && { git ls-files '*.md' \
-      | grep -vE '^(docs/specs/|docs/retro/|docs/decisions/|docs/handoff/|docs/research/|_meta/|CHANGELOG\.md|docs/CHANGELOG\.md)'; \
+      | grep -vE '^(docs/specs/|docs/retro/|docs/decisions/|docs/handoff/|docs/research/|docs/verification/|_meta/|CHANGELOG\.md|docs/CHANGELOG\.md)'; \
     git ls-files 'install.sh' 'hooks/*.sh'; } \
   | xargs grep -l '/user:' 2>/dev/null)
 if [ -n "$USER_NS_HITS" ]; then
@@ -1450,9 +1450,12 @@ echo "=== V-model lens, convergence, and inventory parity (SPEC-031) ==="
 # does this): a raw `grep -r` sweeps UNTRACKED gauntlet room copies under
 # docs/verification/gauntlet/*/ , which each carry their own test-meta.sh and
 # trip on the string this test names to describe itself (ID-640).
+# docs/verification/ is also excluded below: a proof-of-done record is a
+# point-in-time artifact that legitimately quotes the very string it fixed
+# (like retro/handoff), so it is not a live operating surface.
 PHASES_8_HITS=$(cd "$KIT_DIR" && git ls-files \
       'docs/*' 'commands/*' 'WORKFLOW.md' 'README.md' 'MANUAL.md' 'AGENTS.md' \
-    | grep -vE '^(docs/specs/|docs/decisions/|docs/research/|docs/retro/|docs/handoff/|docs/CHANGELOG\.md)' \
+    | grep -vE '^(docs/specs/|docs/decisions/|docs/research/|docs/retro/|docs/handoff/|docs/verification/|docs/CHANGELOG\.md)' \
     | xargs grep -In -E "8 (workflow|lifecycle )?phases" 2>/dev/null | head -1)
 TOTAL=$((TOTAL + 1))
 if [ -z "$PHASES_8_HITS" ]; then


### PR DESCRIPTION
Follow-up to #476: the git-ls-files scope correctly saw its own proof doc, which quotes the '8 phases' string it fixed. docs/verification/ is a point-in-time proof-record dir (like retro/handoff) that legitimately quotes strings under discussion; add it to both the stale-phases and dead-prefix scan exclusions. Proof: 823/823 with the tracked proof doc present; negative control confirms a live-surface docs/ file with the string still fails.