### PR TITLE
fix(ci): test workflow guards again; battery findings on the repair

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,13 @@
 name: test
 
+# push + pull_request were removed on 2026-08-10 and the workflow then sat hand-disabled
+# until 2026-09-05; master drifted red under it with nothing to notice. Public repo,
+# hosted minutes are free, so every push and PR runs the suites again.
 on:
   workflow_dispatch:
+  push:
+    branches: [master]
+  pull_request:
 
 # Least-privilege token: workflow only reads code and runs tests; no writes,
 # no PR comments, no release operations.
@@ -143,6 +149,7 @@ jobs:
 
       - name: Run bench module tests
         run: bash tests/test-bench.sh
+
       - name: Run outcome-emit-sweep no-orphan check (SPEC-193, harness-loop sub-goal 02)
         run: bash tests/test-outcome-emit-sweep.sh
 

--- a/commands/battery.md
+++ b/commands/battery.md
@@ -9,7 +9,7 @@ and re-reading it. Never "review" inline in the session that wrote the code and 
 it the battery.
 
 
-Bracket the phase for timing (SPEC-129) before dispatching any arm: `bash lib/gate/gate-ledger.sh outcome <rid> review start` (rid = the branch slug, the same key the ship-gate reads).
+Bracket the phase for timing (SPEC-129) before dispatching any arm: `bash lib/gate/gate-ledger.sh outcome <rid> battery start` (rid = the branch slug, the same key the ship-gate reads; the ledger counts `battery` as the review gate).
 ## When this runs
 
 - The operator says "run the battery" / "overtest this" / "full check before merge".
@@ -70,8 +70,8 @@ Skipping a qualifying lens is a decision; record it, do not default into it.
 3. A verifier-caught gap means an AC or test was too weak: strengthen the check in
    the same pass, not only the code.
 4. Write the spec's `## Review` section (replace-not-stack) and record the legs in
-   the gate ledger under the BRANCH SLUG: `bash lib/gate/gate-ledger.sh record <rid> review ran "<verdict> arms=<n> caught=<n>"`
+   the gate ledger under the BRANCH SLUG: `bash lib/gate/gate-ledger.sh record <rid> battery ran "<verdict> arms=<n> caught=<n>"`
    (the slug, never a board ID, is what the ship-gate reads). Then close the
-   timing bracket (SPEC-129): `bash lib/gate/gate-ledger.sh outcome <rid> review end caught=<true if any arm found a defect, else false>`.
+   timing bracket (SPEC-129): `bash lib/gate/gate-ledger.sh outcome <rid> battery end caught=<true if any arm found a defect, else false>`.
 5. Name what each arm caught in the report. Disagreement between arms is the
    signal this battery exists to produce.

--- a/docs/decisions/0034-harness-loop-taxonomy.md
+++ b/docs/decisions/0034-harness-loop-taxonomy.md
@@ -42,6 +42,8 @@ The taxonomy is a consolidation plan, so it opens with what exists. Four surface
 
 Deliberately bin-less (internal libs, command-invoked, not operator CLIs): `ledger`, `telemetry`, `plugin-check`, `skill-curator`, `adopt.sh`, `explain.sh`, `pitch.sh`, `precedent.sh`. Target bin/ after SG-04+08: 11 subsystem entries (`board classify config gate goal learn mega queue session spec stats`) + 2 module CLIs (`prose-rag`, `worktree-provision`) = 13, two grammar classes, both stated in decision 7.
 
+Amendment 2026-09-06: a third class, standalone operator executables that dispatch to no engine because they ARE the whole feature: `activate` (the free-to-pro client, ID-438), `release` (the semver tag + two-channel publish, ID-437), plus `plugin-check`, `skill-improve`, `skill-review` which had already landed in bin/ under the same shape. The census in `tests/test-bin-forwarders.sh` names every entry in all three classes and proves each standalone one answers with its own contract; a bin/ entry outside those lists is still the drift the census exists to catch.
+
 ### skills/, 2 visible, 1 hidden
 
 | Skill | Location today | Target |

