### PR TITLE
docs(playbook): fixture-enumerated gates and stored identifiers

### DIFF
--- a/docs/impl-playbook/financial-data-handling.md
+++ b/docs/impl-playbook/financial-data-handling.md
@@ -10,6 +10,9 @@ Distills Modern Treasury's decimal-vs-float guidance and Stripe's idempotency-ke
 - Prefer an append-only ledger (every balance change is a recorded entry, not an overwritten field) over mutating a running balance in place. The current balance is a derived sum, not the source of truth.
 - Every entry carries enough context to reconstruct why it happened (source, timestamp, actor) so an audit trail exists without extra tooling.
 
+## A stored identifier is not a promise about behaviour
+- A column holding an address, an account number, or a wallet does not mean a deposit to it credits that account. Crediting is governed by a registration (a watch list, a mapping table, a subscription) that can drift from the display field. A "will this deposit be credited" check reads the governing registration, never the field that displays the identifier. Learned 2026-09-05 on a deposit that landed on a stored address no watcher was registered for.
+
 ## Idempotency for money-moving operations
 - Any operation that moves or creates money (a transfer, a mint, a payout) takes an idempotency key from the caller. Replaying the same request with the same key must not double-execute; store seen keys and their result, and return the stored result on a repeat.
 - Idempotency lives at the operation boundary (the API/function that actually moves money), not sprinkled through the call chain.

--- a/docs/impl-playbook/test-case-design.md
+++ b/docs/impl-playbook/test-case-design.md
@@ -15,6 +15,10 @@ Distills the ISTQB CTFL black-box test design techniques plus Cucumber's Gherkin
 - Keep each scenario to 3-5 steps. One scenario, one behavior; a scenario that needs "and also" to describe is two scenarios.
 - Write the acceptance criteria BEFORE building, agreed with whoever signs off (the stakeholder, or your future self reading it in a month). Ambiguous words ("fast", "works correctly") are not acceptance criteria.
 
+## Regression gates enumerate from live code, not from fixtures
+
+A gate that walks a fixture set has a ceiling worth stating out loud: it catches a new case inside a renderer or handler the fixtures already cover, and misses one inside a renderer nothing covers. Enumerate the cases from the code paths themselves (the route table, the formatter registry, the enum) and derive the fixtures from that list, so a newly added path is a failing test before it is a missing one. Learned 2026-09-04 on a message-formatter suite that stayed green while a new event type rendered as raw JSON.
+
 ## At personal scale
 
 Solo-maintained tools do not need a decision-table spreadsheet for every function. Reach for these four techniques together only where a bug would be expensive to miss: money paths, auth/permission boundaries, parsers, anything with 3+ interacting conditions. For everything else, EP + BVA on the one or two trickiest inputs is enough; skip decision tables and state-transition diagrams unless the code genuinely has combinatorial conditions or explicit states.


### PR DESCRIPTION
Two playbook lines from the 2026-09-05 learned-ledger flush. Docs only.