### PR TITLE
Sync identity: stop cross-row corruption and renumber orphaning

### DIFF
--- a/docs/verification/sync-identity-guards.md
+++ b/docs/verification/sync-identity-guards.md
@@ -1,16 +1,35 @@
-# Proof of done: sync identity guards (cross-row title corruption)
+# Proof of done: sync identity guards (cross-row corruption + renumber orphaning)
 
-Root-cause fix for the 2026-09-01 dfoundation board scramble: DF-310/311/312 titles rotated against their notes, identically on two machines syncing one Reminders list. Mechanism: `build_state`'s prefix adoption lacked the `titles_agree` check the link path has, so a mispaired spoke item was adopted with the board's title as snap-truth; the next sync read the spoke text as a retitle and `board_edit_item` overwrote the board row. A 2026-08-16 worktree sync's 180-row cross-board fossil state map seeded the poisoned pairings.
+Two defects in the same identity model, shipped together.
+
+**Defect 2, renumber orphaning (ops-toolkit ID-655).** The link map is keyed by
+board id, so renumbering a linked row strands its entry under a dead id. The row
+then reads as unlinked and the next tick creates a SECOND spoke card for the same
+work. The two idempotency namespaces live apart (the filer's own key versus
+`bls-<bid>`), so the spoke side can never catch it: a broken link that looks like
+a missing one. Found on the personal board, where a vps-mon incident card adopted
+as ID-629 was renumbered to ID-634 to resolve a real id collision, and the next
+sync minted `ID-634 · [vps-mon] CRIT heartbeat-silent on air.upgrade-check`
+alongside the original. Fix reconciles on the row text, which a renumber does not
+change, and declines when more than one unmapped row carries it.
+
+**Defect 1, cross-row title corruption.** Root-cause fix for the 2026-09-01
+dfoundation board scramble: DF-310/311/312 titles rotated against their notes, identically on two machines syncing one Reminders list. Mechanism: `build_state`'s prefix adoption lacked the `titles_agree` check the link path has, so a mispaired spoke item was adopted with the board's title as snap-truth; the next sync read the spoke text as a retitle and `board_edit_item` overwrote the board row. A 2026-08-16 worktree sync's 180-row cross-board fossil state map seeded the poisoned pairings.
 
 ## Green run
 
 | # | Command | Exit | Verdict |
 |---|---|---|---|
 | 1 | `uv run --with pytest pytest lib/sync/tests/` | 0 | PASS 248/248 (4 new: mispaired adoption refused; rotation guard board-wins; genuine retitle still flows; worktree fence refusal) |
+| 2 | `uvx pytest lib/sync/tests/` (after the renumber fix) | 0 | PASS 250/250 (2 new: renumbered row relinks instead of minting a duplicate; ambiguous match declines to relink) |
 
 ## Negative control
 
-Fault injected: removed the `titles_agree` gate from `build_state`'s adoption loop. Result: `FAILED test_core.py::test_build_state_refuses_mispaired_prefix_adoption` (1 failed, 37 passed in test_core.py). Restored; full suite green (run #1).
+Defect 1. Fault injected: removed the `titles_agree` gate from `build_state`'s adoption loop. Result: `FAILED test_core.py::test_build_state_refuses_mispaired_prefix_adoption` (1 failed, 37 passed in test_core.py). Restored; full suite green (run #1).
+
+Defect 2. Fault injected: reverted the rename-reconciliation hunk in `plan_sync`'s map-seeding loop to its pre-fix form, leaving the test file untouched. Result: `FAILED test_core.py::test_renumbered_row_relinks_instead_of_minting_a_duplicate` (1 failed, 39 passed in test_core.py), asserting on `creates(p)` holding `ID-10`. Restored via `git checkout --`; full suite green at 250/250, working tree clean.
+
+The regression test deliberately uses a card with no `ID-NNN ·` prefix, because that is how a sensor-filed card looks and it is precisely why prefix matching cannot recover the stranded link.
 
 ## Reproduce
 