--- a/docs/verification/test-schedule-census-dispatch.md
+++ b/docs/verification/test-schedule-census-dispatch.md
@@ -1,0 +1,40 @@
+# The test workflow guards again, and the battery's findings on the repair
+
+Lane: normal
+
+`/kit:battery` over a95c0f99..be1c062 (PRs #487, #488, #489, the repair of the `test` workflow after three weeks hand-disabled). Verifier: PASS on all 64 workflow steps plus the CI-shape rerun. Reviewer and advisor: FIX THEN SHIP. What landed:
+
+| Sev | Finding | Fix |
+|---|---|---|
+| HIGH | the workflow lost `push` and `pull_request` on 2026-08-10, so re-enabling it made the suites runnable, not guarding | both triggers restored (public repo, hosted minutes free) |
+| HIGH | the inherit fallback ("no config, no `--model`") had no live assertion once the kit-root default was pinned | a case with both config layers pointed at empty dirs asserts SG-02 dispatches with no `--model` |
+| MED | the tests re-implemented the toml parse with `grep '^default_model'` | the expectation comes from `kit_config_get` itself |
+| MED | `KIT_PROJECT_ROOT` was left loose, so a host repo's `.kit.toml` could flip the expectation | pinned to an empty temp dir |
+| MED | the bin/ census was widened in the test alone; `activate` and `release` are standalone executables, not forwarders | ADR-0034 amended with the third class; the census proves each answers with its own contract; header count corrected |
+| MED | `lib/bench/SPEC.md` named a test file that does not exist and omitted two modules | roster and table corrected |
+| LOW | `tests/test-bench.sh` swallowed the failing file's output | re-run visibly on failure |
+| LOW | battery recorded under the `review` phase key, so its timing landed on /kit:review's row in stats | own key `battery`; `normalize_phase` maps it to the review gate |
+
+## Green run
+
+| Command | Exit | Verdict |
+|---|---|---|
+| every `run: bash tests/...` step of `.github/workflows/test.yml`, in order | 0 each | PASS (0 red of 65) |
+| `DWARVES_KIT=/nonexistent bash tests/test-orchestrate.sh` (CI shape) | 0 | PASS, including `no config layer at all -> SG-02 inherits (no --model)` |
+| `bash tests/test-bin-forwarders.sh` | 0 | PASS (32, two new: activate usage line, release semver refusal) |
+
+Recorded run
+- Command: `bash tests/test-orchestrate.sh`
+- Exit: 0
+- Verdict: PASS
+
+## NEGATIVE CONTROL
+
+Targeted edit: make the orchestrator apply a hardcoded default when the config layers are empty (`model="${model:-sonnet}"` after the `kit_config_get`).
+
+- Command: `bash tests/test-orchestrate.sh`
+- Exit: 1, `FAIL inherit fallback lost: SG-02 got a --model with no config` (RED). Restored from a copy: PASS.
+
+## Rollback
+
+Revert the commit. The workflow returns to dispatch-only; nothing outside the repo changes.

--- a/lib/bench/SPEC.md
+++ b/lib/bench/SPEC.md
@@ -14,6 +14,8 @@ The kit's loops (orchestrate, gate, review) need a repeatable way to measure a c
 | `events.py` | the event stream a run emits (start, scenario, score, end) that the report and dashboard consume |
 | `report.py` | summarize one run, diff two runs, render HTML |
 | `dashboard.py` | the terminal frontend over the same events: state machine, mid-run frame, roundtrip |
+| `tui.py` | the interactive terminal view the dashboard drives |
+| `viewer.py` | the read-only run viewer, the roundtrip target of a finished run |
 | `docs/METRICS.md` | what each score means and how it is derived |
 | `docs/test-catalog.md` | the L1 / L2 / L3 coverage map |
 
@@ -21,7 +23,7 @@ The kit's loops (orchestrate, gate, review) need a repeatable way to measure a c
 
 - A suite runs end to end and leaves a run directory whose summary matches its own events (`tests/test_bench.py`).
 - Two runs diff without recomputing scores (`tests/test_report.py`).
-- The dashboard renders a mid-run frame and round-trips a finished run (`tests/test_dashboard.py`, `tests/test_tui.py`).
+- The dashboard renders a mid-run frame and the viewer round-trips a finished run (`tests/test_dashboard.py`, `tests/test_viewer.py`); events are the shared contract (`tests/test_events.py`).
 - Repo-root entry: `bash tests/test-bench.sh` runs every module test the same way CI does.
 
 ## Out of scope

--- a/lib/gate/gate-ledger.sh
+++ b/lib/gate/gate-ledger.sh
@@ -112,7 +112,9 @@ normalize_phase() {
   # ("execute") instead of the matrix gate it owns ("build"), leaving check() blind to a
   # build that ran (seen 2026-07-21, finance-warehouse run). "verify" is NOT aliased to
   # "review": /kit:verify (right-arm re-run) and /kit:review (code review) are distinct gates.
-  case "$p" in execute) p=build ;; esac
+  # "battery" is /kit:battery's own beat: distinct attribution in stats, but it satisfies
+  # the same review gate the ship-gate checks (it IS the fresh-context review).
+  case "$p" in execute) p=build ;; battery) p=review ;; esac
   printf '%s' "$p"
 }
 

