### PR TITLE
docs(wrap): tail sections render as list items

### DIFF
--- a/commands/wrap.md
+++ b/commands/wrap.md
@@ -101,8 +101,16 @@ b. ...
 **Shipped**
 - **<repo>**: #<pr> (<sha>) DEPLOYED <run or fleet line> | #<pr> 🟡 MERGED, NOT DEPLOYED | #<pr> OPEN
 
-**Left alone:** <repo>: <files / worktrees / branches>, <whose>, PULL BLOCKED; <repo>: ...
-**FYI:** <what changes for the operator from now on> | <a state the operator will meet next time> | NOTHING
+**Left alone:**
+- <repo>: <files / worktrees / branches>, <whose>, PULL BLOCKED
+   -- or --
+- NOTHING
+
+**FYI:**
+- <what changes for the operator from now on>
+- <a state the operator will meet next time>
+   -- or --
+- NOTHING
 ```
 
 - `Needs you` leads and is always present, even as `NOTHING`. It is a lettered action list; it sits at the top, ahead of every other section, because this report is read from the top and the items are the whole point.
@@ -110,9 +118,10 @@ b. ...
 - Status words stay UPPERCASE tokens, always the same ones: `NOTHING`, `DEPLOYED`, `MERGED, NOT DEPLOYED`, `OPEN`, `PULL BLOCKED`, and a leading verb on each `Needs you` item from `DECIDE`, `RUN`, `REVIEW`, `UNBLOCK`. Prose stays lowercase.
 - `What happened` is one bullet per workstream, two to four sentences: the problem as the operator saw it, the root cause, what changed, how it was proven. A ten-minute session earns one bullet; a long one earns five or six.
 - `Shipped` is one line per repo: PR number, merge SHA, deploy state.
-- `Left alone` names another session's dirty files, worktrees, and branches with the owner, so the operator knows a repo is not fully clean and why.
-- `FYI` closes the message: what is not the operator's to act on but changes something they will meet next time, or `NOTHING`.
-- An overlay (a consumer's own routing, distill, or knowledge-capture step) appends its own lines after `FYI`; the kit's grammar stops there. A `wrap.before` skill's report lines fold in at that same place.
+- `Left alone` and `FYI` are bullet lists, one item per repo or fact, never joined with `|` or `;`.
+- `Left alone` names another session's dirty files, worktrees, and branches with the owner, one bullet per repo, so the operator knows a repo is not fully clean and why. A single `- NOTHING` bullet when no repo was left alone.
+- `FYI` closes the message: one bullet per fact that is not the operator's to act on but changes something they will meet next time. A single `- NOTHING` bullet when there is nothing to report.
+- An overlay (a consumer's own routing, distill, or knowledge-capture step) appends its own labelled sections after `FYI`, in the same shape: a bold label line followed by bullets, one item per note, candidate, or queue entry; the kit's grammar stops there. A `wrap.before` skill's report lines fold in at that same place.
 - No table unless the session touched four or more repos. No restating what each step did.
 
 Record the run (SPEC-139), one line: `bash lib/gate/gate-ledger.sh record <rid> wrap ran "<summary>"`. Close the timing bracket (SPEC-129): `bash lib/gate/gate-ledger.sh outcome <rid> wrap end caught=<true if a repo hit step 0's foreign-activity STOP, else false>`.


### PR DESCRIPTION
## Summary

The wrap report's tail sections (`Left alone`, `FYI`) were one run-on line per section, joined with `|` or `;`, hard to scan on a terminal. This makes them render as bullet lists, one item per repo or fact.

## Before

```
**Left alone:** <repo>: <files / worktrees / branches>, <whose>, PULL BLOCKED; <repo>: ...
**FYI:** <what changes for the operator from now on> | <a state the operator will meet next time> | NOTHING
```

## After

```
**Left alone:**
- <repo>: <files / worktrees / branches>, <whose>, PULL BLOCKED
   -- or --
- NOTHING

**FYI:**
- <what changes for the operator from now on>
- <a state the operator will meet next time>
   -- or --
- NOTHING
```

The grammar rules now say `Left alone` and `FYI` are bullet lists, one item per repo or fact, never joined with `|` or `;`. An overlay (a consumer's own routing, distill, or knowledge-capture step) appends its own labelled sections after `FYI` in the same shape: a bold label line followed by bullets, one item per note, candidate, or queue entry.

`Needs you`, `What happened`, and `Shipped` are unchanged. Section order and the two-emoji rule are unchanged.

`commands/wrap.md` only. Grepped `docs/` and `README.md` for quotes of the report shape; the hits (SPEC-246, its implementation-notes, verification, CHANGELOG) name the section labels but never reproduce the literal pipe/semicolon-joined line, so nothing else needed updating.

## Test plan
- [x] `bash tests/test-wrap.sh` (all 137 pass)
- [x] `bash tests/test-docs-wiring.sh` (25/25 pass)
- [x] Grepped every rule token from `docs/verification/kit-wrap.md`'s doc-wiring check against the new `commands/wrap.md`; all still present
- [x] Docs-only change, no em/en dashes; ship-gate proof override logged (`wrap-report-lists`: "docs-only: report grammar")