@@ -20,4 +39,11 @@ uv run --with pytest pytest lib/sync/tests/
 
 ## Remediation note (estate-side, not this repo)
 
-The poisoned artifacts remain outside this repo: the dfoundation Reminders list still holds mispaired titles, and both machines' `~/.cache/backlog-sync/.../reminders.state.json` snapshots recorded them. With these guards a re-sync no longer writes them to the board (id-collision notes surface instead); healing = re-title the reminders from board truth (the engine's board-wins conflict path does this once linked) and quarantine the 2026-08-16 worktree fossil state dir. Tracked as ops-toolkit ID-639.
+For defect 2, one duplicate card survives on the personal Hermes board:
+`t_e8340706` (`ID-634 · [vps-mon] CRIT heartbeat-silent on air.upgrade-check`),
+alongside the original `t_bde41a05`. The fix stops new duplicates and relinks the
+row to the surviving card, but it does not retire a card already created. Left in
+place deliberately, pending Han's call on how to close it. `ID-651`
+(growatt-datalogger) is part way through the same adoption path and is now safe.
+
+For defect 1, the poisoned artifacts remain outside this repo: the dfoundation Reminders list still holds mispaired titles, and both machines' `~/.cache/backlog-sync/.../reminders.state.json` snapshots recorded them. With these guards a re-sync no longer writes them to the board (id-collision notes surface instead); healing = re-title the reminders from board truth (the engine's board-wins conflict path does this once linked) and quarantine the 2026-08-16 worktree fossil state dir. Tracked as ops-toolkit ID-639.

--- a/docs/verification/sync-identity-guards.md
+++ b/docs/verification/sync-identity-guards.md
@@ -21,13 +21,13 @@ dfoundation board scramble: DF-310/311/312 titles rotated against their notes, i
 | # | Command | Exit | Verdict |
 |---|---|---|---|
 | 1 | `uv run --with pytest pytest lib/sync/tests/` | 0 | PASS 248/248 (4 new: mispaired adoption refused; rotation guard board-wins; genuine retitle still flows; worktree fence refusal) |
-| 2 | `uvx pytest lib/sync/tests/` (after the renumber fix) | 0 | PASS 250/250 (2 new: renumbered row relinks instead of minting a duplicate; ambiguous match declines to relink) |
+| 2 | `uvx pytest lib/sync/tests/` (after the renumber fix) | 0 | PASS 251/251 (2 new: renumbered row relinks instead of minting a duplicate; ambiguous match declines to relink) |
 
 ## Negative control
 
 Defect 1. Fault injected: removed the `titles_agree` gate from `build_state`'s adoption loop. Result: `FAILED test_core.py::test_build_state_refuses_mispaired_prefix_adoption` (1 failed, 37 passed in test_core.py). Restored; full suite green (run #1).
 
-Defect 2. Fault injected: reverted the rename-reconciliation hunk in `plan_sync`'s map-seeding loop to its pre-fix form, leaving the test file untouched. Result: `FAILED test_core.py::test_renumbered_row_relinks_instead_of_minting_a_duplicate` (1 failed, 39 passed in test_core.py), asserting on `creates(p)` holding `ID-10`. Restored via `git checkout --`; full suite green at 250/250, working tree clean.
+Defect 2. Fault injected: reverted the rename-reconciliation hunk in `plan_sync`'s map-seeding loop to its pre-fix form, leaving the test file untouched. Result: `FAILED test_core.py::test_renumbered_row_relinks_instead_of_minting_a_duplicate` (1 failed, 40 passed in test_core.py), asserting on `creates(p)` holding `ID-10`. Restored via `git checkout --`; full suite green at 251/251, working tree clean.
 
 The regression test deliberately uses a card with no `ID-NNN ·` prefix, because that is how a sensor-filed card looks and it is precisely why prefix matching cannot recover the stranded link.
 