--- a/tests/test-bench.sh
+++ b/tests/test-bench.sh
@@ -6,6 +6,6 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE/../lib/bench" || exit 1
 fails=0
 for t in tests/test_*.py; do
-  if python3 "$t" >/dev/null 2>&1; then echo "  ok   $t"; else echo "  FAIL $t"; fails=$((fails+1)); fi
+  if python3 "$t" >/dev/null 2>&1; then echo "  ok   $t"; else echo "  FAIL $t"; python3 "$t" 2>&1 | tail -20; fails=$((fails+1)); fi
 done
 [ "$fails" = 0 ] && echo "PASS: bench ($(ls tests/test_*.py | wc -l | tr -d ' ') files)" || { echo "FAIL: $fails file(s)"; exit 1; }

--- a/tests/test-bin-forwarders.sh
+++ b/tests/test-bin-forwarders.sh
@@ -3,7 +3,8 @@
 # forwarder's dispatch chain, exercised THROUGH the stable entrypoints (not the deep lib
 # paths the per-tool suites already cover).
 #
-#   1. CENSUS: bin/ contains exactly the ADR-0034 SG-04 target set (10 subsystem entries
+#   1. CENSUS: bin/ contains exactly the ADR-0034 set (11 subsystem entries, 2 module CLIs, and
+#      the standalone executables the 2026-09-06 amendment names
 #      + 2 module CLIs; `config` lands in SG-08), and every retired entry stays gone.
 #   2. DISPATCH: each new/changed forwarder routes a real invocation end to end:
 #      learn debt (the relocated weekend-batch), every session <verb>, board promote,
@@ -28,8 +29,10 @@ echo "== census: bin/ is exactly the ADR-0034 SG-04 target set =="
 # +plugin-check, +skill-improve, +skill-review (SPEC-200 C2, 2026-07-14): each was a module
 # executable reachable from NO operator surface. The contract lint (C2) now fails on that, and
 # this census is the other half of the same guarantee: bin/ may not grow silently either.
-# activate and release joined bin/ after the SG-04 set was written; the census names them so
-# the dispatch-only test workflow stops failing on a roster it was never told about.
+# activate and release are standalone executables (ADR-0034, amendment 2026-09-06), not
+# SPEC-184 forwarders; the census names them because the DISPATCH block below proves each
+# answers with its own contract. A bin/ entry with no such block is still the drift this
+# census exists to catch.
 EXPECTED="activate board classify config gate goal learn mega plugin-check prose-rag queue release session skill-improve skill-review spec stats worktree-provision"
 ACTUAL="$(ls -1 "$KIT_DIR/bin" | sort | tr '\n' ' ' | sed 's/ $//')"
 EXPECTED_SORTED="$(printf '%s\n' $EXPECTED | sort | tr '\n' ' ' | sed 's/ $//')"
@@ -43,6 +46,12 @@ echo "== census NC: every retired entry stays gone =="
 for retired in add-backlog session-intel session-observe session-recall session-report session-semantic; do
   assert_true "bin/$retired absent" "$([ ! -e "$KIT_DIR/bin/$retired" ]; echo $?)"
 done
