### PR TITLE
fix(agents): verifiers mask prefixed tokens, not only hex

### DIFF
--- a/agents/acceptance-verifier.md
+++ b/agents/acceptance-verifier.md
@@ -57,7 +57,7 @@ Verification record:
 - Output (excerpt): <decisive lines: pass/fail counts, the failing assertion, summary>
 ```
 
-Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+Credential-shaped strings in `Output (excerpt)` and `Notes` never appear in full. A long hex token (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appears as `first8…last8`. A prefixed token (`ghp_`, `gho_`, `sk-`, `AKIA`, `xox`, any vendor prefix plus 20+ chars) appears as the prefix plus `first4…last4`, deliberately fake test fixtures included. The lead's secret-scan prompt hook matches on shape alone, and it blocks the task-notification that carries this record, so the lead never receives the verdict.
 
 ### PASS
 

--- a/agents/recheck-verifier.md
+++ b/agents/recheck-verifier.md
@@ -64,7 +64,7 @@ Verification record (fresh re-execution, not a read-back):
 - Output (excerpt): <decisive lines from YOUR run>
 ```
 
-Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+Credential-shaped strings in `Output (excerpt)` and `Notes` never appear in full. A long hex token (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appears as `first8…last8`. A prefixed token (`ghp_`, `gho_`, `sk-`, `AKIA`, `xox`, any vendor prefix plus 20+ chars) appears as the prefix plus `first4…last4`, deliberately fake test fixtures included. The lead's secret-scan prompt hook matches on shape alone, and it blocks the task-notification that carries this record, so the lead never receives the verdict.
 
 ### PASS
 

--- a/agents/system-verifier.md
+++ b/agents/system-verifier.md
@@ -58,7 +58,7 @@ Verification record:
 - Output (excerpt): <decisive lines: pass/fail counts, the failing assertion, summary>
 ```
 
-Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+Credential-shaped strings in `Output (excerpt)` and `Notes` never appear in full. A long hex token (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appears as `first8…last8`. A prefixed token (`ghp_`, `gho_`, `sk-`, `AKIA`, `xox`, any vendor prefix plus 20+ chars) appears as the prefix plus `first4…last4`, deliberately fake test fixtures included. The lead's secret-scan prompt hook matches on shape alone, and it blocks the task-notification that carries this record, so the lead never receives the verdict.
 
 ### PASS
 

--- a/agents/task-verifier.md
+++ b/agents/task-verifier.md
@@ -141,7 +141,7 @@ Verification record:
 - Output (excerpt): <decisive lines: pass/fail counts, failing assertion, summary>
 ```
 
-Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+Credential-shaped strings in `Output (excerpt)` and `Notes` never appear in full. A long hex token (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appears as `first8…last8`. A prefixed token (`ghp_`, `gho_`, `sk-`, `AKIA`, `xox`, any vendor prefix plus 20+ chars) appears as the prefix plus `first4…last4`, deliberately fake test fixtures included. The lead's secret-scan prompt hook matches on shape alone, and it blocks the task-notification that carries this record, so the lead never receives the verdict.
 
 If there was no runnable check, the block's `Command:` is `none` and the verdict line
 is `[NO EXECUTABLE CHECK: <reason>]` (see Section 2) , do not invent a command or a

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -64,7 +64,7 @@ Unwritten (if any):
 1. row [#] -- [why: matrix case unsatisfiable as specified / needs a fixture not available / other]
 ```
 
-Long hex tokens in `Output (excerpt)` and `Notes` (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appear as `first8…last8`, never in full. A full 64-hex value is shape-identical to a private key, and the lead's secret-scan prompt hook blocks the next prompt that carries this record.
+Credential-shaped strings in `Output (excerpt)` and `Notes` never appear in full. A long hex token (a SHA-256, an HMAC, a tx hash, anything 32+ hex chars) appears as `first8…last8`. A prefixed token (`ghp_`, `gho_`, `sk-`, `AKIA`, `xox`, any vendor prefix plus 20+ chars) appears as the prefix plus `first4…last4`, deliberately fake test fixtures included. The lead's secret-scan prompt hook matches on shape alone, and it blocks the task-notification that carries this record, so the lead never receives the verdict.
 
 ## Return contract (distilled return, SPEC-087 Mechanism C)
 


### PR DESCRIPTION
A verifier report reassembled a deliberately fake GitHub PAT fixture in prose. The task-notification carrying that report is a prompt, the scan-secrets hook matched the PAT shape, and the lead never received the PASS verdict. The five agents that emit an Output (excerpt) now mask any vendor-prefixed token as prefix plus first4…last4, alongside the existing hex rule.