@@ -47,3 +47,16 @@ place deliberately, pending Han's call on how to close it. `ID-651`
 (growatt-datalogger) is part way through the same adoption path and is now safe.
 
 For defect 1, the poisoned artifacts remain outside this repo: the dfoundation Reminders list still holds mispaired titles, and both machines' `~/.cache/backlog-sync/.../reminders.state.json` snapshots recorded them. With these guards a re-sync no longer writes them to the board (id-collision notes surface instead); healing = re-title the reminders from board truth (the engine's board-wins conflict path does this once linked) and quarantine the 2026-08-16 worktree fossil state dir. Tracked as ops-toolkit ID-639.
+
+## Rebase re-verification (2026-09-01)
+
+Rebased onto master after 12 intervening commits; two conflicts in `test_core.py`, both in the
+tail where master had added `test_collided_bid_holds_create_instead_of_duplicating` (a sibling
+guard for the title-mismatch collision case). Resolved keeping BOTH sides. Suite re-run at
+251/251, and the negative control re-run against the rebased tree: removing the
+rename-reconciliation hunk fails `test_renumbered_row_relinks_instead_of_minting_a_duplicate`
+(1 failed, 40 passed), restore returns 251/251 with a clean tree.
+
+The first post-rebase negative-control attempt silently injected NO fault (its anchor string no
+longer matched) and reported a green run. Recorded here because a negative control that cannot
+find its target must fail loudly, not pass quietly.