+
+echo "== activate + release: the two non-forwarder CLIs in bin/ answer with their own contract =="
+out="$("$KIT_DIR/bin/activate" 2>&1)"; rc=$?
+assert_true "bin/activate with no args prints its usage line" "$(grep -q 'usage: bin/activate' <<<"$out"; echo $?)"
+out="$("$KIT_DIR/bin/release" --help 2>&1)"; rc=$?
+assert_true "bin/release rejects a non-semver argument with its own message" "$(grep -q 'semver required' <<<"$out"; echo $?)"
 
 echo "== learn: debt dispatches to the relocated weekend-batch =="
 TMPLOG="$(mktemp -d)"

--- a/tests/test-model-routing.sh
+++ b/tests/test-model-routing.sh
@@ -26,6 +26,9 @@ KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # a dev machine has as an installed copy of THIS checkout. Pin it to the checkout so the
 # no-Model: expectations below (read from $KIT/kit.toml) hold in both places.
 export KIT_CONFIG_ROOT="${KIT_CONFIG_ROOT:-$KIT}"
+export KIT_PROJECT_ROOT="${KIT_PROJECT_ROOT:-$(mktemp -d)}"
+# The expectation comes from the resolver itself, never a re-implementation of its toml parse.
+kit_default_model() { ( cd "$KIT" && bash -c 'source lib/config/kit-config.sh; kit_config_get mega.default_model' ); }
 ORCH="$KIT/lib/queue/orchestrate.sh"
 fails=0; total=0
 pass() { total=$((total + 1)); echo "PASS $*"; }
