### PR TITLE
fix(sync): taskboard push never re-creates a pull-marker row

### DIFF
--- a/docs/implementation-notes/SPEC-243-taskboard-push-marker-dedupe.md
+++ b/docs/implementation-notes/SPEC-243-taskboard-push-marker-dedupe.md
@@ -1,0 +1,35 @@
+# Implementation notes, SPEC-243 taskboard push marker dedupe
+
+Delta from the spec only. The spec is the contract; this file records what the
+build decided that the spec left open, and what it deliberately did not do.
+
+## 2026-09-02 DEC-004: an adoption counts as work on the run that writes it
+
+Context: the spec's open question asks whether `src_adopt` should count toward
+`Plan.empty()`.
+
+Decision: `Plan.empty()` stays unchanged (adoption excluded). The run that
+performs an adoption prints `adopted N` via `describe()`'s per-adoption line,
+so that run is visibly not idle even though `empty()` reports no board/spoke
+mutation was queued. A steady-state run afterward (the adopted bid is now in
+`known`) prints `(nothing to do)`, matching the reading operators already
+trust.
+
+Why: an adoption is plan data with a real side effect (a state-map write), so
+the run that makes it should not look silent, but it queues no create/update
+against either side, which is what `empty()` guards for dry-run headers and
+callers that branch on "is there work to preview." Splitting "did this run
+change anything" from "does the plan contain a create/update" keeps both
+readings honest.
+
+Alternatives: fold `src_adopt` into `empty()`'s tuple (rejected: a dry-run
+preview would then claim work exists for a row that produces zero writes to
+either side, which is the "(nothing to do)" reading dfoundation operators
+already rely on); print no adoption line at all (rejected: silent state
+mutation is what caused the tag-filter stopgap `.kit.toml` in the first place).
+
+Impact: `describe()` gains one line class (`= spoke <bid> bound to an existing
+Notion page (pull marker), not created`), rendered whenever `plan.src_adopt`
+is non-empty, dry-run or live.
+
+Open questions: none.