--- a/lib/sync/sync_core.py
+++ b/lib/sync/sync_core.py
@@ -226,8 +226,26 @@ def plan_sync(rows: dict, items: list, state: dict,
     collided: set[str] = set()  # bids with a title-mismatched spoke item
     for bid, entry in smap.items():
         it = by_rid.get(entry.get("rid", ""))
-        if it is not None:
-            linked[bid] = it
+        if it is None:
+            continue
+        if bid not in rows:
+            # rename reconciliation: the map is keyed by board id, so
+            # renumbering a linked row (collision fix, manual edit) strands
+            # its entry under a dead id. The row then reads as unlinked and
+            # the next tick mints a SECOND card for the same work; the two
+            # idempotency namespaces live apart, so the spoke can never catch
+            # it. A renumber does not change the row text, so relink on that
+            # instead, and only when exactly one unmapped row still carries
+            # it. Guessing between candidates is how mispairing starts.
+            cands = [b for b, r in rows.items()
+                     if b not in smap
+                     and titles_agree(entry.get("title", ""), r.item)]
+            if len(cands) != 1:
+                continue
+            bid = cands[0]
+        if bid in linked:
+            continue
+        linked[bid] = it
     claimed_rids = {it["rid"] for it in linked.values()}
     for it in items:
         if it["rid"] in claimed_rids:

--- a/lib/sync/tests/test_core.py
+++ b/lib/sync/tests/test_core.py
@@ -509,3 +509,43 @@ def test_collided_bid_holds_create_instead_of_duplicating():
     assert any("create held" in n for n in p.notes)
     # other rows still create normally
     assert any(bid == "ID-11" for bid, *_ in p.src_create)
+
+
+def test_renumbered_row_relinks_instead_of_minting_a_duplicate():
+    """Renumbering a linked row must not orphan its spoke card.
+
+    The map is keyed by board id, so a renumber (collision fix, manual edit)
+    leaves the entry under a dead id. The row then reads as unlinked and the
+    next tick mints a SECOND card for the same work. Reproduced live on the
+    personal board: an incident card filed by vps-mon was adopted as ID-629,
+    the row was renumbered to ID-634 in git, and the following sync created a
+    duplicate `ID-634 · ...` card. The two idempotency namespaces cannot
+    collide, so spoke-side idempotency can never catch it.
+
+    The card carries no `ID-NNN ·` prefix here on purpose: that is how a
+    sensor-filed card looks, and it is why prefix matching cannot recover the
+    link.
+    """
+    rows = parse_board(BOARD)
+    dead = {"map": {"ID-99": {"rid": "r1", "title": "Fix the frobnicator",
+                              "notes": rows["ID-10"].notes,
+                              "status": rows["ID-10"].status_kw}}}
+    it = item("r1", "[vps-mon] CRIT heartbeat-silent on air.upgrade-check")
+    p = plan_sync(rows, [it], dead)
+    assert "ID-10" not in creates(p), "renumbered row minted a duplicate card"
+    assert p.tombstone == [], "renumbered row must not stop mirroring either"
+
+
+def test_renumber_relink_needs_an_unambiguous_match():
+    """The relink keys on the stored title, so it only fires when exactly one
+    unmapped row still carries that text. Two candidates means we cannot tell
+    which row inherited the card: leave it alone rather than guess."""
+    board = BOARD.replace("| ID-11 | Ship the widget |",
+                          "| ID-11 | Fix the frobnicator |")
+    rows = parse_board(board)
+    dead = {"map": {"ID-99": {"rid": "r1", "title": "Fix the frobnicator",
+                              "notes": rows["ID-10"].notes,
+                              "status": rows["ID-10"].status_kw}}}
+    it = item("r1", "[vps-mon] CRIT heartbeat-silent on air.upgrade-check")
+    p = plan_sync(rows, [it], dead)
+    assert "ID-10" in creates(p) and "ID-11" in creates(p)


### PR DESCRIPTION
Two defects in the sync engine's identity model, shipped together because they share a choke point and a test file.

## Defect 1: cross-row title corruption (was already on this branch, unshipped)

`build_state`'s prefix adoption lacked the `titles_agree` check the link path has, so a mispaired spoke item was adopted with the board's title as snap-truth; the next sync read the spoke text as a retitle and overwrote the board row. This is the 2026-09-01 dfoundation scramble (DF-310/311/312 rotated against their notes, identically on two machines syncing one Reminders list). Adds a rotation guard in `plan_sync` (a spoke retitle landing exactly on another row's item is mispairing, board wins) and the missing `titles_agree` gate in adoption.

## Defect 2: renumber orphaning (new here, ops-toolkit ID-655)

The link map is keyed by board id, so renumbering a linked row strands its entry under a dead id. The row then reads as unlinked and the next tick creates a **second** spoke card for the same work. The two idempotency namespaces live apart (the filer's own key versus `bls-<bid>`), so the spoke side can never catch it: this is a broken link that looks like a missing one.

Found live on the personal Hermes board. A vps-mon incident card was adopted as ID-629, the row was renumbered to ID-634 to resolve a real id collision, and the next sync minted `ID-634 · [vps-mon] CRIT heartbeat-silent on air.upgrade-check` beside the original `t_bde41a05`.

The fix reconciles on the row text, which a renumber does not change, and declines to relink when more than one unmapped row carries that text. Guessing between candidates is how defect 1 starts.

Generic across every spoke (Reminders, GitHub, Notion, Hermes), not specific to the filer that surfaced it.

## Verification

| Check | Result |
|---|---|
| Full sync suite | 250/250 pass |
| Negative control, defect 1 | `titles_agree` gate removed, `test_build_state_refuses_mispaired_prefix_adoption` fails |
| Negative control, defect 2 | reconciliation hunk reverted (test file untouched), `test_renumbered_row_relinks_instead_of_minting_a_duplicate` fails, 1 failed / 39 passed |
| Restore | `git checkout --`, suite back to 250/250, tree clean |

Reproduce: `uvx pytest lib/sync/tests/`

The defect-2 regression test uses a card with **no** `ID-NNN ·` prefix on purpose: that is how a sensor-filed card looks, and it is exactly why prefix matching cannot recover the stranded link.

## Not done here

One duplicate card already exists on the personal board (`t_e8340706`). This stops new ones and relinks the row to the surviving card, but does not retire a card already created; left for Han's call on how to close it. `ID-651` is part way through the same path and is now safe.
