### PR TITLE
fix(agents): verifiers mask long hex digests in the record

### DIFF
--- a/agents/acceptance-verifier.md
+++ b/agents/acceptance-verifier.md
@@ -57,6 +57,8 @@ Verification record:
 - Output (excerpt): <decisive lines: pass/fail counts, the failing assertion, summary>
 ```
 
+Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+
 ### PASS
 
 ```

--- a/agents/recheck-verifier.md
+++ b/agents/recheck-verifier.md
@@ -64,6 +64,8 @@ Verification record (fresh re-execution, not a read-back):
 - Output (excerpt): <decisive lines from YOUR run>
 ```
 
+Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+
 ### PASS
 
 ```

--- a/agents/system-verifier.md
+++ b/agents/system-verifier.md
@@ -58,6 +58,8 @@ Verification record:
 - Output (excerpt): <decisive lines: pass/fail counts, the failing assertion, summary>
 ```
 
+Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+
 ### PASS
 
 ```

--- a/agents/task-verifier.md
+++ b/agents/task-verifier.md
@@ -141,6 +141,8 @@ Verification record:
 - Output (excerpt): <decisive lines: pass/fail counts, failing assertion, summary>
 ```
 
+Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+
 If there was no runnable check, the block's `Command:` is `none` and the verdict line
 is `[NO EXECUTABLE CHECK: <reason>]` (see Section 2) , do not invent a command or a
 passing exit code.

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -64,6 +64,8 @@ Unwritten (if any):
 1. row [#] -- [why: matrix case unsatisfiable as specified / needs a fixture not available / other]
 ```
 
+Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+
 ## Return contract (distilled return, SPEC-087 Mechanism C)
 
 Your response to the lead is a BOUNDED summary, not a dump. Return only:


### PR DESCRIPTION
## Why

A verification record from the vps-mon Go agent session quoted a full 64-hex HMAC digest as a cross-check value. Pasted back into the lead's next prompt, it matched the scan-secrets "hex private key" rule and the UserPromptSubmit hook blocked the prompt. The hook is right (a digest and a private key are shape-identical), so the fix belongs at the source.

## What

The five agents that emit an `Output (excerpt)` block (task-verifier, acceptance-verifier, system-verifier, recheck-verifier, test-writer) carry one rule under the record template: any 32+ hex token appears as `first8…last8`, never in full.

## Test

- `bash tests/test-right-arm-parity.sh`: 38/38 passed
- `bash tests/test-test-writer-contract.sh`: all passed
- `bash tests/test-meta.sh`: all passed

Prompt-only change, no source or behavior change. Proof-gate override logged under `verifier-hex-mask`.