@@ -94,7 +97,7 @@ run_serial_case() {  # tier(opus|sonnet|haiku|none) expect_flag(--model X or emp
   else
     # No Model: field: the kit-root kit.toml's `[mega].default_model` wins when shipped
     # (SPEC-087 chain); with no config the inherit fallback passes no flag.
-    def_model=$(grep -E '^default_model' "$KIT/kit.toml" 2>/dev/null | sed -E 's/^[^"]*"([^"]*)".*/\1/')
+    def_model=$(kit_default_model)
     if [ -n "$def_model" ]; then
       grep -q "^SG-01|.*--model $def_model" "$log" \
         && pass "serial: no Model: field -> kit-root default '--model $def_model'" \

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -10,10 +10,13 @@ KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # a dev machine has as an installed copy of THIS checkout. Pin it to the checkout so the
 # no-Model: expectations below (read from $KIT/kit.toml) hold in both places.
 export KIT_CONFIG_ROOT="${KIT_CONFIG_ROOT:-$KIT}"
+export KIT_PROJECT_ROOT="${KIT_PROJECT_ROOT:-$(mktemp -d)}"
+# The expectation comes from the resolver itself, never a re-implementation of its toml parse.
+kit_default_model() { ( cd "$KIT" && bash -c 'source lib/config/kit-config.sh; kit_config_get mega.default_model' ); }
 ORCH="$KIT/lib/queue/orchestrate.sh"
 # The kit-root kit.toml ships `[mega].default_model`; a sub-goal with no Model: field
 # dispatches it (SPEC-087 chain). Read the shipped value rather than pin either outcome.
-DEF_MODEL=$(grep -E '^default_model' "$KIT/kit.toml" 2>/dev/null | sed -E 's/^[^"]*"([^"]*)".*/\1/')
+DEF_MODEL=$(kit_default_model)
 fails=0
 pass() { echo "PASS $*"; }
 fail() { echo "FAIL $*"; fails=$((fails + 1)); }
@@ -231,6 +234,15 @@ ROUTE_LOG="$TMP/route.log" ROUTE_RM="$DR2/ROADMAP.md" CLAUDE_FLAGS="" \
   CLAUDE_CMD="$TMP/claude-route" bash "$ORCH" run "$DR2" >/dev/null 2>&1
 grep -q '^SG-01|.*--model sonnet --effort low' "$TMP/route.log" \
   && pass "run passes --model/--effort for hinted SG-01" || { fail "SG-01 routing flags missing"; cat "$TMP/route.log"; }
+# The inherit fallback (SPEC-087, "no config -> no flag") stays asserted: with BOTH config
+# layers pointed at empty dirs, SG-02 must dispatch with no --model at all.
+EMPTY_ROOT="$(mktemp -d)"
+DR3="$TMP/mgr3"; mk_routed "$DR3"; : > "$TMP/route3.log"
+KIT_CONFIG_ROOT="$EMPTY_ROOT" KIT_PROJECT_ROOT="$EMPTY_ROOT" ROUTE_LOG="$TMP/route3.log" ROUTE_RM="$DR3/ROADMAP.md" CLAUDE_FLAGS="" \
+  CLAUDE_CMD="$TMP/claude-route" bash "$ORCH" run "$DR3" >/dev/null 2>&1
+{ grep '^SG-02|' "$TMP/route3.log" | grep -qv -- '--model'; } \
+  && pass "no config layer at all -> SG-02 inherits (no --model)" || { fail "inherit fallback lost: SG-02 got a --model with no config"; cat "$TMP/route3.log"; }
+
 # SG-02 carries no Model: field: see DEF_MODEL at the top.
 if [ -n "$DEF_MODEL" ]; then
   grep -q "^SG-02|.*--model $DEF_MODEL" "$TMP/route.log" \


### PR DESCRIPTION
# The test workflow guards again, and the battery's findings on the repair

Lane: normal

`/kit:battery` over a95c0f99..be1c062 (PRs #487, #488, #489, the repair of the `test` workflow after three weeks hand-disabled). Verifier: PASS on all 64 workflow steps plus the CI-shape rerun. Reviewer and advisor: FIX THEN SHIP. What landed:

| Sev | Finding | Fix |
|---|---|---|
| HIGH | the workflow lost `push` and `pull_request` on 2026-08-10, so re-enabling it made the suites runnable, not guarding | both triggers restored (public repo, hosted minutes free) |
| HIGH | the inherit fallback ("no config, no `--model`") had no live assertion once the kit-root default was pinned | a case with both config layers pointed at empty dirs asserts SG-02 dispatches with no `--model` |
| MED | the tests re-implemented the toml parse with `grep '^default_model'` | the expectation comes from `kit_config_get` itself |
| MED | `KIT_PROJECT_ROOT` was left loose, so a host repo's `.kit.toml` could flip the expectation | pinned to an empty temp dir |
| MED | the bin/ census was widened in the test alone; `activate` and `release` are standalone executables, not forwarders | ADR-0034 amended with the third class; the census proves each answers with its own contract; header count corrected |
| MED | `lib/bench/SPEC.md` named a test file that does not exist and omitted two modules | roster and table corrected |
| LOW | `tests/test-bench.sh` swallowed the failing file's output | re-run visibly on failure |
| LOW | battery recorded under the `review` phase key, so its timing landed on /kit:review's row in stats | own key `battery`; `normalize_phase` maps it to the review gate |

## Green run

| Command | Exit | Verdict |
|---|---|---|
| every `run: bash tests/...` step of `.github/workflows/test.yml`, in order | 0 each | PASS (0 red of 65) |
| `DWARVES_KIT=/nonexistent bash tests/test-orchestrate.sh` (CI shape) | 0 | PASS, including `no config layer at all -> SG-02 inherits (no --model)` |
| `bash tests/test-bin-forwarders.sh` | 0 | PASS (32, two new: activate usage line, release semver refusal) |

Recorded run
- Command: `bash tests/test-orchestrate.sh`
- Exit: 0
- Verdict: PASS

## NEGATIVE CONTROL

Targeted edit: make the orchestrator apply a hardcoded default when the config layers are empty (`model="${model:-sonnet}"` after the `kit_config_get`).

- Command: `bash tests/test-orchestrate.sh`
- Exit: 1, `FAIL inherit fallback lost: SG-02 got a --model with no config` (RED). Restored from a copy: PASS.

## Rollback

Revert the commit. The workflow returns to dispatch-only; nothing outside the repo changes.