--- a/docs/specs/SPEC-243-taskboard-push-marker-dedupe.md
+++ b/docs/specs/SPEC-243-taskboard-push-marker-dedupe.md
@@ -1,0 +1,174 @@
+# Spec: Task Board push never re-creates a page that came from the pull
+
+Generated: 2026-09-02
+Status: VALIDATED (lead approval 2026-09-02, normal lane: spec-validate phase is skip per the lane matrix)
+Lane: normal
+File: `docs/specs/SPEC-243-taskboard-push-marker-dedupe.md`
+References: `lib/sync/sources/notion_taskboard_pull.py` (`MARKER_PREFIX`, `_item`, `_NEUTRALIZE`: the marker this guard reads, and the reason it cannot be forged from the Notion side); `lib/sync/sync_core.py` `plan_pull_only` (the sibling guard that already dedupes on the same marker, matched against raw board text, the algorithm to imitate); `lib/sync/sync_core.py` `plan_create_only` + `lib/sync/backlog_sync.py` `sync_create_only` (the push planner and its state checkpoint); `lib/sync/tests/test_notion_taskboard.py` (fake-transport fixture style); dfoundation `.kit.toml` `[sync] notion_taskboard_skip_tags` and `docs/verification/notion-taskboard-pull.md` (the incident and the stopgap).
+
+## Problem
+
+dfoundation runs both legs against one Notion Task Board. The pull leg reads team-approved pages into `_meta/BACKLOG.md`. The push leg sends board rows out as new Notion pages. Nothing tells the push leg that a row was born on the very board it pushes to.
+
+The push dedupes on two things only. The local state map keyed by board id, in `plan_create_only`:
+
+```python
+known = set(state.get("map", {}))
+for bid, row in rows.items():
+    if bid in known:
+        continue
+```
+
+And the `in_scope()` tag filter. An intake row has no state-map entry, because the push never created it. So only the tag filter holds it back.
+
+That filter is a stopgap. dfoundation's `.kit.toml` sets `notion_taskboard_skip_tags = "inbox"` after DF-409 through DF-417 were pushed back to the Task Board on 2026-09-01 00:40 and cleaned up by hand. `#inbox` is the intake quarantine tag that `apply_board` stamps on a new row. Triage strips it. The moment triage strips it, `in_scope()` returns true, `plan_create_only` emits a create, and the push mints a second, title-prefixed copy (`DF-412 · <item>`) of a page that still exists in Notion.
+
+The pull leg already solves the same identity problem correctly. Every intake row carries the source page id in its notes cell, and `plan_pull_only` skips any item whose marker is already in the board text. The push leg ignores that marker.
+
+## Solution
+
+### Approaches considered
+
+1. **Marker-aware push identity.** `plan_create_only` treats a row whose notes carry `notion-page:<pid>` as already bound: no create, and the binding is recorded in the state map so later runs are cheap. Tradeoff: it only catches duplicates the pull leg caused, not ones a human made.
+2. **Remote title-prefix query before every create.** Query the Task Board for a page whose title starts with `<bid> ·` and skip the create when one exists. Tradeoff: one network read per run (or per create), and it catches only the prefixed form, so it cannot see the unprefixed original page an intake row came from.
+3. **Keep widening `skip_tags`.** Rejected. It is per-consumer config that depends on a tag surviving human triage, which is exactly the assumption that failed.
+
+### Chosen approach + why
+
+Approach 1 as the primary fix, in the kit's own `lib/sync`, so every adopter gets it and no config carries the guarantee. It is deterministic, needs no network, and reads an identity the Notion side cannot forge: `_NEUTRALIZE` in the pull adapter already replaces `notion-page:`, a bare 32-hex string, and any `ID-NNN` token with `[defanged]` before untrusted text reaches the row. So a marker in a board row was written by the pull adapter, never by a Task Board editor.
+
+Approach 2 is recommended as a follow-up, not part of this spec's required scope, and it is listed in Out of Scope with its own trigger. It covers a different failure class: a hand-made duplicate, and a push after the local state map is lost (the map lives in `~/.cache/backlog-sync/<slug>/notion-taskboard.state.json`, which no backup owns). Neither class is what burned dfoundation, and adding a remote read to a planner that is currently pure costs more than it buys today.
+
+### Extensibility & boundaries
+
+- The load-bearing dimension is board size, not page count. The guard is a regex over each row's notes cell, so it stays linear in rows and adds no I/O.
+- The marker string stays owned by the pull adapter. The push planner must not import the pull module: the two adapters are independent by design and `sync_core` imports neither. Put the pattern in `sync_core` and have the pull adapter's `MARKER_PREFIX` stay the writer's copy, with a test asserting the two agree.
+- Unit boundary: `plan_create_only` decides, `sync_create_only` persists. The planner stays pure and returns the adoption as plan data, exactly as it already returns creates.
+
+## Picture
+
+```
+Notion Task Board (team-owned, one database)
+   |                                    ^
+   | pull leg (read-only)               | push leg (insert-only)
+   v                                    |
+_meta/BACKLOG.md row                    |
+  notes: "... #notion-intake ;          |
+          notion-page:<32-hex> ;        |
+          ... ; #inbox"                 |
+   |                                    |
+   |  triage strips #inbox              |
+   v                                    |
+  notes: "... notion-page:<32-hex> ..." |
+   |                                    |
+   +--> plan_create_only                |
+          |                             |
+          |  TODAY: no state entry,     |
+          |  in_scope() true            |
+          +---- src_create -------------+   ==> duplicate page
+
+          |  AFTER: marker found
+          +---- src_adopt (bid, pid) --> state map, no create
+```
+
+## Design
+
+### Diagram (state of one board row, push leg)
+
+```
+ unpushed ----(no marker, in scope)----> src_create --> Notion page --> mapped
+     |
+     +--------(marker in notes)--------> src_adopt --------------------> mapped
+                                          (no network call)
+ mapped ------------------------------->  frozen (bid in state map)
+```
+
+### Interfaces (I/O contract)
+
+- New in `sync_core`: `PULL_MARKER_RE = re.compile(r"notion-page:([0-9a-f]{32})")`, and a helper `bound_page_id(notes: str) -> str | None` returning the first match's group 1.
+- New `Plan` field: `src_adopt: list  # [(bid, rid)]`, and `Plan.empty()` unchanged (an adoption is not work on either side, it only records what is already true; state persistence is a side effect of the run, not a plan action).
+- `plan_create_only`: for each row not in `known` and not skipped by status or scope, if `bound_page_id(row.notes)` returns an id, append `(bid, pid)` to `src_adopt` and continue; otherwise append to `src_create` as today.
+- `sync_create_only`: before the apply, write each `src_adopt` pair into `new_map` as `{"rid": pid, "via": "pull-marker"}` and checkpoint once. The `via` field marks a binding that no POST created, so an operator reading the state file can tell the two apart. Nothing in the create-only path dereferences `rid`, so the dash-free form the marker carries is safe to store as is.
+- `describe()`: one line per adoption, in the existing grammar, e.g. `  = spoke     DF-412 bound to an existing Notion page (pull marker), not created`.
+
+### Order of checks
+
+The marker check runs after the status skip and after `in_scope()`. A dropped or filtered row produces neither a create nor an adoption, which keeps the existing skip semantics untouched.
+
+### ADR link(s)
+
+None. This restates an identity rule the pull leg already holds; it makes no lasting new decision.
+
+## Task Breakdown
+
+### Phase 1
+
+- [ ] TASK-001: Add `PULL_MARKER_RE` + `bound_page_id()` and the `src_adopt` field to `lib/sync/sync_core.py`; teach `plan_create_only` to emit an adoption instead of a create when a row carries a marker. Acceptance: a `Row` whose notes carry a marker and no `#inbox` tag produces zero `src_create` and one `src_adopt`.
+- [ ] TASK-002: Persist adoptions in `sync_create_only` (`lib/sync/backlog_sync.py`) and render them in `describe()`. Acceptance: after a run, the state map holds the bid with the marker's page id and `via: pull-marker`; a second run plans nothing for that row.
+- [ ] TASK-003: Tests in `lib/sync/tests/test_notion_taskboard.py`, fake transport only, per the file's `rows()` and `FakeNtn` fixtures. Acceptance: the three cases in `## Acceptance Criteria` are asserted, plus one asserting `sync_core.PULL_MARKER_RE` matches the string the pull adapter writes (`MARKER_PREFIX + pid`), so a rename on either side turns the suite red.
+- [ ] TASK-004: Update `lib/sync/README.md` and `lib/sync/docs/proof-of-done.md` with the guard and its run evidence.
+
+## After state
+
+- [ ] A board row carrying `notion-page:<pid>` is never pushed to the Task Board, whatever its tags. (Today: it is pushed as soon as triage strips `#inbox`.)
+- [ ] The push run records the binding, so the row is skipped by the cheap state check from the second run on. (Today: there is no binding to record.)
+- [ ] dfoundation's `notion_taskboard_skip_tags = "inbox"` becomes belt-and-braces rather than the only guard. (Today: it is the only guard.)
+- [ ] `bash tests/test-sync.sh` green, including the new cases.
+
+## Acceptance Criteria (global)
+
+1. A row with a pull marker in its notes and no `#inbox` tag plans no create, and plans one adoption carrying the marker's page id.
+2. A normal row, no marker, still plans a create, unchanged.
+3. After `sync_create_only`, the state map contains the adopted bid; a second plan against the same board is empty for that row, with no ntn call issued for it (`FakeNtn.page_bodies()` empty).
+4. A dropped row, or one filtered out by `skip_tags`, plans neither a create nor an adoption.
+5. No test issues a write to Notion: every ntn call recorded by the fake is a read, as `test_notion_taskboard_pull.py` already asserts with its `READ_CALLS` allowlist.
+6. Negative control: revert the guard in `sync_core.py`, keep the new tests, and case 1 fails.
+
+## Verification
+
+```
+uv run --no-project --with pytest -- pytest lib/sync/tests/test_notion_taskboard.py -q
+bash tests/test-sync.sh
+# negative control:
+git stash push -- lib/sync/sync_core.py
+uv run --no-project --with pytest -- pytest lib/sync/tests/test_notion_taskboard.py -k marker -v
+git stash pop
+```
+
+## Edge Cases
+
+1. A row carries two markers (a merged row). The first match wins, and the row is never created. Recording one binding is enough; the create is what must not happen.
+2. A marker appears in a row that also sits in state already. The state check runs first, so nothing changes.
+3. A marker with wrong case or dashes. The pull adapter writes lowercase, dash-free ids, so the pattern stays anchored to that form. A malformed marker means no adoption and a create, which is the pre-existing behavior, not a regression.
+4. A Task Board editor pastes `notion-page:<some id>` into a task's Notes. `_NEUTRALIZE` rewrites it to `[defanged]` before the pull adapter builds the row, so no forged marker reaches the board.
+5. The state file is deleted. Marker rows re-adopt for free on the next run. Rows the push originally created still re-push; that is the gap approach 2 would close.
+
+## Failure modes
+
+| Failure class | Detection signal | Mitigation / recovery |
+|---|---|---|
+| The pull adapter's marker format changes and the push guard stops matching | The cross-module test in TASK-003 goes red | The two constants are asserted equal in the suite, so the change cannot merge silently |
+| A pushed page is later deleted in Notion while its adoption stays in the map | Nothing; the push is insert-only and never reads back | Out of scope by contract: the team owns the card after it lands |
+| State-map loss re-pushes rows the push itself created | Duplicate prefixed cards on the Task Board | Approach 2 (remote title-prefix query), tracked as a follow-up |
+
+## Out of Scope
+
+- The remote title-prefix dedupe (approach 2). Its trigger is a second duplicate incident from either a hand-made copy or a lost state map. It belongs in `NotionTaskBoardSource.preflight`, where the schema read already happens, not in the pure planner.
+- Changing dfoundation's `.kit.toml`. `notion_taskboard_skip_tags = "inbox"` stays as a second layer; a consumer keeping its own guard is correct even once the kit holds the durable one.
+- Any live Notion write during tests. Every case runs against the fake transport.
+- Deleting or reconciling the duplicate pages already cleaned up by hand.
+
+## Touches
+
+- lib/sync/**
+- tests/**
+
+## Decision Log
+
+- DEC-001: Guard in the kit, not in consumer config. Config depends on a tag surviving human triage; the marker does not.
+- DEC-002: The marker pattern lives in `sync_core`, and the pull adapter keeps its own `MARKER_PREFIX`. A cross-import would couple two adapters the design keeps independent; a test asserts the two agree instead.
+- DEC-003: Adoption is plan data, not a side effect inside the planner. `plan_create_only` stays pure, matching every other planner in the file.
+
+## Open questions
+
+None blocking. Whether `src_adopt` should also count toward `Plan.empty()` is the implementer's call; treating an adoption as non-work keeps a steady-state run reporting `(nothing to do)`, which is the reading operators already trust.

--- a/lib/sync/README.md
+++ b/lib/sync/README.md
@@ -150,6 +150,17 @@ option. `dropped` rows are skipped; a state absent from the map uses
 preflight, so `--dry-run` surfaces config errors with zero writes, and state is
 checkpointed after each create so a mid-batch failure never re-pushes a page.
 
+A row whose notes already carry `notion-page:<32-hex>` (the identity marker
+`notion-taskboard-pull` below writes on intake) is never pushed as a create,
+whatever its tags: `plan_create_only` binds it into the state map instead
+(`{"rid": pid, "via": "pull-marker"}`), with no network call. This is what
+stops a team-approved intake row from minting a second, title-prefixed copy of
+the very page it came from the moment human triage strips its `#inbox`
+quarantine tag; a consumer's own `notion_taskboard_skip_tags` config is
+belt-and-braces on top, not the only guard. `describe()` prints one line per
+adoption (`= spoke DF-412 bound to an existing Notion page (pull marker), not
+created`); a steady-state run afterward reads `(nothing to do)` like any other.
+
 ```toml
 [sync]
 apps                             = "notion-taskboard"

--- a/lib/sync/backlog_sync.py
+++ b/lib/sync/backlog_sync.py
@@ -102,12 +102,23 @@ def sync_create_only(src, backlog: Path, state_path: Path, dry_run: bool,
     new_map = dict(state.get("map", {}))
     state_path.parent.mkdir(parents=True, exist_ok=True)
 
-    def checkpoint(bid: str, rid: str) -> None:
-        new_map[bid] = {"rid": rid}
+    def write_state() -> None:
         new_state = {"map": new_map}
         if getattr(src, "binding", None):
             new_state["binding"] = src.binding
         atomic_write(state_path, json.dumps(new_state, indent=1))
+
+    def checkpoint(bid: str, rid: str) -> None:
+        new_map[bid] = {"rid": rid}
+        write_state()
+
+    # Adoptions bind an existing page with no network call, so they are
+    # persisted up front rather than through the create-only checkpoint,
+    # which fires per POST.
+    if plan.src_adopt:
+        for bid, pid in plan.src_adopt:
+            new_map[bid] = {"rid": pid, "via": "pull-marker"}
+        write_state()
 
     created = src.apply(plan, {}, rows, on_created=checkpoint)
     print(f"synced {header}")

--- a/lib/sync/docs/proof-of-done.md
+++ b/lib/sync/docs/proof-of-done.md
@@ -226,6 +226,50 @@ rollback: the pull path only appends board rows. To undo a run, delete the
 appended rows from `### Reminders inbox`; there is no state file to clear and
 nothing was written to Notion.
 
+## SPEC-243, taskboard push marker dedupe (2026-09-02)
+
+The push leg (`notion-taskboard`, SPEC-003) never re-creates a page that came
+from the pull leg (`notion-taskboard-pull`, SPEC-004). A row whose notes carry
+the pull adapter's own identity marker (`notion-page:<32-hex>`) is bound into
+the create-only state map instead of pushed, closing the gap that let a
+dfoundation intake row mint a second, title-prefixed Task Board card the
+moment human triage stripped its `#inbox` quarantine tag
+(`notion_taskboard_skip_tags = "inbox"` stays as belt-and-braces, no longer the
+only guard).
+
+| When | Command | Exit | Verdict |
+|---|---|---|---|
+| 2026-09-02 | `uv run --no-project --with pytest -- pytest lib/sync/tests/test_notion_taskboard.py -q` | 0 | 35 passed (30 pre-change + 5 new marker cases) |
+| 2026-09-02 | `bash tests/test-sync.sh` | 0 | 256 passed, whole sync suite unchanged elsewhere (zero blast radius on the two-way mesh, the pull leg, or cockpit) |
+| 2026-09-02 | manual: `sync_create_only` against a one-row board carrying `notion-page:<pid>`, fake ntn | 0 | `describe()` printed `= spoke DF-1 bound to an existing Notion page (pull marker), not created`; zero POSTs (`fake.page_bodies() == []`); state map recorded `{"rid": "<pid>", "via": "pull-marker"}`; a second run against the persisted state printed `(nothing to do)` with zero POSTs |
+| 2026-09-02 | NEGATIVE CONTROL: `git show <pre-guard-sha>:lib/sync/sync_core.py` written over the working copy, keeping the new tests, then `pytest -k marker -v` | 1 | red: `ImportError: cannot import name 'PULL_MARKER_RE' from 'sync_core'`, collection aborts before any case runs; file restored via `git checkout -- lib/sync/sync_core.py`, suite back to green (35 passed) |
+
+Acceptance criteria mapping (SPEC-243 `## Acceptance Criteria`): (1) marker row
+with no `#inbox` tag plans zero creates and one adoption --
+`test_marker_row_adopts_instead_of_creating`; (2) a normal row still creates --
+`test_normal_row_without_marker_still_creates`; (3) the adoption persists and a
+second run is empty with no ntn write for that row --
+`test_adoption_persists_to_state_and_second_run_is_empty`; (4) a dropped or
+filtered marker row plans neither -- `test_dropped_or_filtered_marker_row_plans_nothing`;
+(5) no test in the suite issues a Notion write (unchanged from SPEC-003); (6)
+the negative control above.
+
+Cross-module guard: `test_marker_pattern_matches_pull_adapter_prefix` asserts
+`sync_core.PULL_MARKER_RE` matches `sources.notion_taskboard_pull.MARKER_PREFIX
++ <pid>`, so a rename on either side turns the suite red before it can turn any
+row red.
+
+DEC-004 (see `docs/implementation-notes/SPEC-243-taskboard-push-marker-dedupe.md`):
+an adoption is plan data, not counted in `Plan.empty()`. The run that performs
+one prints the adoption line (visibly not idle); a steady-state run afterward
+prints `(nothing to do)`, matching the reading operators already trust.
+
+rollback: the guard only changes what the push planner decides; it writes no
+new state shape beyond an extra `via` key alongside the existing `rid`. To
+undo, drop the `src_adopt` branch in `plan_create_only` and the persistence
+block in `sync_create_only`; existing `{"rid": ...}` map entries (no `via` key)
+are read the same as before.
+
 ## Reproduce
 
 ```

--- a/lib/sync/sync_core.py
+++ b/lib/sync/sync_core.py
@@ -162,6 +162,7 @@ def strip_tags(notes: str) -> str:
 @dataclass
 class Plan:
     src_create: list = field(default_factory=list)     # [(bid, title, body, kw)]
+    src_adopt: list = field(default_factory=list)      # [(bid, pid)]
     src_set_title: list = field(default_factory=list)  # [(rid, new_title)]
     src_set_body: list = field(default_factory=list)   # [(rid, body)]
     src_set_status: list = field(default_factory=list)  # [(rid, board_kw)]
@@ -399,6 +400,20 @@ def plan_sync(rows: dict, items: list, state: dict,
     return p
 
 
+# The pull adapter's identity marker (sources/notion_taskboard_pull.py
+# MARKER_PREFIX), matched against a row's raw notes cell. A row carrying this
+# was written by the pull adapter (`_NEUTRALIZE` there defangs the same
+# pattern before untrusted text reaches the board), never by a Task Board
+# editor, so the push leg can trust it as proof the row already has a page.
+PULL_MARKER_RE = re.compile(r"notion-page:([0-9a-f]{32})")
+
+
+def bound_page_id(notes: str) -> str | None:
+    """The Notion page id a row's notes already carry, or None."""
+    m = PULL_MARKER_RE.search(notes)
+    return m.group(1) if m else None
+
+
 def plan_create_only(rows: dict, state: dict, skip_kw: set | None = None,
                      filt: dict | None = None) -> Plan:
     """One-way, insert-only plan for a write-only sink (SPEC-003).
@@ -408,6 +423,11 @@ def plan_create_only(rows: dict, state: dict, skip_kw: set | None = None,
     (default `{"dropped"}`). Never updates, tombstones, or touches the board:
     the map is the identity index and a row is pushed exactly once, so a team
     member's later edits on the sink are never overwritten.
+
+    A row whose notes already carry a pull-adapter marker (`notion-page:<id>`)
+    is bound, not created: it was born on this very Task Board, so a create
+    would mint a duplicate page. `src_adopt` records the binding as plan data
+    so `sync_create_only` can persist it without a network call.
     """
     p = Plan()
     skip = skip_kw if skip_kw is not None else {"dropped"}
@@ -418,6 +438,10 @@ def plan_create_only(rows: dict, state: dict, skip_kw: set | None = None,
         if row.status_kw in skip:
             continue
         if not in_scope(row, filt):
+            continue
+        pid = bound_page_id(row.notes)
+        if pid is not None:
+            p.src_adopt.append((bid, pid))
             continue
         p.src_create.append((bid, title_for(bid, row.item), row.notes,
                              row.status_kw))
@@ -608,6 +632,9 @@ def describe(plan: Plan, assigned: dict | None = None) -> str:
     out = []
     for bid, t, _b, _kw in plan.src_create:
         out.append(f"  + spoke     {t}")
+    for bid, _pid in plan.src_adopt:
+        out.append(f"  = spoke     {bid} bound to an existing Notion page "
+                   "(pull marker), not created")
     for rid, kw in plan.src_set_status:
         out.append(f"  ~ spoke     {rid} -> {kw}")
     for rid, t in plan.src_set_title:

--- a/lib/sync/tests/test_notion_taskboard.py
+++ b/lib/sync/tests/test_notion_taskboard.py
@@ -11,7 +11,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from sources.notion_taskboard import (NotionTaskBoardSource, _rich,  # noqa: E402
                                       parse_map)
-from sync_core import Plan, Row, plan_create_only  # noqa: E402
+from sources.notion_taskboard_pull import MARKER_PREFIX  # noqa: E402
+from sync_core import (PULL_MARKER_RE, Plan, Row,  # noqa: E402
+                       plan_create_only)
 
 
 class FakeNtn:
@@ -100,6 +102,62 @@ def test_custom_skip_kw_extends_dropped():
     r = rows(("DF-1", "a", "shipped", ""), ("DF-2", "b", "queued", ""))
     plan = plan_create_only(r, {}, skip_kw={"dropped", "shipped"})
     assert [c[0] for c in plan.src_create] == ["DF-2"]
+
+
+# --- marker-aware adoption: never re-create a row the pull leg made ------
+
+PULL_PID = "0123456789abcdef0123456789abcdef"
+
+
+def test_marker_row_adopts_instead_of_creating():
+    r = rows(("DF-1", "intake row", "queued",
+              f"notion-intake ; notion-page:{PULL_PID} ; some body"))
+    plan = plan_create_only(r, {})
+    assert plan.src_create == []
+    assert plan.src_adopt == [("DF-1", PULL_PID)]
+
+
+def test_normal_row_without_marker_still_creates():
+    r = rows(("DF-1", "plain row", "queued", "no marker here"))
+    plan = plan_create_only(r, {})
+    assert [c[0] for c in plan.src_create] == ["DF-1"]
+    assert plan.src_adopt == []
+
+
+def test_dropped_or_filtered_marker_row_plans_nothing():
+    r = rows(("DF-1", "dropped intake", "dropped", f"notion-page:{PULL_PID}"),
+             ("DF-2", "filtered intake", "queued",
+              f"#family notion-page:{PULL_PID}"))
+    plan = plan_create_only(r, {}, filt={"skip_tags": {"family"}})
+    assert plan.src_create == [] and plan.src_adopt == []
+
+
+def test_adoption_persists_to_state_and_second_run_is_empty(tmp_path):
+    import backlog_sync
+
+    board = tmp_path / "BACKLOG.md"
+    board.write_text(
+        "| ID | Item | Notes & source | Status |\n|---|---|---|---|\n"
+        f"| DF-1 | intake row | notion-page:{PULL_PID} | queued |\n")
+    state = tmp_path / "s.json"
+
+    src, fake = make_src()
+    backlog_sync.sync_create_only(src, board, state, dry_run=False)
+    assert fake.page_bodies() == []
+    saved = json.loads(state.read_text())
+    assert saved["map"]["DF-1"] == {"rid": PULL_PID, "via": "pull-marker"}
+
+    src2, fake2 = make_src()
+    backlog_sync.sync_create_only(src2, board, state, dry_run=False)
+    assert fake2.page_bodies() == []  # no ntn write call for the adopted row
+
+
+def test_marker_pattern_matches_pull_adapter_prefix():
+    # A rename on either side (this pattern or the pull adapter's own
+    # constant) must turn this test red before it can turn any row red.
+    text = MARKER_PREFIX + PULL_PID
+    m = PULL_MARKER_RE.search(text)
+    assert m and m.group(1) == PULL_PID
 
 
 # --- apply: field mapping (case 1, 4) ------------------------------------


### PR DESCRIPTION
## Summary

Spec: `docs/specs/SPEC-243-taskboard-push-marker-dedupe.md`

The push leg (`notion-taskboard`, SPEC-003) now recognizes a row whose notes
already carry the pull leg's own identity marker (`notion-page:<32-hex>`,
written by `notion-taskboard-pull`, SPEC-004) and adopts it into the
create-only state map instead of creating a duplicate page. This closes the
gap that let a dfoundation intake row mint a second, title-prefixed Task
Board card the moment human triage stripped its `#inbox` quarantine tag.

## Per-task acceptance status

- TASK-001 (`sync_core.py`): `PULL_MARKER_RE` + `bound_page_id()` + `Plan.src_adopt`; `plan_create_only` emits an adoption instead of a create when a row carries a marker. AC: verified — a marker row with no `#inbox` tag produces zero `src_create` and one `src_adopt`.
- TASK-002 (`backlog_sync.py`): `sync_create_only` persists each adoption into the state map as `{"rid": pid, "via": "pull-marker"}` before the create-only apply, and `describe()` renders one line per adoption. AC: verified — after a run the state map holds the binding; a second run plans nothing for that row.
- TASK-003 (`tests/test_notion_taskboard.py`): 5 new cases cover the 4 global acceptance criteria plus a cross-module test asserting `sync_core.PULL_MARKER_RE` matches `notion_taskboard_pull.MARKER_PREFIX + pid`.
- TASK-004 (`lib/sync/README.md`, `lib/sync/docs/proof-of-done.md`): guard documented, run evidence recorded in a new `## SPEC-243` proof-of-done section.

## Verification

```
uv run --no-project --with pytest -- pytest lib/sync/tests/test_notion_taskboard.py -q
# 35 passed (30 pre-change + 5 new)

bash tests/test-sync.sh
# 256 passed
```

Negative control: reverted `lib/sync/sync_core.py` to the pre-guard commit
(`git show <parent-sha>:lib/sync/sync_core.py` over the working copy), kept
the new tests, re-ran `pytest -k marker -v` → red (`ImportError: cannot
import name 'PULL_MARKER_RE' from 'sync_core'`, collection aborts before any
case runs). Restored via `git checkout -- lib/sync/sync_core.py`, suite back
to green (35 passed).

`bash tests/test-meta.sh`: 823/824. The one failure (`docs/FEATURES.md is
fresh`) is pre-existing and untouched by this branch — `docs/FEATURES.md`
does not appear in this diff (`git diff origin/master...HEAD --stat`).

## Notes

- dfoundation's `.kit.toml` `notion_taskboard_skip_tags = "inbox"` stays in
  place as belt-and-braces, per the spec's Out of Scope — this PR does not
  touch consumer config.
- DEC-004 (open question resolved): `Plan.empty()` stays unchanged (adoption
  excluded). The run that performs an adoption prints the adoption line via
  `describe()` (visibly not idle); a steady-state run afterward prints
  `(nothing to do)`, matching the reading operators already trust. See
  `docs/implementation-notes/SPEC-243-taskboard-push-marker-dedupe.md`.

## Test plan

- [x] `pytest lib/sync/tests/test_notion_taskboard.py -q`
- [x] `bash tests/test-sync.sh`
- [x] Negative control (guard reverted, new tests go red)
- [x] `bash tests/test-meta.sh` (pre-existing unrelated failure noted)