### PR TITLE
feat(tests): run-workflow.sh -j N runs suites concurrently

### DIFF
--- a/docs/verification/run-workflow.md
+++ b/docs/verification/run-workflow.md
@@ -18,6 +18,16 @@ Recorded run
 - Exit: 0
 - Verdict: PASS
 
+## Parallel run (`-j N`, 2026-09-06)
+
+Every suite builds its own temp dirs, so steps run concurrently; each step's block prints whole, failures are counted through marker files.
+
+| Command | Exit | Verdict |
+|---|---|---|
+| `bash tests/run-workflow.sh -j 4` on the real list | 0 | PASS, `0 red of 64 steps`, wall 156s |
+| `bash tests/run-workflow.sh` (serial, same tree) | 0 | PASS, `0 red of 64 steps`, wall 454s |
+| fixture with one red among three, `-j 3` and serial | 1 | PASS, the red step reported in both modes |
+
 ## NEGATIVE CONTROL
 
 Targeted edit: blind the runner to step exit codes (`rc=0` after each step).

--- a/tests/run-workflow.sh
+++ b/tests/run-workflow.sh
@@ -6,6 +6,9 @@
 #
 #   bash tests/run-workflow.sh            # failures only, then a one-line summary
 #   bash tests/run-workflow.sh -v         # every step with its exit code
+#   bash tests/run-workflow.sh -j 4       # four suites at a time (they each build their own
+#                                         # temp dirs; measured 2026-09-06: macOS CI leg 417s
+#                                         # serial, the top four suites alone 226s of it)
 #
 # A few suites rewrite their sample docs under docs/verification as a side effect; any tracked
 # file that was clean before the run and dirty after it is restored, so a local run leaves the
@@ -14,22 +17,36 @@ set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE/.." || exit 1
 WF="${RUN_WORKFLOW_FILE:-.github/workflows/test.yml}"
-verbose=0; [ "${1:-}" = "-v" ] && verbose=1
+verbose=0; jobs=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -v) verbose=1 ;;
+    -j) jobs="${2:-4}"; shift ;;
+    *) echo "usage: run-workflow.sh [-v] [-j N]" >&2; exit 2 ;;
+  esac
+  shift
+done
 
 before=$(git status --porcelain 2>/dev/null | awk '$1=="M"||$1==" M"{print $2}' | sort)
-total=0; red=0
-while read -r cmd; do
-  [ -n "$cmd" ] || continue
-  total=$((total + 1))
+# one step: run it, print RED (or ok under -v) as a single block, leave a marker on failure
+run_step() {
+  local cmd="$1" out rc
   out=$($cmd 2>&1); rc=$?
   if [ "$rc" -ne 0 ]; then
-    red=$((red + 1))
-    echo "RED  $cmd (rc=$rc)"
-    printf '%s\n' "$out" | grep -E 'FAIL|ORPHAN|offend|Error' | grep -v PASS | head -4 | sed 's/^/       /'
-  elif [ "$verbose" = 1 ]; then
+    { echo "RED  $cmd (rc=$rc)"; printf '%s\n' "$out" | grep -E 'FAIL|ORPHAN|offend|Error' | grep -v PASS | head -4 | sed 's/^/       /'; }
+    : > "$RW_MARKS/$(printf '%s' "$cmd" | tr -c 'A-Za-z0-9' '_')"
+  elif [ "$RW_VERBOSE" = 1 ]; then
     echo "ok   $cmd"
   fi
-done < <(grep -E '^\s+(- )?run: bash tests/' "$WF" | sed 's/.*run: //')
+}
+export -f run_step
+RW_MARKS=$(mktemp -d); export RW_MARKS RW_VERBOSE="$verbose"
+steps=$(grep -E '^\s+(- )?run: bash tests/' "$WF" | sed 's/.*run: //')
+total=$(printf '%s\n' "$steps" | grep -c .)
+# -P keeps the order of START only; each step's block prints whole, so red lines never interleave
+printf '%s\n' "$steps" | xargs -P "$jobs" -I{} bash -c 'run_step "$1"' _ {}
+red=$(ls "$RW_MARKS" | wc -l | tr -d ' ')
+rm -rf "$RW_MARKS"
 
 # restore side-effect files: tracked, clean before, modified by the run
 after=$(git status --porcelain 2>/dev/null | awk '$1=="M"||$1==" M"{print $2}' | sort)


### PR DESCRIPTION
Local CI stand-in gets a -j N flag: suites run concurrently (each builds its own temp dirs), each step prints as one block, failures counted via marker files. Measured on an M4: serial 454s, -j 4 156s, both 0 red of 64. Fixture self-check passes in both modes. Record: docs/verification/run-workflow.md.