### PR TITLE
fix(board): a complete on a gone or terminal card records done

### DIFF
--- a/docs/verification/mirror-complete-idempotent.md
+++ b/docs/verification/mirror-complete-idempotent.md
@@ -1,0 +1,52 @@
+# Verification: a `complete` on a gone or terminal card records done
+
+Change: `lib/board/board-mirror.sh` `cmd_apply_plan`, plus test NC8 in `tests/test-board-mirror.sh`.
+Source incident: ops-toolkit ID-727, every hourly `board-sync-all` mirror tick on the Mini ended
+`applied 0 create, 0 change, 0 complete, 58 error(s)`, all `cannot complete t_... (unknown id or
+terminal state)` for shipped rows whose snapshot card id no longer exists in the pinned personal
+Hermes store.
+
+## Green run
+
+Command: `bash tests/test-board-mirror.sh` (worktree at commit d2e4899).
+
+```
+=== NC8: a 'complete' op failing with 'unknown id or terminal state' records ok/done, not error ===
+  PASS NC8: a dead-card complete is reported status:ok
+  PASS NC8: a dead-card complete is reported hermes_status:done
+  PASS NC8: a dead-card complete preserves the origin
+  PASS NC8: any OTHER complete failure still reports status:error
+  TOTAL: 76   PASS: 76   FAIL: 0   SKIP: 0
+```
+
+Sibling suites, same tree: `tests/test-board.sh` 36 PASS 0 FAIL 1 SKIP (pre-existing skip),
+`tests/test-board-writeback.sh` 53 PASS 0 FAIL 1 SKIP (pre-existing skip).
+
+Verdict: PASS
+
+## NEGATIVE CONTROL
+
+The same suite with `lib/board/board-mirror.sh` reverted to `origin/master` (fix removed, test kept):
+
+```
+  FAIL NC8: a dead-card complete is reported status:ok
+  FAIL NC8: a dead-card complete is reported hermes_status:done
+  PASS NC8: a dead-card complete preserves the origin
+  PASS NC8: any OTHER complete failure still reports status:error
+  TOTAL: 76   PASS: 74   FAIL: 2   SKIP: 0
+```
+
+The two assertions that encode the fix fail without it; the other-failure assertion passes on both
+trees, which shows the error path is untouched.
+
+## Reproducible
+
+`bash tests/test-board-mirror.sh` from the repo root. The live confirmation is the next
+`board-sync-all` tick on the Mini after the kit checkout there fast-forwards: the mirror line must
+read `0 error(s)` and the snapshot must no longer carry the shipped rows' origins.
+
+## Rollback
+
+Revert the commit. The snapshot lines already dropped by the fix stay dropped; the rows they named
+are shipped, and shipped rows are never re-created by the mirror (`status 'shipped' not bridged`),
+so nothing regresses on revert.

