### PR TITLE
fix(tests): pin the kit-root config layer to the checkout

### DIFF
--- a/tests/test-model-routing.sh
+++ b/tests/test-model-routing.sh
@@ -22,6 +22,10 @@
 
 set -uo pipefail
 KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The kit-root config layer is $HOME/.claude/dwarves-kit by default, which CI does not have and
+# a dev machine has as an installed copy of THIS checkout. Pin it to the checkout so the
+# no-Model: expectations below (read from $KIT/kit.toml) hold in both places.
+export KIT_CONFIG_ROOT="${KIT_CONFIG_ROOT:-$KIT}"
 ORCH="$KIT/lib/queue/orchestrate.sh"
 fails=0; total=0
 pass() { total=$((total + 1)); echo "PASS $*"; }

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -6,6 +6,10 @@
 # Negative control: a session that does NOT flip its box halts the loop (no self-claim).
 set -uo pipefail
 KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The kit-root config layer is $HOME/.claude/dwarves-kit by default, which CI does not have and
+# a dev machine has as an installed copy of THIS checkout. Pin it to the checkout so the
+# no-Model: expectations below (read from $KIT/kit.toml) hold in both places.
+export KIT_CONFIG_ROOT="${KIT_CONFIG_ROOT:-$KIT}"
 ORCH="$KIT/lib/queue/orchestrate.sh"
 # The kit-root kit.toml ships `[mega].default_model`; a sub-goal with no Model: field
 # dispatches it (SPEC-087 chain). Read the shipped value rather than pin either outcome.


### PR DESCRIPTION
The kit-root config layer defaults to ~/.claude/dwarves-kit, which CI does not have and a dev machine has as an installed copy of this checkout, so the no-Model: routing expectations resolved differently in the two places (CI: no default, "inherit"; local: sonnet). Both routing tests now export KIT_CONFIG_ROOT=$KIT so the checkout kit.toml is the layer everywhere. Proof: DWARVES_KIT=/nonexistent (CI shape) red before, green after; normal local run green; test-meta green.