--- a/lib/board/board-mirror.sh
+++ b/lib/board/board-mirror.sh
@@ -504,7 +504,10 @@ cmd_plan() {
 # so a caller piping this over `ssh` can persist the snapshot incrementally per line, satisfying
 # "per successfully-loaded row" even across the network boundary. A single op's failure is
 # reported (status=error) and does NOT abort the remaining ops (one bad row must not block the
-# rest of the batch, same posture `board.sh queue` already takes for a bad Notes cell).
+# rest of the batch, same posture `board.sh queue` already takes for a bad Notes cell). Exception:
+# a `complete` op that fails with "unknown id or terminal state" means the card is already gone
+# or already done, so it is reported status=ok/hermes_status=done instead of status=error, letting
+# the snapshot drop the origin rather than re-planning the same complete on every future run.
 # ---------------------------------------------------------------------------
 cmd_apply_plan() {
   local line op origin board hermes_id target followup argv_json new_id out rc
@@ -536,6 +539,18 @@ cmd_apply_plan() {
     # promises.
     if out="$("$HERMES_BIN" "${argv[@]}" 2>&1)"; then rc=0; else rc=$?; fi
     if [ "$rc" -ne 0 ]; then
+      # A `complete` op failing with "unknown id or terminal state" means the Hermes card is
+      # already gone or already terminal (deleted, or completed by some other path). There is
+      # nothing left to complete, so this is not a real error: report it as satisfied (status
+      # "ok", hermes_status "done") the same as a successful complete, so the caller's
+      # snapshot-upsert drops the origin line instead of re-planning the same complete forever.
+      if [ "$op" = "complete" ] && printf '%s' "$out" | grep -qi 'unknown id or terminal state'; then
+        hermes_id="$(printf '%s' "$line" | jq -r '.hermes_id')"
+        echo "board-mirror: complete ${origin} (${hermes_id}): card gone or already terminal, recording done" >&2
+        jq -nc --arg origin "$origin" --arg op "$op" --arg board "$board" --arg hermes_id "$hermes_id" \
+          '{origin:$origin, op:$op, board:$board, hermes_id:$hermes_id, row_hash:null, hermes_status:"done", status:"ok"}'
+        continue
+      fi
       jq -nc --arg origin "$origin" --arg op "$op" --arg board "$board" --arg err "$out" \
         '{origin:$origin, op:$op, board:$board, status:"error", error:$err}'
       continue

--- a/tests/test-board-mirror.sh
+++ b/tests/test-board-mirror.sh
@@ -381,6 +381,40 @@ assert "NC7c: the CHANGE comment carries the untrusted marker" "$(printf '%s' "$
 assert "NC7c: the CHANGE comment strips the #queue{} token" "$(printf '%s' "$CH_COMMENT" | grep -q '#queue{' && echo 1 || echo 0)"
 
 echo ""
+echo "=== NC8: a 'complete' op failing with 'unknown id or terminal state' records ok/done, not error ==="
+# The Mini incident (ops-toolkit ID-727): a snapshot maps an origin to a hermes_id whose card was
+# deleted or otherwise reached a terminal state outside the mirror's control. `hermes kanban
+# complete` on that id fails, and without this handling the op is reported status:error forever
+# (the snapshot line never clears, so the same complete is replanned on every future run).
+STUB_DEAD="$TMPDIR_T/stub-hermes-dead"
+cat > "$STUB_DEAD" <<'STUBDEADEOF'
+#!/usr/bin/env bash
+if [ "$1" = "kanban" ] && [ "$4" = "complete" ]; then
+  echo "cannot complete $5 (unknown id or terminal state)" >&2
+  exit 1
+fi
+echo "stub-hermes-dead: unhandled call: $*" >&2
+exit 1
+STUBDEADEOF
+chmod +x "$STUB_DEAD"
+
+COMPLETE_PLAN="$(jq -nc '{op:"complete", origin:"fixR:ID-999", board:"fixR", hermes_id:"t_dead1234", row_hash:null, argv:["kanban","--board","fixR","complete","t_dead1234","--result","board-mirror: origin removed from fixR board"]}')"
+COMPLETE_RESULT="$(printf '%s\n' "$COMPLETE_PLAN" | HERMES_BIN="$STUB_DEAD" bash "$BOARD_MIRROR" apply-plan)"
+assert "NC8: a dead-card complete is reported status:ok" "$(printf '%s' "$COMPLETE_RESULT" | jq -e '.status=="ok"' >/dev/null 2>&1 && echo 0 || echo 1)"
+assert "NC8: a dead-card complete is reported hermes_status:done" "$(printf '%s' "$COMPLETE_RESULT" | jq -e '.hermes_status=="done"' >/dev/null 2>&1 && echo 0 || echo 1)"
+assert "NC8: a dead-card complete preserves the origin" "$([ "$(printf '%s' "$COMPLETE_RESULT" | jq -r '.origin')" = "fixR:ID-999" ] && echo 0 || echo 1)"
+
+STUB_OTHERERR="$TMPDIR_T/stub-hermes-othererr"
+cat > "$STUB_OTHERERR" <<'STUBERREOF'
+#!/usr/bin/env bash
+echo "some other hermes failure, not the dead-card shape" >&2
+exit 1
+STUBERREOF
+chmod +x "$STUB_OTHERERR"
+OTHERERR_RESULT="$(printf '%s\n' "$COMPLETE_PLAN" | HERMES_BIN="$STUB_OTHERERR" bash "$BOARD_MIRROR" apply-plan)"
+assert "NC8: any OTHER complete failure still reports status:error" "$(printf '%s' "$OTHERERR_RESULT" | jq -e '.status=="error"' >/dev/null 2>&1 && echo 0 || echo 1)"
+
+echo ""
 echo "=== Coverage delta ==="
 BEFORE_COUNT=0   # no lib/board/board-mirror.sh, no mirror/status subcommands, no tests/test-board-mirror.sh before SPEC-147
 AFTER_COUNT="$TOTAL"


### PR DESCRIPTION
## What

`board-mirror.sh apply-plan`: a `complete` op whose `hermes kanban complete` fails with `unknown id or terminal state` is now reported `status:"ok"` / `hermes_status:"done"` (with a stderr note) instead of `status:"error"`, so `board.sh mirror` upserts the snapshot and stops re-planning it. Any other failure still reports `status:"error"`.

## Why

ops-toolkit ID-727: every hourly `board-sync-all` mirror run on the Mini ended `applied 0 create, 0 change, 0 complete, 58 error(s)`, all `cannot complete t_... (unknown id or terminal state)` for shipped rows. The snapshot maps those rows to card ids that do not exist in the pinned personal store (`hermes kanban list` across live/done/archived has none of them), so the error repeated forever.

## Test

`tests/test-board-mirror.sh` NC8: a stub hermes failing with the dead-card message yields ok/done and keeps the origin; a stub failing with any other message still yields error. Negative control (fix reverted, test kept): exactly the two fix assertions fail. Record: `docs/verification/mirror-complete-idempotent.md`.

```
tests/test-board-mirror.sh    76 PASS 0 FAIL
tests/test-board.sh           36 PASS 0 FAIL 1 SKIP (pre-existing)
tests/test-board-writeback.sh 53 PASS 0 FAIL 1 SKIP (pre-existing)
```
