### PR TITLE
test: make printf-into-grep-q safe under pipefail

### DIFF
--- a/docs/verification/test-grep-pipefail-negctl.sh
+++ b/docs/verification/test-grep-pipefail-negctl.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Negative control: a payload larger than the pipe buffer makes the race
+# deterministic. Old form dies under pipefail in both signal regimes; the
+# guarded form returns grep's status.
+set -uo pipefail
+big="match-me$(printf '%*s' 300000 '' | tr ' ' 'x')"
+printf '%s\n' "$big" "$big" "$big" | grep -q match-me; old_default=$?
+( trap '' PIPE; printf '%s\n' "$big" "$big" "$big" | grep -q match-me ); old_ignored=$?
+{ trap '' PIPE; printf '%s\n' "$big" "$big" "$big" 2>/dev/null || :; } | grep -q match-me; new_default=$?
+( trap '' PIPE; { trap '' PIPE; printf '%s\n' "$big" "$big" "$big" 2>/dev/null || :; } | grep -q match-me ); new_ignored=$?
+{ trap '' PIPE; printf '%s\n' "$big" 2>/dev/null || :; } | grep -q nomatch; new_miss=$?
+echo "old form, SIGPIPE default: exit=$old_default (RED expected)"
+echo "old form, SIGPIPE ignored (CI): exit=$old_ignored (RED expected)"
+echo "guarded form, SIGPIPE default: exit=$new_default (0 expected)"
+echo "guarded form, SIGPIPE ignored (CI): exit=$new_ignored (0 expected)"
+echo "guarded form, no match: exit=$new_miss (1 expected)"
+[ $old_default -ne 0 ] && [ $old_ignored -ne 0 ] && [ $new_default -eq 0 ] && [ $new_ignored -eq 0 ] && [ $new_miss -eq 1 ] && echo "CONTROL: PASS" || echo "CONTROL: FAIL"

--- a/docs/verification/test-grep-pipefail.md
+++ b/docs/verification/test-grep-pipefail.md
@@ -1,0 +1,37 @@
+# Proof of done: printf-into-grep-q under pipefail
+
+Scope: every `printf ... | grep -q` site in `tests/*.sh` (303 after the sweep, 47 files) now wraps the producer as `{ trap '' PIPE; printf ... 2>/dev/null || :; }` so the pipeline exit is grep's. No assertion changed. Origin: the macOS CI job on #508 failed `test-config-registry.sh` line 133 with `printf: write error: Broken pipe`.
+
+## Root cause
+
+`grep -q` exits on the first match. printf then writes to a closed pipe. With SIGPIPE at its default the subshell dies with 141; with SIGPIPE ignored (the GitHub runner) printf returns 1. Under `set -o pipefail` either turns a matched grep into a failed pipeline. The race only lands when the payload outruns grep's first read, which is why it surfaced as a flake.
+
+The first cut (`{ printf ... || :; }` alone) covered only the ignored-signal regime: with SIGPIPE default the subshell is killed before `|| :` runs. The `trap '' PIPE` inside the group covers both.
+
+## Green run (commit 4658dca, detached worktree at a plain path, macOS, bash 3.2 and 5.3)
+
+| Step | Command | Result |
+|---|---|---|
+| Syntax | `for f in tests/*.sh; do bash -n "$f"; done` | 0 errors |
+| Site census | grep for `printf ... \| grep -q` unguarded | 0 left, 303 guarded, 0 double-guarded |
+| CI script set | the 68 scripts named in `.github/workflows/test.yml`, run one by one | 66 PASS, 2 FAIL (below) |
+
+The two local failures are not the sweep:
+
+- `tests/test-kit-gates-cost.sh` runs from `lib/stats` in CI; the local runner invoked it from the repo root (path artifact of the runner script).
+- `tests/test-orchestrate-wavefront.sh` fails `wave_run g`, `wave_run h2`, `dispatch k` on this host. Bisect in the same worktree: the first-wrap commit fails, the trap commit with the wavefront file reverted fails, and master's own `tests/` on the final libs fails the same three. The mock barrier sessions exit 7 (sibling never overlapped) in every leg, a host timing condition. It had passed on the same commit earlier in the day.
+
+## Negative control (`docs/verification/test-grep-pipefail-negctl.sh`)
+
+A 300 KB payload outruns the pipe buffer, so the race is deterministic.
+
+```
+old form, SIGPIPE default: exit=141 (RED expected)
+old form, SIGPIPE ignored (CI): exit=1 (RED expected)
+guarded form, SIGPIPE default: exit=0 (0 expected)
+guarded form, SIGPIPE ignored (CI): exit=0 (0 expected)
+guarded form, no match: exit=1 (1 expected)
+CONTROL: PASS
+```
+
+Same output under `/bin/bash` 3.2.57 and Homebrew bash 5.3.15.

--- a/docs/verification/test-grep-pipefail.md
+++ b/docs/verification/test-grep-pipefail.md
@@ -21,6 +21,26 @@ The two local failures are not the sweep:
 - `tests/test-kit-gates-cost.sh` runs from `lib/stats` in CI; the local runner invoked it from the repo root (path artifact of the runner script).
 - `tests/test-orchestrate-wavefront.sh` fails `wave_run g`, `wave_run h2`, `dispatch k` on this host. Bisect in the same worktree: the first-wrap commit fails, the trap commit with the wavefront file reverted fails, and master's own `tests/` on the final libs fails the same three. The mock barrier sessions exit 7 (sibling never overlapped) in every leg, a host timing condition. It had passed on the same commit earlier in the day.
 
+Recorded run:
+
+```
+Command: bash tests/test-meta.sh
+Exit: 0
+Verdict: PASS (840/840)
+
+Command: bash tests/test-config-registry.sh
+Exit: 0
+Verdict: PASS (19/19, the assertion that failed on the #508 macOS job)
+
+Command: bash docs/verification/test-grep-pipefail-negctl.sh
+Exit: 0
+Verdict: PASS (CONTROL: PASS, both signal regimes)
+```
+
+## Rollback
+
+`git revert` of the sweep commits restores the bare `printf | grep -q` form. Nothing else depends on the guarded shape; the tests assert the same things either way.
+
 ## Negative control (`docs/verification/test-grep-pipefail-negctl.sh`)
 
 A 300 KB payload outruns the pipe buffer, so the race is deterministic.

--- a/tests/proof-loop-09-scenario-b.sh
+++ b/tests/proof-loop-09-scenario-b.sh
@@ -17,7 +17,7 @@ KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PASS=0; FAIL=0; TOTAL=0
 RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 assert_eq() { TOTAL=$((TOTAL+1)); if [ "$2" = "$3" ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 (expected '$3', got '$2')"; FAIL=$((FAIL+1)); fi; }
-assert_contains() { TOTAL=$((TOTAL+1)); if printf '%s' "$2" | grep -qF "$3"; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 (missing '$3')"; FAIL=$((FAIL+1)); fi; }
+assert_contains() { TOTAL=$((TOTAL+1)); if { printf '%s' "$2" 2>/dev/null || :; } | grep -qF "$3"; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 (missing '$3')"; FAIL=$((FAIL+1)); fi; }
 
 ROOT="$(mktemp -d -t sp199-recheck.XXXXXX)"
 trap 'rm -rf "$ROOT"' EXIT

--- a/tests/proof-loop-09-scenario-b.sh
+++ b/tests/proof-loop-09-scenario-b.sh
@@ -17,7 +17,7 @@ KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PASS=0; FAIL=0; TOTAL=0
 RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 assert_eq() { TOTAL=$((TOTAL+1)); if [ "$2" = "$3" ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 (expected '$3', got '$2')"; FAIL=$((FAIL+1)); fi; }
-assert_contains() { TOTAL=$((TOTAL+1)); if { printf '%s' "$2" 2>/dev/null || :; } | grep -qF "$3"; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 (missing '$3')"; FAIL=$((FAIL+1)); fi; }
+assert_contains() { TOTAL=$((TOTAL+1)); if { trap '' PIPE; printf '%s' "$2" 2>/dev/null || :; } | grep -qF "$3"; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1 (missing '$3')"; FAIL=$((FAIL+1)); fi; }
 
 ROOT="$(mktemp -d -t sp199-recheck.XXXXXX)"
 trap 'rm -rf "$ROOT"' EXIT

--- a/tests/test-adopt.sh
+++ b/tests/test-adopt.sh
@@ -120,8 +120,8 @@ fi
 # 13. That same fresh adopt wires the kit-root-default-enabled modules' hooks into the
 # project's settings.json (board/session/advisor default true; cosmetic defaults false).
 W13="$(wired_hooks "$T8/.claude/settings.json")"
-if { printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx backlog-stage.sh && { printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx context-hints.sh \
-  && ! { printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx auto-format.sh; then
+if { trap '' PIPE; printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx backlog-stage.sh && { trap '' PIPE; printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx context-hints.sh \
+  && ! { trap '' PIPE; printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx auto-format.sh; then
   ok "fresh adopt wires kit-root-default-enabled modules' hooks (board/advisor in, cosmetic out)"
 else
   no "fresh adopt wired the wrong hook set: [$W13]"
@@ -132,7 +132,7 @@ fi
 T9="$(newrepo)"
 bash lib/adopt.sh --with cosmetic "$T9" >/dev/null
 if grep -qx 'cosmetic = true' "$T9/.kit.toml" \
-  && { printf '%s\n' "$(wired_hooks "$T9/.claude/settings.json")" 2>/dev/null || :; } | grep -qx auto-format.sh; then
+  && { trap '' PIPE; printf '%s\n' "$(wired_hooks "$T9/.claude/settings.json")" 2>/dev/null || :; } | grep -qx auto-format.sh; then
   ok "--with cosmetic on a fresh repo seeds cosmetic=true and wires its hook"
 else
   no "--with cosmetic did not seed/wire cosmetic for a fresh repo"
@@ -143,20 +143,20 @@ fi
 T10="$(newrepo)"
 bash lib/adopt.sh "$T10" >/dev/null
 W15_BEFORE="$(wired_hooks "$T10/.claude/settings.json")"
-{ printf '%s\n' "$W15_BEFORE" 2>/dev/null || :; } | grep -qx backlog-stage.sh \
+{ trap '' PIPE; printf '%s\n' "$W15_BEFORE" 2>/dev/null || :; } | grep -qx backlog-stage.sh \
   && ok "precondition: board's hook is wired before the override (kit-root default board=true)" \
   || no "precondition failed: board's hook was never wired to begin with"
 sed -i.bak 's/^board = true$/board = false/' "$T10/.kit.toml" && rm -f "$T10/.kit.toml.bak"
 grep -qx 'board = false' "$T10/.kit.toml" || no "test setup: could not flip board=false in $T10/.kit.toml"
 bash lib/adopt.sh --refresh "$T10" >/dev/null
 W15_AFTER="$(wired_hooks "$T10/.claude/settings.json")"
-if ! { printf '%s\n' "$W15_AFTER" 2>/dev/null || :; } | grep -qx backlog-stage.sh; then
+if ! { trap '' PIPE; printf '%s\n' "$W15_AFTER" 2>/dev/null || :; } | grep -qx backlog-stage.sh; then
   ok "DONE=: project .kit.toml [modules] board=false -> board's hook is NOT wired (settings.json)"
 else
   no "DONE=: board=false in .kit.toml did not stop board's hook from being wired"
 fi
 # session's hook must be untouched by the board-only edit (surgical re-wiring, not a full reset).
-if { printf '%s\n' "$W15_AFTER" 2>/dev/null || :; } | grep -qx context-readiness.sh; then
+if { trap '' PIPE; printf '%s\n' "$W15_AFTER" 2>/dev/null || :; } | grep -qx context-readiness.sh; then
   ok "re-wiring after a board=false edit leaves the still-enabled session module's hooks wired"
 else
   no "re-wiring after a board=false edit dropped an unrelated still-enabled module's hooks"

--- a/tests/test-adopt.sh
+++ b/tests/test-adopt.sh
@@ -120,8 +120,8 @@ fi
 # 13. That same fresh adopt wires the kit-root-default-enabled modules' hooks into the
 # project's settings.json (board/session/advisor default true; cosmetic defaults false).
 W13="$(wired_hooks "$T8/.claude/settings.json")"
-if printf '%s\n' "$W13" | grep -qx backlog-stage.sh && printf '%s\n' "$W13" | grep -qx context-hints.sh \
-  && ! printf '%s\n' "$W13" | grep -qx auto-format.sh; then
+if { printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx backlog-stage.sh && { printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx context-hints.sh \
+  && ! { printf '%s\n' "$W13" 2>/dev/null || :; } | grep -qx auto-format.sh; then
   ok "fresh adopt wires kit-root-default-enabled modules' hooks (board/advisor in, cosmetic out)"
 else
   no "fresh adopt wired the wrong hook set: [$W13]"
@@ -132,7 +132,7 @@ fi
 T9="$(newrepo)"
 bash lib/adopt.sh --with cosmetic "$T9" >/dev/null
 if grep -qx 'cosmetic = true' "$T9/.kit.toml" \
-  && printf '%s\n' "$(wired_hooks "$T9/.claude/settings.json")" | grep -qx auto-format.sh; then
+  && { printf '%s\n' "$(wired_hooks "$T9/.claude/settings.json")" 2>/dev/null || :; } | grep -qx auto-format.sh; then
   ok "--with cosmetic on a fresh repo seeds cosmetic=true and wires its hook"
 else
   no "--with cosmetic did not seed/wire cosmetic for a fresh repo"
@@ -143,20 +143,20 @@ fi
 T10="$(newrepo)"
 bash lib/adopt.sh "$T10" >/dev/null
 W15_BEFORE="$(wired_hooks "$T10/.claude/settings.json")"
-printf '%s\n' "$W15_BEFORE" | grep -qx backlog-stage.sh \
+{ printf '%s\n' "$W15_BEFORE" 2>/dev/null || :; } | grep -qx backlog-stage.sh \
   && ok "precondition: board's hook is wired before the override (kit-root default board=true)" \
   || no "precondition failed: board's hook was never wired to begin with"
 sed -i.bak 's/^board = true$/board = false/' "$T10/.kit.toml" && rm -f "$T10/.kit.toml.bak"
 grep -qx 'board = false' "$T10/.kit.toml" || no "test setup: could not flip board=false in $T10/.kit.toml"
 bash lib/adopt.sh --refresh "$T10" >/dev/null
 W15_AFTER="$(wired_hooks "$T10/.claude/settings.json")"
-if ! printf '%s\n' "$W15_AFTER" | grep -qx backlog-stage.sh; then
+if ! { printf '%s\n' "$W15_AFTER" 2>/dev/null || :; } | grep -qx backlog-stage.sh; then
   ok "DONE=: project .kit.toml [modules] board=false -> board's hook is NOT wired (settings.json)"
 else
   no "DONE=: board=false in .kit.toml did not stop board's hook from being wired"
 fi
 # session's hook must be untouched by the board-only edit (surgical re-wiring, not a full reset).
-if printf '%s\n' "$W15_AFTER" | grep -qx context-readiness.sh; then
+if { printf '%s\n' "$W15_AFTER" 2>/dev/null || :; } | grep -qx context-readiness.sh; then
   ok "re-wiring after a board=false edit leaves the still-enabled session module's hooks wired"
 else
   no "re-wiring after a board=false edit dropped an unrelated still-enabled module's hooks"

--- a/tests/test-advisor-ledger-emit.sh
+++ b/tests/test-advisor-ledger-emit.sh
@@ -81,8 +81,8 @@ grep -qiE 'FINAL sub-goal' "$RT"; assert "AC2: review-team.md names the final-su
 # mid-phrase, so a single-line grep on a multi-word phrase is fragile; normalize, then match.
 MEGA_FLAT="$(tr '\n' ' ' < "$MEGA")"
 grep -qiE 'convergence gate dispatches advisor' "$MEGA"; assert "AC3: mega.md names an explicit convergence-gate advisor dispatch" $?
-printf '%s' "$MEGA_FLAT" | grep -qE 'P5[[:space:]]*\(critique\)'; assert "AC3: mega.md names P5 critique explicitly" $?
-printf '%s' "$MEGA_FLAT" | grep -qE 'P6[[:space:]]*\(over-suggest\)'; assert "AC3: mega.md names P6 over-suggest explicitly" $?
+{ printf '%s' "$MEGA_FLAT" 2>/dev/null || :; } | grep -qE 'P5[[:space:]]*\(critique\)'; assert "AC3: mega.md names P5 critique explicitly" $?
+{ printf '%s' "$MEGA_FLAT" 2>/dev/null || :; } | grep -qE 'P6[[:space:]]*\(over-suggest\)'; assert "AC3: mega.md names P6 over-suggest explicitly" $?
 grep -qE 'mode=P5 findings=<N> actor=' "$MEGA" && grep -qE 'mode=P6 findings=<N> actor=' "$MEGA"
 assert "AC3: mega.md emits BOTH mode=P5 and mode=P6 rows" $?
 fail_open_call "$MEGA"; assert "AC3: mega.md's advisor emit is fail-open (|| WARNING fallback)" $?

--- a/tests/test-advisor-ledger-emit.sh
+++ b/tests/test-advisor-ledger-emit.sh
@@ -81,8 +81,8 @@ grep -qiE 'FINAL sub-goal' "$RT"; assert "AC2: review-team.md names the final-su
 # mid-phrase, so a single-line grep on a multi-word phrase is fragile; normalize, then match.
 MEGA_FLAT="$(tr '\n' ' ' < "$MEGA")"
 grep -qiE 'convergence gate dispatches advisor' "$MEGA"; assert "AC3: mega.md names an explicit convergence-gate advisor dispatch" $?
-{ printf '%s' "$MEGA_FLAT" 2>/dev/null || :; } | grep -qE 'P5[[:space:]]*\(critique\)'; assert "AC3: mega.md names P5 critique explicitly" $?
-{ printf '%s' "$MEGA_FLAT" 2>/dev/null || :; } | grep -qE 'P6[[:space:]]*\(over-suggest\)'; assert "AC3: mega.md names P6 over-suggest explicitly" $?
+{ trap '' PIPE; printf '%s' "$MEGA_FLAT" 2>/dev/null || :; } | grep -qE 'P5[[:space:]]*\(critique\)'; assert "AC3: mega.md names P5 critique explicitly" $?
+{ trap '' PIPE; printf '%s' "$MEGA_FLAT" 2>/dev/null || :; } | grep -qE 'P6[[:space:]]*\(over-suggest\)'; assert "AC3: mega.md names P6 over-suggest explicitly" $?
 grep -qE 'mode=P5 findings=<N> actor=' "$MEGA" && grep -qE 'mode=P6 findings=<N> actor=' "$MEGA"
 assert "AC3: mega.md emits BOTH mode=P5 and mode=P6 rows" $?
 fail_open_call "$MEGA"; assert "AC3: mega.md's advisor emit is fail-open (|| WARNING fallback)" $?

--- a/tests/test-audit-scanner-contract.sh
+++ b/tests/test-audit-scanner-contract.sh
@@ -37,12 +37,12 @@ roster_is_read_only() {
   local file="$1" fm rc=0
   fm="$(awk '/^---$/{c++; next} c==1' "$file")"
   # no bare Bash
-  printf '%s\n' "$fm" | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$' && { echo "bare Bash"; rc=1; }
+  { printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$' && { echo "bare Bash"; rc=1; }
   # no write-capable tools
-  printf '%s\n' "$fm" | grep -qE '^[[:space:]]*-[[:space:]]*(Write|Edit|NotebookEdit)[[:space:]]*$' && { echo "write tool"; rc=1; }
+  { printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*(Write|Edit|NotebookEdit)[[:space:]]*$' && { echo "write tool"; rc=1; }
   # Read/Grep/Glob present
   for t in Read Grep Glob; do
-    printf '%s\n' "$fm" | grep -qE "^[[:space:]]*-[[:space:]]*$t[[:space:]]*\$" || { echo "missing $t"; rc=1; }
+    { printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE "^[[:space:]]*-[[:space:]]*$t[[:space:]]*\$" || { echo "missing $t"; rc=1; }
   done
   # every Bash(...) pattern from the read-only verb allowlist
   local pats

--- a/tests/test-audit-scanner-contract.sh
+++ b/tests/test-audit-scanner-contract.sh
@@ -37,12 +37,12 @@ roster_is_read_only() {
   local file="$1" fm rc=0
   fm="$(awk '/^---$/{c++; next} c==1' "$file")"
   # no bare Bash
-  { printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$' && { echo "bare Bash"; rc=1; }
+  { trap '' PIPE; printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$' && { echo "bare Bash"; rc=1; }
   # no write-capable tools
-  { printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*(Write|Edit|NotebookEdit)[[:space:]]*$' && { echo "write tool"; rc=1; }
+  { trap '' PIPE; printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*(Write|Edit|NotebookEdit)[[:space:]]*$' && { echo "write tool"; rc=1; }
   # Read/Grep/Glob present
   for t in Read Grep Glob; do
-    { printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE "^[[:space:]]*-[[:space:]]*$t[[:space:]]*\$" || { echo "missing $t"; rc=1; }
+    { trap '' PIPE; printf '%s\n' "$fm" 2>/dev/null || :; } | grep -qE "^[[:space:]]*-[[:space:]]*$t[[:space:]]*\$" || { echo "missing $t"; rc=1; }
   done
   # every Bash(...) pattern from the read-only verb allowlist
   local pats

--- a/tests/test-board-mirror.sh
+++ b/tests/test-board-mirror.sh
@@ -131,7 +131,7 @@ echo "=== AC1: row-hash is deterministic and content-sensitive ==="
 H1="$(bash "$BOARD_MIRROR" row-hash fixR ID-001 "Do the thing" "some notes" queued)"
 H2="$(bash "$BOARD_MIRROR" row-hash fixR ID-001 "Do the thing" "some notes" queued)"
 H3="$(bash "$BOARD_MIRROR" row-hash fixR ID-001 "Do the thing CHANGED" "some notes" queued)"
-assert "row-hash is 64 lowercase hex chars" "$(printf '%s' "$H1" | grep -qE '^[0-9a-f]{64}$' && echo 0 || echo 1)"
+assert "row-hash is 64 lowercase hex chars" "$({ printf '%s' "$H1" 2>/dev/null || :; } | grep -qE '^[0-9a-f]{64}$' && echo 0 || echo 1)"
 assert "row-hash is deterministic (same inputs -> same hash)" "$([ "$H1" = "$H2" ] && echo 0 || echo 1)"
 assert "row-hash is content-sensitive (changed item -> different hash)" "$([ "$H1" != "$H3" ] && echo 0 || echo 1)"
 
@@ -147,19 +147,19 @@ assert "ID-003 (speccing) -> target ready"   "$([ "$(tnative ID-003)" = "ready" 
 assert "ID-004 (validated) -> target ready"  "$([ "$(tnative ID-004)" = "ready" ] && echo 0 || echo 1)"
 assert "ID-005 (executing) -> target ready"  "$([ "$(tnative ID-005)" = "ready" ] && echo 0 || echo 1)"
 assert "ID-006 (parked) -> target blocked"   "$([ "$(tnative ID-006)" = "blocked" ] && echo 0 || echo 1)"
-assert "ID-007 (shipped) is EXCLUDED from extraction" "$(printf '%s\n' "$ROWS" | grep -q 'ID-007' && echo 1 || echo 0)"
-assert "ID-008 (dropped) is EXCLUDED from extraction" "$(printf '%s\n' "$ROWS" | grep -q 'ID-008' && echo 1 || echo 0)"
-assert "ID-007's skip reason is logged" "$(printf '%s\n' "$ERRS" | grep -q 'skip ID-007' && echo 0 || echo 1)"
-assert "ID-008's skip reason is logged" "$(printf '%s\n' "$ERRS" | grep -q 'skip ID-008' && echo 0 || echo 1)"
+assert "ID-007 (shipped) is EXCLUDED from extraction" "$({ printf '%s\n' "$ROWS" 2>/dev/null || :; } | grep -q 'ID-007' && echo 1 || echo 0)"
+assert "ID-008 (dropped) is EXCLUDED from extraction" "$({ printf '%s\n' "$ROWS" 2>/dev/null || :; } | grep -q 'ID-008' && echo 1 || echo 0)"
+assert "ID-007's skip reason is logged" "$({ printf '%s\n' "$ERRS" 2>/dev/null || :; } | grep -q 'skip ID-007' && echo 0 || echo 1)"
+assert "ID-008's skip reason is logged" "$({ printf '%s\n' "$ERRS" 2>/dev/null || :; } | grep -q 'skip ID-008' && echo 0 || echo 1)"
 assert "extract-rows emits exactly the 6 bridgeable rows (001-006), not 8" \
   "$([ "$(printf '%s\n' "$ROWS" | grep -c . )" -eq 6 ] && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC3: extract-megas -- active detection, progress, held flag, inactive-skip ==="
 MEGAS="$(bash "$BOARD_MIRROR" extract-megas "$FIXR" fixR)"
-assert "the active mega (1 unchecked box) is emitted" "$(printf '%s\n' "$MEGAS" | grep -q 'megagoals:fixR/mymega' && echo 0 || echo 1)"
-assert "progress reads 1/2 (one checked, one unchecked)" "$(printf '%s\n' "$MEGAS" | grep -q 'progress 1/2' && echo 0 || echo 1)"
-assert "the held-PR text signal is surfaced" "$(printf '%s\n' "$MEGAS" | grep -qi 'held-PR flag set' && echo 0 || echo 1)"
+assert "the active mega (1 unchecked box) is emitted" "$({ printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -q 'megagoals:fixR/mymega' && echo 0 || echo 1)"
+assert "progress reads 1/2 (one checked, one unchecked)" "$({ printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -q 'progress 1/2' && echo 0 || echo 1)"
+assert "the held-PR text signal is surfaced" "$({ printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -qi 'held-PR flag set' && echo 0 || echo 1)"
 assert "mega target_native is ready" "$(printf '%s\n' "$MEGAS" | awk -F'\t' '{print $7}' | grep -qx ready && echo 0 || echo 1)"
 # A fully-checked (inactive) roadmap in a second mega dir must NOT be emitted.
 mkdir -p "$FIXR/_meta/megagoals/donemega"
@@ -170,7 +170,7 @@ cat > "$FIXR/_meta/megagoals/donemega/ROADMAP.md" <<'ROADMAP_DONE'
 - [x] 02-thing also done
 ROADMAP_DONE
 MEGAS2="$(bash "$BOARD_MIRROR" extract-megas "$FIXR" fixR)"
-assert "a fully-checked (inactive) mega is NOT emitted" "$(printf '%s\n' "$MEGAS2" | grep -q 'donemega' && echo 1 || echo 0)"
+assert "a fully-checked (inactive) mega is NOT emitted" "$({ printf '%s\n' "$MEGAS2" 2>/dev/null || :; } | grep -q 'donemega' && echo 1 || echo 0)"
 rm -rf "$FIXR/_meta/megagoals/donemega"
 
 echo ""
@@ -198,7 +198,7 @@ echo ""
 echo "=== Apply the AC4 plan for real (against the stub), building the golden snapshot for NC2 ==="
 : > "$CALLS"; echo 0 > "$IDCTR"; : > "$SNAP"
 APPLY1_ERR="$(STUB_CALL_LOG="$CALLS" STUB_ID_COUNTER="$IDCTR" HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1 >/dev/null)"
-assert "run 1 applies with 0 errors" "$(printf '%s\n' "$APPLY1_ERR" | grep -q '7 create, 0 change, 0 complete, 0 error' && echo 0 || echo 1)"
+assert "run 1 applies with 0 errors" "$({ printf '%s\n' "$APPLY1_ERR" 2>/dev/null || :; } | grep -q '7 create, 0 change, 0 complete, 0 error' && echo 0 || echo 1)"
 assert "run 1 writes 7 rows to the snapshot" "$([ "$(wc -l < "$SNAP" | tr -d ' ')" -eq 7 ] && echo 0 || echo 1)"
 assert "run 1 makes real stub calls (create + the ID-006 block-needs-input followup)" \
   "$(grep -q 'create \[untrusted\] Do the thing' "$CALLS" && grep -q 'block .* --kind needs_input' "$CALLS" && echo 0 || echo 1)"
@@ -208,18 +208,18 @@ assert "run 1 never issues a --kind dependency call (todo has no durable synthet
 echo ""
 echo "=== AC5 / board status ==="
 STATUS1="$(bash "$BOARD" status --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1)"
-assert "status reports up to date right after a mirror" "$(printf '%s\n' "$STATUS1" | grep -qi 'up to date' && echo 0 || echo 1)"
-assert "status summary line matches the contract wording" "$(printf '%s\n' "$STATUS1" | grep -qE '^[0-9]+ repos changed since last mirror, last synced' && echo 0 || echo 1)"
+assert "status reports up to date right after a mirror" "$({ printf '%s\n' "$STATUS1" 2>/dev/null || :; } | grep -qi 'up to date' && echo 0 || echo 1)"
+assert "status summary line matches the contract wording" "$({ printf '%s\n' "$STATUS1" 2>/dev/null || :; } | grep -qE '^[0-9]+ repos changed since last mirror, last synced' && echo 0 || echo 1)"
 cat >> "$FIXR/_meta/BACKLOG.md" <<'BOARD_R2'
 | ID-009 | New row after mirror | notes9 | queued |
 BOARD_R2
 git -C "$FIXR" add -A && git -C "$FIXR" commit -q -m "test: add ID-009 after first mirror"
 STATUS2="$(bash "$BOARD" status --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1)"
-assert "status detects drift after a real git touch" "$(printf '%s\n' "$STATUS2" | grep -qi 'changed since last mirror' && echo 0 || echo 1)"
+assert "status detects drift after a real git touch" "$({ printf '%s\n' "$STATUS2" 2>/dev/null || :; } | grep -qi 'changed since last mirror' && echo 0 || echo 1)"
 STUB_CALL_LOG="$TMPDIR_T/calls-heal.log" STUB_ID_COUNTER="$IDCTR" HERMES_BIN="$STUB" \
   bash "$BOARD" mirror --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" >/dev/null 2>&1
 STATUS3="$(bash "$BOARD" status --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1)"
-assert "status heals back to up to date after re-mirroring" "$(printf '%s\n' "$STATUS3" | grep -qi 'up to date' && echo 0 || echo 1)"
+assert "status heals back to up to date after re-mirroring" "$({ printf '%s\n' "$STATUS3" 2>/dev/null || :; } | grep -qi 'up to date' && echo 0 || echo 1)"
 # revert the ID-009 addition so NC2's golden-fixture idempotence check below is unaffected by it
 git -C "$FIXR" revert -q --no-edit HEAD >/dev/null 2>&1 || true
 
@@ -248,10 +248,10 @@ assert "NC2: second (real, non-dry-run) run makes ZERO stub-hermes calls" "$([ !
 
 echo ""
 echo "=== NC3: an opted-OUT repo (fixTrading) never appears in any plan or applied calls ==="
-assert "NC3: fixTrading's TR-001 never appears in the AC4 plan" "$(printf '%s\n' "$DRYPLAN" | grep -q 'TR-001\|fixTrading' && echo 1 || echo 0)"
+assert "NC3: fixTrading's TR-001 never appears in the AC4 plan" "$({ printf '%s\n' "$DRYPLAN" 2>/dev/null || :; } | grep -q 'TR-001\|fixTrading' && echo 1 || echo 0)"
 assert "NC3: fixTrading never appears in any stub call log so far" \
   "$(grep -qi 'trading\|TR-001\|secret trading' "$CALLS" "$TMPDIR_T"/*.log 2>/dev/null && echo 1 || echo 0)"
-assert "NC3: fixTrading never appears in board status output" "$(printf '%s\n%s\n%s\n' "$STATUS1" "$STATUS2" "$STATUS3" | grep -qi trading && echo 1 || echo 0)"
+assert "NC3: fixTrading never appears in board status output" "$({ printf '%s\n%s\n%s\n' "$STATUS1" "$STATUS2" "$STATUS3" 2>/dev/null || :; } | grep -qi trading && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC4: every write is a recorded hermes CLI call; no direct DB access ==="
@@ -286,7 +286,7 @@ assert "NC5: the complete op targets 'done'" "$([ "$(printf '%s' "$NC5_COMPLETE"
 STUB_CALL_LOG="$TMPDIR_T/nc5-calls.log" HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" >/dev/null 2>&1
 assert "NC5: after applying, the completed row is DROPPED from the snapshot (never re-touched)" "$(grep -q 'fixR:ID-003' "$SNAP" && echo 1 || echo 0)"
 NC5_PLAN2="$(HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" --dry-run 2>/dev/null)"
-assert "NC5: re-running the plan does NOT re-complete ID-003 (idempotent even for disappeared rows)" "$(printf '%s\n' "$NC5_PLAN2" | grep -q 'ID-003' && echo 1 || echo 0)"
+assert "NC5: re-running the plan does NOT re-complete ID-003 (idempotent even for disappeared rows)" "$({ printf '%s\n' "$NC5_PLAN2" 2>/dev/null || :; } | grep -q 'ID-003' && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC6: REGISTRY NON-REGRESSION -- board/next/priority/states/queue unaffected by the bridge column ==="
@@ -297,16 +297,16 @@ fixTrading  $FIXT/_meta/BACKLOG.md        off
 REG3
 ALL_BOARD="$(bash "$BOARD" all board --registry "$NC6_REG")"
 assert "NC6: 'board all board' still renders both repo headers with a bridge column present" \
-  "$(printf '%s\n' "$ALL_BOARD" | grep -q '=== fixR ===' && printf '%s\n' "$ALL_BOARD" | grep -q '=== fixTrading ===' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixR ===' && { printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixTrading ===' && echo 0 || echo 1)"
 ALL_NEXT="$(bash "$BOARD" all next --registry "$NC6_REG")"
-assert "NC6: 'board all next' still resolves fixR's next queued row" "$(printf '%s\n' "$ALL_NEXT" | grep -q 'fixR' && echo 0 || echo 1)"
+assert "NC6: 'board all next' still resolves fixR's next queued row" "$({ printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixR' && echo 0 || echo 1)"
 ALL_STATES="$(bash "$BOARD" all states --registry "$NC6_REG")"
-assert "NC6: 'board all states' still renders per repo" "$(printf '%s\n' "$ALL_STATES" | grep -q '=== fixR ===' && echo 0 || echo 1)"
+assert "NC6: 'board all states' still renders per repo" "$({ printf '%s\n' "$ALL_STATES" 2>/dev/null || :; } | grep -q '=== fixR ===' && echo 0 || echo 1)"
 bash "$BOARD" queue --registry "$NC6_REG" >/dev/null 2>"$TMPDIR_T/nc6-queue.err"; QUEUE_RC=$?
 assert "NC6: 'board queue' still exits 0 with the bridge column present (no #queue{} tokens seeded here, so 0 rows is correct)" \
   "$([ "$QUEUE_RC" -eq 0 ] && grep -q '0 rows' "$TMPDIR_T/nc6-queue.err" && echo 0 || echo 1)"
 PRIO_SINGLE="$(bash "$BOARD" priority overview --backlog-file "$FIXR/_meta/BACKLOG.md")"
-assert "NC6: single-repo 'board priority overview' is unaffected" "$(printf '%s\n' "$PRIO_SINGLE" | grep -q 'DO NOW' && echo 0 || echo 1)"
+assert "NC6: single-repo 'board priority overview' is unaffected" "$({ printf '%s\n' "$PRIO_SINGLE" 2>/dev/null || :; } | grep -q 'DO NOW' && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC7: SECURITY -- untrusted BACKLOG content is LABELLED + routing-tags stripped before it reaches a Hermes card (stored-injection hardening) ==="
@@ -335,9 +335,9 @@ INJ_ROWS="$(bash "$BOARD_MIRROR" extract-rows "$FIXINJ/_meta/BACKLOG.md" fixInj 
 # extract-rows TSV layout: 1=origin 2=repo 3=id 4=item 5=notes 6=status 7=target 8=hash
 INJ_ITEM="$(printf '%s\n' "$INJ_ROWS" | awk -F'\t' '$3=="ID-901"{print $4}')"
 INJ_NOTES="$(printf '%s\n' "$INJ_ROWS" | awk -F'\t' '$3=="ID-901"{print $5}')"
-assert "NC7: extract-rows strips the #queue{} token from the item" "$(printf '%s' "$INJ_ITEM" | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7: extract-rows strips the #queue{} token from the notes" "$(printf '%s' "$INJ_NOTES" | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7: the item's own PROSE is retained (labelled, never dropped)" "$(printf '%s' "$INJ_ITEM" | grep -q 'IGNORE ALL PREVIOUS INSTRUCTIONS' && echo 0 || echo 1)"
+assert "NC7: extract-rows strips the #queue{} token from the item" "$({ printf '%s' "$INJ_ITEM" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7: extract-rows strips the #queue{} token from the notes" "$({ printf '%s' "$INJ_NOTES" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7: the item's own PROSE is retained (labelled, never dropped)" "$({ printf '%s' "$INJ_ITEM" 2>/dev/null || :; } | grep -q 'IGNORE ALL PREVIOUS INSTRUCTIONS' && echo 0 || echo 1)"
 
 INJ_REG="$TMPDIR_T/boards-inj.txt"
 printf 'fixInj  %s/_meta/BACKLOG.md  on\n' "$FIXINJ" > "$INJ_REG"
@@ -347,10 +347,10 @@ INJ_CREATE="$(printf '%s\n' "$INJ_PLAN" | jq -c 'select(.origin=="fixInj:ID-901"
 INJ_BODY="$(printf '%s' "$INJ_CREATE" | jq -r '.argv as $a | ($a | index("--body")) as $i | $a[$i+1]')"
 INJ_TITLE="$(printf '%s' "$INJ_CREATE" | jq -r '.argv as $a | ($a | index("create")) as $i | $a[$i+1]')"
 assert "NC7: the card BODY begins with the untrusted-content marker" "$(printf '%s' "$INJ_BODY" | head -1 | grep -q '^\[AUTOMATED MIRROR' && echo 0 || echo 1)"
-assert "NC7: the card TITLE carries the compact untrusted tag" "$(printf '%s' "$INJ_TITLE" | grep -q '^\[untrusted\] ' && echo 0 || echo 1)"
-assert "NC7: the #queue{} token never reaches the card title" "$(printf '%s' "$INJ_TITLE" | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7: the #queue{} token never reaches the card body" "$(printf '%s' "$INJ_BODY" | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7: the injection prose survives into the card (labelled, not censored)" "$(printf '%s' "$INJ_TITLE" | grep -q 'IGNORE ALL PREVIOUS INSTRUCTIONS' && echo 0 || echo 1)"
+assert "NC7: the card TITLE carries the compact untrusted tag" "$({ printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q '^\[untrusted\] ' && echo 0 || echo 1)"
+assert "NC7: the #queue{} token never reaches the card title" "$({ printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7: the #queue{} token never reaches the card body" "$({ printf '%s' "$INJ_BODY" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7: the injection prose survives into the card (labelled, not censored)" "$({ printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q 'IGNORE ALL PREVIOUS INSTRUCTIONS' && echo 0 || echo 1)"
 
 # NC7b: the MEGAS path (title from a ROADMAP.md `# Mega-goal:` line) gets the SAME strip + tag.
 mkdir -p "$FIXINJ/_meta/megagoals/injmega"
@@ -363,8 +363,8 @@ git -C "$FIXINJ" add -A && git -C "$FIXINJ" commit -q -m "test: seed injection m
 INJ_PLAN2="$(HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$FIXINJ" --registry "$INJ_REG" --snapshot "$TMPDIR_T/snap-inj2.jsonl" --dry-run 2>/dev/null)"
 MEGA_CREATE="$(printf '%s\n' "$INJ_PLAN2" | jq -c 'select(.origin=="megagoals:fixInj/injmega")')"
 MEGA_TITLE="$(printf '%s' "$MEGA_CREATE" | jq -r '.argv as $a | ($a | index("create")) as $i | $a[$i+1]')"
-assert "NC7b: the MEGAS-path title strips the #queue{} token" "$(printf '%s' "$MEGA_TITLE" | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7b: the MEGAS-path title carries the untrusted tag" "$(printf '%s' "$MEGA_TITLE" | grep -q '^\[untrusted\] ' && echo 0 || echo 1)"
+assert "NC7b: the MEGAS-path title strips the #queue{} token" "$({ printf '%s' "$MEGA_TITLE" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7b: the MEGAS-path title carries the untrusted tag" "$({ printf '%s' "$MEGA_TITLE" 2>/dev/null || :; } | grep -q '^\[untrusted\] ' && echo 0 || echo 1)"
 
 # NC7c: the CHANGE-op comment path (a row whose content moved since the snapshot) is ALSO labelled
 # + tag-stripped. Seed a prior snapshot whose row_hash cannot match the current crafted row (a
@@ -377,8 +377,8 @@ CH_PLAN="$(HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$FIXINJ" --regis
 CH_OP="$(printf '%s\n' "$CH_PLAN" | jq -c 'select(.origin=="fixInj:ID-901" and .op=="change")')"
 CH_COMMENT="$(printf '%s' "$CH_OP" | jq -r '.argv | last')"
 assert "NC7c: a CHANGE is planned for the moved row (prior hash differs)" "$([ -n "$CH_OP" ] && echo 0 || echo 1)"
-assert "NC7c: the CHANGE comment carries the untrusted marker" "$(printf '%s' "$CH_COMMENT" | grep -q '\[AUTOMATED MIRROR' && echo 0 || echo 1)"
-assert "NC7c: the CHANGE comment strips the #queue{} token" "$(printf '%s' "$CH_COMMENT" | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7c: the CHANGE comment carries the untrusted marker" "$({ printf '%s' "$CH_COMMENT" 2>/dev/null || :; } | grep -q '\[AUTOMATED MIRROR' && echo 0 || echo 1)"
+assert "NC7c: the CHANGE comment strips the #queue{} token" "$({ printf '%s' "$CH_COMMENT" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC8: a 'complete' op failing with 'unknown id or terminal state' records ok/done, not error ==="

--- a/tests/test-board-mirror.sh
+++ b/tests/test-board-mirror.sh
@@ -131,7 +131,7 @@ echo "=== AC1: row-hash is deterministic and content-sensitive ==="
 H1="$(bash "$BOARD_MIRROR" row-hash fixR ID-001 "Do the thing" "some notes" queued)"
 H2="$(bash "$BOARD_MIRROR" row-hash fixR ID-001 "Do the thing" "some notes" queued)"
 H3="$(bash "$BOARD_MIRROR" row-hash fixR ID-001 "Do the thing CHANGED" "some notes" queued)"
-assert "row-hash is 64 lowercase hex chars" "$({ printf '%s' "$H1" 2>/dev/null || :; } | grep -qE '^[0-9a-f]{64}$' && echo 0 || echo 1)"
+assert "row-hash is 64 lowercase hex chars" "$({ trap '' PIPE; printf '%s' "$H1" 2>/dev/null || :; } | grep -qE '^[0-9a-f]{64}$' && echo 0 || echo 1)"
 assert "row-hash is deterministic (same inputs -> same hash)" "$([ "$H1" = "$H2" ] && echo 0 || echo 1)"
 assert "row-hash is content-sensitive (changed item -> different hash)" "$([ "$H1" != "$H3" ] && echo 0 || echo 1)"
 
@@ -147,19 +147,19 @@ assert "ID-003 (speccing) -> target ready"   "$([ "$(tnative ID-003)" = "ready" 
 assert "ID-004 (validated) -> target ready"  "$([ "$(tnative ID-004)" = "ready" ] && echo 0 || echo 1)"
 assert "ID-005 (executing) -> target ready"  "$([ "$(tnative ID-005)" = "ready" ] && echo 0 || echo 1)"
 assert "ID-006 (parked) -> target blocked"   "$([ "$(tnative ID-006)" = "blocked" ] && echo 0 || echo 1)"
-assert "ID-007 (shipped) is EXCLUDED from extraction" "$({ printf '%s\n' "$ROWS" 2>/dev/null || :; } | grep -q 'ID-007' && echo 1 || echo 0)"
-assert "ID-008 (dropped) is EXCLUDED from extraction" "$({ printf '%s\n' "$ROWS" 2>/dev/null || :; } | grep -q 'ID-008' && echo 1 || echo 0)"
-assert "ID-007's skip reason is logged" "$({ printf '%s\n' "$ERRS" 2>/dev/null || :; } | grep -q 'skip ID-007' && echo 0 || echo 1)"
-assert "ID-008's skip reason is logged" "$({ printf '%s\n' "$ERRS" 2>/dev/null || :; } | grep -q 'skip ID-008' && echo 0 || echo 1)"
+assert "ID-007 (shipped) is EXCLUDED from extraction" "$({ trap '' PIPE; printf '%s\n' "$ROWS" 2>/dev/null || :; } | grep -q 'ID-007' && echo 1 || echo 0)"
+assert "ID-008 (dropped) is EXCLUDED from extraction" "$({ trap '' PIPE; printf '%s\n' "$ROWS" 2>/dev/null || :; } | grep -q 'ID-008' && echo 1 || echo 0)"
+assert "ID-007's skip reason is logged" "$({ trap '' PIPE; printf '%s\n' "$ERRS" 2>/dev/null || :; } | grep -q 'skip ID-007' && echo 0 || echo 1)"
+assert "ID-008's skip reason is logged" "$({ trap '' PIPE; printf '%s\n' "$ERRS" 2>/dev/null || :; } | grep -q 'skip ID-008' && echo 0 || echo 1)"
 assert "extract-rows emits exactly the 6 bridgeable rows (001-006), not 8" \
   "$([ "$(printf '%s\n' "$ROWS" | grep -c . )" -eq 6 ] && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC3: extract-megas -- active detection, progress, held flag, inactive-skip ==="
 MEGAS="$(bash "$BOARD_MIRROR" extract-megas "$FIXR" fixR)"
-assert "the active mega (1 unchecked box) is emitted" "$({ printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -q 'megagoals:fixR/mymega' && echo 0 || echo 1)"
-assert "progress reads 1/2 (one checked, one unchecked)" "$({ printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -q 'progress 1/2' && echo 0 || echo 1)"
-assert "the held-PR text signal is surfaced" "$({ printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -qi 'held-PR flag set' && echo 0 || echo 1)"
+assert "the active mega (1 unchecked box) is emitted" "$({ trap '' PIPE; printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -q 'megagoals:fixR/mymega' && echo 0 || echo 1)"
+assert "progress reads 1/2 (one checked, one unchecked)" "$({ trap '' PIPE; printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -q 'progress 1/2' && echo 0 || echo 1)"
+assert "the held-PR text signal is surfaced" "$({ trap '' PIPE; printf '%s\n' "$MEGAS" 2>/dev/null || :; } | grep -qi 'held-PR flag set' && echo 0 || echo 1)"
 assert "mega target_native is ready" "$(printf '%s\n' "$MEGAS" | awk -F'\t' '{print $7}' | grep -qx ready && echo 0 || echo 1)"
 # A fully-checked (inactive) roadmap in a second mega dir must NOT be emitted.
 mkdir -p "$FIXR/_meta/megagoals/donemega"
@@ -170,7 +170,7 @@ cat > "$FIXR/_meta/megagoals/donemega/ROADMAP.md" <<'ROADMAP_DONE'
 - [x] 02-thing also done
 ROADMAP_DONE
 MEGAS2="$(bash "$BOARD_MIRROR" extract-megas "$FIXR" fixR)"
-assert "a fully-checked (inactive) mega is NOT emitted" "$({ printf '%s\n' "$MEGAS2" 2>/dev/null || :; } | grep -q 'donemega' && echo 1 || echo 0)"
+assert "a fully-checked (inactive) mega is NOT emitted" "$({ trap '' PIPE; printf '%s\n' "$MEGAS2" 2>/dev/null || :; } | grep -q 'donemega' && echo 1 || echo 0)"
 rm -rf "$FIXR/_meta/megagoals/donemega"
 
 echo ""
@@ -198,7 +198,7 @@ echo ""
 echo "=== Apply the AC4 plan for real (against the stub), building the golden snapshot for NC2 ==="
 : > "$CALLS"; echo 0 > "$IDCTR"; : > "$SNAP"
 APPLY1_ERR="$(STUB_CALL_LOG="$CALLS" STUB_ID_COUNTER="$IDCTR" HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1 >/dev/null)"
-assert "run 1 applies with 0 errors" "$({ printf '%s\n' "$APPLY1_ERR" 2>/dev/null || :; } | grep -q '7 create, 0 change, 0 complete, 0 error' && echo 0 || echo 1)"
+assert "run 1 applies with 0 errors" "$({ trap '' PIPE; printf '%s\n' "$APPLY1_ERR" 2>/dev/null || :; } | grep -q '7 create, 0 change, 0 complete, 0 error' && echo 0 || echo 1)"
 assert "run 1 writes 7 rows to the snapshot" "$([ "$(wc -l < "$SNAP" | tr -d ' ')" -eq 7 ] && echo 0 || echo 1)"
 assert "run 1 makes real stub calls (create + the ID-006 block-needs-input followup)" \
   "$(grep -q 'create \[untrusted\] Do the thing' "$CALLS" && grep -q 'block .* --kind needs_input' "$CALLS" && echo 0 || echo 1)"
@@ -208,18 +208,18 @@ assert "run 1 never issues a --kind dependency call (todo has no durable synthet
 echo ""
 echo "=== AC5 / board status ==="
 STATUS1="$(bash "$BOARD" status --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1)"
-assert "status reports up to date right after a mirror" "$({ printf '%s\n' "$STATUS1" 2>/dev/null || :; } | grep -qi 'up to date' && echo 0 || echo 1)"
-assert "status summary line matches the contract wording" "$({ printf '%s\n' "$STATUS1" 2>/dev/null || :; } | grep -qE '^[0-9]+ repos changed since last mirror, last synced' && echo 0 || echo 1)"
+assert "status reports up to date right after a mirror" "$({ trap '' PIPE; printf '%s\n' "$STATUS1" 2>/dev/null || :; } | grep -qi 'up to date' && echo 0 || echo 1)"
+assert "status summary line matches the contract wording" "$({ trap '' PIPE; printf '%s\n' "$STATUS1" 2>/dev/null || :; } | grep -qE '^[0-9]+ repos changed since last mirror, last synced' && echo 0 || echo 1)"
 cat >> "$FIXR/_meta/BACKLOG.md" <<'BOARD_R2'
 | ID-009 | New row after mirror | notes9 | queued |
 BOARD_R2
 git -C "$FIXR" add -A && git -C "$FIXR" commit -q -m "test: add ID-009 after first mirror"
 STATUS2="$(bash "$BOARD" status --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1)"
-assert "status detects drift after a real git touch" "$({ printf '%s\n' "$STATUS2" 2>/dev/null || :; } | grep -qi 'changed since last mirror' && echo 0 || echo 1)"
+assert "status detects drift after a real git touch" "$({ trap '' PIPE; printf '%s\n' "$STATUS2" 2>/dev/null || :; } | grep -qi 'changed since last mirror' && echo 0 || echo 1)"
 STUB_CALL_LOG="$TMPDIR_T/calls-heal.log" STUB_ID_COUNTER="$IDCTR" HERMES_BIN="$STUB" \
   bash "$BOARD" mirror --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" >/dev/null 2>&1
 STATUS3="$(bash "$BOARD" status --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1)"
-assert "status heals back to up to date after re-mirroring" "$({ printf '%s\n' "$STATUS3" 2>/dev/null || :; } | grep -qi 'up to date' && echo 0 || echo 1)"
+assert "status heals back to up to date after re-mirroring" "$({ trap '' PIPE; printf '%s\n' "$STATUS3" 2>/dev/null || :; } | grep -qi 'up to date' && echo 0 || echo 1)"
 # revert the ID-009 addition so NC2's golden-fixture idempotence check below is unaffected by it
 git -C "$FIXR" revert -q --no-edit HEAD >/dev/null 2>&1 || true
 
@@ -248,10 +248,10 @@ assert "NC2: second (real, non-dry-run) run makes ZERO stub-hermes calls" "$([ !
 
 echo ""
 echo "=== NC3: an opted-OUT repo (fixTrading) never appears in any plan or applied calls ==="
-assert "NC3: fixTrading's TR-001 never appears in the AC4 plan" "$({ printf '%s\n' "$DRYPLAN" 2>/dev/null || :; } | grep -q 'TR-001\|fixTrading' && echo 1 || echo 0)"
+assert "NC3: fixTrading's TR-001 never appears in the AC4 plan" "$({ trap '' PIPE; printf '%s\n' "$DRYPLAN" 2>/dev/null || :; } | grep -q 'TR-001\|fixTrading' && echo 1 || echo 0)"
 assert "NC3: fixTrading never appears in any stub call log so far" \
   "$(grep -qi 'trading\|TR-001\|secret trading' "$CALLS" "$TMPDIR_T"/*.log 2>/dev/null && echo 1 || echo 0)"
-assert "NC3: fixTrading never appears in board status output" "$({ printf '%s\n%s\n%s\n' "$STATUS1" "$STATUS2" "$STATUS3" 2>/dev/null || :; } | grep -qi trading && echo 1 || echo 0)"
+assert "NC3: fixTrading never appears in board status output" "$({ trap '' PIPE; printf '%s\n%s\n%s\n' "$STATUS1" "$STATUS2" "$STATUS3" 2>/dev/null || :; } | grep -qi trading && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC4: every write is a recorded hermes CLI call; no direct DB access ==="
@@ -286,7 +286,7 @@ assert "NC5: the complete op targets 'done'" "$([ "$(printf '%s' "$NC5_COMPLETE"
 STUB_CALL_LOG="$TMPDIR_T/nc5-calls.log" HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" >/dev/null 2>&1
 assert "NC5: after applying, the completed row is DROPPED from the snapshot (never re-touched)" "$(grep -q 'fixR:ID-003' "$SNAP" && echo 1 || echo 0)"
 NC5_PLAN2="$(HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" --dry-run 2>/dev/null)"
-assert "NC5: re-running the plan does NOT re-complete ID-003 (idempotent even for disappeared rows)" "$({ printf '%s\n' "$NC5_PLAN2" 2>/dev/null || :; } | grep -q 'ID-003' && echo 1 || echo 0)"
+assert "NC5: re-running the plan does NOT re-complete ID-003 (idempotent even for disappeared rows)" "$({ trap '' PIPE; printf '%s\n' "$NC5_PLAN2" 2>/dev/null || :; } | grep -q 'ID-003' && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC6: REGISTRY NON-REGRESSION -- board/next/priority/states/queue unaffected by the bridge column ==="
@@ -297,16 +297,16 @@ fixTrading  $FIXT/_meta/BACKLOG.md        off
 REG3
 ALL_BOARD="$(bash "$BOARD" all board --registry "$NC6_REG")"
 assert "NC6: 'board all board' still renders both repo headers with a bridge column present" \
-  "$({ printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixR ===' && { printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixTrading ===' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixR ===' && { trap '' PIPE; printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixTrading ===' && echo 0 || echo 1)"
 ALL_NEXT="$(bash "$BOARD" all next --registry "$NC6_REG")"
-assert "NC6: 'board all next' still resolves fixR's next queued row" "$({ printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixR' && echo 0 || echo 1)"
+assert "NC6: 'board all next' still resolves fixR's next queued row" "$({ trap '' PIPE; printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixR' && echo 0 || echo 1)"
 ALL_STATES="$(bash "$BOARD" all states --registry "$NC6_REG")"
-assert "NC6: 'board all states' still renders per repo" "$({ printf '%s\n' "$ALL_STATES" 2>/dev/null || :; } | grep -q '=== fixR ===' && echo 0 || echo 1)"
+assert "NC6: 'board all states' still renders per repo" "$({ trap '' PIPE; printf '%s\n' "$ALL_STATES" 2>/dev/null || :; } | grep -q '=== fixR ===' && echo 0 || echo 1)"
 bash "$BOARD" queue --registry "$NC6_REG" >/dev/null 2>"$TMPDIR_T/nc6-queue.err"; QUEUE_RC=$?
 assert "NC6: 'board queue' still exits 0 with the bridge column present (no #queue{} tokens seeded here, so 0 rows is correct)" \
   "$([ "$QUEUE_RC" -eq 0 ] && grep -q '0 rows' "$TMPDIR_T/nc6-queue.err" && echo 0 || echo 1)"
 PRIO_SINGLE="$(bash "$BOARD" priority overview --backlog-file "$FIXR/_meta/BACKLOG.md")"
-assert "NC6: single-repo 'board priority overview' is unaffected" "$({ printf '%s\n' "$PRIO_SINGLE" 2>/dev/null || :; } | grep -q 'DO NOW' && echo 0 || echo 1)"
+assert "NC6: single-repo 'board priority overview' is unaffected" "$({ trap '' PIPE; printf '%s\n' "$PRIO_SINGLE" 2>/dev/null || :; } | grep -q 'DO NOW' && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC7: SECURITY -- untrusted BACKLOG content is LABELLED + routing-tags stripped before it reaches a Hermes card (stored-injection hardening) ==="
@@ -335,9 +335,9 @@ INJ_ROWS="$(bash "$BOARD_MIRROR" extract-rows "$FIXINJ/_meta/BACKLOG.md" fixInj 
 # extract-rows TSV layout: 1=origin 2=repo 3=id 4=item 5=notes 6=status 7=target 8=hash
 INJ_ITEM="$(printf '%s\n' "$INJ_ROWS" | awk -F'\t' '$3=="ID-901"{print $4}')"
 INJ_NOTES="$(printf '%s\n' "$INJ_ROWS" | awk -F'\t' '$3=="ID-901"{print $5}')"
-assert "NC7: extract-rows strips the #queue{} token from the item" "$({ printf '%s' "$INJ_ITEM" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7: extract-rows strips the #queue{} token from the notes" "$({ printf '%s' "$INJ_NOTES" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7: the item's own PROSE is retained (labelled, never dropped)" "$({ printf '%s' "$INJ_ITEM" 2>/dev/null || :; } | grep -q 'IGNORE ALL PREVIOUS INSTRUCTIONS' && echo 0 || echo 1)"
+assert "NC7: extract-rows strips the #queue{} token from the item" "$({ trap '' PIPE; printf '%s' "$INJ_ITEM" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7: extract-rows strips the #queue{} token from the notes" "$({ trap '' PIPE; printf '%s' "$INJ_NOTES" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7: the item's own PROSE is retained (labelled, never dropped)" "$({ trap '' PIPE; printf '%s' "$INJ_ITEM" 2>/dev/null || :; } | grep -q 'IGNORE ALL PREVIOUS INSTRUCTIONS' && echo 0 || echo 1)"
 
 INJ_REG="$TMPDIR_T/boards-inj.txt"
 printf 'fixInj  %s/_meta/BACKLOG.md  on\n' "$FIXINJ" > "$INJ_REG"
@@ -347,10 +347,10 @@ INJ_CREATE="$(printf '%s\n' "$INJ_PLAN" | jq -c 'select(.origin=="fixInj:ID-901"
 INJ_BODY="$(printf '%s' "$INJ_CREATE" | jq -r '.argv as $a | ($a | index("--body")) as $i | $a[$i+1]')"
 INJ_TITLE="$(printf '%s' "$INJ_CREATE" | jq -r '.argv as $a | ($a | index("create")) as $i | $a[$i+1]')"
 assert "NC7: the card BODY begins with the untrusted-content marker" "$(printf '%s' "$INJ_BODY" | head -1 | grep -q '^\[AUTOMATED MIRROR' && echo 0 || echo 1)"
-assert "NC7: the card TITLE carries the compact untrusted tag" "$({ printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q '^\[untrusted\] ' && echo 0 || echo 1)"
-assert "NC7: the #queue{} token never reaches the card title" "$({ printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7: the #queue{} token never reaches the card body" "$({ printf '%s' "$INJ_BODY" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7: the injection prose survives into the card (labelled, not censored)" "$({ printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q 'IGNORE ALL PREVIOUS INSTRUCTIONS' && echo 0 || echo 1)"
+assert "NC7: the card TITLE carries the compact untrusted tag" "$({ trap '' PIPE; printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q '^\[untrusted\] ' && echo 0 || echo 1)"
+assert "NC7: the #queue{} token never reaches the card title" "$({ trap '' PIPE; printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7: the #queue{} token never reaches the card body" "$({ trap '' PIPE; printf '%s' "$INJ_BODY" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7: the injection prose survives into the card (labelled, not censored)" "$({ trap '' PIPE; printf '%s' "$INJ_TITLE" 2>/dev/null || :; } | grep -q 'IGNORE ALL PREVIOUS INSTRUCTIONS' && echo 0 || echo 1)"
 
 # NC7b: the MEGAS path (title from a ROADMAP.md `# Mega-goal:` line) gets the SAME strip + tag.
 mkdir -p "$FIXINJ/_meta/megagoals/injmega"
@@ -363,8 +363,8 @@ git -C "$FIXINJ" add -A && git -C "$FIXINJ" commit -q -m "test: seed injection m
 INJ_PLAN2="$(HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$FIXINJ" --registry "$INJ_REG" --snapshot "$TMPDIR_T/snap-inj2.jsonl" --dry-run 2>/dev/null)"
 MEGA_CREATE="$(printf '%s\n' "$INJ_PLAN2" | jq -c 'select(.origin=="megagoals:fixInj/injmega")')"
 MEGA_TITLE="$(printf '%s' "$MEGA_CREATE" | jq -r '.argv as $a | ($a | index("create")) as $i | $a[$i+1]')"
-assert "NC7b: the MEGAS-path title strips the #queue{} token" "$({ printf '%s' "$MEGA_TITLE" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
-assert "NC7b: the MEGAS-path title carries the untrusted tag" "$({ printf '%s' "$MEGA_TITLE" 2>/dev/null || :; } | grep -q '^\[untrusted\] ' && echo 0 || echo 1)"
+assert "NC7b: the MEGAS-path title strips the #queue{} token" "$({ trap '' PIPE; printf '%s' "$MEGA_TITLE" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7b: the MEGAS-path title carries the untrusted tag" "$({ trap '' PIPE; printf '%s' "$MEGA_TITLE" 2>/dev/null || :; } | grep -q '^\[untrusted\] ' && echo 0 || echo 1)"
 
 # NC7c: the CHANGE-op comment path (a row whose content moved since the snapshot) is ALSO labelled
 # + tag-stripped. Seed a prior snapshot whose row_hash cannot match the current crafted row (a
@@ -377,8 +377,8 @@ CH_PLAN="$(HERMES_BIN="$STUB" bash "$BOARD" mirror --repo-root "$FIXINJ" --regis
 CH_OP="$(printf '%s\n' "$CH_PLAN" | jq -c 'select(.origin=="fixInj:ID-901" and .op=="change")')"
 CH_COMMENT="$(printf '%s' "$CH_OP" | jq -r '.argv | last')"
 assert "NC7c: a CHANGE is planned for the moved row (prior hash differs)" "$([ -n "$CH_OP" ] && echo 0 || echo 1)"
-assert "NC7c: the CHANGE comment carries the untrusted marker" "$({ printf '%s' "$CH_COMMENT" 2>/dev/null || :; } | grep -q '\[AUTOMATED MIRROR' && echo 0 || echo 1)"
-assert "NC7c: the CHANGE comment strips the #queue{} token" "$({ printf '%s' "$CH_COMMENT" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
+assert "NC7c: the CHANGE comment carries the untrusted marker" "$({ trap '' PIPE; printf '%s' "$CH_COMMENT" 2>/dev/null || :; } | grep -q '\[AUTOMATED MIRROR' && echo 0 || echo 1)"
+assert "NC7c: the CHANGE comment strips the #queue{} token" "$({ trap '' PIPE; printf '%s' "$CH_COMMENT" 2>/dev/null || :; } | grep -q '#queue{' && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC8: a 'complete' op failing with 'unknown id or terminal state' records ok/done, not error ==="

--- a/tests/test-board-writeback.sh
+++ b/tests/test-board-writeback.sh
@@ -182,7 +182,7 @@ assert "ID-001's changeset entry: queued -> claimed" \
 assert "ID-003's changeset entry: parked -> shipped" \
   "$(printf '%s\n' "$DIFF1" | jq -e 'select(.origin=="fixR:ID-003") | .current_status=="parked" and .target_status=="shipped"' >/dev/null 2>&1 && echo 0 || echo 1)"
 assert "ID-002 (no Hermes-side move) never appears in the changeset" \
-  "$({ printf '%s\n' "$DIFF1" 2>/dev/null || :; } | grep -q 'ID-002' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$DIFF1" 2>/dev/null || :; } | grep -q 'ID-002' && echo 1 || echo 0)"
 assert "only ONE hermes call made (batched list, not per-row)" \
   "$([ "$(wc -l < "$CALLS" | tr -d ' ')" -eq 1 ] && echo 0 || echo 1)"
 
@@ -207,8 +207,8 @@ assert "the sync commit body carries actor=hermes" \
 assert "the sync branch's diff touches ONLY the Status column of the two matched rows" \
   "$(git -C "$FIXR" diff "$DEFAULT_BRANCH" chore/board-sync -- _meta/BACKLOG.md | grep -c '^[+-]|' | grep -qx 4 && echo 0 || echo 1)"
 RT_DIFF="$(git -C "$FIXR" diff "$DEFAULT_BRANCH" chore/board-sync -- _meta/BACKLOG.md)"
-assert "RT: the diff shows ID-001 queued->claimed" "$({ printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '-| ID-001 .* queued ' && { printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '+| ID-001 .* claimed' && echo 0 || echo 1)"
-assert "RT: the diff shows ID-003 parked->shipped" "$({ printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '-| ID-003 .* parked ' && { printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '+| ID-003 .* shipped' && echo 0 || echo 1)"
+assert "RT: the diff shows ID-001 queued->claimed" "$({ trap '' PIPE; printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '-| ID-001 .* queued ' && { trap '' PIPE; printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '+| ID-001 .* claimed' && echo 0 || echo 1)"
+assert "RT: the diff shows ID-003 parked->shipped" "$({ trap '' PIPE; printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '-| ID-003 .* parked ' && { trap '' PIPE; printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '+| ID-003 .* shipped' && echo 0 || echo 1)"
 assert "'gh pr create' was called exactly once (never a real API call -- it's the stub)" \
   "$([ "$(wc -l < "$GHCALLS" | tr -d ' ')" -eq 1 ] && echo 0 || echo 1)"
 assert "'gh pr create' argv carries --base/--head/--title/--body-file as discrete args" \
@@ -235,7 +235,7 @@ SYNC_SHA_BEFORE="$(git -C "$FIXR" rev-parse chore/board-sync)"
 WB2_OUT="$(STUB_CALL_LOG="$CALLS" STUB_LIST_JSON="$LIST1" HERMES_BIN="$STUB" GH_BIN="$GHSTUB" GH_CALL_LOG="$GHCALLS" \
   bash "$BOARD" writeback --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1)"; WB2_RC=$?
 assert "NC3: exit 0" "$([ "$WB2_RC" -eq 0 ] && echo 0 || echo 1)"
-assert "NC3: reports '0 changes'" "$({ printf '%s\n' "$WB2_OUT" 2>/dev/null || :; } | grep -q '0 changes' && echo 0 || echo 1)"
+assert "NC3: reports '0 changes'" "$({ trap '' PIPE; printf '%s\n' "$WB2_OUT" 2>/dev/null || :; } | grep -q '0 changes' && echo 0 || echo 1)"
 assert "NC3: zero gh calls made" "$([ ! -s "$GHCALLS" ] && echo 0 || echo 1)"
 assert "NC3: default branch HEAD unchanged" "$([ "$(git -C "$FIXR" rev-parse "$DEFAULT_BRANCH")" = "$HEAD_DEFAULT_BEFORE" ] && echo 0 || echo 1)"
 assert "NC3: chore/board-sync branch unchanged (no new commit)" "$([ "$(git -C "$FIXR" rev-parse chore/board-sync)" = "$SYNC_SHA_BEFORE" ] && echo 0 || echo 1)"
@@ -255,7 +255,7 @@ jq -nc --arg i1 "$ID001" --arg i2 "$ID002" --arg i3 "$ID003" \
   '[{id:$i1,status:"ready",title:"x"},{id:$i2,status:"blocked",title:"x"},{id:$i3,status:"done",title:"x"}]' > "$LIST_NC1"
 : > "$CALLS"
 NC1_ERR="$(STUB_CALL_LOG="$CALLS" STUB_LIST_JSON="$LIST_NC1" HERMES_BIN="$STUB" bash "$BOARD_WRITEBACK" diff --registry "$REGISTRY" --snapshot "$SNAP" 2>&1 >/dev/null)"
-assert "NC1: ID-002's hash-mismatch skip is reported" "$({ printf '%s\n' "$NC1_ERR" 2>/dev/null || :; } | grep -q 'fixR:ID-002.*row_hash mismatch' && echo 0 || echo 1)"
+assert "NC1: ID-002's hash-mismatch skip is reported" "$({ trap '' PIPE; printf '%s\n' "$NC1_ERR" 2>/dev/null || :; } | grep -q 'fixR:ID-002.*row_hash mismatch' && echo 0 || echo 1)"
 NC1_CONTENT_AFTER="$(git -C "$FIXR" show "$DEFAULT_BRANCH":_meta/BACKLOG.md)"
 assert "NC1: the default-branch BACKLOG.md is byte-for-byte untouched by the (rejected) diff" \
   "$([ "$NC1_CONTENT_BEFORE" = "$NC1_CONTENT_AFTER" ] && echo 0 || echo 1)"
@@ -267,7 +267,7 @@ jq -nc --arg i1 "$ID001" --arg i3 "$ID003" \
   '[{id:$i1,status:"in_review",title:"x"},{id:$i3,status:"done",title:"x"}]' > "$LIST_NC2"
 NC2_ERR="$(STUB_LIST_JSON="$LIST_NC2" STUB_CALL_LOG="$CALLS" HERMES_BIN="$STUB" bash "$BOARD_WRITEBACK" diff --registry "$REGISTRY" --snapshot "$SNAP" 2>&1 >/dev/null)"
 assert "NC2: ID-001's illegal-target-status skip is reported by name" \
-  "$({ printf '%s\n' "$NC2_ERR" 2>/dev/null || :; } | grep -q "fixR:ID-001.*no legal backlog.sh mapping" && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$NC2_ERR" 2>/dev/null || :; } | grep -q "fixR:ID-001.*no legal backlog.sh mapping" && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC4: a card from a non-opted-in repo (fixTrading) in the Hermes delta -> refused, NEVER queried ==="
@@ -281,9 +281,9 @@ NC4_ERR="$(STUB_LIST_JSON="$LIST_NC4" STUB_CALL_LOG="$CALLS" HERMES_BIN="$STUB" 
 NC4_RC=$?
 assert "NC4: exit 0 (a per-row rejection, not a whole-run abort)" "$([ "$NC4_RC" -eq 0 ] && echo 0 || echo 1)"
 assert "NC4: fixTrading's row is refused with a named reason" \
-  "$({ printf '%s\n' "$NC4_ERR" 2>/dev/null || :; } | grep -q "fixTrading:TR-001.*not opted in" && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$NC4_ERR" 2>/dev/null || :; } | grep -q "fixTrading:TR-001.*not opted in" && echo 0 || echo 1)"
 assert "NC4: the fixTrading board was NEVER queried (stub would have exited 9 and this diff would have shown the FATAL line otherwise)" \
-  "$({ printf '%s\n' "$NC4_ERR" 2>/dev/null || :; } | grep -q 'FATAL TEST INVARIANT VIOLATION' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$NC4_ERR" 2>/dev/null || :; } | grep -q 'FATAL TEST INVARIANT VIOLATION' && echo 1 || echo 0)"
 assert "NC4: no call log line ever references the fixTrading board" "$(grep -qi 'fixtrading' "$CALLS" && echo 1 || echo 0)"
 
 echo ""
@@ -293,7 +293,7 @@ set +e
 MISSING_ERR="$(bash "$BOARD_WRITEBACK" diff --registry "$REGISTRY" --snapshot "$MISSING_SNAP" 2>&1 >/dev/null)"; MISSING_RC=$?
 set -e
 assert "NC5a: missing snapshot -> nonzero exit" "$([ "$MISSING_RC" -ne 0 ] && echo 0 || echo 1)"
-assert "NC5a: missing snapshot -> explicit REFUSING error" "$({ printf '%s\n' "$MISSING_ERR" 2>/dev/null || :; } | grep -q 'REFUSING all edits' && echo 0 || echo 1)"
+assert "NC5a: missing snapshot -> explicit REFUSING error" "$({ trap '' PIPE; printf '%s\n' "$MISSING_ERR" 2>/dev/null || :; } | grep -q 'REFUSING all edits' && echo 0 || echo 1)"
 
 CORRUPT_SNAP="$TMPDIR_T/corrupt.jsonl"
 printf '{"origin":"fixR:ID-001"}\nTHIS IS NOT JSON\n' > "$CORRUPT_SNAP"
@@ -301,7 +301,7 @@ set +e
 CORRUPT_ERR="$(bash "$BOARD_WRITEBACK" diff --registry "$REGISTRY" --snapshot "$CORRUPT_SNAP" 2>&1 >/dev/null)"; CORRUPT_RC=$?
 set -e
 assert "NC5b: corrupt snapshot -> nonzero exit" "$([ "$CORRUPT_RC" -ne 0 ] && echo 0 || echo 1)"
-assert "NC5b: corrupt snapshot -> explicit REFUSING error" "$({ printf '%s\n' "$CORRUPT_ERR" 2>/dev/null || :; } | grep -q 'REFUSING all edits' && echo 0 || echo 1)"
+assert "NC5b: corrupt snapshot -> explicit REFUSING error" "$({ trap '' PIPE; printf '%s\n' "$CORRUPT_ERR" 2>/dev/null || :; } | grep -q 'REFUSING all edits' && echo 0 || echo 1)"
 
 EMPTY_SNAP="$TMPDIR_T/empty-valid.jsonl"
 : > "$EMPTY_SNAP"
@@ -309,7 +309,7 @@ set +e
 EMPTY_OUT="$(bash "$BOARD" writeback --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$EMPTY_SNAP" 2>&1)"; EMPTY_RC=$?
 set -e
 assert "NC5c: a PRESENT-but-EMPTY snapshot (valid, zero rows) is NOT treated as corrupt -- exit 0" "$([ "$EMPTY_RC" -eq 0 ] && echo 0 || echo 1)"
-assert "NC5c: a present-but-empty snapshot honestly reports 0 changes (not a refusal)" "$({ printf '%s\n' "$EMPTY_OUT" 2>/dev/null || :; } | grep -q '0 changes' && echo 0 || echo 1)"
+assert "NC5c: a present-but-empty snapshot honestly reports 0 changes (not a refusal)" "$({ trap '' PIPE; printf '%s\n' "$EMPTY_OUT" 2>/dev/null || :; } | grep -q '0 changes' && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC6: TWO-WRITER coexistence -- a post-snapshot appended row survives byte-for-byte; branch bases on current HEAD ==="

--- a/tests/test-board-writeback.sh
+++ b/tests/test-board-writeback.sh
@@ -182,7 +182,7 @@ assert "ID-001's changeset entry: queued -> claimed" \
 assert "ID-003's changeset entry: parked -> shipped" \
   "$(printf '%s\n' "$DIFF1" | jq -e 'select(.origin=="fixR:ID-003") | .current_status=="parked" and .target_status=="shipped"' >/dev/null 2>&1 && echo 0 || echo 1)"
 assert "ID-002 (no Hermes-side move) never appears in the changeset" \
-  "$(printf '%s\n' "$DIFF1" | grep -q 'ID-002' && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$DIFF1" 2>/dev/null || :; } | grep -q 'ID-002' && echo 1 || echo 0)"
 assert "only ONE hermes call made (batched list, not per-row)" \
   "$([ "$(wc -l < "$CALLS" | tr -d ' ')" -eq 1 ] && echo 0 || echo 1)"
 
@@ -207,8 +207,8 @@ assert "the sync commit body carries actor=hermes" \
 assert "the sync branch's diff touches ONLY the Status column of the two matched rows" \
   "$(git -C "$FIXR" diff "$DEFAULT_BRANCH" chore/board-sync -- _meta/BACKLOG.md | grep -c '^[+-]|' | grep -qx 4 && echo 0 || echo 1)"
 RT_DIFF="$(git -C "$FIXR" diff "$DEFAULT_BRANCH" chore/board-sync -- _meta/BACKLOG.md)"
-assert "RT: the diff shows ID-001 queued->claimed" "$(printf '%s\n' "$RT_DIFF" | grep -q -- '-| ID-001 .* queued ' && printf '%s\n' "$RT_DIFF" | grep -q -- '+| ID-001 .* claimed' && echo 0 || echo 1)"
-assert "RT: the diff shows ID-003 parked->shipped" "$(printf '%s\n' "$RT_DIFF" | grep -q -- '-| ID-003 .* parked ' && printf '%s\n' "$RT_DIFF" | grep -q -- '+| ID-003 .* shipped' && echo 0 || echo 1)"
+assert "RT: the diff shows ID-001 queued->claimed" "$({ printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '-| ID-001 .* queued ' && { printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '+| ID-001 .* claimed' && echo 0 || echo 1)"
+assert "RT: the diff shows ID-003 parked->shipped" "$({ printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '-| ID-003 .* parked ' && { printf '%s\n' "$RT_DIFF" 2>/dev/null || :; } | grep -q -- '+| ID-003 .* shipped' && echo 0 || echo 1)"
 assert "'gh pr create' was called exactly once (never a real API call -- it's the stub)" \
   "$([ "$(wc -l < "$GHCALLS" | tr -d ' ')" -eq 1 ] && echo 0 || echo 1)"
 assert "'gh pr create' argv carries --base/--head/--title/--body-file as discrete args" \
@@ -235,7 +235,7 @@ SYNC_SHA_BEFORE="$(git -C "$FIXR" rev-parse chore/board-sync)"
 WB2_OUT="$(STUB_CALL_LOG="$CALLS" STUB_LIST_JSON="$LIST1" HERMES_BIN="$STUB" GH_BIN="$GHSTUB" GH_CALL_LOG="$GHCALLS" \
   bash "$BOARD" writeback --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$SNAP" 2>&1)"; WB2_RC=$?
 assert "NC3: exit 0" "$([ "$WB2_RC" -eq 0 ] && echo 0 || echo 1)"
-assert "NC3: reports '0 changes'" "$(printf '%s\n' "$WB2_OUT" | grep -q '0 changes' && echo 0 || echo 1)"
+assert "NC3: reports '0 changes'" "$({ printf '%s\n' "$WB2_OUT" 2>/dev/null || :; } | grep -q '0 changes' && echo 0 || echo 1)"
 assert "NC3: zero gh calls made" "$([ ! -s "$GHCALLS" ] && echo 0 || echo 1)"
 assert "NC3: default branch HEAD unchanged" "$([ "$(git -C "$FIXR" rev-parse "$DEFAULT_BRANCH")" = "$HEAD_DEFAULT_BEFORE" ] && echo 0 || echo 1)"
 assert "NC3: chore/board-sync branch unchanged (no new commit)" "$([ "$(git -C "$FIXR" rev-parse chore/board-sync)" = "$SYNC_SHA_BEFORE" ] && echo 0 || echo 1)"
@@ -255,7 +255,7 @@ jq -nc --arg i1 "$ID001" --arg i2 "$ID002" --arg i3 "$ID003" \
   '[{id:$i1,status:"ready",title:"x"},{id:$i2,status:"blocked",title:"x"},{id:$i3,status:"done",title:"x"}]' > "$LIST_NC1"
 : > "$CALLS"
 NC1_ERR="$(STUB_CALL_LOG="$CALLS" STUB_LIST_JSON="$LIST_NC1" HERMES_BIN="$STUB" bash "$BOARD_WRITEBACK" diff --registry "$REGISTRY" --snapshot "$SNAP" 2>&1 >/dev/null)"
-assert "NC1: ID-002's hash-mismatch skip is reported" "$(printf '%s\n' "$NC1_ERR" | grep -q 'fixR:ID-002.*row_hash mismatch' && echo 0 || echo 1)"
+assert "NC1: ID-002's hash-mismatch skip is reported" "$({ printf '%s\n' "$NC1_ERR" 2>/dev/null || :; } | grep -q 'fixR:ID-002.*row_hash mismatch' && echo 0 || echo 1)"
 NC1_CONTENT_AFTER="$(git -C "$FIXR" show "$DEFAULT_BRANCH":_meta/BACKLOG.md)"
 assert "NC1: the default-branch BACKLOG.md is byte-for-byte untouched by the (rejected) diff" \
   "$([ "$NC1_CONTENT_BEFORE" = "$NC1_CONTENT_AFTER" ] && echo 0 || echo 1)"
@@ -267,7 +267,7 @@ jq -nc --arg i1 "$ID001" --arg i3 "$ID003" \
   '[{id:$i1,status:"in_review",title:"x"},{id:$i3,status:"done",title:"x"}]' > "$LIST_NC2"
 NC2_ERR="$(STUB_LIST_JSON="$LIST_NC2" STUB_CALL_LOG="$CALLS" HERMES_BIN="$STUB" bash "$BOARD_WRITEBACK" diff --registry "$REGISTRY" --snapshot "$SNAP" 2>&1 >/dev/null)"
 assert "NC2: ID-001's illegal-target-status skip is reported by name" \
-  "$(printf '%s\n' "$NC2_ERR" | grep -q "fixR:ID-001.*no legal backlog.sh mapping" && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$NC2_ERR" 2>/dev/null || :; } | grep -q "fixR:ID-001.*no legal backlog.sh mapping" && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC4: a card from a non-opted-in repo (fixTrading) in the Hermes delta -> refused, NEVER queried ==="
@@ -281,9 +281,9 @@ NC4_ERR="$(STUB_LIST_JSON="$LIST_NC4" STUB_CALL_LOG="$CALLS" HERMES_BIN="$STUB" 
 NC4_RC=$?
 assert "NC4: exit 0 (a per-row rejection, not a whole-run abort)" "$([ "$NC4_RC" -eq 0 ] && echo 0 || echo 1)"
 assert "NC4: fixTrading's row is refused with a named reason" \
-  "$(printf '%s\n' "$NC4_ERR" | grep -q "fixTrading:TR-001.*not opted in" && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$NC4_ERR" 2>/dev/null || :; } | grep -q "fixTrading:TR-001.*not opted in" && echo 0 || echo 1)"
 assert "NC4: the fixTrading board was NEVER queried (stub would have exited 9 and this diff would have shown the FATAL line otherwise)" \
-  "$(printf '%s\n' "$NC4_ERR" | grep -q 'FATAL TEST INVARIANT VIOLATION' && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$NC4_ERR" 2>/dev/null || :; } | grep -q 'FATAL TEST INVARIANT VIOLATION' && echo 1 || echo 0)"
 assert "NC4: no call log line ever references the fixTrading board" "$(grep -qi 'fixtrading' "$CALLS" && echo 1 || echo 0)"
 
 echo ""
@@ -293,7 +293,7 @@ set +e
 MISSING_ERR="$(bash "$BOARD_WRITEBACK" diff --registry "$REGISTRY" --snapshot "$MISSING_SNAP" 2>&1 >/dev/null)"; MISSING_RC=$?
 set -e
 assert "NC5a: missing snapshot -> nonzero exit" "$([ "$MISSING_RC" -ne 0 ] && echo 0 || echo 1)"
-assert "NC5a: missing snapshot -> explicit REFUSING error" "$(printf '%s\n' "$MISSING_ERR" | grep -q 'REFUSING all edits' && echo 0 || echo 1)"
+assert "NC5a: missing snapshot -> explicit REFUSING error" "$({ printf '%s\n' "$MISSING_ERR" 2>/dev/null || :; } | grep -q 'REFUSING all edits' && echo 0 || echo 1)"
 
 CORRUPT_SNAP="$TMPDIR_T/corrupt.jsonl"
 printf '{"origin":"fixR:ID-001"}\nTHIS IS NOT JSON\n' > "$CORRUPT_SNAP"
@@ -301,7 +301,7 @@ set +e
 CORRUPT_ERR="$(bash "$BOARD_WRITEBACK" diff --registry "$REGISTRY" --snapshot "$CORRUPT_SNAP" 2>&1 >/dev/null)"; CORRUPT_RC=$?
 set -e
 assert "NC5b: corrupt snapshot -> nonzero exit" "$([ "$CORRUPT_RC" -ne 0 ] && echo 0 || echo 1)"
-assert "NC5b: corrupt snapshot -> explicit REFUSING error" "$(printf '%s\n' "$CORRUPT_ERR" | grep -q 'REFUSING all edits' && echo 0 || echo 1)"
+assert "NC5b: corrupt snapshot -> explicit REFUSING error" "$({ printf '%s\n' "$CORRUPT_ERR" 2>/dev/null || :; } | grep -q 'REFUSING all edits' && echo 0 || echo 1)"
 
 EMPTY_SNAP="$TMPDIR_T/empty-valid.jsonl"
 : > "$EMPTY_SNAP"
@@ -309,7 +309,7 @@ set +e
 EMPTY_OUT="$(bash "$BOARD" writeback --repo-root "$TMPDIR_T" --registry "$REGISTRY" --snapshot "$EMPTY_SNAP" 2>&1)"; EMPTY_RC=$?
 set -e
 assert "NC5c: a PRESENT-but-EMPTY snapshot (valid, zero rows) is NOT treated as corrupt -- exit 0" "$([ "$EMPTY_RC" -eq 0 ] && echo 0 || echo 1)"
-assert "NC5c: a present-but-empty snapshot honestly reports 0 changes (not a refusal)" "$(printf '%s\n' "$EMPTY_OUT" | grep -q '0 changes' && echo 0 || echo 1)"
+assert "NC5c: a present-but-empty snapshot honestly reports 0 changes (not a refusal)" "$({ printf '%s\n' "$EMPTY_OUT" 2>/dev/null || :; } | grep -q '0 changes' && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC6: TWO-WRITER coexistence -- a post-snapshot appended row survives byte-for-byte; branch bases on current HEAD ==="

--- a/tests/test-board.sh
+++ b/tests/test-board.sh
@@ -101,25 +101,25 @@ ROWS_OUT="$(bash "$PARSE_BOARD" rows "$FIXA/_meta/BACKLOG.md")"
 # interprets '\t' inside -E as a tab too, but GNU grep 3.x on Linux/CI does not -- it matches
 # a literal 't'), which silently broke this assertion on ubuntu-latest while staying green on
 # macos-latest. A real tab byte matches identically on both grep implementations.
-assert "pb_rows sees ID-001 as queued" "$(printf '%s\n' "$ROWS_OUT" | grep -qE $'^ID-001\tqueued\t' && echo 0 || echo 1)"
-assert "pb_rows sees ID-008 as claimed" "$(printf '%s\n' "$ROWS_OUT" | grep -qE $'^ID-008\tclaimed\t' && echo 0 || echo 1)"
+assert "pb_rows sees ID-001 as queued" "$({ printf '%s\n' "$ROWS_OUT" 2>/dev/null || :; } | grep -qE $'^ID-001\tqueued\t' && echo 0 || echo 1)"
+assert "pb_rows sees ID-008 as claimed" "$({ printf '%s\n' "$ROWS_OUT" 2>/dev/null || :; } | grep -qE $'^ID-008\tclaimed\t' && echo 0 || echo 1)"
 
 QROWS="$(bash "$PARSE_BOARD" queue-rows "$FIXA/_meta/BACKLOG.md" fixA "$FIXA" 2>/dev/null)"
-assert "ID-002 (megagoals dir) is allow-listed" "$(printf '%s\n' "$QROWS" | grep -q '^ID-002' && echo 0 || echo 1)"
-assert "ID-003 (.claude/goals dir) is allow-listed" "$(printf '%s\n' "$QROWS" | grep -q '^ID-003' && echo 0 || echo 1)"
+assert "ID-002 (megagoals dir) is allow-listed" "$({ printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-002' && echo 0 || echo 1)"
+assert "ID-003 (.claude/goals dir) is allow-listed" "$({ printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-003' && echo 0 || echo 1)"
 RESOLVED_002="$(printf '%s\n' "$QROWS" | awk -F'\t' '$1=="ID-002"{print $3}')"
 assert "ID-002 resolves to the real canonical pointer file" "$([ "$RESOLVED_002" = "$FIXA/_meta/megagoals/mg1/goals/g1.md" ] && echo 0 || echo 1)"
 assert "ID-002's repo-root column is the fixture repo root" "$(printf '%s\n' "$QROWS" | awk -F'\t' '$1=="ID-002"{print $2}' | grep -qx "$FIXA" && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC3: malformed token (missing pointer=) is skipped, not emitted ==="
-assert "ID-007 (no pointer key) never emitted" "$(printf '%s\n' "$QROWS" | grep -q '^ID-007' && echo 1 || echo 0)"
+assert "ID-007 (no pointer key) never emitted" "$({ printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-007' && echo 1 || echo 0)"
 QERR="$(bash "$PARSE_BOARD" queue-rows "$FIXA/_meta/BACKLOG.md" fixA "$FIXA" 2>&1 >/dev/null)"
-assert "ID-007's skip reason is logged" "$(printf '%s\n' "$QERR" | grep -q 'skip ID-007' && echo 0 || echo 1)"
+assert "ID-007's skip reason is logged" "$({ printf '%s\n' "$QERR" 2>/dev/null || :; } | grep -q 'skip ID-007' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC4: a #queue{} token on a NON-queued row is silently ignored ==="
-assert "ID-008 (claimed, has a token) never emitted" "$(printf '%s\n' "$QROWS" | grep -q '^ID-008' && echo 1 || echo 0)"
+assert "ID-008 (claimed, has a token) never emitted" "$({ printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-008' && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC-a: zero tokens -> empty stdout, honest '0 rows' on stderr, exit 0 ==="
@@ -144,26 +144,26 @@ echo ""
 echo "=== NC-b: repo not in boards.txt (cross-repo spoof) -> skipped w/ reason ==="
 Q_FULL_ERR="$(bash "$BOARD" queue --registry "$REGISTRY" 2>&1 >/dev/null)"
 assert "NC-b: ID-006 (claims repo=fixB while living in fixA's board) is skipped" \
-  "$(printf '%s\n' "$Q_FULL_ERR" | grep -q 'skip ID-006' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-006' && echo 0 || echo 1)"
 assert "NC-b: the skip reason names the mismatch" \
   "$(printf '%s\n' "$Q_FULL_ERR" | grep 'ID-006' | grep -qi 'mismatch\|spoof' && echo 0 || echo 1)"
 Q_FULL_OUT="$(bash "$BOARD" queue --registry "$REGISTRY" 2>/dev/null)"
-assert "NC-b: ID-006 never appears in the emitted rows" "$(printf '%s\n' "$Q_FULL_OUT" | grep -q 'ID-006' && echo 1 || echo 0)"
+assert "NC-b: ID-006 never appears in the emitted rows" "$({ printf '%s\n' "$Q_FULL_OUT" 2>/dev/null || :; } | grep -q 'ID-006' && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC-c: pointer outside allow-listed dirs, incl. '../' traversal -> skipped w/ reason ==="
 assert "NC-c: ID-004 ('../../../etc/passwd') is skipped" \
-  "$(printf '%s\n' "$Q_FULL_ERR" | grep -q 'skip ID-004' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-004' && echo 0 || echo 1)"
 assert "NC-c: ID-004's reason names the traversal / disallowed component" \
   "$(printf '%s\n' "$Q_FULL_ERR" | grep 'ID-004' | grep -qi "\\.\\.\\|traversal\\|disallowed" && echo 0 || echo 1)"
 assert "NC-c: ID-005 (lib/board/board.sh, a real file OUTSIDE the allow-listed dirs) is skipped" \
-  "$(printf '%s\n' "$Q_FULL_ERR" | grep -q 'skip ID-005' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-005' && echo 0 || echo 1)"
 assert "NC-c: ID-005's reason names 'outside allow-listed'" \
   "$(printf '%s\n' "$Q_FULL_ERR" | grep 'ID-005' | grep -qi 'outside allow-listed' && echo 0 || echo 1)"
 assert "NC-c: neither ID-004 nor ID-005 ever appears in emitted rows" \
-  "$(printf '%s\n' "$Q_FULL_OUT" | grep -qE 'ID-004|ID-005' && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$Q_FULL_OUT" 2>/dev/null || :; } | grep -qE 'ID-004|ID-005' && echo 1 || echo 0)"
 assert "NC-c: ID-009's dangling (never-created) pointer is also skipped (defense in depth)" \
-  "$(printf '%s\n' "$Q_FULL_ERR" | grep -q 'skip ID-009' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-009' && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC-d: shell-metachar field is parsed as ONE literal argv element, never executed ==="
@@ -189,7 +189,7 @@ echo "metarepo  $METAREPO/_meta/BACKLOG.md" > "$METAREG"
 
 META_OUT="$(bash "$BOARD" queue --registry "$METAREG" 2>"$TMPDIR_T/meta.err")"
 assert "NC-d: the canary file was NEVER created (metachar never reached a shell)" "$([ ! -e "$CANARY" ] && echo 0 || echo 1)"
-assert "NC-d: ID-901 (metachar payload) never appears in emitted rows" "$(printf '%s\n' "$META_OUT" | grep -q 'ID-901' && echo 1 || echo 0)"
+assert "NC-d: ID-901 (metachar payload) never appears in emitted rows" "$({ printf '%s\n' "$META_OUT" 2>/dev/null || :; } | grep -q 'ID-901' && echo 1 || echo 0)"
 assert "NC-d: ID-901 is skipped for disallowed characters" "$(grep 'ID-901' "$TMPDIR_T/meta.err" | grep -qi 'disallowed characters' && echo 0 || echo 1)"
 
 # Static source-audit: neither lib file ever hands a parsed value to a shell for
@@ -205,28 +205,28 @@ assert "NC-d: static audit -- neither lib/board/board.sh nor lib/board/parse-boa
 echo ""
 echo "=== AC5: single-repo board/next/set/states/priority delegate correctly ==="
 BOARD_OUT="$(bash "$BOARD" board --backlog-file "$FIXB/_meta/BACKLOG.md")"
-assert "single board renders DF-001 under queued" "$(printf '%s\n' "$BOARD_OUT" | grep -q 'DF-001' && echo 0 || echo 1)"
+assert "single board renders DF-001 under queued" "$({ printf '%s\n' "$BOARD_OUT" 2>/dev/null || :; } | grep -q 'DF-001' && echo 0 || echo 1)"
 NEXT_OUT="$(bash "$BOARD" next --backlog-file "$FIXB/_meta/BACKLOG.md")"
 assert "single next picks DF-001" "$([ "$NEXT_OUT" = "DF-001" ] && echo 0 || echo 1)"
 bash "$BOARD" set --backlog-file "$FIXB/_meta/BACKLOG.md" DF-001 claimed "test claim" >/dev/null
 assert "single set flips DF-001 to claimed" "$(grep 'DF-001' "$FIXB/_meta/BACKLOG.md" | grep -q 'claimed' && echo 0 || echo 1)"
 STATES_OUT="$(bash "$BOARD" states --backlog-file "$FIXB/_meta/BACKLOG.md")"
-assert "single states lists queued and shipped" "$(printf '%s\n' "$STATES_OUT" | grep -q 'queued' && printf '%s\n' "$STATES_OUT" | grep -q 'shipped' && echo 0 || echo 1)"
+assert "single states lists queued and shipped" "$({ printf '%s\n' "$STATES_OUT" 2>/dev/null || :; } | grep -q 'queued' && { printf '%s\n' "$STATES_OUT" 2>/dev/null || :; } | grep -q 'shipped' && echo 0 || echo 1)"
 PRIO_OUT="$(bash "$BOARD" priority overview --backlog-file "$FIXA/_meta/BACKLOG.md")"
-assert "single priority renders DO NOW section" "$(printf '%s\n' "$PRIO_OUT" | grep -q 'DO NOW' && echo 0 || echo 1)"
+assert "single priority renders DO NOW section" "$({ printf '%s\n' "$PRIO_OUT" 2>/dev/null || :; } | grep -q 'DO NOW' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC6: cross-repo all board|next|priority[overview|matrix]|states on the 2-repo registry ==="
 ALL_BOARD="$(bash "$BOARD" all board --registry "$REGISTRY")"
-assert "all board shows both repo headers" "$(printf '%s\n' "$ALL_BOARD" | grep -q '=== fixA ===' && printf '%s\n' "$ALL_BOARD" | grep -q '=== fixB ===' && echo 0 || echo 1)"
+assert "all board shows both repo headers" "$({ printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixA ===' && { printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixB ===' && echo 0 || echo 1)"
 ALL_NEXT="$(bash "$BOARD" all next --registry "$REGISTRY")"
-assert "all next shows fixA's and fixB's next item" "$(printf '%s\n' "$ALL_NEXT" | grep -q 'fixA' && printf '%s\n' "$ALL_NEXT" | grep -q 'fixB' && echo 0 || echo 1)"
+assert "all next shows fixA's and fixB's next item" "$({ printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixA' && { printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixB' && echo 0 || echo 1)"
 ALL_PRIO="$(bash "$BOARD" all priority overview --registry "$REGISTRY")"
-assert "all priority overview groups by repo" "$(printf '%s\n' "$ALL_PRIO" | grep -q '=== fixA ===' && echo 0 || echo 1)"
+assert "all priority overview groups by repo" "$({ printf '%s\n' "$ALL_PRIO" 2>/dev/null || :; } | grep -q '=== fixA ===' && echo 0 || echo 1)"
 ALL_MATRIX="$(bash "$BOARD" all priority matrix --registry "$REGISTRY")"
-assert "all priority matrix renders the pivot header" "$(printf '%s\n' "$ALL_MATRIX" | grep -q 'Priority matrix' && echo 0 || echo 1)"
+assert "all priority matrix renders the pivot header" "$({ printf '%s\n' "$ALL_MATRIX" 2>/dev/null || :; } | grep -q 'Priority matrix' && echo 0 || echo 1)"
 ALL_STATES="$(bash "$BOARD" all states --registry "$REGISTRY")"
-assert "all states renders per repo" "$(printf '%s\n' "$ALL_STATES" | grep -q '=== fixA ===' && echo 0 || echo 1)"
+assert "all states renders per repo" "$({ printf '%s\n' "$ALL_STATES" 2>/dev/null || :; } | grep -q '=== fixA ===' && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC-e: RENDER NON-REGRESSION against the REAL ops-toolkit cockpit ==="

--- a/tests/test-board.sh
+++ b/tests/test-board.sh
@@ -101,25 +101,25 @@ ROWS_OUT="$(bash "$PARSE_BOARD" rows "$FIXA/_meta/BACKLOG.md")"
 # interprets '\t' inside -E as a tab too, but GNU grep 3.x on Linux/CI does not -- it matches
 # a literal 't'), which silently broke this assertion on ubuntu-latest while staying green on
 # macos-latest. A real tab byte matches identically on both grep implementations.
-assert "pb_rows sees ID-001 as queued" "$({ printf '%s\n' "$ROWS_OUT" 2>/dev/null || :; } | grep -qE $'^ID-001\tqueued\t' && echo 0 || echo 1)"
-assert "pb_rows sees ID-008 as claimed" "$({ printf '%s\n' "$ROWS_OUT" 2>/dev/null || :; } | grep -qE $'^ID-008\tclaimed\t' && echo 0 || echo 1)"
+assert "pb_rows sees ID-001 as queued" "$({ trap '' PIPE; printf '%s\n' "$ROWS_OUT" 2>/dev/null || :; } | grep -qE $'^ID-001\tqueued\t' && echo 0 || echo 1)"
+assert "pb_rows sees ID-008 as claimed" "$({ trap '' PIPE; printf '%s\n' "$ROWS_OUT" 2>/dev/null || :; } | grep -qE $'^ID-008\tclaimed\t' && echo 0 || echo 1)"
 
 QROWS="$(bash "$PARSE_BOARD" queue-rows "$FIXA/_meta/BACKLOG.md" fixA "$FIXA" 2>/dev/null)"
-assert "ID-002 (megagoals dir) is allow-listed" "$({ printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-002' && echo 0 || echo 1)"
-assert "ID-003 (.claude/goals dir) is allow-listed" "$({ printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-003' && echo 0 || echo 1)"
+assert "ID-002 (megagoals dir) is allow-listed" "$({ trap '' PIPE; printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-002' && echo 0 || echo 1)"
+assert "ID-003 (.claude/goals dir) is allow-listed" "$({ trap '' PIPE; printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-003' && echo 0 || echo 1)"
 RESOLVED_002="$(printf '%s\n' "$QROWS" | awk -F'\t' '$1=="ID-002"{print $3}')"
 assert "ID-002 resolves to the real canonical pointer file" "$([ "$RESOLVED_002" = "$FIXA/_meta/megagoals/mg1/goals/g1.md" ] && echo 0 || echo 1)"
 assert "ID-002's repo-root column is the fixture repo root" "$(printf '%s\n' "$QROWS" | awk -F'\t' '$1=="ID-002"{print $2}' | grep -qx "$FIXA" && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC3: malformed token (missing pointer=) is skipped, not emitted ==="
-assert "ID-007 (no pointer key) never emitted" "$({ printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-007' && echo 1 || echo 0)"
+assert "ID-007 (no pointer key) never emitted" "$({ trap '' PIPE; printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-007' && echo 1 || echo 0)"
 QERR="$(bash "$PARSE_BOARD" queue-rows "$FIXA/_meta/BACKLOG.md" fixA "$FIXA" 2>&1 >/dev/null)"
-assert "ID-007's skip reason is logged" "$({ printf '%s\n' "$QERR" 2>/dev/null || :; } | grep -q 'skip ID-007' && echo 0 || echo 1)"
+assert "ID-007's skip reason is logged" "$({ trap '' PIPE; printf '%s\n' "$QERR" 2>/dev/null || :; } | grep -q 'skip ID-007' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC4: a #queue{} token on a NON-queued row is silently ignored ==="
-assert "ID-008 (claimed, has a token) never emitted" "$({ printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-008' && echo 1 || echo 0)"
+assert "ID-008 (claimed, has a token) never emitted" "$({ trap '' PIPE; printf '%s\n' "$QROWS" 2>/dev/null || :; } | grep -q '^ID-008' && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC-a: zero tokens -> empty stdout, honest '0 rows' on stderr, exit 0 ==="
@@ -144,26 +144,26 @@ echo ""
 echo "=== NC-b: repo not in boards.txt (cross-repo spoof) -> skipped w/ reason ==="
 Q_FULL_ERR="$(bash "$BOARD" queue --registry "$REGISTRY" 2>&1 >/dev/null)"
 assert "NC-b: ID-006 (claims repo=fixB while living in fixA's board) is skipped" \
-  "$({ printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-006' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-006' && echo 0 || echo 1)"
 assert "NC-b: the skip reason names the mismatch" \
   "$(printf '%s\n' "$Q_FULL_ERR" | grep 'ID-006' | grep -qi 'mismatch\|spoof' && echo 0 || echo 1)"
 Q_FULL_OUT="$(bash "$BOARD" queue --registry "$REGISTRY" 2>/dev/null)"
-assert "NC-b: ID-006 never appears in the emitted rows" "$({ printf '%s\n' "$Q_FULL_OUT" 2>/dev/null || :; } | grep -q 'ID-006' && echo 1 || echo 0)"
+assert "NC-b: ID-006 never appears in the emitted rows" "$({ trap '' PIPE; printf '%s\n' "$Q_FULL_OUT" 2>/dev/null || :; } | grep -q 'ID-006' && echo 1 || echo 0)"
 
 echo ""
 echo "=== NC-c: pointer outside allow-listed dirs, incl. '../' traversal -> skipped w/ reason ==="
 assert "NC-c: ID-004 ('../../../etc/passwd') is skipped" \
-  "$({ printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-004' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-004' && echo 0 || echo 1)"
 assert "NC-c: ID-004's reason names the traversal / disallowed component" \
   "$(printf '%s\n' "$Q_FULL_ERR" | grep 'ID-004' | grep -qi "\\.\\.\\|traversal\\|disallowed" && echo 0 || echo 1)"
 assert "NC-c: ID-005 (lib/board/board.sh, a real file OUTSIDE the allow-listed dirs) is skipped" \
-  "$({ printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-005' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-005' && echo 0 || echo 1)"
 assert "NC-c: ID-005's reason names 'outside allow-listed'" \
   "$(printf '%s\n' "$Q_FULL_ERR" | grep 'ID-005' | grep -qi 'outside allow-listed' && echo 0 || echo 1)"
 assert "NC-c: neither ID-004 nor ID-005 ever appears in emitted rows" \
-  "$({ printf '%s\n' "$Q_FULL_OUT" 2>/dev/null || :; } | grep -qE 'ID-004|ID-005' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$Q_FULL_OUT" 2>/dev/null || :; } | grep -qE 'ID-004|ID-005' && echo 1 || echo 0)"
 assert "NC-c: ID-009's dangling (never-created) pointer is also skipped (defense in depth)" \
-  "$({ printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-009' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$Q_FULL_ERR" 2>/dev/null || :; } | grep -q 'skip ID-009' && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC-d: shell-metachar field is parsed as ONE literal argv element, never executed ==="
@@ -189,7 +189,7 @@ echo "metarepo  $METAREPO/_meta/BACKLOG.md" > "$METAREG"
 
 META_OUT="$(bash "$BOARD" queue --registry "$METAREG" 2>"$TMPDIR_T/meta.err")"
 assert "NC-d: the canary file was NEVER created (metachar never reached a shell)" "$([ ! -e "$CANARY" ] && echo 0 || echo 1)"
-assert "NC-d: ID-901 (metachar payload) never appears in emitted rows" "$({ printf '%s\n' "$META_OUT" 2>/dev/null || :; } | grep -q 'ID-901' && echo 1 || echo 0)"
+assert "NC-d: ID-901 (metachar payload) never appears in emitted rows" "$({ trap '' PIPE; printf '%s\n' "$META_OUT" 2>/dev/null || :; } | grep -q 'ID-901' && echo 1 || echo 0)"
 assert "NC-d: ID-901 is skipped for disallowed characters" "$(grep 'ID-901' "$TMPDIR_T/meta.err" | grep -qi 'disallowed characters' && echo 0 || echo 1)"
 
 # Static source-audit: neither lib file ever hands a parsed value to a shell for
@@ -205,28 +205,28 @@ assert "NC-d: static audit -- neither lib/board/board.sh nor lib/board/parse-boa
 echo ""
 echo "=== AC5: single-repo board/next/set/states/priority delegate correctly ==="
 BOARD_OUT="$(bash "$BOARD" board --backlog-file "$FIXB/_meta/BACKLOG.md")"
-assert "single board renders DF-001 under queued" "$({ printf '%s\n' "$BOARD_OUT" 2>/dev/null || :; } | grep -q 'DF-001' && echo 0 || echo 1)"
+assert "single board renders DF-001 under queued" "$({ trap '' PIPE; printf '%s\n' "$BOARD_OUT" 2>/dev/null || :; } | grep -q 'DF-001' && echo 0 || echo 1)"
 NEXT_OUT="$(bash "$BOARD" next --backlog-file "$FIXB/_meta/BACKLOG.md")"
 assert "single next picks DF-001" "$([ "$NEXT_OUT" = "DF-001" ] && echo 0 || echo 1)"
 bash "$BOARD" set --backlog-file "$FIXB/_meta/BACKLOG.md" DF-001 claimed "test claim" >/dev/null
 assert "single set flips DF-001 to claimed" "$(grep 'DF-001' "$FIXB/_meta/BACKLOG.md" | grep -q 'claimed' && echo 0 || echo 1)"
 STATES_OUT="$(bash "$BOARD" states --backlog-file "$FIXB/_meta/BACKLOG.md")"
-assert "single states lists queued and shipped" "$({ printf '%s\n' "$STATES_OUT" 2>/dev/null || :; } | grep -q 'queued' && { printf '%s\n' "$STATES_OUT" 2>/dev/null || :; } | grep -q 'shipped' && echo 0 || echo 1)"
+assert "single states lists queued and shipped" "$({ trap '' PIPE; printf '%s\n' "$STATES_OUT" 2>/dev/null || :; } | grep -q 'queued' && { trap '' PIPE; printf '%s\n' "$STATES_OUT" 2>/dev/null || :; } | grep -q 'shipped' && echo 0 || echo 1)"
 PRIO_OUT="$(bash "$BOARD" priority overview --backlog-file "$FIXA/_meta/BACKLOG.md")"
-assert "single priority renders DO NOW section" "$({ printf '%s\n' "$PRIO_OUT" 2>/dev/null || :; } | grep -q 'DO NOW' && echo 0 || echo 1)"
+assert "single priority renders DO NOW section" "$({ trap '' PIPE; printf '%s\n' "$PRIO_OUT" 2>/dev/null || :; } | grep -q 'DO NOW' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC6: cross-repo all board|next|priority[overview|matrix]|states on the 2-repo registry ==="
 ALL_BOARD="$(bash "$BOARD" all board --registry "$REGISTRY")"
-assert "all board shows both repo headers" "$({ printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixA ===' && { printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixB ===' && echo 0 || echo 1)"
+assert "all board shows both repo headers" "$({ trap '' PIPE; printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixA ===' && { trap '' PIPE; printf '%s\n' "$ALL_BOARD" 2>/dev/null || :; } | grep -q '=== fixB ===' && echo 0 || echo 1)"
 ALL_NEXT="$(bash "$BOARD" all next --registry "$REGISTRY")"
-assert "all next shows fixA's and fixB's next item" "$({ printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixA' && { printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixB' && echo 0 || echo 1)"
+assert "all next shows fixA's and fixB's next item" "$({ trap '' PIPE; printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixA' && { trap '' PIPE; printf '%s\n' "$ALL_NEXT" 2>/dev/null || :; } | grep -q 'fixB' && echo 0 || echo 1)"
 ALL_PRIO="$(bash "$BOARD" all priority overview --registry "$REGISTRY")"
-assert "all priority overview groups by repo" "$({ printf '%s\n' "$ALL_PRIO" 2>/dev/null || :; } | grep -q '=== fixA ===' && echo 0 || echo 1)"
+assert "all priority overview groups by repo" "$({ trap '' PIPE; printf '%s\n' "$ALL_PRIO" 2>/dev/null || :; } | grep -q '=== fixA ===' && echo 0 || echo 1)"
 ALL_MATRIX="$(bash "$BOARD" all priority matrix --registry "$REGISTRY")"
-assert "all priority matrix renders the pivot header" "$({ printf '%s\n' "$ALL_MATRIX" 2>/dev/null || :; } | grep -q 'Priority matrix' && echo 0 || echo 1)"
+assert "all priority matrix renders the pivot header" "$({ trap '' PIPE; printf '%s\n' "$ALL_MATRIX" 2>/dev/null || :; } | grep -q 'Priority matrix' && echo 0 || echo 1)"
 ALL_STATES="$(bash "$BOARD" all states --registry "$REGISTRY")"
-assert "all states renders per repo" "$({ printf '%s\n' "$ALL_STATES" 2>/dev/null || :; } | grep -q '=== fixA ===' && echo 0 || echo 1)"
+assert "all states renders per repo" "$({ trap '' PIPE; printf '%s\n' "$ALL_STATES" 2>/dev/null || :; } | grep -q '=== fixA ===' && echo 0 || echo 1)"
 
 echo ""
 echo "=== NC-e: RENDER NON-REGRESSION against the REAL ops-toolkit cockpit ==="

--- a/tests/test-break-it.sh
+++ b/tests/test-break-it.sh
@@ -71,7 +71,7 @@ Bash(git diff *)
 Bash(git log *)'
 [ "$(printf '%s\n' "$ROSTER" | sort)" = "$(printf '%s\n' "$EXPECTED_ROSTER" | sort)" ]
 assert "T1-DEC-007: the tool roster is exactly the read-only set (no runner grants)" $?
-{ printf '%s\n' "$ROSTER" 2>/dev/null || :; } | grep -qE '^Bash\((npm|go|pytest|cargo|make|just|bash) '
+{ trap '' PIPE; printf '%s\n' "$ROSTER" 2>/dev/null || :; } | grep -qE '^Bash\((npm|go|pytest|cargo|make|just|bash) '
 assert "T1-DEC-007 [NEGATIVE CONTROL]: no test-runner grant executes branch code" $([ $? -eq 0 ] && echo 1 || echo 0)
 
 # --- TASK-001 AC4 [NEGATIVE CONTROL]: the naming-axis arm is load-bearing -----

--- a/tests/test-break-it.sh
+++ b/tests/test-break-it.sh
@@ -71,7 +71,7 @@ Bash(git diff *)
 Bash(git log *)'
 [ "$(printf '%s\n' "$ROSTER" | sort)" = "$(printf '%s\n' "$EXPECTED_ROSTER" | sort)" ]
 assert "T1-DEC-007: the tool roster is exactly the read-only set (no runner grants)" $?
-printf '%s\n' "$ROSTER" | grep -qE '^Bash\((npm|go|pytest|cargo|make|just|bash) '
+{ printf '%s\n' "$ROSTER" 2>/dev/null || :; } | grep -qE '^Bash\((npm|go|pytest|cargo|make|just|bash) '
 assert "T1-DEC-007 [NEGATIVE CONTROL]: no test-runner grant executes branch code" $([ $? -eq 0 ] && echo 1 || echo 0)
 
 # --- TASK-001 AC4 [NEGATIVE CONTROL]: the naming-axis arm is load-bearing -----

--- a/tests/test-command-emit-sweep.sh
+++ b/tests/test-command-emit-sweep.sh
@@ -65,7 +65,7 @@ sweep_check() {
     [ -f "$f" ] || continue
     base="$(basename "$f" .md)"
     grep -qi 'gate-ledger' "$f" && continue
-    { printf '%s\n' "$exempt" 2>/dev/null || :; } | grep -qxF "$base" && continue
+    { trap '' PIPE; printf '%s\n' "$exempt" 2>/dev/null || :; } | grep -qxF "$base" && continue
     echo "  ORPHAN: $base.md (no gate-ledger mention, not in the exemption table)"
     orphans=$((orphans + 1))
   done
@@ -149,13 +149,13 @@ FIXTURE_OUT="$(sweep_check "$FIXTURE_DIR" "$EXEMPT")"
 FIXTURE_RC=$?
 assert_eq "the sweep flags exactly 1 orphan in the fixture dir (the fabricated bad command)" "$FIXTURE_RC" "1"
 
-if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: fixture-bad-command.md"; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: fixture-bad-command.md"; then RC=0; else RC=1; fi
 assert "the flagged orphan is specifically fixture-bad-command.md (not a false hit on the legit copies)" $RC
 
-if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: review.md"; then RC=1; else RC=0; fi
+if { trap '' PIPE; printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: review.md"; then RC=1; else RC=0; fi
 assert "the legit 'emits' copy (review.md) is NOT flagged" $RC
 
-if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: next.md"; then RC=1; else RC=0; fi
+if { trap '' PIPE; printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: next.md"; then RC=1; else RC=0; fi
 assert "the legit 'exempt' copy (next.md) is NOT flagged" $RC
 
 echo ""
@@ -170,7 +170,7 @@ WITHOUT_OUT="$(sweep_check "$COMMANDS_DIR" "$EXEMPT_WITHOUT_DISPATCH")"
 WITHOUT_RC=$?
 assert_eq "removing dispatch's exemption entry alone makes the sweep flag exactly 1 new orphan (dispatch.md)" "$WITHOUT_RC" "1"
 
-if { printf '%s\n' "$WITHOUT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: dispatch.md"; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$WITHOUT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: dispatch.md"; then RC=0; else RC=1; fi
 assert "...and that orphan is specifically dispatch.md" $RC
 
 echo ""

--- a/tests/test-command-emit-sweep.sh
+++ b/tests/test-command-emit-sweep.sh
@@ -65,7 +65,7 @@ sweep_check() {
     [ -f "$f" ] || continue
     base="$(basename "$f" .md)"
     grep -qi 'gate-ledger' "$f" && continue
-    printf '%s\n' "$exempt" | grep -qxF "$base" && continue
+    { printf '%s\n' "$exempt" 2>/dev/null || :; } | grep -qxF "$base" && continue
     echo "  ORPHAN: $base.md (no gate-ledger mention, not in the exemption table)"
     orphans=$((orphans + 1))
   done
@@ -149,13 +149,13 @@ FIXTURE_OUT="$(sweep_check "$FIXTURE_DIR" "$EXEMPT")"
 FIXTURE_RC=$?
 assert_eq "the sweep flags exactly 1 orphan in the fixture dir (the fabricated bad command)" "$FIXTURE_RC" "1"
 
-if printf '%s\n' "$FIXTURE_OUT" | grep -qF "ORPHAN: fixture-bad-command.md"; then RC=0; else RC=1; fi
+if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: fixture-bad-command.md"; then RC=0; else RC=1; fi
 assert "the flagged orphan is specifically fixture-bad-command.md (not a false hit on the legit copies)" $RC
 
-if printf '%s\n' "$FIXTURE_OUT" | grep -q "ORPHAN: review.md"; then RC=1; else RC=0; fi
+if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: review.md"; then RC=1; else RC=0; fi
 assert "the legit 'emits' copy (review.md) is NOT flagged" $RC
 
-if printf '%s\n' "$FIXTURE_OUT" | grep -q "ORPHAN: next.md"; then RC=1; else RC=0; fi
+if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: next.md"; then RC=1; else RC=0; fi
 assert "the legit 'exempt' copy (next.md) is NOT flagged" $RC
 
 echo ""
@@ -170,7 +170,7 @@ WITHOUT_OUT="$(sweep_check "$COMMANDS_DIR" "$EXEMPT_WITHOUT_DISPATCH")"
 WITHOUT_RC=$?
 assert_eq "removing dispatch's exemption entry alone makes the sweep flag exactly 1 new orphan (dispatch.md)" "$WITHOUT_RC" "1"
 
-if printf '%s\n' "$WITHOUT_OUT" | grep -qF "ORPHAN: dispatch.md"; then RC=0; else RC=1; fi
+if { printf '%s\n' "$WITHOUT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: dispatch.md"; then RC=0; else RC=1; fi
 assert "...and that orphan is specifically dispatch.md" $RC
 
 echo ""

--- a/tests/test-config-registry.sh
+++ b/tests/test-config-registry.sh
@@ -76,7 +76,7 @@ EOF
 PLANT_OUT="$(manifest_diff_flat "$PLANT_DIR/lib" "$SEED_RE" "$REGISTRY" "$ALLOW_RE")"
 PLANT_RC=$?
 assert_eq "the plant is flagged exactly 1 orphan" "$PLANT_RC" "1"
-if printf '%s\n' "$PLANT_OUT" | grep -qF "ORPHAN: KIT_TOTALLY_UNREGISTERED_PLANT"; then RC=0; else RC=1; fi
+if { printf '%s\n' "$PLANT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: KIT_TOTALLY_UNREGISTERED_PLANT"; then RC=0; else RC=1; fi
 assert "the flagged orphan is specifically KIT_TOTALLY_UNREGISTERED_PLANT" $RC
 
 echo ""
@@ -126,19 +126,19 @@ cat > "$FIXDIR/proj/.kit.toml" <<'EOF'
 wave_cap = 5
 EOF
 FIXTURE_LIST="$(KIT_CONFIG_ROOT="$FIXDIR/root" KIT_PROJECT_ROOT="$FIXDIR/proj" KIT_DELIVERY_RATIO_WARN=99 bash "$CONFIG_BIN" list)"
-if printf '%s\n' "$FIXTURE_LIST" | grep -qE '^WAVE_CAP[[:space:]]+\[impl\][[:space:]]+5[[:space:]]+project \.kit\.toml'; then RC=0; else RC=1; fi
+if { printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^WAVE_CAP[[:space:]]+\[impl\][[:space:]]+5[[:space:]]+project \.kit\.toml'; then RC=0; else RC=1; fi
 assert "list: a project .kit.toml override visibly wins WAVE_CAP's row (5, project .kit.toml)" $RC
-if printf '%s\n' "$FIXTURE_LIST" | grep -qE '^KIT_DELIVERY_RATIO_WARN[[:space:]]+\[impl\][[:space:]]+99[[:space:]]+env'; then RC=0; else RC=1; fi
+if { printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^KIT_DELIVERY_RATIO_WARN[[:space:]]+\[impl\][[:space:]]+99[[:space:]]+env'; then RC=0; else RC=1; fi
 assert "list: an env override visibly wins KIT_DELIVERY_RATIO_WARN's row (99, env)" $RC
-if printf '%s\n' "$FIXTURE_LIST" | grep -qE '^TIER4_CLOSE[[:space:]]+\[impl\][[:space:]]+true[[:space:]]+kit-root kit\.toml'; then RC=0; else RC=1; fi
+if { printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^TIER4_CLOSE[[:space:]]+\[impl\][[:space:]]+true[[:space:]]+kit-root kit\.toml'; then RC=0; else RC=1; fi
 assert "list: no override falls to kit-root kit.toml (TIER4_CLOSE = true, kit-root kit.toml)" $RC
 
 EXPLAIN_OUT="$(KIT_CONFIG_ROOT="$FIXDIR/root" KIT_PROJECT_ROOT="$FIXDIR/proj" bash "$CONFIG_BIN" explain mega.wave_cap)"
-if printf '%s\n' "$EXPLAIN_OUT" | grep -qE '^Effective: 5   \(source: project \.kit\.toml\)$'; then RC=0; else RC=1; fi
+if { printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '^Effective: 5   \(source: project \.kit\.toml\)$'; then RC=0; else RC=1; fi
 assert "explain mega.wave_cap: the winner line names project .kit.toml + the resolved 5" $RC
-if printf '%s\n' "$EXPLAIN_OUT" | grep -qE '2\. project \.kit\.toml \[mega\.wave_cap\][[:space:]]+= 5'; then RC=0; else RC=1; fi
+if { printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '2\. project \.kit\.toml \[mega\.wave_cap\][[:space:]]+= 5'; then RC=0; else RC=1; fi
 assert "explain mega.wave_cap: level 2 (project) shows the winning value 5" $RC
-if printf '%s\n' "$EXPLAIN_OUT" | grep -qE '3\. kit-root kit\.toml \[mega\.wave_cap\][[:space:]]+= 2'; then RC=0; else RC=1; fi
+if { printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '3\. kit-root kit\.toml \[mega\.wave_cap\][[:space:]]+= 2'; then RC=0; else RC=1; fi
 assert "explain mega.wave_cap: level 3 (kit-root) shows the shadowed value 2" $RC
 
 # Multi-env-var tie-break: ledger.location is shared by two env rows (KIT_LEDGER_DIR listed

--- a/tests/test-config-registry.sh
+++ b/tests/test-config-registry.sh
@@ -76,7 +76,7 @@ EOF
 PLANT_OUT="$(manifest_diff_flat "$PLANT_DIR/lib" "$SEED_RE" "$REGISTRY" "$ALLOW_RE")"
 PLANT_RC=$?
 assert_eq "the plant is flagged exactly 1 orphan" "$PLANT_RC" "1"
-if { printf '%s\n' "$PLANT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: KIT_TOTALLY_UNREGISTERED_PLANT"; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$PLANT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: KIT_TOTALLY_UNREGISTERED_PLANT"; then RC=0; else RC=1; fi
 assert "the flagged orphan is specifically KIT_TOTALLY_UNREGISTERED_PLANT" $RC
 
 echo ""
@@ -126,19 +126,19 @@ cat > "$FIXDIR/proj/.kit.toml" <<'EOF'
 wave_cap = 5
 EOF
 FIXTURE_LIST="$(KIT_CONFIG_ROOT="$FIXDIR/root" KIT_PROJECT_ROOT="$FIXDIR/proj" KIT_DELIVERY_RATIO_WARN=99 bash "$CONFIG_BIN" list)"
-if { printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^WAVE_CAP[[:space:]]+\[impl\][[:space:]]+5[[:space:]]+project \.kit\.toml'; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^WAVE_CAP[[:space:]]+\[impl\][[:space:]]+5[[:space:]]+project \.kit\.toml'; then RC=0; else RC=1; fi
 assert "list: a project .kit.toml override visibly wins WAVE_CAP's row (5, project .kit.toml)" $RC
-if { printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^KIT_DELIVERY_RATIO_WARN[[:space:]]+\[impl\][[:space:]]+99[[:space:]]+env'; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^KIT_DELIVERY_RATIO_WARN[[:space:]]+\[impl\][[:space:]]+99[[:space:]]+env'; then RC=0; else RC=1; fi
 assert "list: an env override visibly wins KIT_DELIVERY_RATIO_WARN's row (99, env)" $RC
-if { printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^TIER4_CLOSE[[:space:]]+\[impl\][[:space:]]+true[[:space:]]+kit-root kit\.toml'; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$FIXTURE_LIST" 2>/dev/null || :; } | grep -qE '^TIER4_CLOSE[[:space:]]+\[impl\][[:space:]]+true[[:space:]]+kit-root kit\.toml'; then RC=0; else RC=1; fi
 assert "list: no override falls to kit-root kit.toml (TIER4_CLOSE = true, kit-root kit.toml)" $RC
 
 EXPLAIN_OUT="$(KIT_CONFIG_ROOT="$FIXDIR/root" KIT_PROJECT_ROOT="$FIXDIR/proj" bash "$CONFIG_BIN" explain mega.wave_cap)"
-if { printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '^Effective: 5   \(source: project \.kit\.toml\)$'; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '^Effective: 5   \(source: project \.kit\.toml\)$'; then RC=0; else RC=1; fi
 assert "explain mega.wave_cap: the winner line names project .kit.toml + the resolved 5" $RC
-if { printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '2\. project \.kit\.toml \[mega\.wave_cap\][[:space:]]+= 5'; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '2\. project \.kit\.toml \[mega\.wave_cap\][[:space:]]+= 5'; then RC=0; else RC=1; fi
 assert "explain mega.wave_cap: level 2 (project) shows the winning value 5" $RC
-if { printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '3\. kit-root kit\.toml \[mega\.wave_cap\][[:space:]]+= 2'; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$EXPLAIN_OUT" 2>/dev/null || :; } | grep -qE '3\. kit-root kit\.toml \[mega\.wave_cap\][[:space:]]+= 2'; then RC=0; else RC=1; fi
 assert "explain mega.wave_cap: level 3 (kit-root) shows the shadowed value 2" $RC
 
 # Multi-env-var tie-break: ledger.location is shared by two env rows (KIT_LEDGER_DIR listed

--- a/tests/test-coverage-delta.sh
+++ b/tests/test-coverage-delta.sh
@@ -34,8 +34,8 @@ D="$WORK/t1"; make_repo "$D"
 echo "changed() { echo behavior; }" >> "$D/lib/thing.sh"     # source moved, no test change
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if printf '%s' "$OUT" | grep -q 'WARNING under-tested'; then pass "T1 under-tested diff is FLAGGED"; else fail "T1 expected WARNING, got: $OUT"; fi
-if printf '%s' "$OUT" | grep -q 'lib/thing.sh'; then pass "T1 warning NAMES the uncovered source file"; else fail "T1 warning did not name lib/thing.sh: $OUT"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING under-tested'; then pass "T1 under-tested diff is FLAGGED"; else fail "T1 expected WARNING, got: $OUT"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'lib/thing.sh'; then pass "T1 warning NAMES the uncovered source file"; else fail "T1 warning did not name lib/thing.sh: $OUT"; fi
 
 # --- T2: FALSE-POSITIVE NEGATIVE CONTROL (load-bearing): well-tested -> NOT flagged (AC2) ---
 D="$WORK/t2"; make_repo "$D"
@@ -43,15 +43,15 @@ echo "changed() { echo behavior; }" >> "$D/lib/thing.sh"     # source moved
 echo "test_changed() { changed; }"  >> "$D/tests/test-thing.sh"  # AND test moved
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if printf '%s' "$OUT" | grep -q 'WARNING'; then fail "T2 (NC) well-tested diff wrongly FLAGGED: $OUT"; else pass "T2 (false-positive NC) well-tested diff does NOT trip"; fi
-if printf '%s' "$OUT" | grep -q '^\[coverage-delta\] ok'; then pass "T2 well-tested reports ok"; else fail "T2 expected ok, got: $OUT"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING'; then fail "T2 (NC) well-tested diff wrongly FLAGGED: $OUT"; else pass "T2 (false-positive NC) well-tested diff does NOT trip"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '^\[coverage-delta\] ok'; then pass "T2 well-tested reports ok"; else fail "T2 expected ok, got: $OUT"; fi
 
 # --- T3: docs-only -> exempt (AC3) ---
 D="$WORK/t3"; make_repo "$D"
 echo "more docs" >> "$D/README.md"
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if printf '%s' "$OUT" | grep -q 'exempt'; then pass "T3 docs-only diff is exempt"; else fail "T3 expected exempt, got: $OUT"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T3 docs-only diff is exempt"; else fail "T3 expected exempt, got: $OUT"; fi
 
 # --- T4: ADVISORY-CANNOT-BLOCK: the FLAG fixture still exits 0 (AC4) ---
 D="$WORK/t4"; make_repo "$D"
@@ -65,14 +65,14 @@ D="$WORK/t5"; make_repo "$D"
 echo "test_extra() { :; }" >> "$D/tests/test-thing.sh"       # only test moved
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if printf '%s' "$OUT" | grep -q 'exempt'; then pass "T5 test-only diff is exempt"; else fail "T5 expected exempt, got: $OUT"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T5 test-only diff is exempt"; else fail "T5 expected exempt, got: $OUT"; fi
 
 # --- T6: generated-only -> exempt (AC3, generated class) ---
 D="$WORK/t6"; make_repo "$D"
 echo "relocked" >> "$D/pnpm-lock.yaml"                       # only a lockfile moved
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if printf '%s' "$OUT" | grep -q 'exempt'; then pass "T6 generated-only diff is exempt"; else fail "T6 expected exempt, got: $OUT"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T6 generated-only diff is exempt"; else fail "T6 expected exempt, got: $OUT"; fi
 
 # --- T7: classification, one path per class (AC via `class` subcommand) ---
 declare -a cases=("README.md:docs" "pnpm-lock.yaml:generated" "tests/test-x.sh:test" "src/latest-value.js:source")
@@ -86,7 +86,7 @@ D="$WORK/t8"; make_repo "$D"
 echo "staged_change() { :; }" >> "$D/lib/thing.sh"
 git -C "$D" add -A                                            # staged, NOT committed
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if printf '%s' "$OUT" | grep -q 'WARNING under-tested'; then pass "T8 staged-only source change is seen + flagged"; else fail "T8 staged change not seen: $OUT"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING under-tested'; then pass "T8 staged-only source change is seen + flagged"; else fail "T8 staged change not seen: $OUT"; fi
 
 # --- T9: real-runner hook: COVERAGE_DELTA_RUNNER used; non-zero runner still exit 0 (AC7) ---
 D="$WORK/t9"; make_repo "$D"
@@ -94,7 +94,7 @@ echo "changed() { :; }" >> "$D/lib/thing.sh"; git -C "$D" add -A
 RUNNER="$WORK/runner.sh"
 printf '#!/usr/bin/env bash\necho "covered=3 uncovered=1"\nexit 7\n' > "$RUNNER"; chmod +x "$RUNNER"
 OUT="$(COVERAGE_DELTA_RUNNER="$RUNNER" bash "$GATE" check "$D" "$(base "$D")")"; rc=$?
-if printf '%s' "$OUT" | grep -q 'runner runner.sh: covered=3 uncovered=1'; then pass "T9 runner hook verdict is used"; else fail "T9 runner verdict missing: $OUT"; fi
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'runner runner.sh: covered=3 uncovered=1'; then pass "T9 runner hook verdict is used"; else fail "T9 runner verdict missing: $OUT"; fi
 if [ "$rc" -eq 0 ]; then pass "T9 non-zero runner still leaves gate at exit 0"; else fail "T9 gate exited $rc with a non-zero runner, must be 0"; fi
 
 # --- T10: ledger record: check --rid appends one GATE|coverage-delta|ran line (AC8) ---
@@ -105,8 +105,8 @@ LEDGER_ROOT="$WORK/ledger"; mkdir -p "$LEDGER_ROOT"
 export DWARVES_KIT_LOG_DIR="$LEDGER_ROOT"
 bash "$GATE" check "$D" "$(base "$D")" --rid cd-test-run >/dev/null 2>&1
 LINE="$(grep -rh 'coverage-delta' "$LEDGER_ROOT" 2>/dev/null | head -1)"
-if printf '%s' "$LINE" | grep -qE '\| GATE \| coverage-delta \| ran \|'; then pass "T10 ledger has a GATE|coverage-delta|ran line"; else fail "T10 no coverage-delta GATE line found (got: '$LINE')"; fi
-if printf '%s' "$LINE" | grep -qE 'src=[0-9]+ test=[0-9]+'; then pass "T10 ledger line carries src=/test= counts"; else fail "T10 line missing src=/test=: '$LINE'"; fi
+if { printf '%s' "$LINE" 2>/dev/null || :; } | grep -qE '\| GATE \| coverage-delta \| ran \|'; then pass "T10 ledger has a GATE|coverage-delta|ran line"; else fail "T10 no coverage-delta GATE line found (got: '$LINE')"; fi
+if { printf '%s' "$LINE" 2>/dev/null || :; } | grep -qE 'src=[0-9]+ test=[0-9]+'; then pass "T10 ledger line carries src=/test= counts"; else fail "T10 line missing src=/test=: '$LINE'"; fi
 unset DWARVES_KIT_LOG_DIR
 
 echo "---"

--- a/tests/test-coverage-delta.sh
+++ b/tests/test-coverage-delta.sh
@@ -34,8 +34,8 @@ D="$WORK/t1"; make_repo "$D"
 echo "changed() { echo behavior; }" >> "$D/lib/thing.sh"     # source moved, no test change
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING under-tested'; then pass "T1 under-tested diff is FLAGGED"; else fail "T1 expected WARNING, got: $OUT"; fi
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'lib/thing.sh'; then pass "T1 warning NAMES the uncovered source file"; else fail "T1 warning did not name lib/thing.sh: $OUT"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING under-tested'; then pass "T1 under-tested diff is FLAGGED"; else fail "T1 expected WARNING, got: $OUT"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'lib/thing.sh'; then pass "T1 warning NAMES the uncovered source file"; else fail "T1 warning did not name lib/thing.sh: $OUT"; fi
 
 # --- T2: FALSE-POSITIVE NEGATIVE CONTROL (load-bearing): well-tested -> NOT flagged (AC2) ---
 D="$WORK/t2"; make_repo "$D"
@@ -43,15 +43,15 @@ echo "changed() { echo behavior; }" >> "$D/lib/thing.sh"     # source moved
 echo "test_changed() { changed; }"  >> "$D/tests/test-thing.sh"  # AND test moved
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING'; then fail "T2 (NC) well-tested diff wrongly FLAGGED: $OUT"; else pass "T2 (false-positive NC) well-tested diff does NOT trip"; fi
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '^\[coverage-delta\] ok'; then pass "T2 well-tested reports ok"; else fail "T2 expected ok, got: $OUT"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING'; then fail "T2 (NC) well-tested diff wrongly FLAGGED: $OUT"; else pass "T2 (false-positive NC) well-tested diff does NOT trip"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '^\[coverage-delta\] ok'; then pass "T2 well-tested reports ok"; else fail "T2 expected ok, got: $OUT"; fi
 
 # --- T3: docs-only -> exempt (AC3) ---
 D="$WORK/t3"; make_repo "$D"
 echo "more docs" >> "$D/README.md"
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T3 docs-only diff is exempt"; else fail "T3 expected exempt, got: $OUT"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T3 docs-only diff is exempt"; else fail "T3 expected exempt, got: $OUT"; fi
 
 # --- T4: ADVISORY-CANNOT-BLOCK: the FLAG fixture still exits 0 (AC4) ---
 D="$WORK/t4"; make_repo "$D"
@@ -65,14 +65,14 @@ D="$WORK/t5"; make_repo "$D"
 echo "test_extra() { :; }" >> "$D/tests/test-thing.sh"       # only test moved
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T5 test-only diff is exempt"; else fail "T5 expected exempt, got: $OUT"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T5 test-only diff is exempt"; else fail "T5 expected exempt, got: $OUT"; fi
 
 # --- T6: generated-only -> exempt (AC3, generated class) ---
 D="$WORK/t6"; make_repo "$D"
 echo "relocked" >> "$D/pnpm-lock.yaml"                       # only a lockfile moved
 git -C "$D" add -A
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T6 generated-only diff is exempt"; else fail "T6 expected exempt, got: $OUT"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'exempt'; then pass "T6 generated-only diff is exempt"; else fail "T6 expected exempt, got: $OUT"; fi
 
 # --- T7: classification, one path per class (AC via `class` subcommand) ---
 declare -a cases=("README.md:docs" "pnpm-lock.yaml:generated" "tests/test-x.sh:test" "src/latest-value.js:source")
@@ -86,7 +86,7 @@ D="$WORK/t8"; make_repo "$D"
 echo "staged_change() { :; }" >> "$D/lib/thing.sh"
 git -C "$D" add -A                                            # staged, NOT committed
 OUT="$(bash "$GATE" check "$D" "$(base "$D")")"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING under-tested'; then pass "T8 staged-only source change is seen + flagged"; else fail "T8 staged change not seen: $OUT"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'WARNING under-tested'; then pass "T8 staged-only source change is seen + flagged"; else fail "T8 staged change not seen: $OUT"; fi
 
 # --- T9: real-runner hook: COVERAGE_DELTA_RUNNER used; non-zero runner still exit 0 (AC7) ---
 D="$WORK/t9"; make_repo "$D"
@@ -94,7 +94,7 @@ echo "changed() { :; }" >> "$D/lib/thing.sh"; git -C "$D" add -A
 RUNNER="$WORK/runner.sh"
 printf '#!/usr/bin/env bash\necho "covered=3 uncovered=1"\nexit 7\n' > "$RUNNER"; chmod +x "$RUNNER"
 OUT="$(COVERAGE_DELTA_RUNNER="$RUNNER" bash "$GATE" check "$D" "$(base "$D")")"; rc=$?
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'runner runner.sh: covered=3 uncovered=1'; then pass "T9 runner hook verdict is used"; else fail "T9 runner verdict missing: $OUT"; fi
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'runner runner.sh: covered=3 uncovered=1'; then pass "T9 runner hook verdict is used"; else fail "T9 runner verdict missing: $OUT"; fi
 if [ "$rc" -eq 0 ]; then pass "T9 non-zero runner still leaves gate at exit 0"; else fail "T9 gate exited $rc with a non-zero runner, must be 0"; fi
 
 # --- T10: ledger record: check --rid appends one GATE|coverage-delta|ran line (AC8) ---
@@ -105,8 +105,8 @@ LEDGER_ROOT="$WORK/ledger"; mkdir -p "$LEDGER_ROOT"
 export DWARVES_KIT_LOG_DIR="$LEDGER_ROOT"
 bash "$GATE" check "$D" "$(base "$D")" --rid cd-test-run >/dev/null 2>&1
 LINE="$(grep -rh 'coverage-delta' "$LEDGER_ROOT" 2>/dev/null | head -1)"
-if { printf '%s' "$LINE" 2>/dev/null || :; } | grep -qE '\| GATE \| coverage-delta \| ran \|'; then pass "T10 ledger has a GATE|coverage-delta|ran line"; else fail "T10 no coverage-delta GATE line found (got: '$LINE')"; fi
-if { printf '%s' "$LINE" 2>/dev/null || :; } | grep -qE 'src=[0-9]+ test=[0-9]+'; then pass "T10 ledger line carries src=/test= counts"; else fail "T10 line missing src=/test=: '$LINE'"; fi
+if { trap '' PIPE; printf '%s' "$LINE" 2>/dev/null || :; } | grep -qE '\| GATE \| coverage-delta \| ran \|'; then pass "T10 ledger has a GATE|coverage-delta|ran line"; else fail "T10 no coverage-delta GATE line found (got: '$LINE')"; fi
+if { trap '' PIPE; printf '%s' "$LINE" 2>/dev/null || :; } | grep -qE 'src=[0-9]+ test=[0-9]+'; then pass "T10 ledger line carries src=/test= counts"; else fail "T10 line missing src=/test=: '$LINE'"; fi
 unset DWARVES_KIT_LOG_DIR
 
 echo "---"

--- a/tests/test-delivery-ratio.sh
+++ b/tests/test-delivery-ratio.sh
@@ -22,8 +22,8 @@ seq 220 > "$D1/docs/proof/kitmod.md"
 git -C "$D1" add -A; git -C "$D1" commit -qm work
 OUT1="$(bash "$PL" delivery-ratio "$D1" HEAD~1)"; RC1=$?
 echo "  case1: $OUT1"
-printf '%s' "$OUT1" | grep -q 'real=6 proof=220'; assert "CASE1: counts 6 real / 220 proof" $?
-printf '%s' "$OUT1" | grep -q 'THIN-WARN'; assert "CASE1: flags THIN-WARN (real<40 AND proof>=3x)" $?
+{ printf '%s' "$OUT1" 2>/dev/null || :; } | grep -q 'real=6 proof=220'; assert "CASE1: counts 6 real / 220 proof" $?
+{ printf '%s' "$OUT1" 2>/dev/null || :; } | grep -q 'THIN-WARN'; assert "CASE1: flags THIN-WARN (real<40 AND proof>=3x)" $?
 assert "CASE1: exit 0 (advisory never blocks)" $RC1
 
 # CASE 2 OK: substantial real code (60 lines) with proportionate proof.
@@ -32,8 +32,8 @@ seq 60 > "$D2/lib/feature.sh"; seq 30 > "$D2/tests/test-feature.sh"
 git -C "$D2" add -A; git -C "$D2" commit -qm work
 OUT2="$(bash "$PL" delivery-ratio "$D2" HEAD~1)"
 echo "  case2: $OUT2"
-printf '%s' "$OUT2" | grep -q 'real=60 proof=30'; assert "CASE2: counts 60 real / 30 proof (tests=proof)" $?
-printf '%s' "$OUT2" | grep -qE '\| OK'; assert "CASE2: substantial real change => OK" $?
+{ printf '%s' "$OUT2" 2>/dev/null || :; } | grep -q 'real=60 proof=30'; assert "CASE2: counts 60 real / 30 proof (tests=proof)" $?
+{ printf '%s' "$OUT2" 2>/dev/null || :; } | grep -qE '\| OK'; assert "CASE2: substantial real change => OK" $?
 
 # CASE 3 NOTICE: docs/proof-only branch (real=0) -- fine for a docs sub-goal, suspect for a build claim.
 D3="$(mkrepo)"; mkdir -p "$D3/docs/verification"
@@ -41,8 +41,8 @@ seq 40 > "$D3/docs/verification/x.md"
 git -C "$D3" add -A; git -C "$D3" commit -qm work
 OUT3="$(bash "$PL" delivery-ratio "$D3" HEAD~1)"
 echo "  case3: $OUT3"
-printf '%s' "$OUT3" | grep -q 'real=0 proof=40'; assert "CASE3: counts 0 real / 40 proof" $?
-printf '%s' "$OUT3" | grep -q 'NOTICE'; assert "CASE3: docs-only => NOTICE (not a hard verdict)" $?
+{ printf '%s' "$OUT3" 2>/dev/null || :; } | grep -q 'real=0 proof=40'; assert "CASE3: counts 0 real / 40 proof" $?
+{ printf '%s' "$OUT3" 2>/dev/null || :; } | grep -q 'NOTICE'; assert "CASE3: docs-only => NOTICE (not a hard verdict)" $?
 
 # CASE 4 [HONEST LIMIT, documented]: a 47-line append (the real #195 shape) is NOT flagged
 # because real(47) >= floor(40). Line-count cannot tell a thin-for-a-"rewrite" 47-line append
@@ -52,7 +52,7 @@ seq 47 > "$D4/README.md"; seq 228 > "$D4/docs/proof/x.md"
 git -C "$D4" add -A; git -C "$D4" commit -qm work
 OUT4="$(bash "$PL" delivery-ratio "$D4" HEAD~1)"
 echo "  case4 (known blind spot): $OUT4"
-printf '%s' "$OUT4" | grep -qE '\| OK'; assert "CASE4: 47-real append reads OK (documented blind spot: floor=40)" $?
+{ printf '%s' "$OUT4" 2>/dev/null || :; } | grep -qE '\| OK'; assert "CASE4: 47-real append reads OK (documented blind spot: floor=40)" $?
 
 echo "=== $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/tests/test-delivery-ratio.sh
+++ b/tests/test-delivery-ratio.sh
@@ -22,8 +22,8 @@ seq 220 > "$D1/docs/proof/kitmod.md"
 git -C "$D1" add -A; git -C "$D1" commit -qm work
 OUT1="$(bash "$PL" delivery-ratio "$D1" HEAD~1)"; RC1=$?
 echo "  case1: $OUT1"
-{ printf '%s' "$OUT1" 2>/dev/null || :; } | grep -q 'real=6 proof=220'; assert "CASE1: counts 6 real / 220 proof" $?
-{ printf '%s' "$OUT1" 2>/dev/null || :; } | grep -q 'THIN-WARN'; assert "CASE1: flags THIN-WARN (real<40 AND proof>=3x)" $?
+{ trap '' PIPE; printf '%s' "$OUT1" 2>/dev/null || :; } | grep -q 'real=6 proof=220'; assert "CASE1: counts 6 real / 220 proof" $?
+{ trap '' PIPE; printf '%s' "$OUT1" 2>/dev/null || :; } | grep -q 'THIN-WARN'; assert "CASE1: flags THIN-WARN (real<40 AND proof>=3x)" $?
 assert "CASE1: exit 0 (advisory never blocks)" $RC1
 
 # CASE 2 OK: substantial real code (60 lines) with proportionate proof.
@@ -32,8 +32,8 @@ seq 60 > "$D2/lib/feature.sh"; seq 30 > "$D2/tests/test-feature.sh"
 git -C "$D2" add -A; git -C "$D2" commit -qm work
 OUT2="$(bash "$PL" delivery-ratio "$D2" HEAD~1)"
 echo "  case2: $OUT2"
-{ printf '%s' "$OUT2" 2>/dev/null || :; } | grep -q 'real=60 proof=30'; assert "CASE2: counts 60 real / 30 proof (tests=proof)" $?
-{ printf '%s' "$OUT2" 2>/dev/null || :; } | grep -qE '\| OK'; assert "CASE2: substantial real change => OK" $?
+{ trap '' PIPE; printf '%s' "$OUT2" 2>/dev/null || :; } | grep -q 'real=60 proof=30'; assert "CASE2: counts 60 real / 30 proof (tests=proof)" $?
+{ trap '' PIPE; printf '%s' "$OUT2" 2>/dev/null || :; } | grep -qE '\| OK'; assert "CASE2: substantial real change => OK" $?
 
 # CASE 3 NOTICE: docs/proof-only branch (real=0) -- fine for a docs sub-goal, suspect for a build claim.
 D3="$(mkrepo)"; mkdir -p "$D3/docs/verification"
@@ -41,8 +41,8 @@ seq 40 > "$D3/docs/verification/x.md"
 git -C "$D3" add -A; git -C "$D3" commit -qm work
 OUT3="$(bash "$PL" delivery-ratio "$D3" HEAD~1)"
 echo "  case3: $OUT3"
-{ printf '%s' "$OUT3" 2>/dev/null || :; } | grep -q 'real=0 proof=40'; assert "CASE3: counts 0 real / 40 proof" $?
-{ printf '%s' "$OUT3" 2>/dev/null || :; } | grep -q 'NOTICE'; assert "CASE3: docs-only => NOTICE (not a hard verdict)" $?
+{ trap '' PIPE; printf '%s' "$OUT3" 2>/dev/null || :; } | grep -q 'real=0 proof=40'; assert "CASE3: counts 0 real / 40 proof" $?
+{ trap '' PIPE; printf '%s' "$OUT3" 2>/dev/null || :; } | grep -q 'NOTICE'; assert "CASE3: docs-only => NOTICE (not a hard verdict)" $?
 
 # CASE 4 [HONEST LIMIT, documented]: a 47-line append (the real #195 shape) is NOT flagged
 # because real(47) >= floor(40). Line-count cannot tell a thin-for-a-"rewrite" 47-line append
@@ -52,7 +52,7 @@ seq 47 > "$D4/README.md"; seq 228 > "$D4/docs/proof/x.md"
 git -C "$D4" add -A; git -C "$D4" commit -qm work
 OUT4="$(bash "$PL" delivery-ratio "$D4" HEAD~1)"
 echo "  case4 (known blind spot): $OUT4"
-{ printf '%s' "$OUT4" 2>/dev/null || :; } | grep -qE '\| OK'; assert "CASE4: 47-real append reads OK (documented blind spot: floor=40)" $?
+{ trap '' PIPE; printf '%s' "$OUT4" 2>/dev/null || :; } | grep -qE '\| OK'; assert "CASE4: 47-real append reads OK (documented blind spot: floor=40)" $?
 
 echo "=== $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/tests/test-deployable-done.sh
+++ b/tests/test-deployable-done.sh
@@ -55,7 +55,7 @@ else
 fi
 MSG1="$(run_check "$D1" "$B1" "deploy-noproof" 2>&1 || true)"
 assert "AC1: the block message names the stateful class + missing proof" \
-  $({ printf '%s' "$MSG1" 2>/dev/null || :; } | grep -qi "stateful" && { printf '%s' "$MSG1" 2>/dev/null || :; } | grep -qi "proof" && echo 0 || echo 1)
+  $({ trap '' PIPE; printf '%s' "$MSG1" 2>/dev/null || :; } | grep -qi "stateful" && { trap '' PIPE; printf '%s' "$MSG1" 2>/dev/null || :; } | grep -qi "proof" && echo 0 || echo 1)
 
 # ============================================================
 echo ""
@@ -107,7 +107,7 @@ cp "$FIX/deploy-rollout.sh" "$D4/deploy/rollout.sh"
 git -C "$D4" add -A; git -C "$D4" commit -qm "deploy: add rollout script"
 # ID-299: overrides are repo-scoped, so log the override FROM the repo it applies to.
 OUT4="$( cd "$D4" && DWARVES_KIT_LOG_DIR="$LOGDIR" bash "$LIB" override deploy-noproof-override "emergency hotfix, deploy verified manually" 2>&1)"
-assert "AC4: override command reports the trace log path" $({ printf '%s' "$OUT4" 2>/dev/null || :; } | grep -qi "trace" && echo 0 || echo 1)
+assert "AC4: override command reports the trace log path" $({ trap '' PIPE; printf '%s' "$OUT4" 2>/dev/null || :; } | grep -qi "trace" && echo 0 || echo 1)
 if run_check "$D4" "$B4" "deploy-noproof-override" >/dev/null 2>&1; then
   assert "AC4: deployable diff with a LOGGED override PASSES (no proof file needed)" 0
 else

--- a/tests/test-deployable-done.sh
+++ b/tests/test-deployable-done.sh
@@ -55,7 +55,7 @@ else
 fi
 MSG1="$(run_check "$D1" "$B1" "deploy-noproof" 2>&1 || true)"
 assert "AC1: the block message names the stateful class + missing proof" \
-  $(printf '%s' "$MSG1" | grep -qi "stateful" && printf '%s' "$MSG1" | grep -qi "proof" && echo 0 || echo 1)
+  $({ printf '%s' "$MSG1" 2>/dev/null || :; } | grep -qi "stateful" && { printf '%s' "$MSG1" 2>/dev/null || :; } | grep -qi "proof" && echo 0 || echo 1)
 
 # ============================================================
 echo ""
@@ -107,7 +107,7 @@ cp "$FIX/deploy-rollout.sh" "$D4/deploy/rollout.sh"
 git -C "$D4" add -A; git -C "$D4" commit -qm "deploy: add rollout script"
 # ID-299: overrides are repo-scoped, so log the override FROM the repo it applies to.
 OUT4="$( cd "$D4" && DWARVES_KIT_LOG_DIR="$LOGDIR" bash "$LIB" override deploy-noproof-override "emergency hotfix, deploy verified manually" 2>&1)"
-assert "AC4: override command reports the trace log path" $(printf '%s' "$OUT4" | grep -qi "trace" && echo 0 || echo 1)
+assert "AC4: override command reports the trace log path" $({ printf '%s' "$OUT4" 2>/dev/null || :; } | grep -qi "trace" && echo 0 || echo 1)
 if run_check "$D4" "$B4" "deploy-noproof-override" >/dev/null 2>&1; then
   assert "AC4: deployable diff with a LOGGED override PASSES (no proof file needed)" 0
 else

--- a/tests/test-docs-wiring.sh
+++ b/tests/test-docs-wiring.sh
@@ -58,7 +58,7 @@ grep -qi 'opt-in and off by default\|opt-in, off by default\|off by default' "$W
 overclaim_hit=0
 while IFS= read -r line; do
   [ -z "$line" ] && continue
-  if ! { printf '%s' "$line" 2>/dev/null || :; } | grep -qiE 'not |never|n.t describe|opt-in|off by default'; then
+  if ! { trap '' PIPE; printf '%s' "$line" 2>/dev/null || :; } | grep -qiE 'not |never|n.t describe|opt-in|off by default'; then
     overclaim_hit=1
   fi
 done < <(grep -inE 'multiplexer.{0,40}(default-on|on by default|enabled by default)' "$WORKFLOW")

--- a/tests/test-docs-wiring.sh
+++ b/tests/test-docs-wiring.sh
@@ -58,7 +58,7 @@ grep -qi 'opt-in and off by default\|opt-in, off by default\|off by default' "$W
 overclaim_hit=0
 while IFS= read -r line; do
   [ -z "$line" ] && continue
-  if ! printf '%s' "$line" | grep -qiE 'not |never|n.t describe|opt-in|off by default'; then
+  if ! { printf '%s' "$line" 2>/dev/null || :; } | grep -qiE 'not |never|n.t describe|opt-in|off by default'; then
     overclaim_hit=1
   fi
 done < <(grep -inE 'multiplexer.{0,40}(default-on|on by default|enabled by default)' "$WORKFLOW")

--- a/tests/test-e2e.sh
+++ b/tests/test-e2e.sh
@@ -20,7 +20,7 @@ PASS=0; FAIL=0; TOTAL=0
 ok()   { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad()  { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
 expect() {  # <name> <needle> <haystack>  (grep -q = BRE: parens in needles are LITERAL)
-  if printf '%s' "$3" | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2')"; fi
+  if { printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2')"; fi
 }
 
 echo "=== golden run: one task end to end (SPEC-067) ==="

--- a/tests/test-e2e.sh
+++ b/tests/test-e2e.sh
@@ -20,7 +20,7 @@ PASS=0; FAIL=0; TOTAL=0
 ok()   { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad()  { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
 expect() {  # <name> <needle> <haystack>  (grep -q = BRE: parens in needles are LITERAL)
-  if { printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2')"; fi
+  if { trap '' PIPE; printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2')"; fi
 }
 
 echo "=== golden run: one task end to end (SPEC-067) ==="

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1401,7 +1401,7 @@ assert_exit "registry: slashed slug rejected (no subdir split)" 64 "$?"
 REG_LIST=$(bash "$REG" list 2>/dev/null)
 assert_output_contains "registry: list shows admitted goal-a" "goal-a" "$REG_LIST"
 assert_output_contains "registry: list shows admitted goal-b" "goal-b" "$REG_LIST"
-{ printf '%s' "$REG_LIST" 2>/dev/null || :; } | grep -q 'goal-c'
+{ trap '' PIPE; printf '%s' "$REG_LIST" 2>/dev/null || :; } | grep -q 'goal-c'
 assert_exit "registry: list omits the refused goal-c" 1 "$?"
 
 bash "$REG" log goal-a "tried approach X" >/dev/null 2>&1

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1401,7 +1401,7 @@ assert_exit "registry: slashed slug rejected (no subdir split)" 64 "$?"
 REG_LIST=$(bash "$REG" list 2>/dev/null)
 assert_output_contains "registry: list shows admitted goal-a" "goal-a" "$REG_LIST"
 assert_output_contains "registry: list shows admitted goal-b" "goal-b" "$REG_LIST"
-printf '%s' "$REG_LIST" | grep -q 'goal-c'
+{ printf '%s' "$REG_LIST" 2>/dev/null || :; } | grep -q 'goal-c'
 assert_exit "registry: list omits the refused goal-c" 1 "$?"
 
 bash "$REG" log goal-a "tried approach X" >/dev/null 2>&1

--- a/tests/test-install-compat.sh
+++ b/tests/test-install-compat.sh
@@ -19,7 +19,7 @@ trap 'rm -rf "$TMP" "${TMP2:-}" "$HOME_SB1" "$HOME_SB2"' EXIT
 mkdir -p "$TMP/plugins/cache/dwarves-marketplace/kit/1.0.0/lib"
 out="$(HOME="$HOME_SB1" CLAUDE_DIR="$TMP" bash "$KIT_DIR/install.sh" 2>&1)"
 
-{ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'COMPAT-ONLY'; chk "took the compat branch" $?
+{ trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q 'COMPAT-ONLY'; chk "took the compat branch" $?
 [ -L "$TMP/dwarves-kit/lib" ];         chk "lib symlink created" $?
 [ -L "$TMP/dwarves-kit/WORKFLOW.md" ]; chk "WORKFLOW.md symlink created" $?
 [ -L "$TMP/dwarves-kit/docs/WORKFLOW.md" ]; chk "docs/WORKFLOW.md symlink created (SPEC-185 bulk)" $?
@@ -31,7 +31,7 @@ out="$(HOME="$HOME_SB1" CLAUDE_DIR="$TMP" bash "$KIT_DIR/install.sh" 2>&1)"
 TMP2="$(mktemp -d)"
 mkdir -p "$TMP2/plugins/cache/dwarves-marketplace/kit/1.0.0/lib"
 out2="$(HOME="$HOME_SB2" CLAUDE_DIR="$TMP2" KIT_FORCE_FULL=1 bash "$KIT_DIR/install.sh" 2>&1 || true)"
-if { printf '%s' "$out2" 2>/dev/null || :; } | grep -q 'COMPAT-ONLY'; then echo "FAIL KIT_FORCE_FULL still compat"; fail=1; else echo "ok   KIT_FORCE_FULL bypasses compat"; fi
+if { trap '' PIPE; printf '%s' "$out2" 2>/dev/null || :; } | grep -q 'COMPAT-ONLY'; then echo "FAIL KIT_FORCE_FULL still compat"; fail=1; else echo "ok   KIT_FORCE_FULL bypasses compat"; fi
 
 # --- Tripwire (ID-463): the compat branch's CLI-shim write must never escape
 # into the REAL $HOME, no matter what changes upstream in install.sh. $HOME is

--- a/tests/test-install-compat.sh
+++ b/tests/test-install-compat.sh
@@ -19,7 +19,7 @@ trap 'rm -rf "$TMP" "${TMP2:-}" "$HOME_SB1" "$HOME_SB2"' EXIT
 mkdir -p "$TMP/plugins/cache/dwarves-marketplace/kit/1.0.0/lib"
 out="$(HOME="$HOME_SB1" CLAUDE_DIR="$TMP" bash "$KIT_DIR/install.sh" 2>&1)"
 
-printf '%s' "$out" | grep -q 'COMPAT-ONLY'; chk "took the compat branch" $?
+{ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'COMPAT-ONLY'; chk "took the compat branch" $?
 [ -L "$TMP/dwarves-kit/lib" ];         chk "lib symlink created" $?
 [ -L "$TMP/dwarves-kit/WORKFLOW.md" ]; chk "WORKFLOW.md symlink created" $?
 [ -L "$TMP/dwarves-kit/docs/WORKFLOW.md" ]; chk "docs/WORKFLOW.md symlink created (SPEC-185 bulk)" $?
@@ -31,7 +31,7 @@ printf '%s' "$out" | grep -q 'COMPAT-ONLY'; chk "took the compat branch" $?
 TMP2="$(mktemp -d)"
 mkdir -p "$TMP2/plugins/cache/dwarves-marketplace/kit/1.0.0/lib"
 out2="$(HOME="$HOME_SB2" CLAUDE_DIR="$TMP2" KIT_FORCE_FULL=1 bash "$KIT_DIR/install.sh" 2>&1 || true)"
-if printf '%s' "$out2" | grep -q 'COMPAT-ONLY'; then echo "FAIL KIT_FORCE_FULL still compat"; fail=1; else echo "ok   KIT_FORCE_FULL bypasses compat"; fi
+if { printf '%s' "$out2" 2>/dev/null || :; } | grep -q 'COMPAT-ONLY'; then echo "FAIL KIT_FORCE_FULL still compat"; fail=1; else echo "ok   KIT_FORCE_FULL bypasses compat"; fi
 
 # --- Tripwire (ID-463): the compat branch's CLI-shim write must never escape
 # into the REAL $HOME, no matter what changes upstream in install.sh. $HOME is

--- a/tests/test-install-modules.sh
+++ b/tests/test-install-modules.sh
@@ -82,7 +82,7 @@ echo "== NC un-opted-hook-absent: a cosmetic/session/advisor hook never reaches 
 UNWANTED="auto-format.sh notification.sh slop-cleaner.sh statusline.sh codebase-index.sh permission-auto-approve.sh context-hints.sh tool-policy-guard.sh harvest.sh session-state-save.sh citation-guard.sh context-readiness.sh output-offload.sh pre-compact-backup.sh post-compact-reinject.sh money-gate.sh prose-rag.sh"
 LEAKED=""
 for h in $UNWANTED; do
-  { printf '%s\n' "$WIRED2" 2>/dev/null || :; } | grep -qx "$h" && LEAKED="$LEAKED $h"
+  { trap '' PIPE; printf '%s\n' "$WIRED2" 2>/dev/null || :; } | grep -qx "$h" && LEAKED="$LEAKED $h"
 done
 assert_true "no un-opted-in module hook present after --with board,stats (leaked:${LEAKED:-none})" "$([ -z "$LEAKED" ]; echo $?)"
 
@@ -92,7 +92,7 @@ echo "== NC team_mode reserved: --with team_mode is a clean error, not installab
 H3="$(mktemp -d)"
 ERR3="$(HOME="$H3" bash "$KIT_DIR/install.sh" --with team_mode 2>&1)"; RC3=$?
 assert_true "--with team_mode exits nonzero" "$([ "$RC3" -ne 0 ]; echo $?)"
-assert_true "--with team_mode error names the reserved reason" "$({ printf '%s' "$ERR3" 2>/dev/null || :; } | grep -qi 'reserved'; echo $?)"
+assert_true "--with team_mode error names the reserved reason" "$({ trap '' PIPE; printf '%s' "$ERR3" 2>/dev/null || :; } | grep -qi 'reserved'; echo $?)"
 assert_true "--with team_mode never wrote a settings.json" "$([ ! -f "$H3/.claude/settings.json" ]; echo $?)"
 
 # ============================================================
@@ -101,7 +101,7 @@ echo "== NC unknown module name: clean error, not silent =="
 H4="$(mktemp -d)"
 ERR4="$(HOME="$H4" bash "$KIT_DIR/install.sh" --with bogus-module 2>&1)"; RC4=$?
 assert_true "--with bogus-module exits nonzero" "$([ "$RC4" -ne 0 ]; echo $?)"
-assert_true "--with bogus-module error names the unknown module" "$({ printf '%s' "$ERR4" 2>/dev/null || :; } | grep -q 'bogus-module'; echo $?)"
+assert_true "--with bogus-module error names the unknown module" "$({ trap '' PIPE; printf '%s' "$ERR4" 2>/dev/null || :; } | grep -q 'bogus-module'; echo $?)"
 assert_true "--with bogus-module never wrote a settings.json" "$([ ! -f "$H4/.claude/settings.json" ]; echo $?)"
 
 # ============================================================
@@ -172,8 +172,8 @@ source "$(dirname "$0")/../lib/config/kit-config.sh" 2>/dev/null || true
 grep -q board "$HOME/.claude/dwarves-kit/kit.toml" 2>/dev/null
 FAKEHOOK
 NC_LEAK="$(grep -rl 'kit\.toml' "$NC_HOOKS_DIR" 2>/dev/null || true)"
-assert_true "NC: lint catches a planted hook reading kit.toml (caught: ${NC_LEAK:-NONE-BUG})" "$({ printf '%s' "$NC_LEAK" 2>/dev/null || :; } | grep -q 'fake-config-reader.sh'; echo $?)"
-if { printf '%s' "$NC_LEAK" 2>/dev/null || :; } | grep -qx "$NC_HOOKS_DIR/safety-gate.sh"; then FP_RC=1; else FP_RC=0; fi
+assert_true "NC: lint catches a planted hook reading kit.toml (caught: ${NC_LEAK:-NONE-BUG})" "$({ trap '' PIPE; printf '%s' "$NC_LEAK" 2>/dev/null || :; } | grep -q 'fake-config-reader.sh'; echo $?)"
+if { trap '' PIPE; printf '%s' "$NC_LEAK" 2>/dev/null || :; } | grep -qx "$NC_HOOKS_DIR/safety-gate.sh"; then FP_RC=1; else FP_RC=0; fi
 assert_true "NC: lint does not false-positive the untouched real hook" "$FP_RC"
 rm -rf "$NC_HOOKS_DIR"
 

--- a/tests/test-install-modules.sh
+++ b/tests/test-install-modules.sh
@@ -82,7 +82,7 @@ echo "== NC un-opted-hook-absent: a cosmetic/session/advisor hook never reaches 
 UNWANTED="auto-format.sh notification.sh slop-cleaner.sh statusline.sh codebase-index.sh permission-auto-approve.sh context-hints.sh tool-policy-guard.sh harvest.sh session-state-save.sh citation-guard.sh context-readiness.sh output-offload.sh pre-compact-backup.sh post-compact-reinject.sh money-gate.sh prose-rag.sh"
 LEAKED=""
 for h in $UNWANTED; do
-  printf '%s\n' "$WIRED2" | grep -qx "$h" && LEAKED="$LEAKED $h"
+  { printf '%s\n' "$WIRED2" 2>/dev/null || :; } | grep -qx "$h" && LEAKED="$LEAKED $h"
 done
 assert_true "no un-opted-in module hook present after --with board,stats (leaked:${LEAKED:-none})" "$([ -z "$LEAKED" ]; echo $?)"
 
@@ -92,7 +92,7 @@ echo "== NC team_mode reserved: --with team_mode is a clean error, not installab
 H3="$(mktemp -d)"
 ERR3="$(HOME="$H3" bash "$KIT_DIR/install.sh" --with team_mode 2>&1)"; RC3=$?
 assert_true "--with team_mode exits nonzero" "$([ "$RC3" -ne 0 ]; echo $?)"
-assert_true "--with team_mode error names the reserved reason" "$(printf '%s' "$ERR3" | grep -qi 'reserved'; echo $?)"
+assert_true "--with team_mode error names the reserved reason" "$({ printf '%s' "$ERR3" 2>/dev/null || :; } | grep -qi 'reserved'; echo $?)"
 assert_true "--with team_mode never wrote a settings.json" "$([ ! -f "$H3/.claude/settings.json" ]; echo $?)"
 
 # ============================================================
@@ -101,7 +101,7 @@ echo "== NC unknown module name: clean error, not silent =="
 H4="$(mktemp -d)"
 ERR4="$(HOME="$H4" bash "$KIT_DIR/install.sh" --with bogus-module 2>&1)"; RC4=$?
 assert_true "--with bogus-module exits nonzero" "$([ "$RC4" -ne 0 ]; echo $?)"
-assert_true "--with bogus-module error names the unknown module" "$(printf '%s' "$ERR4" | grep -q 'bogus-module'; echo $?)"
+assert_true "--with bogus-module error names the unknown module" "$({ printf '%s' "$ERR4" 2>/dev/null || :; } | grep -q 'bogus-module'; echo $?)"
 assert_true "--with bogus-module never wrote a settings.json" "$([ ! -f "$H4/.claude/settings.json" ]; echo $?)"
 
 # ============================================================
@@ -172,8 +172,8 @@ source "$(dirname "$0")/../lib/config/kit-config.sh" 2>/dev/null || true
 grep -q board "$HOME/.claude/dwarves-kit/kit.toml" 2>/dev/null
 FAKEHOOK
 NC_LEAK="$(grep -rl 'kit\.toml' "$NC_HOOKS_DIR" 2>/dev/null || true)"
-assert_true "NC: lint catches a planted hook reading kit.toml (caught: ${NC_LEAK:-NONE-BUG})" "$(printf '%s' "$NC_LEAK" | grep -q 'fake-config-reader.sh'; echo $?)"
-if printf '%s' "$NC_LEAK" | grep -qx "$NC_HOOKS_DIR/safety-gate.sh"; then FP_RC=1; else FP_RC=0; fi
+assert_true "NC: lint catches a planted hook reading kit.toml (caught: ${NC_LEAK:-NONE-BUG})" "$({ printf '%s' "$NC_LEAK" 2>/dev/null || :; } | grep -q 'fake-config-reader.sh'; echo $?)"
+if { printf '%s' "$NC_LEAK" 2>/dev/null || :; } | grep -qx "$NC_HOOKS_DIR/safety-gate.sh"; then FP_RC=1; else FP_RC=0; fi
 assert_true "NC: lint does not false-positive the untouched real hook" "$FP_RC"
 rm -rf "$NC_HOOKS_DIR"
 

--- a/tests/test-kit-foldin-hooks.sh
+++ b/tests/test-kit-foldin-hooks.sh
@@ -47,7 +47,7 @@ assert_eq() {
 assert_contains() {
   local NAME="$1" NEEDLE="$2" HAY="$3"
   TOTAL=$((TOTAL + 1))
-  if printf '%s' "$HAY" | grep -qF "$NEEDLE"; then
+  if { printf '%s' "$HAY" 2>/dev/null || :; } | grep -qF "$NEEDLE"; then
     echo -e "  ${GREEN}PASS${NC} $NAME"
     PASS=$((PASS + 1))
   else
@@ -59,7 +59,7 @@ assert_contains() {
 assert_not_contains() {
   local NAME="$1" NEEDLE="$2" HAY="$3"
   TOTAL=$((TOTAL + 1))
-  if printf '%s' "$HAY" | grep -qF "$NEEDLE"; then
+  if { printf '%s' "$HAY" 2>/dev/null || :; } | grep -qF "$NEEDLE"; then
     echo -e "  ${RED}FAIL${NC} $NAME (unexpectedly found '$NEEDLE')"
     FAIL=$((FAIL + 1))
   else

--- a/tests/test-kit-foldin-hooks.sh
+++ b/tests/test-kit-foldin-hooks.sh
@@ -47,7 +47,7 @@ assert_eq() {
 assert_contains() {
   local NAME="$1" NEEDLE="$2" HAY="$3"
   TOTAL=$((TOTAL + 1))
-  if { printf '%s' "$HAY" 2>/dev/null || :; } | grep -qF "$NEEDLE"; then
+  if { trap '' PIPE; printf '%s' "$HAY" 2>/dev/null || :; } | grep -qF "$NEEDLE"; then
     echo -e "  ${GREEN}PASS${NC} $NAME"
     PASS=$((PASS + 1))
   else
@@ -59,7 +59,7 @@ assert_contains() {
 assert_not_contains() {
   local NAME="$1" NEEDLE="$2" HAY="$3"
   TOTAL=$((TOTAL + 1))
-  if { printf '%s' "$HAY" 2>/dev/null || :; } | grep -qF "$NEEDLE"; then
+  if { trap '' PIPE; printf '%s' "$HAY" 2>/dev/null || :; } | grep -qF "$NEEDLE"; then
     echo -e "  ${RED}FAIL${NC} $NAME (unexpectedly found '$NEEDLE')"
     FAIL=$((FAIL + 1))
   else

--- a/tests/test-lane-deescalate.sh
+++ b/tests/test-lane-deescalate.sh
@@ -26,7 +26,7 @@ assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${
 assert_contains() {
   local name="$1" needle="$2" haystack="$3"
   TOTAL=$((TOTAL+1))
-  if printf '%s' "$haystack" | grep -qF "$needle"; then
+  if { printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
     echo -e "  ${GREEN}PASS${NC} $name"; PASS=$((PASS+1))
   else
     echo -e "  ${RED}FAIL${NC} $name"; FAIL=$((FAIL+1))

--- a/tests/test-lane-deescalate.sh
+++ b/tests/test-lane-deescalate.sh
@@ -26,7 +26,7 @@ assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${
 assert_contains() {
   local name="$1" needle="$2" haystack="$3"
   TOTAL=$((TOTAL+1))
-  if { printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
+  if { trap '' PIPE; printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
     echo -e "  ${GREEN}PASS${NC} $name"; PASS=$((PASS+1))
   else
     echo -e "  ${RED}FAIL${NC} $name"; FAIL=$((FAIL+1))

--- a/tests/test-lane-escalation.sh
+++ b/tests/test-lane-escalation.sh
@@ -28,7 +28,7 @@ assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${
 assert_contains() {
   local name="$1" needle="$2" haystack="$3"
   TOTAL=$((TOTAL+1))
-  if printf '%s' "$haystack" | grep -qF "$needle"; then
+  if { printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
     echo -e "  ${GREEN}PASS${NC} $name"; PASS=$((PASS+1))
   else
     echo -e "  ${RED}FAIL${NC} $name"; FAIL=$((FAIL+1))
@@ -57,7 +57,7 @@ echo "=== DOWNGRADE GUARD [NEGATIVE CONTROL]: full + trivial spec never downgrad
 OUT_NEG="$(bash "$LC" escalate full "$FIX/trivial-spec.md" 2>&1)"
 EXIT_NEG=$?
 assert_contains "AC3 [NEGATIVE CONTROL]: escalate full+trivial-spec HOLDs at full (never downgrades)" "HOLD full" "$OUT_NEG"
-if printf '%s' "$OUT_NEG" | grep -qE '^ESCALATE'; then
+if { printf '%s' "$OUT_NEG" 2>/dev/null || :; } | grep -qE '^ESCALATE'; then
   assert "AC3 [NEGATIVE CONTROL]: no ESCALATE line ever appears for a lighter re-class" 1
 else
   assert "AC3 [NEGATIVE CONTROL]: no ESCALATE line ever appears for a lighter re-class" 0
@@ -95,7 +95,7 @@ fi
 DWARVES_KIT_LOG_DIR="$LOG_DIR" bash "$GL" start --amend "$RID" full tiny feature feature testrepo >/dev/null 2>&1
 LEDGER_TAIL="$(DWARVES_KIT_LOG_DIR="$LOG_DIR" bash "$GL" show "$RID" 2>/dev/null | grep -E 'START|START-AMEND' | tail -1)"
 assert_contains "AC4: last START-AMEND wins -- ledger's effective lane is now full" "lane=full" "$LEDGER_TAIL"
-if printf '%s' "$LEDGER_TAIL" | grep -q 'START-AMEND'; then
+if { printf '%s' "$LEDGER_TAIL" 2>/dev/null || :; } | grep -q 'START-AMEND'; then
   assert "AC4: the amend line is recorded as START-AMEND, not a second plain START" 0
 else
   assert "AC4: the amend line is recorded as START-AMEND, not a second plain START" 1

--- a/tests/test-lane-escalation.sh
+++ b/tests/test-lane-escalation.sh
@@ -28,7 +28,7 @@ assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${
 assert_contains() {
   local name="$1" needle="$2" haystack="$3"
   TOTAL=$((TOTAL+1))
-  if { printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
+  if { trap '' PIPE; printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
     echo -e "  ${GREEN}PASS${NC} $name"; PASS=$((PASS+1))
   else
     echo -e "  ${RED}FAIL${NC} $name"; FAIL=$((FAIL+1))
@@ -57,7 +57,7 @@ echo "=== DOWNGRADE GUARD [NEGATIVE CONTROL]: full + trivial spec never downgrad
 OUT_NEG="$(bash "$LC" escalate full "$FIX/trivial-spec.md" 2>&1)"
 EXIT_NEG=$?
 assert_contains "AC3 [NEGATIVE CONTROL]: escalate full+trivial-spec HOLDs at full (never downgrades)" "HOLD full" "$OUT_NEG"
-if { printf '%s' "$OUT_NEG" 2>/dev/null || :; } | grep -qE '^ESCALATE'; then
+if { trap '' PIPE; printf '%s' "$OUT_NEG" 2>/dev/null || :; } | grep -qE '^ESCALATE'; then
   assert "AC3 [NEGATIVE CONTROL]: no ESCALATE line ever appears for a lighter re-class" 1
 else
   assert "AC3 [NEGATIVE CONTROL]: no ESCALATE line ever appears for a lighter re-class" 0
@@ -95,7 +95,7 @@ fi
 DWARVES_KIT_LOG_DIR="$LOG_DIR" bash "$GL" start --amend "$RID" full tiny feature feature testrepo >/dev/null 2>&1
 LEDGER_TAIL="$(DWARVES_KIT_LOG_DIR="$LOG_DIR" bash "$GL" show "$RID" 2>/dev/null | grep -E 'START|START-AMEND' | tail -1)"
 assert_contains "AC4: last START-AMEND wins -- ledger's effective lane is now full" "lane=full" "$LEDGER_TAIL"
-if { printf '%s' "$LEDGER_TAIL" 2>/dev/null || :; } | grep -q 'START-AMEND'; then
+if { trap '' PIPE; printf '%s' "$LEDGER_TAIL" 2>/dev/null || :; } | grep -q 'START-AMEND'; then
   assert "AC4: the amend line is recorded as START-AMEND, not a second plain START" 0
 else
   assert "AC4: the amend line is recorded as START-AMEND, not a second plain START" 1

--- a/tests/test-lane-telemetry.sh
+++ b/tests/test-lane-telemetry.sh
@@ -14,7 +14,7 @@ GL="$KIT_DIR/lib/gate/gate-ledger.sh"
 PASS=0; FAIL=0; TOTAL=0
 RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 ok() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
-has() { { printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$1"; }
+has() { { trap '' PIPE; printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$1"; }
 
 # seeded corpus: a fixed DWARVES_KIT_LOG_DIR with three runs of distinct lane/type
 export DWARVES_KIT_LOG_DIR="$(mktemp -d)/logs"
@@ -53,7 +53,7 @@ has "no runs match" "$OUTN"; ok "filter with no match degrades gracefully" $?
 OUTD="$(NO_COLOR=1 bash "$LT" render "." 2>&1)"
 has "no runs match" "$OUTD"; ok "filter '.' is literal (no regex over-match)" $?
 OUTB="$(NO_COLOR=1 bash "$LT" render "[" 2>&1)"
-if { printf '%s' "$OUTB" 2>/dev/null || :; } | grep -qiE 'awk|character class|syntax'; then ok "filter '[' does not crash awk [NC]" 1; else ok "filter '[' does not crash awk [NC]" 0; fi
+if { trap '' PIPE; printf '%s' "$OUTB" 2>/dev/null || :; } | grep -qiE 'awk|character class|syntax'; then ok "filter '[' does not crash awk [NC]" 1; else ok "filter '[' does not crash awk [NC]" 0; fi
 
 # --- gate coverage counts DISTINCT runs, not raw lines (a re-recorded phase counts once) ---
 DD="$(mktemp -d)/logs"
@@ -79,19 +79,19 @@ DWARVES_KIT_LOG_DIR="$TT" bash "$GL" tokens ta in=1000 out=200 cache_read=5000 c
 DWARVES_KIT_LOG_DIR="$TT" bash "$GL" start tb normal normal spec-feature spec-feature rp >/dev/null 2>&1   # NO tokens -> usage=?
 OUTT="$(DWARVES_KIT_LOG_DIR="$TT" NO_COLOR=1 bash "$LT" report 2>&1)"
 has "token efficiency" "$OUTT"; ok "SPEC-110: report has a token efficiency section" $?
-{ printf '%s' "$OUTT" 2>/dev/null || :; } | grep -qF "usage=?"; ok "SPEC-110: report shows usage=? for the uncaptured run (honest null, not zero)" $?
-{ printf '%s' "$OUTT" 2>/dev/null || :; } | grep -qE 'full[[:space:]]+1200'; ok "SPEC-110: report shows the captured lane's median tokens-to-done" $?
+{ trap '' PIPE; printf '%s' "$OUTT" 2>/dev/null || :; } | grep -qF "usage=?"; ok "SPEC-110: report shows usage=? for the uncaptured run (honest null, not zero)" $?
+{ trap '' PIPE; printf '%s' "$OUTT" 2>/dev/null || :; } | grep -qE 'full[[:space:]]+1200'; ok "SPEC-110: report shows the captured lane's median tokens-to-done" $?
 OUTM="$(DWARVES_KIT_LOG_DIR="$TT" NO_COLOR=1 bash "$LT" render --mermaid 2>&1)"
-{ printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qF '```mermaid'; ok "SPEC-110: render --mermaid emits a mermaid block" $?
-{ printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qE 'lane_full.*1200 tok'; ok "SPEC-110: mermaid annotates the lane node with median tokens" $?
-{ printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qF 'usage=?'; ok "SPEC-110: mermaid shows usage=? for the uncaptured lane" $?
+{ trap '' PIPE; printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qF '```mermaid'; ok "SPEC-110: render --mermaid emits a mermaid block" $?
+{ trap '' PIPE; printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qE 'lane_full.*1200 tok'; ok "SPEC-110: mermaid annotates the lane node with median tokens" $?
+{ trap '' PIPE; printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qF 'usage=?'; ok "SPEC-110: mermaid shows usage=? for the uncaptured lane" $?
 OUTA="$(DWARVES_KIT_LOG_DIR="$TT" NO_COLOR=1 bash "$LT" render 2>&1)"
-{ { printf '%s' "$OUTA" 2>/dev/null || :; } | grep -q "Lane routing" && ! { printf '%s' "$OUTA" 2>/dev/null || :; } | grep -qF '```mermaid'; }; ok "SPEC-110 NC: ASCII render unchanged (no mermaid block without the flag)" $?
+{ { trap '' PIPE; printf '%s' "$OUTA" 2>/dev/null || :; } | grep -q "Lane routing" && ! { trap '' PIPE; printf '%s' "$OUTA" 2>/dev/null || :; } | grep -qF '```mermaid'; }; ok "SPEC-110 NC: ASCII render unchanged (no mermaid block without the flag)" $?
 
 # --- graceful-empty NEGATIVE CONTROL: empty/fresh LOG_DIR ---
 OUTE="$(DWARVES_KIT_LOG_DIR="$(mktemp -d)/empty" NO_COLOR=1 bash "$LT" render 2>&1)"
 has "no runs recorded" "$OUTE"; ok "empty corpus renders an honest 'no runs recorded' [NC]" $?
-if { printf '%s' "$OUTE" 2>/dev/null || :; } | grep -qiE 'error|not found|unbound|syntax'; then ok "empty render does not crash [NC]" 1; else ok "empty render does not crash [NC]" 0; fi
+if { trap '' PIPE; printf '%s' "$OUTE" 2>/dev/null || :; } | grep -qiE 'error|not found|unbound|syntax'; then ok "empty render does not crash [NC]" 1; else ok "empty render does not crash [NC]" 0; fi
 
 # --- ID-398: failure-policy breakdown in `report` ---
 PD="$(mktemp -d)/logs"
@@ -103,12 +103,12 @@ DWARVES_KIT_LOG_DIR="$PD" bash "$GL" outcome pr2 build start >/dev/null 2>&1
 DWARVES_KIT_LOG_DIR="$PD" bash "$GL" outcome pr2 build end caught=false policy=continue >/dev/null 2>&1
 OUTP="$(DWARVES_KIT_LOG_DIR="$PD" NO_COLOR=1 bash "$LT" report 2>&1)"
 has "failure policy" "$OUTP"; ok "ID-398: report has a failure-policy section" $?
-{ printf '%s' "$OUTP" 2>/dev/null || :; } | grep -qE 'escalate[[:space:]]+1'; ok "ID-398: report counts an escalate outcome" $?
-{ printf '%s' "$OUTP" 2>/dev/null || :; } | grep -qE 'continue[[:space:]]+1'; ok "ID-398: report counts a continue outcome" $?
+{ trap '' PIPE; printf '%s' "$OUTP" 2>/dev/null || :; } | grep -qE 'escalate[[:space:]]+1'; ok "ID-398: report counts an escalate outcome" $?
+{ trap '' PIPE; printf '%s' "$OUTP" 2>/dev/null || :; } | grep -qE 'continue[[:space:]]+1'; ok "ID-398: report counts a continue outcome" $?
 
 # --- ID-398 NEGATIVE CONTROL: no policy= anywhere -> section omitted entirely ---
 OUTNP="$(NO_COLOR=1 bash "$LT" report 2>&1)"   # the seeded corpus at the top of this file has no policy= fields
-if { printf '%s' "$OUTNP" 2>/dev/null || :; } | grep -qF "failure policy"; then ok "ID-398 NC: no policy-carrying runs -> section omitted" 1; else ok "ID-398 NC: no policy-carrying runs -> section omitted" 0; fi
+if { trap '' PIPE; printf '%s' "$OUTNP" 2>/dev/null || :; } | grep -qF "failure policy"; then ok "ID-398 NC: no policy-carrying runs -> section omitted" 1; else ok "ID-398 NC: no policy-carrying runs -> section omitted" 0; fi
 
 echo ""
 echo "=== $PASS/$TOTAL passed, $FAIL failed ==="

--- a/tests/test-lane-telemetry.sh
+++ b/tests/test-lane-telemetry.sh
@@ -14,7 +14,7 @@ GL="$KIT_DIR/lib/gate/gate-ledger.sh"
 PASS=0; FAIL=0; TOTAL=0
 RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 ok() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
-has() { printf '%s' "$2" | grep -qF -- "$1"; }
+has() { { printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$1"; }
 
 # seeded corpus: a fixed DWARVES_KIT_LOG_DIR with three runs of distinct lane/type
 export DWARVES_KIT_LOG_DIR="$(mktemp -d)/logs"
@@ -53,7 +53,7 @@ has "no runs match" "$OUTN"; ok "filter with no match degrades gracefully" $?
 OUTD="$(NO_COLOR=1 bash "$LT" render "." 2>&1)"
 has "no runs match" "$OUTD"; ok "filter '.' is literal (no regex over-match)" $?
 OUTB="$(NO_COLOR=1 bash "$LT" render "[" 2>&1)"
-if printf '%s' "$OUTB" | grep -qiE 'awk|character class|syntax'; then ok "filter '[' does not crash awk [NC]" 1; else ok "filter '[' does not crash awk [NC]" 0; fi
+if { printf '%s' "$OUTB" 2>/dev/null || :; } | grep -qiE 'awk|character class|syntax'; then ok "filter '[' does not crash awk [NC]" 1; else ok "filter '[' does not crash awk [NC]" 0; fi
 
 # --- gate coverage counts DISTINCT runs, not raw lines (a re-recorded phase counts once) ---
 DD="$(mktemp -d)/logs"
@@ -79,19 +79,19 @@ DWARVES_KIT_LOG_DIR="$TT" bash "$GL" tokens ta in=1000 out=200 cache_read=5000 c
 DWARVES_KIT_LOG_DIR="$TT" bash "$GL" start tb normal normal spec-feature spec-feature rp >/dev/null 2>&1   # NO tokens -> usage=?
 OUTT="$(DWARVES_KIT_LOG_DIR="$TT" NO_COLOR=1 bash "$LT" report 2>&1)"
 has "token efficiency" "$OUTT"; ok "SPEC-110: report has a token efficiency section" $?
-printf '%s' "$OUTT" | grep -qF "usage=?"; ok "SPEC-110: report shows usage=? for the uncaptured run (honest null, not zero)" $?
-printf '%s' "$OUTT" | grep -qE 'full[[:space:]]+1200'; ok "SPEC-110: report shows the captured lane's median tokens-to-done" $?
+{ printf '%s' "$OUTT" 2>/dev/null || :; } | grep -qF "usage=?"; ok "SPEC-110: report shows usage=? for the uncaptured run (honest null, not zero)" $?
+{ printf '%s' "$OUTT" 2>/dev/null || :; } | grep -qE 'full[[:space:]]+1200'; ok "SPEC-110: report shows the captured lane's median tokens-to-done" $?
 OUTM="$(DWARVES_KIT_LOG_DIR="$TT" NO_COLOR=1 bash "$LT" render --mermaid 2>&1)"
-printf '%s' "$OUTM" | grep -qF '```mermaid'; ok "SPEC-110: render --mermaid emits a mermaid block" $?
-printf '%s' "$OUTM" | grep -qE 'lane_full.*1200 tok'; ok "SPEC-110: mermaid annotates the lane node with median tokens" $?
-printf '%s' "$OUTM" | grep -qF 'usage=?'; ok "SPEC-110: mermaid shows usage=? for the uncaptured lane" $?
+{ printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qF '```mermaid'; ok "SPEC-110: render --mermaid emits a mermaid block" $?
+{ printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qE 'lane_full.*1200 tok'; ok "SPEC-110: mermaid annotates the lane node with median tokens" $?
+{ printf '%s' "$OUTM" 2>/dev/null || :; } | grep -qF 'usage=?'; ok "SPEC-110: mermaid shows usage=? for the uncaptured lane" $?
 OUTA="$(DWARVES_KIT_LOG_DIR="$TT" NO_COLOR=1 bash "$LT" render 2>&1)"
-{ printf '%s' "$OUTA" | grep -q "Lane routing" && ! printf '%s' "$OUTA" | grep -qF '```mermaid'; }; ok "SPEC-110 NC: ASCII render unchanged (no mermaid block without the flag)" $?
+{ { printf '%s' "$OUTA" 2>/dev/null || :; } | grep -q "Lane routing" && ! { printf '%s' "$OUTA" 2>/dev/null || :; } | grep -qF '```mermaid'; }; ok "SPEC-110 NC: ASCII render unchanged (no mermaid block without the flag)" $?
 
 # --- graceful-empty NEGATIVE CONTROL: empty/fresh LOG_DIR ---
 OUTE="$(DWARVES_KIT_LOG_DIR="$(mktemp -d)/empty" NO_COLOR=1 bash "$LT" render 2>&1)"
 has "no runs recorded" "$OUTE"; ok "empty corpus renders an honest 'no runs recorded' [NC]" $?
-if printf '%s' "$OUTE" | grep -qiE 'error|not found|unbound|syntax'; then ok "empty render does not crash [NC]" 1; else ok "empty render does not crash [NC]" 0; fi
+if { printf '%s' "$OUTE" 2>/dev/null || :; } | grep -qiE 'error|not found|unbound|syntax'; then ok "empty render does not crash [NC]" 1; else ok "empty render does not crash [NC]" 0; fi
 
 # --- ID-398: failure-policy breakdown in `report` ---
 PD="$(mktemp -d)/logs"
@@ -103,12 +103,12 @@ DWARVES_KIT_LOG_DIR="$PD" bash "$GL" outcome pr2 build start >/dev/null 2>&1
 DWARVES_KIT_LOG_DIR="$PD" bash "$GL" outcome pr2 build end caught=false policy=continue >/dev/null 2>&1
 OUTP="$(DWARVES_KIT_LOG_DIR="$PD" NO_COLOR=1 bash "$LT" report 2>&1)"
 has "failure policy" "$OUTP"; ok "ID-398: report has a failure-policy section" $?
-printf '%s' "$OUTP" | grep -qE 'escalate[[:space:]]+1'; ok "ID-398: report counts an escalate outcome" $?
-printf '%s' "$OUTP" | grep -qE 'continue[[:space:]]+1'; ok "ID-398: report counts a continue outcome" $?
+{ printf '%s' "$OUTP" 2>/dev/null || :; } | grep -qE 'escalate[[:space:]]+1'; ok "ID-398: report counts an escalate outcome" $?
+{ printf '%s' "$OUTP" 2>/dev/null || :; } | grep -qE 'continue[[:space:]]+1'; ok "ID-398: report counts a continue outcome" $?
 
 # --- ID-398 NEGATIVE CONTROL: no policy= anywhere -> section omitted entirely ---
 OUTNP="$(NO_COLOR=1 bash "$LT" report 2>&1)"   # the seeded corpus at the top of this file has no policy= fields
-if printf '%s' "$OUTNP" | grep -qF "failure policy"; then ok "ID-398 NC: no policy-carrying runs -> section omitted" 1; else ok "ID-398 NC: no policy-carrying runs -> section omitted" 0; fi
+if { printf '%s' "$OUTNP" 2>/dev/null || :; } | grep -qF "failure policy"; then ok "ID-398 NC: no policy-carrying runs -> section omitted" 1; else ok "ID-398 NC: no policy-carrying runs -> section omitted" 0; fi
 
 echo ""
 echo "=== $PASS/$TOTAL passed, $FAIL failed ==="

--- a/tests/test-ledger-durability.sh
+++ b/tests/test-ledger-durability.sh
@@ -71,7 +71,7 @@ assert "AC2/AC8: seeded kit-harden corpus present at durable path after migratio
 rm -rf "$HH/.claude/dwarves-kit"
 REP="$(run "$LT" report 2>/dev/null)"; MIS="$(run "$LT" misfires 2>/dev/null)"
 [ ! -d "$HH/.claude/dwarves-kit" ]; assert "AC3 [NC]: legacy dir is gone (reinstall simulated)" $?
-printf '%s%s' "$REP" "$MIS" | grep -q "." ; assert "AC3 [NC]: lane-telemetry still reads records after the wipe" $?
+{ printf '%s%s' "$REP" "$MIS" 2>/dev/null || :; } | grep -q "." ; assert "AC3 [NC]: lane-telemetry still reads records after the wipe" $?
 [ -f "$DURABLE/runs/kit-harden-01-eff-val.log" ]; assert "AC3 [NC]: migrated corpus survives the wipe" $?
 
 # --- AC4a: idempotent (sentinel short-circuit) ---
@@ -135,7 +135,7 @@ bash "$GL" override ov think "shared blanket reason" >/dev/null 2>&1; assert "AC
 bash "$GL" override ov design "shared blanket reason" >/dev/null 2>&1
 [ $? -eq 65 ]; assert "AC6: blanket override (same reason, other gate) rejected exit 65" $?
 ERRTXT="$(bash "$GL" override ov build "shared blanket reason" 2>&1 >/dev/null)"
-printf '%s' "$ERRTXT" | grep -q "already used"; assert "AC6: rejection message names the duplicate" $?
+{ printf '%s' "$ERRTXT" 2>/dev/null || :; } | grep -q "already used"; assert "AC6: rejection message names the duplicate" $?
 bash "$GL" override ov design "a distinct design reason" >/dev/null 2>&1; assert "AC6: distinct per-gate reason accepted" $?
 
 # --- AC7: idempotent same-phase override allowed ---
@@ -157,7 +157,7 @@ bash "$GL" override inj design "$INJ" >/dev/null 2>&1 || true
 [ "$(wc -l < "$DWARVES_KIT_LOG_DIR/runs/inj.log")" -eq 1 ]; assert "SEC-1: reason newline collapsed to ONE ledger line" $?
 # capture-then-grep: check() exits 1 on missing gates, which pipefail would mask
 CHK="$(bash "$GL" check full inj 2>&1 || true)"
-printf '%s' "$CHK" | grep -q "MISSING-GATE: build"; assert "SEC-1: forged 'build | ran' does NOT satisfy check() (still reported missing)" $?
+{ printf '%s' "$CHK" 2>/dev/null || :; } | grep -q "MISSING-GATE: build"; assert "SEC-1: forged 'build | ran' does NOT satisfy check() (still reported missing)" $?
 unset DWARVES_KIT_LOG_DIR
 
 # --- SPEC-110: the tokens verb writes an ADDITIVE marker that check() IGNORES ---

--- a/tests/test-ledger-durability.sh
+++ b/tests/test-ledger-durability.sh
@@ -71,7 +71,7 @@ assert "AC2/AC8: seeded kit-harden corpus present at durable path after migratio
 rm -rf "$HH/.claude/dwarves-kit"
 REP="$(run "$LT" report 2>/dev/null)"; MIS="$(run "$LT" misfires 2>/dev/null)"
 [ ! -d "$HH/.claude/dwarves-kit" ]; assert "AC3 [NC]: legacy dir is gone (reinstall simulated)" $?
-{ printf '%s%s' "$REP" "$MIS" 2>/dev/null || :; } | grep -q "." ; assert "AC3 [NC]: lane-telemetry still reads records after the wipe" $?
+{ trap '' PIPE; printf '%s%s' "$REP" "$MIS" 2>/dev/null || :; } | grep -q "." ; assert "AC3 [NC]: lane-telemetry still reads records after the wipe" $?
 [ -f "$DURABLE/runs/kit-harden-01-eff-val.log" ]; assert "AC3 [NC]: migrated corpus survives the wipe" $?
 
 # --- AC4a: idempotent (sentinel short-circuit) ---
@@ -135,7 +135,7 @@ bash "$GL" override ov think "shared blanket reason" >/dev/null 2>&1; assert "AC
 bash "$GL" override ov design "shared blanket reason" >/dev/null 2>&1
 [ $? -eq 65 ]; assert "AC6: blanket override (same reason, other gate) rejected exit 65" $?
 ERRTXT="$(bash "$GL" override ov build "shared blanket reason" 2>&1 >/dev/null)"
-{ printf '%s' "$ERRTXT" 2>/dev/null || :; } | grep -q "already used"; assert "AC6: rejection message names the duplicate" $?
+{ trap '' PIPE; printf '%s' "$ERRTXT" 2>/dev/null || :; } | grep -q "already used"; assert "AC6: rejection message names the duplicate" $?
 bash "$GL" override ov design "a distinct design reason" >/dev/null 2>&1; assert "AC6: distinct per-gate reason accepted" $?
 
 # --- AC7: idempotent same-phase override allowed ---
@@ -157,7 +157,7 @@ bash "$GL" override inj design "$INJ" >/dev/null 2>&1 || true
 [ "$(wc -l < "$DWARVES_KIT_LOG_DIR/runs/inj.log")" -eq 1 ]; assert "SEC-1: reason newline collapsed to ONE ledger line" $?
 # capture-then-grep: check() exits 1 on missing gates, which pipefail would mask
 CHK="$(bash "$GL" check full inj 2>&1 || true)"
-{ printf '%s' "$CHK" 2>/dev/null || :; } | grep -q "MISSING-GATE: build"; assert "SEC-1: forged 'build | ran' does NOT satisfy check() (still reported missing)" $?
+{ trap '' PIPE; printf '%s' "$CHK" 2>/dev/null || :; } | grep -q "MISSING-GATE: build"; assert "SEC-1: forged 'build | ran' does NOT satisfy check() (still reported missing)" $?
 unset DWARVES_KIT_LOG_DIR
 
 # --- SPEC-110: the tokens verb writes an ADDITIVE marker that check() IGNORES ---

--- a/tests/test-ledger-substrate.sh
+++ b/tests/test-ledger-substrate.sh
@@ -41,7 +41,7 @@ if [ -z "$OUT" ] && [ "$rc" -eq 0 ]; then ok "missing stream -> empty, exit 0"; 
 
 echo "== NC empty-KIT_LEDGER_DIR: a set-but-empty root is a clean fatal error =="
 ERR="$(KIT_LEDGER_DIR="" bash "$LEDGER" append "runs/boom.log" "x" 2>&1)"; rc=$?
-if [ "$rc" -ne 0 ] && printf '%s' "$ERR" | grep -qi "empty"; then
+if [ "$rc" -ne 0 ] && { printf '%s' "$ERR" 2>/dev/null || :; } | grep -qi "empty"; then
   ok "empty KIT_LEDGER_DIR -> nonzero exit + a clear 'empty' error (not a silent relative write)"
 else
   bad "empty KIT_LEDGER_DIR should fatal cleanly (rc=$rc err='$ERR')"
@@ -66,7 +66,7 @@ RID="substrate-shared-test"
 KIT_LEDGER_DIR="$TMP5" bash "$GATE_LEDGER" record "$RID" build ran "wrote via gate-ledger" >/dev/null 2>&1
 # the substrate reads the same runs/<rid>.log gate-ledger wrote (rid slug = runid())
 SR="$(KIT_LEDGER_DIR="$TMP5" bash "$LEDGER" read "runs/$RID.log")"
-if printf '%s' "$SR" | grep -q "| GATE | build | ran |"; then
+if { printf '%s' "$SR" 2>/dev/null || :; } | grep -q "| GATE | build | ran |"; then
   ok "the GATE line gate-ledger wrote is readable through the substrate on the same root"
 else
   bad "shared-root broken: substrate read did not see gate-ledger's write (got '$SR')"

--- a/tests/test-ledger-substrate.sh
+++ b/tests/test-ledger-substrate.sh
@@ -41,7 +41,7 @@ if [ -z "$OUT" ] && [ "$rc" -eq 0 ]; then ok "missing stream -> empty, exit 0"; 
 
 echo "== NC empty-KIT_LEDGER_DIR: a set-but-empty root is a clean fatal error =="
 ERR="$(KIT_LEDGER_DIR="" bash "$LEDGER" append "runs/boom.log" "x" 2>&1)"; rc=$?
-if [ "$rc" -ne 0 ] && { printf '%s' "$ERR" 2>/dev/null || :; } | grep -qi "empty"; then
+if [ "$rc" -ne 0 ] && { trap '' PIPE; printf '%s' "$ERR" 2>/dev/null || :; } | grep -qi "empty"; then
   ok "empty KIT_LEDGER_DIR -> nonzero exit + a clear 'empty' error (not a silent relative write)"
 else
   bad "empty KIT_LEDGER_DIR should fatal cleanly (rc=$rc err='$ERR')"
@@ -66,7 +66,7 @@ RID="substrate-shared-test"
 KIT_LEDGER_DIR="$TMP5" bash "$GATE_LEDGER" record "$RID" build ran "wrote via gate-ledger" >/dev/null 2>&1
 # the substrate reads the same runs/<rid>.log gate-ledger wrote (rid slug = runid())
 SR="$(KIT_LEDGER_DIR="$TMP5" bash "$LEDGER" read "runs/$RID.log")"
-if { printf '%s' "$SR" 2>/dev/null || :; } | grep -q "| GATE | build | ran |"; then
+if { trap '' PIPE; printf '%s' "$SR" 2>/dev/null || :; } | grep -q "| GATE | build | ran |"; then
   ok "the GATE line gate-ledger wrote is readable through the substrate on the same root"
 else
   bad "shared-root broken: substrate read did not see gate-ledger's write (got '$SR')"

--- a/tests/test-mega-merge.sh
+++ b/tests/test-mega-merge.sh
@@ -17,7 +17,7 @@ US=$'\037'
 PASS=0; FAIL=0; TOTAL=0
 RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 ok() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
-has() { { printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$1"; }
+has() { { trap '' PIPE; printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$1"; }
 
 TMP="$(mktemp -d)"
 # injected gate-ledger stubs: one that passes, one that fails

--- a/tests/test-mega-merge.sh
+++ b/tests/test-mega-merge.sh
@@ -17,7 +17,7 @@ US=$'\037'
 PASS=0; FAIL=0; TOTAL=0
 RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 ok() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi; }
-has() { printf '%s' "$2" | grep -qF -- "$1"; }
+has() { { printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$1"; }
 
 TMP="$(mktemp -d)"
 # injected gate-ledger stubs: one that passes, one that fails

--- a/tests/test-mega-reconcile.sh
+++ b/tests/test-mega-reconcile.sh
@@ -20,7 +20,7 @@ assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${
 assert_contains() {
   local name="$1" needle="$2" haystack="$3"
   TOTAL=$((TOTAL+1))
-  if { printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
+  if { trap '' PIPE; printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
     echo -e "  ${GREEN}PASS${NC} $name"; PASS=$((PASS+1))
   else
     echo -e "  ${RED}FAIL${NC} $name"; FAIL=$((FAIL+1))

--- a/tests/test-mega-reconcile.sh
+++ b/tests/test-mega-reconcile.sh
@@ -20,7 +20,7 @@ assert() { TOTAL=$((TOTAL+1)); if [ "$2" -eq 0 ]; then echo -e "  ${GREEN}PASS${
 assert_contains() {
   local name="$1" needle="$2" haystack="$3"
   TOTAL=$((TOTAL+1))
-  if printf '%s' "$haystack" | grep -qF "$needle"; then
+  if { printf '%s' "$haystack" 2>/dev/null || :; } | grep -qF "$needle"; then
     echo -e "  ${GREEN}PASS${NC} $name"; PASS=$((PASS+1))
   else
     echo -e "  ${RED}FAIL${NC} $name"; FAIL=$((FAIL+1))

--- a/tests/test-mega.sh
+++ b/tests/test-mega.sh
@@ -216,13 +216,13 @@ cat > "$BOARDREPO/_meta/BACKLOG.md" <<'BOARDMD'
 BOARDMD
 
 WITH_MEGA_OUT="$(GH_BIN="$STUBGH" bash "$BOARD_SH" board --with-mega --mega-code-root "$CODEROOT" --backlog-file "$BOARDREPO/_meta/BACKLOG.md" 2>&1)"
-if printf '%s\n' "$WITH_MEGA_OUT" | grep -qF "testmega: 1/8 ok  ⚠ 3 drift"; then
+if { printf '%s\n' "$WITH_MEGA_OUT" 2>/dev/null || :; } | grep -qF "testmega: 1/8 ok  ⚠ 3 drift"; then
   ok "board board --with-mega surfaces the mega rollup in a trailing MEGA ROLLUP section"
 else
   no "board --with-mega did not surface the rollup: $WITH_MEGA_OUT"
 fi
 WITHOUT_MEGA_OUT="$(bash "$BOARD_SH" board --backlog-file "$BOARDREPO/_meta/BACKLOG.md" 2>&1)"
-if ! printf '%s\n' "$WITHOUT_MEGA_OUT" | grep -q "MEGA ROLLUP"; then
+if ! { printf '%s\n' "$WITHOUT_MEGA_OUT" 2>/dev/null || :; } | grep -q "MEGA ROLLUP"; then
   ok "board board WITHOUT --with-mega never touches gh / never prints a rollup (opt-in, non-regressing default)"
 else
   no "board board without --with-mega should not print a MEGA ROLLUP section"

--- a/tests/test-mega.sh
+++ b/tests/test-mega.sh
@@ -216,13 +216,13 @@ cat > "$BOARDREPO/_meta/BACKLOG.md" <<'BOARDMD'
 BOARDMD
 
 WITH_MEGA_OUT="$(GH_BIN="$STUBGH" bash "$BOARD_SH" board --with-mega --mega-code-root "$CODEROOT" --backlog-file "$BOARDREPO/_meta/BACKLOG.md" 2>&1)"
-if { printf '%s\n' "$WITH_MEGA_OUT" 2>/dev/null || :; } | grep -qF "testmega: 1/8 ok  ⚠ 3 drift"; then
+if { trap '' PIPE; printf '%s\n' "$WITH_MEGA_OUT" 2>/dev/null || :; } | grep -qF "testmega: 1/8 ok  ⚠ 3 drift"; then
   ok "board board --with-mega surfaces the mega rollup in a trailing MEGA ROLLUP section"
 else
   no "board --with-mega did not surface the rollup: $WITH_MEGA_OUT"
 fi
 WITHOUT_MEGA_OUT="$(bash "$BOARD_SH" board --backlog-file "$BOARDREPO/_meta/BACKLOG.md" 2>&1)"
-if ! { printf '%s\n' "$WITHOUT_MEGA_OUT" 2>/dev/null || :; } | grep -q "MEGA ROLLUP"; then
+if ! { trap '' PIPE; printf '%s\n' "$WITHOUT_MEGA_OUT" 2>/dev/null || :; } | grep -q "MEGA ROLLUP"; then
   ok "board board WITHOUT --with-mega never touches gh / never prints a rollup (opt-in, non-regressing default)"
 else
   no "board board without --with-mega should not print a MEGA ROLLUP section"

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -816,7 +816,7 @@ fi
 # check to the description line itself so it is not vacuously satisfied by Step 2's own text.
 TOTAL=$((TOTAL + 1))
 TPRT_DESC_LINE=$(grep -m1 '^description:' "$TPRT_CMD" 2>/dev/null || true)
-if { printf '%s' "$TPRT_DESC_LINE" 2>/dev/null || :; } | grep -qF '6 test-design lenses'; then
+if { trap '' PIPE; printf '%s' "$TPRT_DESC_LINE" 2>/dev/null || :; } | grep -qF '6 test-design lenses'; then
   echo -e "  ${GREEN}PASS${NC} test-plan-review-team.md frontmatter description says '6 test-design lenses' (SPEC-201 AC3)"
   PASS=$((PASS + 1))
 else
@@ -2216,7 +2216,7 @@ fi
 # (d) The State model section names BOTH stores side by side (draft + registry).
 SM_SECTION=$(awk '/^## State model/{f=1; print; next} f && /^## /{exit} f{print}' "$KIT_DIR/docs/architecture.md" 2>/dev/null)
 TOTAL=$((TOTAL + 1))
-if { printf '%s' "$SM_SECTION" 2>/dev/null || :; } | grep -q '\.claude/goals' && { printf '%s' "$SM_SECTION" 2>/dev/null || :; } | grep -q 'kit-goals'; then
+if { trap '' PIPE; printf '%s' "$SM_SECTION" 2>/dev/null || :; } | grep -q '\.claude/goals' && { trap '' PIPE; printf '%s' "$SM_SECTION" 2>/dev/null || :; } | grep -q 'kit-goals'; then
   echo -e "  ${GREEN}PASS${NC} architecture.md State model names both the draft store and kit-goals registry (SPEC-037)"
   PASS=$((PASS + 1))
 else
@@ -2507,9 +2507,9 @@ done
 
 CONTRACT_OUT="$(bash "$KIT_DIR/lib/gate/proof-gate.sh" contract 'build a CLI to pull data from the API' 2>/dev/null)"
 assert_true "proof-gate contract names the data-tool type" \
-  "$({ printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -q 'type=data-tool' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -q 'type=data-tool' && echo 0 || echo 1)"
 assert_true "proof-gate contract names the recorded-run artifact + owning skill" \
-  "$({ printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -qi 'recorded live run' && { printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -qi 'ops-tool-shape' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -qi 'recorded live run' && { trap '' PIPE; printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -qi 'ops-tool-shape' && echo 0 || echo 1)"
 assert_true "proof-gate contract upgrades a migration to stateful (class wins on rigor)" \
   "$(bash "$KIT_DIR/lib/gate/proof-gate.sh" contract 'migrate the database schema' 2>/dev/null | grep -q 'class=stateful' && echo 0 || echo 1)"
 

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -816,7 +816,7 @@ fi
 # check to the description line itself so it is not vacuously satisfied by Step 2's own text.
 TOTAL=$((TOTAL + 1))
 TPRT_DESC_LINE=$(grep -m1 '^description:' "$TPRT_CMD" 2>/dev/null || true)
-if printf '%s' "$TPRT_DESC_LINE" | grep -qF '6 test-design lenses'; then
+if { printf '%s' "$TPRT_DESC_LINE" 2>/dev/null || :; } | grep -qF '6 test-design lenses'; then
   echo -e "  ${GREEN}PASS${NC} test-plan-review-team.md frontmatter description says '6 test-design lenses' (SPEC-201 AC3)"
   PASS=$((PASS + 1))
 else
@@ -2216,7 +2216,7 @@ fi
 # (d) The State model section names BOTH stores side by side (draft + registry).
 SM_SECTION=$(awk '/^## State model/{f=1; print; next} f && /^## /{exit} f{print}' "$KIT_DIR/docs/architecture.md" 2>/dev/null)
 TOTAL=$((TOTAL + 1))
-if printf '%s' "$SM_SECTION" | grep -q '\.claude/goals' && printf '%s' "$SM_SECTION" | grep -q 'kit-goals'; then
+if { printf '%s' "$SM_SECTION" 2>/dev/null || :; } | grep -q '\.claude/goals' && { printf '%s' "$SM_SECTION" 2>/dev/null || :; } | grep -q 'kit-goals'; then
   echo -e "  ${GREEN}PASS${NC} architecture.md State model names both the draft store and kit-goals registry (SPEC-037)"
   PASS=$((PASS + 1))
 else
@@ -2507,9 +2507,9 @@ done
 
 CONTRACT_OUT="$(bash "$KIT_DIR/lib/gate/proof-gate.sh" contract 'build a CLI to pull data from the API' 2>/dev/null)"
 assert_true "proof-gate contract names the data-tool type" \
-  "$(printf '%s' "$CONTRACT_OUT" | grep -q 'type=data-tool' && echo 0 || echo 1)"
+  "$({ printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -q 'type=data-tool' && echo 0 || echo 1)"
 assert_true "proof-gate contract names the recorded-run artifact + owning skill" \
-  "$(printf '%s' "$CONTRACT_OUT" | grep -qi 'recorded live run' && printf '%s' "$CONTRACT_OUT" | grep -qi 'ops-tool-shape' && echo 0 || echo 1)"
+  "$({ printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -qi 'recorded live run' && { printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -qi 'ops-tool-shape' && echo 0 || echo 1)"
 assert_true "proof-gate contract upgrades a migration to stateful (class wins on rigor)" \
   "$(bash "$KIT_DIR/lib/gate/proof-gate.sh" contract 'migrate the database schema' 2>/dev/null | grep -q 'class=stateful' && echo 0 || echo 1)"
 

--- a/tests/test-mutation-smoke.sh
+++ b/tests/test-mutation-smoke.sh
@@ -21,8 +21,8 @@ GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
 PASS=0; FAIL=0; TOTAL=0
 ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
-expect()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
-refute()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
+expect()  { if { trap '' PIPE; printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+refute()  { if { trap '' PIPE; printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
 eq()      { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
 
 TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/kit-mut-smoke.XXXXXX")"

--- a/tests/test-mutation-smoke.sh
+++ b/tests/test-mutation-smoke.sh
@@ -21,8 +21,8 @@ GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
 PASS=0; FAIL=0; TOTAL=0
 ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
-expect()  { if printf '%s' "$3" | grep -qF "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
-refute()  { if printf '%s' "$3" | grep -qF "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
+expect()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+refute()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
 eq()      { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
 
 TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/kit-mut-smoke.XXXXXX")"

--- a/tests/test-orchestrate-gate-dispatch.sh
+++ b/tests/test-orchestrate-gate-dispatch.sh
@@ -256,11 +256,11 @@ rc=0; run_gate_fixture "$DG5" "$TMP/b5.out" WAVE_CAP=2 || rc=$?
 # --- B6: --dry-run names the dispatch-then-hold plan ---
 DG6="$TMP/mg-gate-dry"; mk_megagoal "$DG6"
 out=$(bash "$ORCH" run "$DG6" --dry-run 2>&1)
-printf '%s' "$out" | grep -q 'SG-02 (gate, dispatch then hold for human merge)' \
+{ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'SG-02 (gate, dispatch then hold for human merge)' \
   && pass "B6: dry-run plan says 'gate, dispatch then hold for human merge'" \
   || { fail "B6: dry-run plan wrong"; printf '%s\n' "$out"; }
 out=$(MEGA_GATE_DISPATCH=0 bash "$ORCH" run "$DG6" --dry-run 2>&1)
-printf '%s' "$out" | grep -q 'SG-02 (gate)' \
+{ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'SG-02 (gate)' \
   && pass "B6 (neg control): MEGA_GATE_DISPATCH=0 dry-run keeps the plain '(gate)' label" \
   || { fail "B6 neg control wrong"; printf '%s\n' "$out"; }
 

--- a/tests/test-orchestrate-gate-dispatch.sh
+++ b/tests/test-orchestrate-gate-dispatch.sh
@@ -256,11 +256,11 @@ rc=0; run_gate_fixture "$DG5" "$TMP/b5.out" WAVE_CAP=2 || rc=$?
 # --- B6: --dry-run names the dispatch-then-hold plan ---
 DG6="$TMP/mg-gate-dry"; mk_megagoal "$DG6"
 out=$(bash "$ORCH" run "$DG6" --dry-run 2>&1)
-{ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'SG-02 (gate, dispatch then hold for human merge)' \
+{ trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q 'SG-02 (gate, dispatch then hold for human merge)' \
   && pass "B6: dry-run plan says 'gate, dispatch then hold for human merge'" \
   || { fail "B6: dry-run plan wrong"; printf '%s\n' "$out"; }
 out=$(MEGA_GATE_DISPATCH=0 bash "$ORCH" run "$DG6" --dry-run 2>&1)
-{ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'SG-02 (gate)' \
+{ trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q 'SG-02 (gate)' \
   && pass "B6 (neg control): MEGA_GATE_DISPATCH=0 dry-run keeps the plain '(gate)' label" \
   || { fail "B6 neg control wrong"; printf '%s\n' "$out"; }
 

--- a/tests/test-orchestrate-wavefront.sh
+++ b/tests/test-orchestrate-wavefront.sh
@@ -882,7 +882,7 @@ _sg_dependents "$HB/ROADMAP.md" SG-04 && fail "edge a: SG-04 (leaf) should have 
 
 # (a) WRITE side: SG-01's prompt tells it to overwrite the per-edge HANDOFF-SG-01.md.
 p01=$(_build_prompt "$HB" SG-01)
-printf '%s' "$p01" | grep -q 'overwrite HANDOFF-SG-01.md with' \
+{ printf '%s' "$p01" 2>/dev/null || :; } | grep -q 'overwrite HANDOFF-SG-01.md with' \
   && pass "edge a: SG-01 (has dependents) write-target is HANDOFF-SG-01.md" \
   || { fail "edge a: SG-01 write-target not per-edge"; printf '%s\n' "$p01" | grep -i overwrite; }
 
@@ -890,7 +890,7 @@ printf '%s' "$p01" | grep -q 'overwrite HANDOFF-SG-01.md with' \
 printf 'HOTFEED-FROM-SG02-unique\n' > "$HB/HANDOFF-SG-02.md"
 printf 'HOTFEED-FROM-SG03-unique\n' > "$HB/HANDOFF-SG-03.md"
 p04=$(_build_prompt "$HB" SG-04)
-{ printf '%s' "$p04" | grep -q 'HOTFEED-FROM-SG02-unique' && printf '%s' "$p04" | grep -q 'HOTFEED-FROM-SG03-unique'; } \
+{ { printf '%s' "$p04" 2>/dev/null || :; } | grep -q 'HOTFEED-FROM-SG02-unique' && { printf '%s' "$p04" 2>/dev/null || :; } | grep -q 'HOTFEED-FROM-SG03-unique'; } \
   && pass "edge a: SG-04 prompt injects BOTH dep-parent handoffs (HANDOFF-SG-02 + HANDOFF-SG-03)" \
   || { fail "edge a: SG-04 missing a parent handoff"; printf '%s\n' "$p04"; }
 
@@ -907,7 +907,7 @@ echo "POINTER: resume" > "$HFB/POINTER_PROMPT.md"
 make_goal "$HFB" SG-01; make_goal "$HFB" SG-02
 printf 'PLAIN-HANDOFF-fallback-unique\n' > "$HFB/HANDOFF.md"   # parent wrote plain; no HANDOFF-SG-01.md
 pfb=$(_build_prompt "$HFB" SG-02)
-printf '%s' "$pfb" | grep -q 'PLAIN-HANDOFF-fallback-unique' \
+{ printf '%s' "$pfb" 2>/dev/null || :; } | grep -q 'PLAIN-HANDOFF-fallback-unique' \
   && pass "edge b: absent per-edge file -> child falls back to plain HANDOFF.md" \
   || { fail "edge b: fallback lost the plain handoff"; printf '%s\n' "$pfb"; }
 
@@ -923,9 +923,9 @@ echo "POINTER: resume" > "$HLN/POINTER_PROMPT.md"
 make_goal "$HLN" SG-01; make_goal "$HLN" SG-02
 printf 'PLAIN-LINEAR-unique\n' > "$HLN/HANDOFF.md"
 pln=$(_build_prompt "$HLN" SG-02)
-{ printf '%s' "$pln" | grep -q 'PLAIN-LINEAR-unique' \
-  && printf '%s' "$pln" | grep -q 'overwrite HANDOFF.md with' \
-  && ! printf '%s' "$pln" | grep -q 'HANDOFF-SG'; } \
+{ { printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'PLAIN-LINEAR-unique' \
+  && { printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'overwrite HANDOFF.md with' \
+  && ! { printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'HANDOFF-SG'; } \
   && pass "edge c: linear/no-deps writes+reads plain HANDOFF.md (no per-edge filename)" \
   || { fail "edge c: linear path not plain"; printf '%s\n' "$pln"; }
 

--- a/tests/test-orchestrate-wavefront.sh
+++ b/tests/test-orchestrate-wavefront.sh
@@ -882,7 +882,7 @@ _sg_dependents "$HB/ROADMAP.md" SG-04 && fail "edge a: SG-04 (leaf) should have 
 
 # (a) WRITE side: SG-01's prompt tells it to overwrite the per-edge HANDOFF-SG-01.md.
 p01=$(_build_prompt "$HB" SG-01)
-{ printf '%s' "$p01" 2>/dev/null || :; } | grep -q 'overwrite HANDOFF-SG-01.md with' \
+{ trap '' PIPE; printf '%s' "$p01" 2>/dev/null || :; } | grep -q 'overwrite HANDOFF-SG-01.md with' \
   && pass "edge a: SG-01 (has dependents) write-target is HANDOFF-SG-01.md" \
   || { fail "edge a: SG-01 write-target not per-edge"; printf '%s\n' "$p01" | grep -i overwrite; }
 
@@ -890,7 +890,7 @@ p01=$(_build_prompt "$HB" SG-01)
 printf 'HOTFEED-FROM-SG02-unique\n' > "$HB/HANDOFF-SG-02.md"
 printf 'HOTFEED-FROM-SG03-unique\n' > "$HB/HANDOFF-SG-03.md"
 p04=$(_build_prompt "$HB" SG-04)
-{ { printf '%s' "$p04" 2>/dev/null || :; } | grep -q 'HOTFEED-FROM-SG02-unique' && { printf '%s' "$p04" 2>/dev/null || :; } | grep -q 'HOTFEED-FROM-SG03-unique'; } \
+{ { trap '' PIPE; printf '%s' "$p04" 2>/dev/null || :; } | grep -q 'HOTFEED-FROM-SG02-unique' && { trap '' PIPE; printf '%s' "$p04" 2>/dev/null || :; } | grep -q 'HOTFEED-FROM-SG03-unique'; } \
   && pass "edge a: SG-04 prompt injects BOTH dep-parent handoffs (HANDOFF-SG-02 + HANDOFF-SG-03)" \
   || { fail "edge a: SG-04 missing a parent handoff"; printf '%s\n' "$p04"; }
 
@@ -907,7 +907,7 @@ echo "POINTER: resume" > "$HFB/POINTER_PROMPT.md"
 make_goal "$HFB" SG-01; make_goal "$HFB" SG-02
 printf 'PLAIN-HANDOFF-fallback-unique\n' > "$HFB/HANDOFF.md"   # parent wrote plain; no HANDOFF-SG-01.md
 pfb=$(_build_prompt "$HFB" SG-02)
-{ printf '%s' "$pfb" 2>/dev/null || :; } | grep -q 'PLAIN-HANDOFF-fallback-unique' \
+{ trap '' PIPE; printf '%s' "$pfb" 2>/dev/null || :; } | grep -q 'PLAIN-HANDOFF-fallback-unique' \
   && pass "edge b: absent per-edge file -> child falls back to plain HANDOFF.md" \
   || { fail "edge b: fallback lost the plain handoff"; printf '%s\n' "$pfb"; }
 
@@ -923,9 +923,9 @@ echo "POINTER: resume" > "$HLN/POINTER_PROMPT.md"
 make_goal "$HLN" SG-01; make_goal "$HLN" SG-02
 printf 'PLAIN-LINEAR-unique\n' > "$HLN/HANDOFF.md"
 pln=$(_build_prompt "$HLN" SG-02)
-{ { printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'PLAIN-LINEAR-unique' \
-  && { printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'overwrite HANDOFF.md with' \
-  && ! { printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'HANDOFF-SG'; } \
+{ { trap '' PIPE; printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'PLAIN-LINEAR-unique' \
+  && { trap '' PIPE; printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'overwrite HANDOFF.md with' \
+  && ! { trap '' PIPE; printf '%s' "$pln" 2>/dev/null || :; } | grep -q 'HANDOFF-SG'; } \
   && pass "edge c: linear/no-deps writes+reads plain HANDOFF.md (no per-edge filename)" \
   || { fail "edge c: linear path not plain"; printf '%s\n' "$pln"; }
 

--- a/tests/test-outcome-emit-sweep.sh
+++ b/tests/test-outcome-emit-sweep.sh
@@ -127,10 +127,10 @@ FIXTURE_OUT="$(manifest_diff_by_phase "$FIXTURE_DIR" "*.md" "$SITE_PATTERN" "$CO
 FIXTURE_RC=$?
 assert_eq "the sweep flags exactly 1 orphan in the fixture dir (the unbracketed fixture)" "$FIXTURE_RC" "1"
 
-if printf '%s\n' "$FIXTURE_OUT" | grep -qF "ORPHAN: fixture-unbracketed.md (fixture-phase)"; then RC=0; else RC=1; fi
+if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: fixture-unbracketed.md (fixture-phase)"; then RC=0; else RC=1; fi
 assert "the flagged orphan is specifically fixture-unbracketed.md (fixture-phase)" $RC
 
-if printf '%s\n' "$FIXTURE_OUT" | grep -q "ORPHAN: think.md"; then RC=1; else RC=0; fi
+if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: think.md"; then RC=1; else RC=0; fi
 assert "the legit bracketed copy (think.md) is NOT flagged" $RC
 
 echo ""
@@ -144,7 +144,7 @@ WITHOUT_OUT="$(manifest_diff_by_phase "$COMMANDS_DIR" "*.md" "$SITE_PATTERN" "$C
 WITHOUT_RC=$?
 RC=1; [ "$WITHOUT_RC" -ge 1 ] && RC=0
 assert "removing the 'ship' exemption alone makes the sweep flag >=1 new orphan (ship.md)" "$RC"
-if printf '%s\n' "$WITHOUT_OUT" | grep -qF "ORPHAN: ship.md (Ship)"; then RC=0; else RC=1; fi
+if { printf '%s\n' "$WITHOUT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: ship.md (Ship)"; then RC=0; else RC=1; fi
 assert "...and that orphan is specifically ship.md (Ship)" $RC
 
 echo ""

--- a/tests/test-outcome-emit-sweep.sh
+++ b/tests/test-outcome-emit-sweep.sh
@@ -127,10 +127,10 @@ FIXTURE_OUT="$(manifest_diff_by_phase "$FIXTURE_DIR" "*.md" "$SITE_PATTERN" "$CO
 FIXTURE_RC=$?
 assert_eq "the sweep flags exactly 1 orphan in the fixture dir (the unbracketed fixture)" "$FIXTURE_RC" "1"
 
-if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: fixture-unbracketed.md (fixture-phase)"; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: fixture-unbracketed.md (fixture-phase)"; then RC=0; else RC=1; fi
 assert "the flagged orphan is specifically fixture-unbracketed.md (fixture-phase)" $RC
 
-if { printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: think.md"; then RC=1; else RC=0; fi
+if { trap '' PIPE; printf '%s\n' "$FIXTURE_OUT" 2>/dev/null || :; } | grep -q "ORPHAN: think.md"; then RC=1; else RC=0; fi
 assert "the legit bracketed copy (think.md) is NOT flagged" $RC
 
 echo ""
@@ -144,7 +144,7 @@ WITHOUT_OUT="$(manifest_diff_by_phase "$COMMANDS_DIR" "*.md" "$SITE_PATTERN" "$C
 WITHOUT_RC=$?
 RC=1; [ "$WITHOUT_RC" -ge 1 ] && RC=0
 assert "removing the 'ship' exemption alone makes the sweep flag >=1 new orphan (ship.md)" "$RC"
-if { printf '%s\n' "$WITHOUT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: ship.md (Ship)"; then RC=0; else RC=1; fi
+if { trap '' PIPE; printf '%s\n' "$WITHOUT_OUT" 2>/dev/null || :; } | grep -qF "ORPHAN: ship.md (Ship)"; then RC=0; else RC=1; fi
 assert "...and that orphan is specifically ship.md (Ship)" $RC
 
 echo ""

--- a/tests/test-pane-viewer.sh
+++ b/tests/test-pane-viewer.sh
@@ -262,7 +262,7 @@ fi
 # ============================ T9: allowlist pre-flight rejection ============================
 F=$(mk_mega "$TMP/repo-f")
 out=$(PANE_VIEWER=bogus bash "$ORCH" run "$F" --dry-run 2>&1); frc=$?
-if [ "$frc" = 64 ] && { printf '%s' "$out" 2>/dev/null || :; } | grep -q 'PANE_VIEWER must be one of: auto|cmux|kitty|wezterm|ghostty|iterm|terminal|none'; then
+if [ "$frc" = 64 ] && { trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q 'PANE_VIEWER must be one of: auto|cmux|kitty|wezterm|ghostty|iterm|terminal|none'; then
   pass "T9 allowlist: unknown PANE_VIEWER rejected at pre-flight (rc 64) naming the allowed set"
 else
   fail "T9 allowlist: rc=$frc, out: $out"
@@ -318,7 +318,7 @@ v=$(viewer_argv ghostty orch-vg)
 v=$(viewer_argv iterm orch-vi)
 case "$v" in
   osascript\ -e\ on\ run\ argv*iTerm*"end run orch-vi")
-    if { printf '%s' "$v" 2>/dev/null || :; } | grep -q 'attach -t orch-vi'; then
+    if { trap '' PIPE; printf '%s' "$v" 2>/dev/null || :; } | grep -q 'attach -t orch-vi'; then
       fail "T10b iterm: session name SPLICED into the AppleScript source: '$v'"
     else
       pass "T10b iterm: osascript gets the session name as a trailing argv item, never spliced into the source"
@@ -328,7 +328,7 @@ esac
 v=$(viewer_argv terminal orch-vt)
 case "$v" in
   osascript\ -e\ on\ run\ argv*Terminal*"end run orch-vt")
-    if { printf '%s' "$v" 2>/dev/null || :; } | grep -q 'attach -t orch-vt'; then
+    if { trap '' PIPE; printf '%s' "$v" 2>/dev/null || :; } | grep -q 'attach -t orch-vt'; then
       fail "T10b terminal: session name SPLICED into the AppleScript source: '$v'"
     else
       pass "T10b terminal: osascript gets the session name as a trailing argv item, never spliced into the source"

--- a/tests/test-pane-viewer.sh
+++ b/tests/test-pane-viewer.sh
@@ -262,7 +262,7 @@ fi
 # ============================ T9: allowlist pre-flight rejection ============================
 F=$(mk_mega "$TMP/repo-f")
 out=$(PANE_VIEWER=bogus bash "$ORCH" run "$F" --dry-run 2>&1); frc=$?
-if [ "$frc" = 64 ] && printf '%s' "$out" | grep -q 'PANE_VIEWER must be one of: auto|cmux|kitty|wezterm|ghostty|iterm|terminal|none'; then
+if [ "$frc" = 64 ] && { printf '%s' "$out" 2>/dev/null || :; } | grep -q 'PANE_VIEWER must be one of: auto|cmux|kitty|wezterm|ghostty|iterm|terminal|none'; then
   pass "T9 allowlist: unknown PANE_VIEWER rejected at pre-flight (rc 64) naming the allowed set"
 else
   fail "T9 allowlist: rc=$frc, out: $out"
@@ -318,7 +318,7 @@ v=$(viewer_argv ghostty orch-vg)
 v=$(viewer_argv iterm orch-vi)
 case "$v" in
   osascript\ -e\ on\ run\ argv*iTerm*"end run orch-vi")
-    if printf '%s' "$v" | grep -q 'attach -t orch-vi'; then
+    if { printf '%s' "$v" 2>/dev/null || :; } | grep -q 'attach -t orch-vi'; then
       fail "T10b iterm: session name SPLICED into the AppleScript source: '$v'"
     else
       pass "T10b iterm: osascript gets the session name as a trailing argv item, never spliced into the source"
@@ -328,7 +328,7 @@ esac
 v=$(viewer_argv terminal orch-vt)
 case "$v" in
   osascript\ -e\ on\ run\ argv*Terminal*"end run orch-vt")
-    if printf '%s' "$v" | grep -q 'attach -t orch-vt'; then
+    if { printf '%s' "$v" 2>/dev/null || :; } | grep -q 'attach -t orch-vt'; then
       fail "T10b terminal: session name SPLICED into the AppleScript source: '$v'"
     else
       pass "T10b terminal: osascript gets the session name as a trailing argv item, never spliced into the source"

--- a/tests/test-pitch.sh
+++ b/tests/test-pitch.sh
@@ -84,45 +84,45 @@ assert "AC1 outcome section names the real spec (SPEC-139-kit-emit-sweep)" \
 # weakening what it proves.
 OUT_REAL_SAMPLE="$(_render_with_origin real-sample)"
 assert "AC1 evidence section carries a real PR link (#168)" \
-  "$({ printf '%s' "$OUT_REAL_SAMPLE" 2>/dev/null || :; } | grep -q 'pull/168' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_REAL_SAMPLE" 2>/dev/null || :; } | grep -q 'pull/168' && echo 0 || echo 1)"
 assert "AC1 unknowns section surfaces the real grill skip (reason=operator-wave)" \
-  "$({ printf '%s' "$OUT_REAL_SAMPLE" 2>/dev/null || :; } | grep -q 'reason=operator-wave' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_REAL_SAMPLE" 2>/dev/null || :; } | grep -q 'reason=operator-wave' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC2 + AC4a: grill record -- NO-grill fixture (load-bearing) vs full fixture (contrast) ==="
 OUT_NOGRILL="$(_render no-grill)"
 OUT_FULL="$(_render full)"
 assert "AC2 no-grill fixture prints the literal absence line" \
-  "$({ printf '%s' "$OUT_NOGRILL" 2>/dev/null || :; } | grep -qF 'no grill record for this run' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_NOGRILL" 2>/dev/null || :; } | grep -qF 'no grill record for this run' && echo 0 || echo 1)"
 assert "AC2 no-grill fixture never fabricates a grill answer (no 'branches resolved' text)" \
-  "$({ printf '%s' "$OUT_NOGRILL" 2>/dev/null || :; } | grep -q 'branches resolved' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_NOGRILL" 2>/dev/null || :; } | grep -q 'branches resolved' && echo 1 || echo 0)"
 assert "AC4a full fixture does NOT print the grill absence line" \
-  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qF 'no grill record for this run' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qF 'no grill record for this run' && echo 1 || echo 0)"
 assert "AC4a full fixture DOES surface its real grill content" \
-  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'branches resolved' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'branches resolved' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC3 + AC4b: implementation-notes -- NO-implnotes fixture (load-bearing) vs full fixture ==="
 OUT_NOTES="$(_render no-implnotes)"
 assert "AC3 no-implnotes fixture prints the literal absence line" \
-  "$({ printf '%s' "$OUT_NOTES" 2>/dev/null || :; } | grep -qF 'no implementation-notes file for this run' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_NOTES" 2>/dev/null || :; } | grep -qF 'no implementation-notes file for this run' && echo 0 || echo 1)"
 assert "AC3 no-implnotes fixture never fabricates a deviation (no 'fixture deviation' text)" \
-  "$({ printf '%s' "$OUT_NOTES" 2>/dev/null || :; } | grep -q 'fixture deviation' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_NOTES" 2>/dev/null || :; } | grep -q 'fixture deviation' && echo 1 || echo 0)"
 assert "AC4b full fixture does NOT print the implementation-notes absence line" \
-  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qF 'no implementation-notes file for this run' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qF 'no implementation-notes file for this run' && echo 1 || echo 0)"
 assert "AC4b full fixture DOES surface its real deviation entries (both of them)" \
   "$([ "$(printf '%s' "$OUT_FULL" | grep -c 'fixture deviation')" -eq 2 ] && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC4c: negative controls + evidence + cost sections, full fixture ==="
 assert "AC4c unknowns section surfaces the proof's negative control" \
-  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qi 'negative control' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qi 'negative control' && echo 0 || echo 1)"
 assert "AC4c evidence section carries the verbatim acceptance-criteria table" \
-  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'fixture thing happens' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'fixture thing happens' && echo 0 || echo 1)"
 assert "AC4c cost section surfaces the spec's Out of Scope block" \
-  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'fixture-feature-x' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'fixture-feature-x' && echo 0 || echo 1)"
 assert "AC4c ask section is always emitted (pure template, no source to miss)" \
-  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qi 'approve' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qi 'approve' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC5: NEVER-AUTO-POST (load-bearing) -- grep negative control ==="
@@ -183,7 +183,7 @@ _would_offer() {  # <fixture-name> <gh-stub-mode>
   local name="$1" mode="$2" ws last
   ws="$(_mkws "$name")"
   last="$(cd "$ws" && DWARVES_KIT_LOG_DIR="$ws/logs" bash "$LEDGER" show "$name" | grep '| DEBT |' | tail -1)"
-  if { printf '%s' "$last" 2>/dev/null || :; } | grep -q 'significance=high' \
+  if { trap '' PIPE; printf '%s' "$last" 2>/dev/null || :; } | grep -q 'significance=high' \
      && PATH="$FAKEBIN:$PATH" GH_STUB_MODE="$mode" bash "$LIB" team-shared >/dev/null 2>&1; then
     echo yes
   else

--- a/tests/test-pitch.sh
+++ b/tests/test-pitch.sh
@@ -84,45 +84,45 @@ assert "AC1 outcome section names the real spec (SPEC-139-kit-emit-sweep)" \
 # weakening what it proves.
 OUT_REAL_SAMPLE="$(_render_with_origin real-sample)"
 assert "AC1 evidence section carries a real PR link (#168)" \
-  "$(printf '%s' "$OUT_REAL_SAMPLE" | grep -q 'pull/168' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_REAL_SAMPLE" 2>/dev/null || :; } | grep -q 'pull/168' && echo 0 || echo 1)"
 assert "AC1 unknowns section surfaces the real grill skip (reason=operator-wave)" \
-  "$(printf '%s' "$OUT_REAL_SAMPLE" | grep -q 'reason=operator-wave' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_REAL_SAMPLE" 2>/dev/null || :; } | grep -q 'reason=operator-wave' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC2 + AC4a: grill record -- NO-grill fixture (load-bearing) vs full fixture (contrast) ==="
 OUT_NOGRILL="$(_render no-grill)"
 OUT_FULL="$(_render full)"
 assert "AC2 no-grill fixture prints the literal absence line" \
-  "$(printf '%s' "$OUT_NOGRILL" | grep -qF 'no grill record for this run' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_NOGRILL" 2>/dev/null || :; } | grep -qF 'no grill record for this run' && echo 0 || echo 1)"
 assert "AC2 no-grill fixture never fabricates a grill answer (no 'branches resolved' text)" \
-  "$(printf '%s' "$OUT_NOGRILL" | grep -q 'branches resolved' && echo 1 || echo 0)"
+  "$({ printf '%s' "$OUT_NOGRILL" 2>/dev/null || :; } | grep -q 'branches resolved' && echo 1 || echo 0)"
 assert "AC4a full fixture does NOT print the grill absence line" \
-  "$(printf '%s' "$OUT_FULL" | grep -qF 'no grill record for this run' && echo 1 || echo 0)"
+  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qF 'no grill record for this run' && echo 1 || echo 0)"
 assert "AC4a full fixture DOES surface its real grill content" \
-  "$(printf '%s' "$OUT_FULL" | grep -q 'branches resolved' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'branches resolved' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC3 + AC4b: implementation-notes -- NO-implnotes fixture (load-bearing) vs full fixture ==="
 OUT_NOTES="$(_render no-implnotes)"
 assert "AC3 no-implnotes fixture prints the literal absence line" \
-  "$(printf '%s' "$OUT_NOTES" | grep -qF 'no implementation-notes file for this run' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_NOTES" 2>/dev/null || :; } | grep -qF 'no implementation-notes file for this run' && echo 0 || echo 1)"
 assert "AC3 no-implnotes fixture never fabricates a deviation (no 'fixture deviation' text)" \
-  "$(printf '%s' "$OUT_NOTES" | grep -q 'fixture deviation' && echo 1 || echo 0)"
+  "$({ printf '%s' "$OUT_NOTES" 2>/dev/null || :; } | grep -q 'fixture deviation' && echo 1 || echo 0)"
 assert "AC4b full fixture does NOT print the implementation-notes absence line" \
-  "$(printf '%s' "$OUT_FULL" | grep -qF 'no implementation-notes file for this run' && echo 1 || echo 0)"
+  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qF 'no implementation-notes file for this run' && echo 1 || echo 0)"
 assert "AC4b full fixture DOES surface its real deviation entries (both of them)" \
   "$([ "$(printf '%s' "$OUT_FULL" | grep -c 'fixture deviation')" -eq 2 ] && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC4c: negative controls + evidence + cost sections, full fixture ==="
 assert "AC4c unknowns section surfaces the proof's negative control" \
-  "$(printf '%s' "$OUT_FULL" | grep -qi 'negative control' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qi 'negative control' && echo 0 || echo 1)"
 assert "AC4c evidence section carries the verbatim acceptance-criteria table" \
-  "$(printf '%s' "$OUT_FULL" | grep -q 'fixture thing happens' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'fixture thing happens' && echo 0 || echo 1)"
 assert "AC4c cost section surfaces the spec's Out of Scope block" \
-  "$(printf '%s' "$OUT_FULL" | grep -q 'fixture-feature-x' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -q 'fixture-feature-x' && echo 0 || echo 1)"
 assert "AC4c ask section is always emitted (pure template, no source to miss)" \
-  "$(printf '%s' "$OUT_FULL" | grep -qi 'approve' && echo 0 || echo 1)"
+  "$({ printf '%s' "$OUT_FULL" 2>/dev/null || :; } | grep -qi 'approve' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC5: NEVER-AUTO-POST (load-bearing) -- grep negative control ==="
@@ -183,7 +183,7 @@ _would_offer() {  # <fixture-name> <gh-stub-mode>
   local name="$1" mode="$2" ws last
   ws="$(_mkws "$name")"
   last="$(cd "$ws" && DWARVES_KIT_LOG_DIR="$ws/logs" bash "$LEDGER" show "$name" | grep '| DEBT |' | tail -1)"
-  if printf '%s' "$last" | grep -q 'significance=high' \
+  if { printf '%s' "$last" 2>/dev/null || :; } | grep -q 'significance=high' \
      && PATH="$FAKEBIN:$PATH" GH_STUB_MODE="$mode" bash "$LIB" team-shared >/dev/null 2>&1; then
     echo yes
   else

--- a/tests/test-precedent.sh
+++ b/tests/test-precedent.sh
@@ -259,7 +259,7 @@ RECORDS_LINE="$(printf '%s\n' "$OUT" | grep -n '^## records$' | head -1 | cut -d
 FIRST_INVENTORY_LINE="$(printf '%s\n' "$OUT" | grep -nE '^## [a-z]' | grep -v '^[0-9]*:## records$' | head -1 | cut -d: -f1)"
 if [ "$RC" -eq 0 ] && [ -n "$RECORDS_LINE" ] && [ -n "$FIRST_INVENTORY_LINE" ] \
    && [ "$RECORDS_LINE" -lt "$FIRST_INVENTORY_LINE" ] \
-   && { printf '%s' "$LAST_LINE" 2>/dev/null || :; } | grep -qE '^precedent: [1-9][0-9]* record matches, [1-9][0-9]* inventory hits in [0-9]+ sections; top: .+$'; then
+   && { trap '' PIPE; printf '%s' "$LAST_LINE" 2>/dev/null || :; } | grep -qE '^precedent: [1-9][0-9]* record matches, [1-9][0-9]* inventory hits in [0-9]+ sections; top: .+$'; then
   assert "default (all) surface: records block before inventory, nonzero summary line" 0
 else
   assert "default (all) surface: records block before inventory, nonzero summary line" 1
@@ -293,8 +293,8 @@ fi
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find "notion sync" --quiet 2>&1)"; RC=$?
 if [ "$RC" -eq 0 ] \
-   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^precedent: [0-9]+ record matches, [0-9]+ inventory hits in [0-9]+ sections; top: .+$' \
-   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'sections with no match or skipped)'; then
+   && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^precedent: [0-9]+ record matches, [0-9]+ inventory hits in [0-9]+ sections; top: .+$' \
+   && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'sections with no match or skipped)'; then
   assert "all --quiet: summary line and the empty/skipped collapse line both present" 0
 else
   assert "all --quiet: summary line and the empty/skipped collapse line both present" 1
@@ -313,7 +313,7 @@ cat > "$KIT_ROOT_AC_D/kit.toml" <<TOML
 registry = "$FIX_REGISTRY"
 TOML
 OUT="$(env -u PRECEDENT_REGISTRY KIT_CONFIG_ROOT="$KIT_ROOT_AC_D" "$PRECEDENT_BIN" find notion --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
   assert "kit-root kit.toml [precedent] registry (no PRECEDENT_REGISTRY) still scans the registry's scripts row" 0
 else
   assert "kit-root kit.toml [precedent] registry (no PRECEDENT_REGISTRY) still scans the registry's scripts row" 1
@@ -335,7 +335,7 @@ registry = "$FIX_REGISTRY"
 TOML
 OUT="$(env -u PRECEDENT_REGISTRY KIT_CONFIG_ROOT="$EMPTY_ROOT_FOR_OP" \
   KIT_CONFIG_OPERATOR="$OP_CONF_DIR" "$PRECEDENT_BIN" find notion --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
   assert "operator kit.toml [precedent] registry (no PRECEDENT_REGISTRY) still scans the registry's scripts row" 0
 else
   assert "operator kit.toml [precedent] registry (no PRECEDENT_REGISTRY) still scans the registry's scripts row" 1
@@ -359,7 +359,7 @@ TOML
 EMPTY_KIT_ROOT="$TMPDIR_T/kit-root-empty"
 mkdir -p "$EMPTY_KIT_ROOT"
 OUT="$(env -u PRECEDENT_REGISTRY KIT_CONFIG_ROOT="$EMPTY_KIT_ROOT" "$PRECEDENT_BIN" find --explain /etc/hosts --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 1 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
+if [ "$RC" -eq 1 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
   assert "a project .kit.toml registry cannot select the registry: --explain /etc/hosts still refused" 0
 else
   assert "a project .kit.toml registry cannot select the registry: --explain /etc/hosts still refused" 1
@@ -368,7 +368,7 @@ fi
 
 OUT="$(env -u PRECEDENT_REGISTRY KIT_CONFIG_ROOT="$EMPTY_KIT_ROOT" "$PRECEDENT_BIN" find zeta --surface inventory 2>&1)"; RC=$?
 rm -f "$FIX_REPO/.kit.toml"
-if [ "$RC" -eq 0 ] && ! { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
+if [ "$RC" -eq 0 ] && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
   assert "a project .kit.toml registry cannot select the registry: zeta.sh never surfaces" 0
 else
   assert "a project .kit.toml registry cannot select the registry: zeta.sh never surfaces" 1
@@ -405,7 +405,7 @@ fi
 # AC6: --help
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" --help 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q -- '--surface'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q -- '--surface'; then
   assert "--help exits 0 and documents --surface" 0
 else
   assert "--help exits 0 and documents --surface" 1
@@ -434,7 +434,7 @@ fi
 # ---------------------------------------------------------------------------
 FIRST_TOOLS_HIT="$("$PRECEDENT_BIN" find alpha --surface inventory --json 2>&1 \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["tools"]["hits"][0])' 2>/dev/null)"
-if { printf '%s' "$FIRST_TOOLS_HIT" 2>/dev/null || :; } | grep -q 'tools/alpha/'; then
+if { trap '' PIPE; printf '%s' "$FIRST_TOOLS_HIT" 2>/dev/null || :; } | grep -q 'tools/alpha/'; then
   assert "name-over-body: the tools section's first hit names tools/alpha/" 0
 else
   assert "name-over-body: the tools section's first hit names tools/alpha/" 1
@@ -462,7 +462,7 @@ fi
 # TASK-003 AC4: registry skip note for the missing `repo /nonexistent/path/for/test` row.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find notion --surface inventory 2>&1)"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/path/for/test'; then
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/path/for/test'; then
   assert "registry skip note for a missing repo path" 0
 else
   assert "registry skip note for a missing repo path" 1
@@ -473,7 +473,7 @@ fi
 # (a unique word, "zorbington") shows up as a hit.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find zorbington --surface inventory 2>&1)"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'eta-repo/scripts/eta.sh'; then
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'eta-repo/scripts/eta.sh'; then
   assert "~ expansion: the eta-repo registry row is scanned" 0
 else
   assert "~ expansion: the eta-repo registry row is scanned" 1
@@ -484,7 +484,7 @@ fi
 # [redacted], never in the clear.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find "token rotation" --surface inventory 2>&1)"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '\[redacted\]' && ! { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'ghp_abcdefghij'; then
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '\[redacted\]' && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'ghp_abcdefghij'; then
   assert "secret redaction: a ghp_ token prints as [redacted]" 0
 else
   assert "secret redaction: a ghp_ token prints as [redacted]" 1
@@ -510,7 +510,7 @@ fi
 # TASK-003 AC8: --quiet collapses every empty/skipped section to one count line.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find "notion zzzqqq" --surface inventory --quiet 2>&1)"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'sections with no match or skipped)'; then
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'sections with no match or skipped)'; then
   assert "--quiet collapses empty/skipped sections to one line" 0
 else
   assert "--quiet collapses empty/skipped sections to one line" 1
@@ -521,7 +521,7 @@ fi
 # exits 1.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find --explain "skill delta" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'name: delta'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'name: delta'; then
   assert "--explain \"skill delta\" prints the SKILL.md header, exit 0" 0
 else
   assert "--explain \"skill delta\" prints the SKILL.md header, exit 0" 1
@@ -575,8 +575,8 @@ fi
 OUT="$("$PRECEDENT_BIN" find "notion sync" 3 2>&1)"; RC=$?
 HIT_COUNT="$(printf '%s\n' "$OUT" | grep -cE '^[[:space:]]*[0-9]+x[[:space:]]' || true)"
 if [ "$RC" -eq 0 ] \
-   && ! { printf '%s\n' "$OUT" 2>/dev/null || :; } | grep -q '^## ' \
-   && ! { printf '%s\n' "$OUT" 2>/dev/null || :; } | grep -q '^precedent:' \
+   && ! { trap '' PIPE; printf '%s\n' "$OUT" 2>/dev/null || :; } | grep -q '^## ' \
+   && ! { trap '' PIPE; printf '%s\n' "$OUT" 2>/dev/null || :; } | grep -q '^precedent:' \
    && [ "$HIT_COUNT" -le 3 ]; then
   assert "positional [max] with no --surface: records-only output, no header or summary line" 0
 else
@@ -589,7 +589,7 @@ fi
 # refused, whether reached via an absolute label, a `../` traversal, or a `~`-relative one.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find --explain /etc/hosts --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 1 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
+if [ "$RC" -eq 1 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
   assert "--explain /etc/hosts: outside the scanned roots, exit 1" 0
 else
   assert "--explain /etc/hosts: outside the scanned roots, exit 1" 1
@@ -597,7 +597,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain "../../../../../../../../../../../../../../../../etc/hosts" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 1 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
+if [ "$RC" -eq 1 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
   assert "--explain ../traversal to /etc/hosts: outside the scanned roots, exit 1" 0
 else
   assert "--explain ../traversal to /etc/hosts: outside the scanned roots, exit 1" 1
@@ -605,7 +605,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain ~/.gitconfig --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 1 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
+if [ "$RC" -eq 1 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
   assert "--explain ~/.gitconfig: refused by confinement (file exists, still outside roots), exit 1" 0
 else
   assert "--explain ~/.gitconfig: refused by confinement (file exists, still outside roots), exit 1" 1
@@ -617,7 +617,7 @@ fi
 # relative (tool.toml/README fallback), each confined inside an allowed root.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find --explain "kit lib/precedent/precedent.sh" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*lib/precedent/precedent\.sh$'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*lib/precedent/precedent\.sh$'; then
   assert "--explain \"kit lib/precedent/precedent.sh\" resolves inside KIT_ROOT, exit 0" 0
 else
   assert "--explain \"kit lib/precedent/precedent.sh\" resolves inside KIT_ROOT, exit 0" 1
@@ -625,7 +625,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain "memory $FIX_REPO/.claude/memory/gamma.md" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*gamma\.md$'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*gamma\.md$'; then
   assert "--explain \"memory <abs gamma.md>\" resolves via the registry repo row, exit 0" 0
 else
   assert "--explain \"memory <abs gamma.md>\" resolves via the registry repo row, exit 0" 1
@@ -633,7 +633,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain "~/eta-repo/scripts/eta.sh" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*eta-repo/scripts/eta\.sh$'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*eta-repo/scripts/eta\.sh$'; then
   assert "--explain \"~/eta-repo/scripts/eta.sh\" resolves via the registry repo row, exit 0" 0
 else
   assert "--explain \"~/eta-repo/scripts/eta.sh\" resolves via the registry repo row, exit 0" 1
@@ -641,7 +641,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain "tools/alpha/" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*tools/alpha/tool\.toml$'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*tools/alpha/tool\.toml$'; then
   assert "--explain \"tools/alpha/\" (bare relative) falls through to tool.toml, exit 0" 0
 else
   assert "--explain \"tools/alpha/\" (bare relative) falls through to tool.toml, exit 0" 1
@@ -671,7 +671,7 @@ fi
 # Review finding 6: the `memory <dir>` one-level `*/memory/*.md` walk surfaces a nested note.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find iotaunique --surface inventory 2>&1)"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'proj-a/memory/iota.md'; then
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'proj-a/memory/iota.md'; then
   assert "nested */memory/*.md registry row: the one-level-down note surfaces" 0
 else
   assert "nested */memory/*.md registry row: the one-level-down note surfaces" 1
@@ -692,7 +692,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find "rotate" 2>&1)"
-if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '\[redacted\]' && ! { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'ghp_abcdefghij'; then
+if { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '\[redacted\]' && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'ghp_abcdefghij'; then
   assert "records headline redaction: a ghp_ token in a spec heading prints as [redacted]" 0
 else
   assert "records headline redaction: a ghp_ token in a spec heading prints as [redacted]" 1
@@ -741,10 +741,10 @@ memory /nonexistent/memory/dir
 EOF
 OUT="$(PRECEDENT_REGISTRY="$SKIP_REGISTRY" "$PRECEDENT_BIN" find "sync notion" --surface inventory 2>&1)"; RC=$?
 if [ "$RC" -eq 0 ] \
-   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skill delta' \
-   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'gamma.md' \
-   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/skills/dir' \
-   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/memory/dir'; then
+   && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skill delta' \
+   && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'gamma.md' \
+   && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/skills/dir' \
+   && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/memory/dir'; then
   assert "set_skip keeps existing hits: skills/memory sections show hits AND the skip note" 0
 else
   assert "set_skip keeps existing hits: skills/memory sections show hits AND the skip note" 1
@@ -780,7 +780,7 @@ cat > "$FIX_HOME/eta-registry.txt" <<EOF
 repo $FIX_HOME/eta-repo
 EOF
 OUT="$(PRECEDENT_REGISTRY='~/eta-registry.txt' "$PRECEDENT_BIN" find zorbington --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'eta-repo/scripts/eta.sh'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'eta-repo/scripts/eta.sh'; then
   assert "PRECEDENT_REGISTRY='~/...' is expanded against HOME and scanned" 0
 else
   assert "PRECEDENT_REGISTRY='~/...' is expanded against HOME and scanned" 1
@@ -788,7 +788,7 @@ else
 fi
 
 OUT="$(PRECEDENT_REGISTRY=/no/such/registry "$PRECEDENT_BIN" find notion --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'precedent: registry not found: /no/such/registry'; then
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'precedent: registry not found: /no/such/registry'; then
   assert "a missing explicit PRECEDENT_REGISTRY prints the not-found stderr line and exits 0" 0
 else
   assert "a missing explicit PRECEDENT_REGISTRY prints the not-found stderr line and exits 0" 1
@@ -801,8 +801,8 @@ fi
 fake_log_token_a="ghp_abcdefghij"; fake_log_token_b="klmnopqrstuvwxyz0123456789"
 "$PRECEDENT_BIN" find "notion ${fake_log_token_a}${fake_log_token_b}" --surface inventory >/dev/null 2>&1
 LAST_LOG_LINE="$(tail -n1 "$LOG_FILE")"
-if { printf '%s' "$LAST_LOG_LINE" 2>/dev/null || :; } | grep -q '\[redacted\]' \
-   && ! { printf '%s' "$LAST_LOG_LINE" 2>/dev/null || :; } | grep -q "${fake_log_token_a}${fake_log_token_b}"; then
+if { trap '' PIPE; printf '%s' "$LAST_LOG_LINE" 2>/dev/null || :; } | grep -q '\[redacted\]' \
+   && ! { trap '' PIPE; printf '%s' "$LAST_LOG_LINE" 2>/dev/null || :; } | grep -q "${fake_log_token_a}${fake_log_token_b}"; then
   assert "append_log redacts a secret-shaped query before writing the log line" 0
 else
   assert "append_log redacts a secret-shaped query before writing the log line" 1
@@ -840,7 +840,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find zzzqqqxx --quiet 2>&1)"
-if ! { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '^## records$'; then
+if ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '^## records$'; then
   assert "empty records surface: no ## records header under --quiet" 0
 else
   assert "empty records surface: no ## records header under --quiet" 1

--- a/tests/test-precedent.sh
+++ b/tests/test-precedent.sh
@@ -259,7 +259,7 @@ RECORDS_LINE="$(printf '%s\n' "$OUT" | grep -n '^## records$' | head -1 | cut -d
 FIRST_INVENTORY_LINE="$(printf '%s\n' "$OUT" | grep -nE '^## [a-z]' | grep -v '^[0-9]*:## records$' | head -1 | cut -d: -f1)"
 if [ "$RC" -eq 0 ] && [ -n "$RECORDS_LINE" ] && [ -n "$FIRST_INVENTORY_LINE" ] \
    && [ "$RECORDS_LINE" -lt "$FIRST_INVENTORY_LINE" ] \
-   && printf '%s' "$LAST_LINE" | grep -qE '^precedent: [1-9][0-9]* record matches, [1-9][0-9]* inventory hits in [0-9]+ sections; top: .+$'; then
+   && { printf '%s' "$LAST_LINE" 2>/dev/null || :; } | grep -qE '^precedent: [1-9][0-9]* record matches, [1-9][0-9]* inventory hits in [0-9]+ sections; top: .+$'; then
   assert "default (all) surface: records block before inventory, nonzero summary line" 0
 else
   assert "default (all) surface: records block before inventory, nonzero summary line" 1
@@ -293,8 +293,8 @@ fi
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find "notion sync" --quiet 2>&1)"; RC=$?
 if [ "$RC" -eq 0 ] \
-   && printf '%s' "$OUT" | grep -qE '^precedent: [0-9]+ record matches, [0-9]+ inventory hits in [0-9]+ sections; top: .+$' \
-   && printf '%s' "$OUT" | grep -q 'sections with no match or skipped)'; then
+   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^precedent: [0-9]+ record matches, [0-9]+ inventory hits in [0-9]+ sections; top: .+$' \
+   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'sections with no match or skipped)'; then
   assert "all --quiet: summary line and the empty/skipped collapse line both present" 0
 else
   assert "all --quiet: summary line and the empty/skipped collapse line both present" 1
@@ -313,7 +313,7 @@ cat > "$KIT_ROOT_AC_D/kit.toml" <<TOML
 registry = "$FIX_REGISTRY"
 TOML
 OUT="$(env -u PRECEDENT_REGISTRY KIT_CONFIG_ROOT="$KIT_ROOT_AC_D" "$PRECEDENT_BIN" find notion --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q 'zeta.sh'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
   assert "kit-root kit.toml [precedent] registry (no PRECEDENT_REGISTRY) still scans the registry's scripts row" 0
 else
   assert "kit-root kit.toml [precedent] registry (no PRECEDENT_REGISTRY) still scans the registry's scripts row" 1
@@ -335,7 +335,7 @@ registry = "$FIX_REGISTRY"
 TOML
 OUT="$(env -u PRECEDENT_REGISTRY KIT_CONFIG_ROOT="$EMPTY_ROOT_FOR_OP" \
   KIT_CONFIG_OPERATOR="$OP_CONF_DIR" "$PRECEDENT_BIN" find notion --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q 'zeta.sh'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
   assert "operator kit.toml [precedent] registry (no PRECEDENT_REGISTRY) still scans the registry's scripts row" 0
 else
   assert "operator kit.toml [precedent] registry (no PRECEDENT_REGISTRY) still scans the registry's scripts row" 1
@@ -359,7 +359,7 @@ TOML
 EMPTY_KIT_ROOT="$TMPDIR_T/kit-root-empty"
 mkdir -p "$EMPTY_KIT_ROOT"
 OUT="$(env -u PRECEDENT_REGISTRY KIT_CONFIG_ROOT="$EMPTY_KIT_ROOT" "$PRECEDENT_BIN" find --explain /etc/hosts --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'outside the scanned roots'; then
+if [ "$RC" -eq 1 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
   assert "a project .kit.toml registry cannot select the registry: --explain /etc/hosts still refused" 0
 else
   assert "a project .kit.toml registry cannot select the registry: --explain /etc/hosts still refused" 1
@@ -368,7 +368,7 @@ fi
 
 OUT="$(env -u PRECEDENT_REGISTRY KIT_CONFIG_ROOT="$EMPTY_KIT_ROOT" "$PRECEDENT_BIN" find zeta --surface inventory 2>&1)"; RC=$?
 rm -f "$FIX_REPO/.kit.toml"
-if [ "$RC" -eq 0 ] && ! printf '%s' "$OUT" | grep -q 'zeta.sh'; then
+if [ "$RC" -eq 0 ] && ! { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'zeta.sh'; then
   assert "a project .kit.toml registry cannot select the registry: zeta.sh never surfaces" 0
 else
   assert "a project .kit.toml registry cannot select the registry: zeta.sh never surfaces" 1
@@ -405,7 +405,7 @@ fi
 # AC6: --help
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" --help 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q -- '--surface'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q -- '--surface'; then
   assert "--help exits 0 and documents --surface" 0
 else
   assert "--help exits 0 and documents --surface" 1
@@ -434,7 +434,7 @@ fi
 # ---------------------------------------------------------------------------
 FIRST_TOOLS_HIT="$("$PRECEDENT_BIN" find alpha --surface inventory --json 2>&1 \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["tools"]["hits"][0])' 2>/dev/null)"
-if printf '%s' "$FIRST_TOOLS_HIT" | grep -q 'tools/alpha/'; then
+if { printf '%s' "$FIRST_TOOLS_HIT" 2>/dev/null || :; } | grep -q 'tools/alpha/'; then
   assert "name-over-body: the tools section's first hit names tools/alpha/" 0
 else
   assert "name-over-body: the tools section's first hit names tools/alpha/" 1
@@ -462,7 +462,7 @@ fi
 # TASK-003 AC4: registry skip note for the missing `repo /nonexistent/path/for/test` row.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find notion --surface inventory 2>&1)"
-if printf '%s' "$OUT" | grep -q 'skipped: no dir at /nonexistent/path/for/test'; then
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/path/for/test'; then
   assert "registry skip note for a missing repo path" 0
 else
   assert "registry skip note for a missing repo path" 1
@@ -473,7 +473,7 @@ fi
 # (a unique word, "zorbington") shows up as a hit.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find zorbington --surface inventory 2>&1)"
-if printf '%s' "$OUT" | grep -q 'eta-repo/scripts/eta.sh'; then
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'eta-repo/scripts/eta.sh'; then
   assert "~ expansion: the eta-repo registry row is scanned" 0
 else
   assert "~ expansion: the eta-repo registry row is scanned" 1
@@ -484,7 +484,7 @@ fi
 # [redacted], never in the clear.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find "token rotation" --surface inventory 2>&1)"
-if printf '%s' "$OUT" | grep -q '\[redacted\]' && ! printf '%s' "$OUT" | grep -q 'ghp_abcdefghij'; then
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '\[redacted\]' && ! { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'ghp_abcdefghij'; then
   assert "secret redaction: a ghp_ token prints as [redacted]" 0
 else
   assert "secret redaction: a ghp_ token prints as [redacted]" 1
@@ -510,7 +510,7 @@ fi
 # TASK-003 AC8: --quiet collapses every empty/skipped section to one count line.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find "notion zzzqqq" --surface inventory --quiet 2>&1)"
-if printf '%s' "$OUT" | grep -q 'sections with no match or skipped)'; then
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'sections with no match or skipped)'; then
   assert "--quiet collapses empty/skipped sections to one line" 0
 else
   assert "--quiet collapses empty/skipped sections to one line" 1
@@ -521,7 +521,7 @@ fi
 # exits 1.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find --explain "skill delta" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q 'name: delta'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'name: delta'; then
   assert "--explain \"skill delta\" prints the SKILL.md header, exit 0" 0
 else
   assert "--explain \"skill delta\" prints the SKILL.md header, exit 0" 1
@@ -575,8 +575,8 @@ fi
 OUT="$("$PRECEDENT_BIN" find "notion sync" 3 2>&1)"; RC=$?
 HIT_COUNT="$(printf '%s\n' "$OUT" | grep -cE '^[[:space:]]*[0-9]+x[[:space:]]' || true)"
 if [ "$RC" -eq 0 ] \
-   && ! printf '%s\n' "$OUT" | grep -q '^## ' \
-   && ! printf '%s\n' "$OUT" | grep -q '^precedent:' \
+   && ! { printf '%s\n' "$OUT" 2>/dev/null || :; } | grep -q '^## ' \
+   && ! { printf '%s\n' "$OUT" 2>/dev/null || :; } | grep -q '^precedent:' \
    && [ "$HIT_COUNT" -le 3 ]; then
   assert "positional [max] with no --surface: records-only output, no header or summary line" 0
 else
@@ -589,7 +589,7 @@ fi
 # refused, whether reached via an absolute label, a `../` traversal, or a `~`-relative one.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find --explain /etc/hosts --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'outside the scanned roots'; then
+if [ "$RC" -eq 1 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
   assert "--explain /etc/hosts: outside the scanned roots, exit 1" 0
 else
   assert "--explain /etc/hosts: outside the scanned roots, exit 1" 1
@@ -597,7 +597,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain "../../../../../../../../../../../../../../../../etc/hosts" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'outside the scanned roots'; then
+if [ "$RC" -eq 1 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
   assert "--explain ../traversal to /etc/hosts: outside the scanned roots, exit 1" 0
 else
   assert "--explain ../traversal to /etc/hosts: outside the scanned roots, exit 1" 1
@@ -605,7 +605,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain ~/.gitconfig --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 1 ] && printf '%s' "$OUT" | grep -q 'outside the scanned roots'; then
+if [ "$RC" -eq 1 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'outside the scanned roots'; then
   assert "--explain ~/.gitconfig: refused by confinement (file exists, still outside roots), exit 1" 0
 else
   assert "--explain ~/.gitconfig: refused by confinement (file exists, still outside roots), exit 1" 1
@@ -617,7 +617,7 @@ fi
 # relative (tool.toml/README fallback), each confined inside an allowed root.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find --explain "kit lib/precedent/precedent.sh" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -qE '^# precedent --explain: .*lib/precedent/precedent\.sh$'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*lib/precedent/precedent\.sh$'; then
   assert "--explain \"kit lib/precedent/precedent.sh\" resolves inside KIT_ROOT, exit 0" 0
 else
   assert "--explain \"kit lib/precedent/precedent.sh\" resolves inside KIT_ROOT, exit 0" 1
@@ -625,7 +625,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain "memory $FIX_REPO/.claude/memory/gamma.md" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -qE '^# precedent --explain: .*gamma\.md$'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*gamma\.md$'; then
   assert "--explain \"memory <abs gamma.md>\" resolves via the registry repo row, exit 0" 0
 else
   assert "--explain \"memory <abs gamma.md>\" resolves via the registry repo row, exit 0" 1
@@ -633,7 +633,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain "~/eta-repo/scripts/eta.sh" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -qE '^# precedent --explain: .*eta-repo/scripts/eta\.sh$'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*eta-repo/scripts/eta\.sh$'; then
   assert "--explain \"~/eta-repo/scripts/eta.sh\" resolves via the registry repo row, exit 0" 0
 else
   assert "--explain \"~/eta-repo/scripts/eta.sh\" resolves via the registry repo row, exit 0" 1
@@ -641,7 +641,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find --explain "tools/alpha/" --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -qE '^# precedent --explain: .*tools/alpha/tool\.toml$'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -qE '^# precedent --explain: .*tools/alpha/tool\.toml$'; then
   assert "--explain \"tools/alpha/\" (bare relative) falls through to tool.toml, exit 0" 0
 else
   assert "--explain \"tools/alpha/\" (bare relative) falls through to tool.toml, exit 0" 1
@@ -671,7 +671,7 @@ fi
 # Review finding 6: the `memory <dir>` one-level `*/memory/*.md` walk surfaces a nested note.
 # ---------------------------------------------------------------------------
 OUT="$("$PRECEDENT_BIN" find iotaunique --surface inventory 2>&1)"
-if printf '%s' "$OUT" | grep -q 'proj-a/memory/iota.md'; then
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'proj-a/memory/iota.md'; then
   assert "nested */memory/*.md registry row: the one-level-down note surfaces" 0
 else
   assert "nested */memory/*.md registry row: the one-level-down note surfaces" 1
@@ -692,7 +692,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find "rotate" 2>&1)"
-if printf '%s' "$OUT" | grep -q '\[redacted\]' && ! printf '%s' "$OUT" | grep -q 'ghp_abcdefghij'; then
+if { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '\[redacted\]' && ! { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'ghp_abcdefghij'; then
   assert "records headline redaction: a ghp_ token in a spec heading prints as [redacted]" 0
 else
   assert "records headline redaction: a ghp_ token in a spec heading prints as [redacted]" 1
@@ -741,10 +741,10 @@ memory /nonexistent/memory/dir
 EOF
 OUT="$(PRECEDENT_REGISTRY="$SKIP_REGISTRY" "$PRECEDENT_BIN" find "sync notion" --surface inventory 2>&1)"; RC=$?
 if [ "$RC" -eq 0 ] \
-   && printf '%s' "$OUT" | grep -q 'skill delta' \
-   && printf '%s' "$OUT" | grep -q 'gamma.md' \
-   && printf '%s' "$OUT" | grep -q 'skipped: no dir at /nonexistent/skills/dir' \
-   && printf '%s' "$OUT" | grep -q 'skipped: no dir at /nonexistent/memory/dir'; then
+   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skill delta' \
+   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'gamma.md' \
+   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/skills/dir' \
+   && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'skipped: no dir at /nonexistent/memory/dir'; then
   assert "set_skip keeps existing hits: skills/memory sections show hits AND the skip note" 0
 else
   assert "set_skip keeps existing hits: skills/memory sections show hits AND the skip note" 1
@@ -780,7 +780,7 @@ cat > "$FIX_HOME/eta-registry.txt" <<EOF
 repo $FIX_HOME/eta-repo
 EOF
 OUT="$(PRECEDENT_REGISTRY='~/eta-registry.txt' "$PRECEDENT_BIN" find zorbington --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q 'eta-repo/scripts/eta.sh'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'eta-repo/scripts/eta.sh'; then
   assert "PRECEDENT_REGISTRY='~/...' is expanded against HOME and scanned" 0
 else
   assert "PRECEDENT_REGISTRY='~/...' is expanded against HOME and scanned" 1
@@ -788,7 +788,7 @@ else
 fi
 
 OUT="$(PRECEDENT_REGISTRY=/no/such/registry "$PRECEDENT_BIN" find notion --surface inventory 2>&1)"; RC=$?
-if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q 'precedent: registry not found: /no/such/registry'; then
+if [ "$RC" -eq 0 ] && { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'precedent: registry not found: /no/such/registry'; then
   assert "a missing explicit PRECEDENT_REGISTRY prints the not-found stderr line and exits 0" 0
 else
   assert "a missing explicit PRECEDENT_REGISTRY prints the not-found stderr line and exits 0" 1
@@ -801,8 +801,8 @@ fi
 fake_log_token_a="ghp_abcdefghij"; fake_log_token_b="klmnopqrstuvwxyz0123456789"
 "$PRECEDENT_BIN" find "notion ${fake_log_token_a}${fake_log_token_b}" --surface inventory >/dev/null 2>&1
 LAST_LOG_LINE="$(tail -n1 "$LOG_FILE")"
-if printf '%s' "$LAST_LOG_LINE" | grep -q '\[redacted\]' \
-   && ! printf '%s' "$LAST_LOG_LINE" | grep -q "${fake_log_token_a}${fake_log_token_b}"; then
+if { printf '%s' "$LAST_LOG_LINE" 2>/dev/null || :; } | grep -q '\[redacted\]' \
+   && ! { printf '%s' "$LAST_LOG_LINE" 2>/dev/null || :; } | grep -q "${fake_log_token_a}${fake_log_token_b}"; then
   assert "append_log redacts a secret-shaped query before writing the log line" 0
 else
   assert "append_log redacts a secret-shaped query before writing the log line" 1
@@ -840,7 +840,7 @@ else
 fi
 
 OUT="$("$PRECEDENT_BIN" find zzzqqqxx --quiet 2>&1)"
-if ! printf '%s' "$OUT" | grep -q '^## records$'; then
+if ! { printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '^## records$'; then
   assert "empty records surface: no ## records header under --quiet" 0
 else
   assert "empty records surface: no ## records header under --quiet" 1

--- a/tests/test-proof-table-gen.sh
+++ b/tests/test-proof-table-gen.sh
@@ -19,8 +19,8 @@ PASS=0; FAIL=0; TOTAL=0
 
 ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
-expect()  { if printf '%s' "$3" | grep -qF "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
-refute()  { if printf '%s' "$3" | grep -qF "$2"; then bad "$1 (unexpected '$2' present)"; else ok "$1"; fi; }
+expect()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+refute()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then bad "$1 (unexpected '$2' present)"; else ok "$1"; fi; }
 assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$3', got '$2')"; fi; }
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/kit-proof-table-gen.XXXXXX")"

--- a/tests/test-proof-table-gen.sh
+++ b/tests/test-proof-table-gen.sh
@@ -19,8 +19,8 @@ PASS=0; FAIL=0; TOTAL=0
 
 ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
-expect()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
-refute()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then bad "$1 (unexpected '$2' present)"; else ok "$1"; fi; }
+expect()  { if { trap '' PIPE; printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+refute()  { if { trap '' PIPE; printf '%s' "$3" 2>/dev/null || :; } | grep -qF "$2"; then bad "$1 (unexpected '$2' present)"; else ok "$1"; fi; }
 assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$3', got '$2')"; fi; }
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/kit-proof-table-gen.XXXXXX")"

--- a/tests/test-quiz-gate.sh
+++ b/tests/test-quiz-gate.sh
@@ -56,13 +56,13 @@ done
 assert "AC1 each of Q1..Q5 appears exactly once (no dup/drop)" "$EACH_ONCE"
 # grounded: a question names a real changed file
 assert "AC1 questions reference a real changed file (widget.js)" \
-  "$(printf '%s' "$QOUT" | grep -q 'widget.js' && echo 0 || echo 1)"
+  "$({ printf '%s' "$QOUT" 2>/dev/null || :; } | grep -q 'widget.js' && echo 0 || echo 1)"
 # grounded in ADDED LINES, not the commit message: the added identifier `widget` appears
 assert "AC1 questions quote the actual added code (names 'widget')" \
-  "$(printf '%s' "$QOUT" | grep -q 'function widget' && echo 0 || echo 1)"
+  "$({ printf '%s' "$QOUT" 2>/dev/null || :; } | grep -q 'function widget' && echo 0 || echo 1)"
 # grounded in the RECORDED test verdict (not invented)
 assert "AC1 questions carry the recorded test verdict (PASS from the proof)" \
-  "$(printf '%s' "$QOUT" | grep -qi 'PASS\|Exit: 0' && echo 0 || echo 1)"
+  "$({ printf '%s' "$QOUT" 2>/dev/null || :; } | grep -qi 'PASS\|Exit: 0' && echo 0 || echo 1)"
 
 echo "=== AC2: three responses each land in the debt ledger ==="
 RID="ac2-rid-$$"
@@ -81,18 +81,18 @@ assert "AC2 wave logged"    "$(grep -q '| DEBT | response=wave'   "$LF" && echo 
 # writer's format -- a regression widening check()'s awk predicate to match DEBT would fail HERE.
 CHK="$( bash "$GL" check full "$RID" 2>&1 )"; CHK_RC=$?
 assert "AC2 a DEBT-only ledger fails gate check (response lines never satisfy a required gate)" \
-  "$([ "$CHK_RC" -ne 0 ] && printf '%s' "$CHK" | grep -q 'MISSING-GATE' && echo 0 || echo 1)"
+  "$([ "$CHK_RC" -ne 0 ] && { printf '%s' "$CHK" 2>/dev/null || :; } | grep -q 'MISSING-GATE' && echo 0 || echo 1)"
 
 echo "=== AC3: engage routes through deep-understand (dispatch, not reimplementation) ==="
 ROUT="$( cd "$DA" && bash "$QG" respond "engage-rid-$$" engage --ref "$REFA" )"
 assert "AC3 engage output names the deep-understand engine" \
-  "$(printf '%s' "$ROUT" | grep -q 'deep-understand' && echo 0 || echo 1)"
+  "$({ printf '%s' "$ROUT" 2>/dev/null || :; } | grep -q 'deep-understand' && echo 0 || echo 1)"
 assert "AC3 engage output names the AskUserQuestion mastery gate" \
-  "$(printf '%s' "$ROUT" | grep -qi 'AskUserQuestion' && echo 0 || echo 1)"
+  "$({ printf '%s' "$ROUT" 2>/dev/null || :; } | grep -qi 'AskUserQuestion' && echo 0 || echo 1)"
 # defer / wave do NOT route to deep-understand (only engage does)
 DWAVE="$( bash "$QG" respond "wave-rid-$$" wave )"
 assert "AC3 wave does NOT route to deep-understand" \
-  "$(printf '%s' "$DWAVE" | grep -q 'deep-understand' && echo 1 || echo 0)"
+  "$({ printf '%s' "$DWAVE" 2>/dev/null || :; } | grep -q 'deep-understand' && echo 1 || echo 0)"
 # the kit does NOT reimplement a quiz scorer: quiz-gate.sh has no answer-key / grading logic
 assert "AC3 quiz-gate.sh reimplements no scorer (no answer-key/grade/score logic)" \
   "$(grep -qiE 'answer[_ -]?key|def .*score|grade_quiz|correct_answer|is_correct' "$QG" && echo 1 || echo 0)"
@@ -112,13 +112,13 @@ gitq "$DB" commit -qm "update calc helper" -m "Adds a multiply operation as requ
 REFB="$(gitq "$DB" rev-parse HEAD)"
 QB="$( cd "$DB" && bash "$QG" questions "$REFB" )"
 assert "AC4 quiz describes the DIFF (names 'subtract')" \
-  "$(printf '%s' "$QB" | grep -q 'subtract' && echo 0 || echo 1)"
+  "$({ printf '%s' "$QB" 2>/dev/null || :; } | grep -q 'subtract' && echo 0 || echo 1)"
 assert "AC4 quiz does NOT parrot the false narrative ('multiply')" \
-  "$(printf '%s' "$QB" | grep -qi 'multiply' && echo 1 || echo 0)"
+  "$({ printf '%s' "$QB" 2>/dev/null || :; } | grep -qi 'multiply' && echo 1 || echo 0)"
 # MINOR-4: Fixture B has a code change but NO recorded proof -> Q4 must fall back to the honest
 # "[no recorded test result]" string, never an invented verdict (the honesty guarantee).
 assert "AC4 no recorded proof -> Q4 says '[no recorded test result]' (does not invent a verdict)" \
-  "$(printf '%s' "$QB" | grep -q '\[no recorded test result' && echo 0 || echo 1)"
+  "$({ printf '%s' "$QB" 2>/dev/null || :; } | grep -q '\[no recorded test result' && echo 0 || echo 1)"
 
 echo "=== Edges: docs/tests-only change + a range ref ==="
 # MAJOR-2: a change touching ONLY docs/ + tests/ has no primary code file -> Q3 fires the
@@ -134,13 +134,13 @@ QD="$( cd "$DD" && bash "$QG" questions "$REFD" )"
 assert "Edge docs/tests-only: still exactly 5 questions" \
   "$([ "$(printf '%s\n' "$QD" | grep -c '^Q[1-5]\.')" -eq 5 ] && echo 0 || echo 1)"
 assert "Edge docs/tests-only: Q3 fires the 'touches only docs/tests' branch (no mis-labeled primary)" \
-  "$(printf '%s' "$QD" | grep -qi 'only docs/tests' && echo 0 || echo 1)"
+  "$({ printf '%s' "$QD" 2>/dev/null || :; } | grep -qi 'only docs/tests' && echo 0 || echo 1)"
 
 # MINOR-3: a range ref (A..B) is the code's other resolve branch; assert it grounds the same as a SHA.
 BASEA="$(gitq "$DA" rev-parse "${REFA}^1")"
 QRANGE="$( cd "$DA" && bash "$QG" questions "${BASEA}..${REFA}" )"
 assert "Edge range ref (A..B): 5 questions, still names the real changed file (widget.js)" \
-  "$([ "$(printf '%s\n' "$QRANGE" | grep -c '^Q[1-5]\.')" -eq 5 ] && printf '%s' "$QRANGE" | grep -q 'widget.js' && echo 0 || echo 1)"
+  "$([ "$(printf '%s\n' "$QRANGE" | grep -c '^Q[1-5]\.')" -eq 5 ] && { printf '%s' "$QRANGE" 2>/dev/null || :; } | grep -q 'widget.js' && echo 0 || echo 1)"
 
 echo "=== AC5: WIRING negative control (fires on tap, absent on wave / not-significant / non-gate) ==="
 TAP_DESC="add a new data model migration that introduces a primitive future work will build on"    # -> tap
@@ -157,7 +157,7 @@ V_NS="$(   bash "$KIT_DIR/lib/classify/significance-classify.sh" classify "$NS_D
 assert "AC5 classifier sanity: tap/$V_TAP wave/$V_WAVE ns/$V_NS" \
   "$([ "$V_TAP" = tap ] && [ "$V_WAVE" = wave ] && [ "$V_NS" = not-significant ] && echo 0 || echo 1)"
 assert "AC5 tap FIRES on a tap-verdict gate PR (nudge printed)" \
-  "$(printf '%s' "$T_TAP" | grep -q '★ worth understanding' && echo 0 || echo 1)"
+  "$({ printf '%s' "$T_TAP" 2>/dev/null || :; } | grep -q '★ worth understanding' && echo 0 || echo 1)"
 assert "AC5 tap ABSENT on a wave-verdict change (anti-fatigue)" \
   "$([ -z "$T_WAVE" ] && echo 0 || echo 1)"
 assert "AC5 tap ABSENT on a not-significant change" \

--- a/tests/test-quiz-gate.sh
+++ b/tests/test-quiz-gate.sh
@@ -56,13 +56,13 @@ done
 assert "AC1 each of Q1..Q5 appears exactly once (no dup/drop)" "$EACH_ONCE"
 # grounded: a question names a real changed file
 assert "AC1 questions reference a real changed file (widget.js)" \
-  "$({ printf '%s' "$QOUT" 2>/dev/null || :; } | grep -q 'widget.js' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$QOUT" 2>/dev/null || :; } | grep -q 'widget.js' && echo 0 || echo 1)"
 # grounded in ADDED LINES, not the commit message: the added identifier `widget` appears
 assert "AC1 questions quote the actual added code (names 'widget')" \
-  "$({ printf '%s' "$QOUT" 2>/dev/null || :; } | grep -q 'function widget' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$QOUT" 2>/dev/null || :; } | grep -q 'function widget' && echo 0 || echo 1)"
 # grounded in the RECORDED test verdict (not invented)
 assert "AC1 questions carry the recorded test verdict (PASS from the proof)" \
-  "$({ printf '%s' "$QOUT" 2>/dev/null || :; } | grep -qi 'PASS\|Exit: 0' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$QOUT" 2>/dev/null || :; } | grep -qi 'PASS\|Exit: 0' && echo 0 || echo 1)"
 
 echo "=== AC2: three responses each land in the debt ledger ==="
 RID="ac2-rid-$$"
@@ -81,18 +81,18 @@ assert "AC2 wave logged"    "$(grep -q '| DEBT | response=wave'   "$LF" && echo 
 # writer's format -- a regression widening check()'s awk predicate to match DEBT would fail HERE.
 CHK="$( bash "$GL" check full "$RID" 2>&1 )"; CHK_RC=$?
 assert "AC2 a DEBT-only ledger fails gate check (response lines never satisfy a required gate)" \
-  "$([ "$CHK_RC" -ne 0 ] && { printf '%s' "$CHK" 2>/dev/null || :; } | grep -q 'MISSING-GATE' && echo 0 || echo 1)"
+  "$([ "$CHK_RC" -ne 0 ] && { trap '' PIPE; printf '%s' "$CHK" 2>/dev/null || :; } | grep -q 'MISSING-GATE' && echo 0 || echo 1)"
 
 echo "=== AC3: engage routes through deep-understand (dispatch, not reimplementation) ==="
 ROUT="$( cd "$DA" && bash "$QG" respond "engage-rid-$$" engage --ref "$REFA" )"
 assert "AC3 engage output names the deep-understand engine" \
-  "$({ printf '%s' "$ROUT" 2>/dev/null || :; } | grep -q 'deep-understand' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$ROUT" 2>/dev/null || :; } | grep -q 'deep-understand' && echo 0 || echo 1)"
 assert "AC3 engage output names the AskUserQuestion mastery gate" \
-  "$({ printf '%s' "$ROUT" 2>/dev/null || :; } | grep -qi 'AskUserQuestion' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$ROUT" 2>/dev/null || :; } | grep -qi 'AskUserQuestion' && echo 0 || echo 1)"
 # defer / wave do NOT route to deep-understand (only engage does)
 DWAVE="$( bash "$QG" respond "wave-rid-$$" wave )"
 assert "AC3 wave does NOT route to deep-understand" \
-  "$({ printf '%s' "$DWAVE" 2>/dev/null || :; } | grep -q 'deep-understand' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s' "$DWAVE" 2>/dev/null || :; } | grep -q 'deep-understand' && echo 1 || echo 0)"
 # the kit does NOT reimplement a quiz scorer: quiz-gate.sh has no answer-key / grading logic
 assert "AC3 quiz-gate.sh reimplements no scorer (no answer-key/grade/score logic)" \
   "$(grep -qiE 'answer[_ -]?key|def .*score|grade_quiz|correct_answer|is_correct' "$QG" && echo 1 || echo 0)"
@@ -112,13 +112,13 @@ gitq "$DB" commit -qm "update calc helper" -m "Adds a multiply operation as requ
 REFB="$(gitq "$DB" rev-parse HEAD)"
 QB="$( cd "$DB" && bash "$QG" questions "$REFB" )"
 assert "AC4 quiz describes the DIFF (names 'subtract')" \
-  "$({ printf '%s' "$QB" 2>/dev/null || :; } | grep -q 'subtract' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$QB" 2>/dev/null || :; } | grep -q 'subtract' && echo 0 || echo 1)"
 assert "AC4 quiz does NOT parrot the false narrative ('multiply')" \
-  "$({ printf '%s' "$QB" 2>/dev/null || :; } | grep -qi 'multiply' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s' "$QB" 2>/dev/null || :; } | grep -qi 'multiply' && echo 1 || echo 0)"
 # MINOR-4: Fixture B has a code change but NO recorded proof -> Q4 must fall back to the honest
 # "[no recorded test result]" string, never an invented verdict (the honesty guarantee).
 assert "AC4 no recorded proof -> Q4 says '[no recorded test result]' (does not invent a verdict)" \
-  "$({ printf '%s' "$QB" 2>/dev/null || :; } | grep -q '\[no recorded test result' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$QB" 2>/dev/null || :; } | grep -q '\[no recorded test result' && echo 0 || echo 1)"
 
 echo "=== Edges: docs/tests-only change + a range ref ==="
 # MAJOR-2: a change touching ONLY docs/ + tests/ has no primary code file -> Q3 fires the
@@ -134,13 +134,13 @@ QD="$( cd "$DD" && bash "$QG" questions "$REFD" )"
 assert "Edge docs/tests-only: still exactly 5 questions" \
   "$([ "$(printf '%s\n' "$QD" | grep -c '^Q[1-5]\.')" -eq 5 ] && echo 0 || echo 1)"
 assert "Edge docs/tests-only: Q3 fires the 'touches only docs/tests' branch (no mis-labeled primary)" \
-  "$({ printf '%s' "$QD" 2>/dev/null || :; } | grep -qi 'only docs/tests' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$QD" 2>/dev/null || :; } | grep -qi 'only docs/tests' && echo 0 || echo 1)"
 
 # MINOR-3: a range ref (A..B) is the code's other resolve branch; assert it grounds the same as a SHA.
 BASEA="$(gitq "$DA" rev-parse "${REFA}^1")"
 QRANGE="$( cd "$DA" && bash "$QG" questions "${BASEA}..${REFA}" )"
 assert "Edge range ref (A..B): 5 questions, still names the real changed file (widget.js)" \
-  "$([ "$(printf '%s\n' "$QRANGE" | grep -c '^Q[1-5]\.')" -eq 5 ] && { printf '%s' "$QRANGE" 2>/dev/null || :; } | grep -q 'widget.js' && echo 0 || echo 1)"
+  "$([ "$(printf '%s\n' "$QRANGE" | grep -c '^Q[1-5]\.')" -eq 5 ] && { trap '' PIPE; printf '%s' "$QRANGE" 2>/dev/null || :; } | grep -q 'widget.js' && echo 0 || echo 1)"
 
 echo "=== AC5: WIRING negative control (fires on tap, absent on wave / not-significant / non-gate) ==="
 TAP_DESC="add a new data model migration that introduces a primitive future work will build on"    # -> tap
@@ -157,7 +157,7 @@ V_NS="$(   bash "$KIT_DIR/lib/classify/significance-classify.sh" classify "$NS_D
 assert "AC5 classifier sanity: tap/$V_TAP wave/$V_WAVE ns/$V_NS" \
   "$([ "$V_TAP" = tap ] && [ "$V_WAVE" = wave ] && [ "$V_NS" = not-significant ] && echo 0 || echo 1)"
 assert "AC5 tap FIRES on a tap-verdict gate PR (nudge printed)" \
-  "$({ printf '%s' "$T_TAP" 2>/dev/null || :; } | grep -q '★ worth understanding' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$T_TAP" 2>/dev/null || :; } | grep -q '★ worth understanding' && echo 0 || echo 1)"
 assert "AC5 tap ABSENT on a wave-verdict change (anti-fatigue)" \
   "$([ -z "$T_WAVE" ] && echo 0 || echo 1)"
 assert "AC5 tap ABSENT on a not-significant change" \

--- a/tests/test-significance-classify.sh
+++ b/tests/test-significance-classify.sh
@@ -78,7 +78,7 @@ explain_fires() {
   expect="$1"; label="$2"
   TOTAL=$((TOTAL+1))
   out="$(bash "$SC" explain "${args[@]}" 2>/dev/null)"
-  if printf '%s' "$out" | grep -qF "$expect"; then
+  if { printf '%s' "$out" 2>/dev/null || :; } | grep -qF "$expect"; then
     echo -e "  ${GREEN}PASS${NC} $label (fired: $expect)"
     PASS=$((PASS+1))
   else

--- a/tests/test-significance-classify.sh
+++ b/tests/test-significance-classify.sh
@@ -78,7 +78,7 @@ explain_fires() {
   expect="$1"; label="$2"
   TOTAL=$((TOTAL+1))
   out="$(bash "$SC" explain "${args[@]}" 2>/dev/null)"
-  if { printf '%s' "$out" 2>/dev/null || :; } | grep -qF "$expect"; then
+  if { trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -qF "$expect"; then
     echo -e "  ${GREEN}PASS${NC} $label (fired: $expect)"
     PASS=$((PASS+1))
   else

--- a/tests/test-spec-index.sh
+++ b/tests/test-spec-index.sh
@@ -16,8 +16,8 @@ PASS=0; FAIL=0; TOTAL=0
 
 ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
-expect()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
-refute()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
+expect()  { if { trap '' PIPE; printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+refute()  { if { trap '' PIPE; printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
 
 SPEC_INDEX="$KIT_DIR/lib/spec/spec-index.sh"
 

--- a/tests/test-spec-index.sh
+++ b/tests/test-spec-index.sh
@@ -16,8 +16,8 @@ PASS=0; FAIL=0; TOTAL=0
 
 ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
-expect()  { if printf '%s' "$3" | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
-refute()  { if printf '%s' "$3" | grep -q "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
+expect()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+refute()  { if { printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then bad "$1 (unexpected '$2')"; else ok "$1"; fi; }
 
 SPEC_INDEX="$KIT_DIR/lib/spec/spec-index.sh"
 

--- a/tests/test-spec-reserve.sh
+++ b/tests/test-spec-reserve.sh
@@ -19,7 +19,7 @@ PASS=0; FAIL=0; TOTAL=0
 ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
 eq()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
-expect() { if { printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+expect() { if { trap '' PIPE; printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
 # grep -c prints "0" AND exits 1 on no match, so `grep -c || echo 0` double-prints. This
 # returns a single clean integer whether or not the file exists / the pattern matches.
 count() { local c; c="$(grep -c "$1" "$2" 2>/dev/null)"; printf '%s' "${c:-0}"; }
@@ -204,7 +204,7 @@ echo "=== T13: check message byte-identical to SPEC-064 on empty ledger (review 
 R="$(mk_repo)"; RES="$R/res.log"
 MSG13="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" check 005 2>&1)"
 expect "T13 empty-ledger TAKEN message has NO reservation clause" "seen in specs/, a branch, or a recent commit subject)" "$MSG13"
-if { printf '%s' "$MSG13" 2>/dev/null || :; } | grep -q 'reservation'; then bad "T13 empty-ledger message leaked a reservation clause"; else ok "T13 no reservation clause on empty ledger"; fi
+if { trap '' PIPE; printf '%s' "$MSG13" 2>/dev/null || :; } | grep -q 'reservation'; then bad "T13 empty-ledger message leaked a reservation clause"; else ok "T13 no reservation clause on empty ledger"; fi
 
 # ============================================================
 echo "=== T14: a normal reserve FREES the lock (no held lock, no owner leak) ==="
@@ -225,7 +225,7 @@ echo "=== T15: a FRESH (non-stale) foreign lock is RESPECTED, not stolen ==="
 R="$(mk_repo)"; RES="$R/res.log"
 mkdir -p "$(dirname "$RES")"; mkdir "$RES.lock"; printf 'foreign.owner.token' > "$RES.lock/owner"   # current mtime, foreign owner
 OUT15="$(cd "$R" && SPEC_RESERVE_MAX_TRIES=3 SPEC_RESERVE_FILE="$RES" bash "$SN" reserve 2>/dev/null; echo "rc=$?")"
-if { printf '%s' "$OUT15" 2>/dev/null || :; } | grep -qE '^[0-9]{3}$'; then bad "T15 reserve STOLE a fresh foreign lock (fail-open: $OUT15)"; else ok "T15 reserve did not steal a fresh foreign lock"; fi
+if { trap '' PIPE; printf '%s' "$OUT15" 2>/dev/null || :; } | grep -qE '^[0-9]{3}$'; then bad "T15 reserve STOLE a fresh foreign lock (fail-open: $OUT15)"; else ok "T15 reserve did not steal a fresh foreign lock"; fi
 expect "T15 bounded reserve fails loudly rather than fail-open" "rc=1" "$OUT15"
 eq "T15 the fresh foreign lock is still held" "$([ -d "$RES.lock" ] && echo held || echo free)" "held"
 eq "T15 the foreign owner token is untouched" "$(cat "$RES.lock/owner" 2>/dev/null)" "foreign.owner.token"

--- a/tests/test-spec-reserve.sh
+++ b/tests/test-spec-reserve.sh
@@ -19,7 +19,7 @@ PASS=0; FAIL=0; TOTAL=0
 ok()  { TOTAL=$((TOTAL+1)); PASS=$((PASS+1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 bad() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); echo -e "  ${RED}FAIL${NC} $1"; }
 eq()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
-expect() { if printf '%s' "$3" | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
+expect() { if { printf '%s' "$3" 2>/dev/null || :; } | grep -q "$2"; then ok "$1"; else bad "$1 (missing '$2' in: $3)"; fi; }
 # grep -c prints "0" AND exits 1 on no match, so `grep -c || echo 0` double-prints. This
 # returns a single clean integer whether or not the file exists / the pattern matches.
 count() { local c; c="$(grep -c "$1" "$2" 2>/dev/null)"; printf '%s' "${c:-0}"; }
@@ -204,7 +204,7 @@ echo "=== T13: check message byte-identical to SPEC-064 on empty ledger (review 
 R="$(mk_repo)"; RES="$R/res.log"
 MSG13="$(cd "$R" && SPEC_RESERVE_FILE="$RES" bash "$SN" check 005 2>&1)"
 expect "T13 empty-ledger TAKEN message has NO reservation clause" "seen in specs/, a branch, or a recent commit subject)" "$MSG13"
-if printf '%s' "$MSG13" | grep -q 'reservation'; then bad "T13 empty-ledger message leaked a reservation clause"; else ok "T13 no reservation clause on empty ledger"; fi
+if { printf '%s' "$MSG13" 2>/dev/null || :; } | grep -q 'reservation'; then bad "T13 empty-ledger message leaked a reservation clause"; else ok "T13 no reservation clause on empty ledger"; fi
 
 # ============================================================
 echo "=== T14: a normal reserve FREES the lock (no held lock, no owner leak) ==="
@@ -225,7 +225,7 @@ echo "=== T15: a FRESH (non-stale) foreign lock is RESPECTED, not stolen ==="
 R="$(mk_repo)"; RES="$R/res.log"
 mkdir -p "$(dirname "$RES")"; mkdir "$RES.lock"; printf 'foreign.owner.token' > "$RES.lock/owner"   # current mtime, foreign owner
 OUT15="$(cd "$R" && SPEC_RESERVE_MAX_TRIES=3 SPEC_RESERVE_FILE="$RES" bash "$SN" reserve 2>/dev/null; echo "rc=$?")"
-if printf '%s' "$OUT15" | grep -qE '^[0-9]{3}$'; then bad "T15 reserve STOLE a fresh foreign lock (fail-open: $OUT15)"; else ok "T15 reserve did not steal a fresh foreign lock"; fi
+if { printf '%s' "$OUT15" 2>/dev/null || :; } | grep -qE '^[0-9]{3}$'; then bad "T15 reserve STOLE a fresh foreign lock (fail-open: $OUT15)"; else ok "T15 reserve did not steal a fresh foreign lock"; fi
 expect "T15 bounded reserve fails loudly rather than fail-open" "rc=1" "$OUT15"
 eq "T15 the fresh foreign lock is still held" "$([ -d "$RES.lock" ] && echo held || echo free)" "held"
 eq "T15 the foreign owner token is untouched" "$(cat "$RES.lock/owner" 2>/dev/null)" "foreign.owner.token"

--- a/tests/test-stable-interface.sh
+++ b/tests/test-stable-interface.sh
@@ -43,11 +43,11 @@ chk "consumer drives the board through bin/board (stable)" "$r"
 
 # --- 2. the adopt-injected CLAUDE.md block references bin/, not deep lib paths ---
 block="$(sed -n '/claude_block()/,/^}/p' "$KIT_DIR/lib/adopt.sh")"
-{ printf '%s' "$block" 2>/dev/null || :; } | grep -q '/bin/classify lane classify' && r=0 || r=1
+{ trap '' PIPE; printf '%s' "$block" 2>/dev/null || :; } | grep -q '/bin/classify lane classify' && r=0 || r=1
 chk "adopt block references bin/classify (not lib/classify/*)" "$r"
-{ printf '%s' "$block" 2>/dev/null || :; } | grep -q '/bin/gate ledger' && r=0 || r=1
+{ trap '' PIPE; printf '%s' "$block" 2>/dev/null || :; } | grep -q '/bin/gate ledger' && r=0 || r=1
 chk "adopt block references bin/gate (not lib/gate/*)" "$r"
-{ printf '%s' "$block" 2>/dev/null || :; } | grep -q 'lib/classify/lane-classify.sh\|lib/gate/gate-ledger.sh' && r=1 || r=0
+{ trap '' PIPE; printf '%s' "$block" 2>/dev/null || :; } | grep -q 'lib/classify/lane-classify.sh\|lib/gate/gate-ledger.sh' && r=1 || r=0
 chk "adopt block no longer reaches any deep lib path" "$r"
 
 # --- 3. NEGATIVE CONTROL: internal lib rename does NOT break the stable consumer call ---

--- a/tests/test-stable-interface.sh
+++ b/tests/test-stable-interface.sh
@@ -43,11 +43,11 @@ chk "consumer drives the board through bin/board (stable)" "$r"
 
 # --- 2. the adopt-injected CLAUDE.md block references bin/, not deep lib paths ---
 block="$(sed -n '/claude_block()/,/^}/p' "$KIT_DIR/lib/adopt.sh")"
-printf '%s' "$block" | grep -q '/bin/classify lane classify' && r=0 || r=1
+{ printf '%s' "$block" 2>/dev/null || :; } | grep -q '/bin/classify lane classify' && r=0 || r=1
 chk "adopt block references bin/classify (not lib/classify/*)" "$r"
-printf '%s' "$block" | grep -q '/bin/gate ledger' && r=0 || r=1
+{ printf '%s' "$block" 2>/dev/null || :; } | grep -q '/bin/gate ledger' && r=0 || r=1
 chk "adopt block references bin/gate (not lib/gate/*)" "$r"
-printf '%s' "$block" | grep -q 'lib/classify/lane-classify.sh\|lib/gate/gate-ledger.sh' && r=1 || r=0
+{ printf '%s' "$block" 2>/dev/null || :; } | grep -q 'lib/classify/lane-classify.sh\|lib/gate/gate-ledger.sh' && r=1 || r=0
 chk "adopt block no longer reaches any deep lib path" "$r"
 
 # --- 3. NEGATIVE CONTROL: internal lib rename does NOT break the stable consumer call ---

--- a/tests/test-subagent-panes.sh
+++ b/tests/test-subagent-panes.sh
@@ -109,7 +109,7 @@ rc1=$?
   || fail "T1: windows missing: $(ls "$STATE1" 2>/dev/null)"
 n_new_session=$(grep -c '^new-session' "$STATE1/calls.log")
 [ "$n_new_session" = 1 ] && pass "T1: tmux session ensured exactly once" || fail "T1: new-session called $n_new_session times"
-{ printf '%s\n' "$out1" 2>/dev/null || :; } | grep -q 'spawned 2, skipped 0' \
+{ trap '' PIPE; printf '%s\n' "$out1" 2>/dev/null || :; } | grep -q 'spawned 2, skipped 0' \
   && pass "T1: summary line 'spawned 2, skipped 0'" || fail "T1: summary: $out1"
 
 : > "$STATE1/calls.log"
@@ -169,17 +169,17 @@ out3=$(
 )
 rc3=$?
 [ "$rc3" = 0 ] && pass "T3: rc 0 despite multiple skips" || fail "T3: rc=$rc3"
-{ printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'not a readable regular file' \
+{ trap '' PIPE; printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'not a readable regular file' \
   && pass "T3: missing-file skip warns" || fail "T3: no missing-file warning: $out3"
-{ printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'basename does not match' \
+{ trap '' PIPE; printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'basename does not match' \
   && pass "T3: wrong-basename skip warns" || fail "T3: no basename warning: $out3"
-{ printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'empty dir' \
+{ trap '' PIPE; printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'empty dir' \
   && pass "T3: empty-dir warns" || fail "T3: no empty-dir warning: $out3"
-{ printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'spawned 1, skipped 3' \
+{ trap '' PIPE; printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'spawned 1, skipped 3' \
   && pass "T3: summary counts 1 spawned / 3 skipped (valid sibling still spawns)" || fail "T3: summary: $out3"
 
 out3b=$(cmd_panes "$MEGA3" 2>&1); rc3b=$?
-if [ "$rc3b" = 0 ] && { printf '%s\n' "$out3b" 2>/dev/null || :; } | grep -q '^usage:'; then
+if [ "$rc3b" = 0 ] && { trap '' PIPE; printf '%s\n' "$out3b" 2>/dev/null || :; } | grep -q '^usage:'; then
   pass "T3: <2 total args -> usage on stderr, rc 0"
 else
   fail "T3: rc=$rc3b out=$out3b"
@@ -200,21 +200,21 @@ out3b2=$(
   export TMUX_CMD="$TMP/tmux-mock" TMUX_MOCK_STATE="$STATE3B" TMUX_SESSION=orch-panes-t3b PANE_VIEWER=none
   cmd_panes "$MEGA3B" "$FIX3B" 2>&1
 )
-if { printf '%s' "$out3b2" 2>/dev/null || :; } | grep -q "$(printf '\x1b')"; then
+if { trap '' PIPE; printf '%s' "$out3b2" 2>/dev/null || :; } | grep -q "$(printf '\x1b')"; then
   fail "T3b: raw ESC byte reached combined stdout+stderr: $(printf '%s' "$out3b2" | cat -v)"
 else
   pass "T3b: no raw ESC byte in combined output"
 fi
-{ printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -qF 'agent-??52?c?evil?x.jsonl' \
+{ trap '' PIPE; printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -qF 'agent-??52?c?evil?x.jsonl' \
   && pass "T3b: ESC-embedded filename rendered sanitized ('?' replacement)" \
   || fail "T3b: sanitized filename not found: $out3b2"
-{ printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -q 'skip: symlink, not a real transcript file' \
+{ trap '' PIPE; printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -q 'skip: symlink, not a real transcript file' \
   && pass "T3b: symlink target skipped with its own warning (not spawned then ghost-killed)" \
   || fail "T3b: no symlink-skip warning: $out3b2"
 [ ! -f "$STATE3B/win.orch-panes-t3b.sa-link" ] \
   && pass "T3b: no window created for the symlink target" \
   || fail "T3b: a window was created for the symlink target"
-{ printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -q 'spawned 2, skipped 1' \
+{ trap '' PIPE; printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -q 'spawned 2, skipped 1' \
   && pass "T3b: summary counts symlink as skipped (2 spawned: badname + real)" \
   || fail "T3b: summary: $out3b2"
 
@@ -242,7 +242,7 @@ out4=$(
   || fail "T4: expected sa-new window; state: $(ls "$STATE4" 2>/dev/null)"
 [ ! -f "$STATE4/win.orch-panes-t4.sa-old" ] && pass "T4: --latest did NOT also spawn the older session's window" \
   || fail "T4: unexpectedly spawned sa-old too"
-{ printf '%s\n' "$out4" 2>/dev/null || :; } | grep -q 'spawned 1, skipped 0' \
+{ trap '' PIPE; printf '%s\n' "$out4" 2>/dev/null || :; } | grep -q 'spawned 1, skipped 0' \
   && pass "T4: summary reflects exactly one resolved transcript" || fail "T4: summary: $out4"
 
 # --latest with no matching project dir: clean miss, warns, rc 0, no windows.
@@ -252,7 +252,7 @@ out4b=$(
   export HOME="$TMP/no-such-home" TMUX_CMD="$TMP/tmux-mock" TMUX_MOCK_STATE="$STATE4B" TMUX_SESSION=orch-panes-t4b PANE_VIEWER=none
   cmd_panes "$MEGA4" --latest 2>&1
 ); rc4b=$?
-if [ "$rc4b" = 0 ] && { printf '%s\n' "$out4b" 2>/dev/null || :; } | grep -q -- '--latest:' && { printf '%s\n' "$out4b" 2>/dev/null || :; } | grep -q 'spawned 0, skipped 0'; then
+if [ "$rc4b" = 0 ] && { trap '' PIPE; printf '%s\n' "$out4b" 2>/dev/null || :; } | grep -q -- '--latest:' && { trap '' PIPE; printf '%s\n' "$out4b" 2>/dev/null || :; } | grep -q 'spawned 0, skipped 0'; then
   pass "T4: --latest with no project dir is a clean miss (warns, rc 0, spawns nothing)"
 else
   fail "T4: rc=$rc4b out=$out4b"
@@ -266,7 +266,7 @@ VALID_JSONL="$FIX5/agent-valid.jsonl"
 printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}' >| "$VALID_JSONL"
 
 out=$(cmd_pane_tail "$FIX5" "$GOODFMT" 2>&1); rc=$?
-[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'not a regular file' \
+[ "$rc" = 64 ] && { trap '' PIPE; printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'not a regular file' \
   && pass "T5a: a directory is refused, exit 64" || fail "T5a: rc=$rc out=$out"
 
 UNREADABLE="$FIX5/agent-unreadable.jsonl"
@@ -274,23 +274,23 @@ printf '%s\n' '{"type":"assistant"}' >| "$UNREADABLE"
 chmod 000 "$UNREADABLE"
 out=$(cmd_pane_tail "$UNREADABLE" "$GOODFMT" 2>&1); rc=$?
 chmod 644 "$UNREADABLE"
-[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'not readable' \
+[ "$rc" = 64 ] && { trap '' PIPE; printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'not readable' \
   && pass "T5b: an unreadable file is refused, exit 64" || fail "T5b: rc=$rc out=$out"
 
 LINK="$FIX5/agent-link.jsonl"
 ln -sf "$VALID_JSONL" "$LINK"
 out=$(cmd_pane_tail "$LINK" "$GOODFMT" 2>&1); rc=$?
-[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'symlink' \
+[ "$rc" = 64 ] && { trap '' PIPE; printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'symlink' \
   && pass "T5c: a symlink is refused, exit 64 [SECURITY L4]" || fail "T5c: rc=$rc out=$out"
 
 WRONG="$FIX5/not-agent.jsonl"
 printf '%s\n' '{"type":"assistant"}' >| "$WRONG"
 out=$(cmd_pane_tail "$WRONG" "$GOODFMT" 2>&1); rc=$?
-[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'basename does not match' \
+[ "$rc" = 64 ] && { trap '' PIPE; printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'basename does not match' \
   && pass "T5d: a wrong-basename file is refused, exit 64" || fail "T5d: rc=$rc out=$out"
 
 out=$(cmd_pane_tail "$VALID_JSONL" "$FIX5/no-such.jq" 2>&1); rc=$?
-[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'formatter missing or unreadable' \
+[ "$rc" = 64 ] && { trap '' PIPE; printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'formatter missing or unreadable' \
   && pass "T5e: a missing formatter is refused, exit 64" || fail "T5e: rc=$rc out=$out"
 
 # ================================ T6: formatter ================================
@@ -387,7 +387,7 @@ if [ ! -s "$POISON7" ] && [ ! -e "$PWNED7" ]; then
 else
   fail "T7: poison: $(cat "$POISON7" 2>/dev/null), pwned: $([ -e "$PWNED7" ] && echo YES || echo no)"
 fi
-{ printf '%s\n' "$out7" 2>/dev/null || :; } | grep -q 'charset gate' \
+{ trap '' PIPE; printf '%s\n' "$out7" 2>/dev/null || :; } | grep -q 'charset gate' \
   && pass "T7: the refusal names the charset gate (loud)" || fail "T7: no charset-gate warning: $out7"
 
 echo "----"

--- a/tests/test-subagent-panes.sh
+++ b/tests/test-subagent-panes.sh
@@ -109,7 +109,7 @@ rc1=$?
   || fail "T1: windows missing: $(ls "$STATE1" 2>/dev/null)"
 n_new_session=$(grep -c '^new-session' "$STATE1/calls.log")
 [ "$n_new_session" = 1 ] && pass "T1: tmux session ensured exactly once" || fail "T1: new-session called $n_new_session times"
-printf '%s\n' "$out1" | grep -q 'spawned 2, skipped 0' \
+{ printf '%s\n' "$out1" 2>/dev/null || :; } | grep -q 'spawned 2, skipped 0' \
   && pass "T1: summary line 'spawned 2, skipped 0'" || fail "T1: summary: $out1"
 
 : > "$STATE1/calls.log"
@@ -169,17 +169,17 @@ out3=$(
 )
 rc3=$?
 [ "$rc3" = 0 ] && pass "T3: rc 0 despite multiple skips" || fail "T3: rc=$rc3"
-printf '%s\n' "$out3" | grep -q 'not a readable regular file' \
+{ printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'not a readable regular file' \
   && pass "T3: missing-file skip warns" || fail "T3: no missing-file warning: $out3"
-printf '%s\n' "$out3" | grep -q 'basename does not match' \
+{ printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'basename does not match' \
   && pass "T3: wrong-basename skip warns" || fail "T3: no basename warning: $out3"
-printf '%s\n' "$out3" | grep -q 'empty dir' \
+{ printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'empty dir' \
   && pass "T3: empty-dir warns" || fail "T3: no empty-dir warning: $out3"
-printf '%s\n' "$out3" | grep -q 'spawned 1, skipped 3' \
+{ printf '%s\n' "$out3" 2>/dev/null || :; } | grep -q 'spawned 1, skipped 3' \
   && pass "T3: summary counts 1 spawned / 3 skipped (valid sibling still spawns)" || fail "T3: summary: $out3"
 
 out3b=$(cmd_panes "$MEGA3" 2>&1); rc3b=$?
-if [ "$rc3b" = 0 ] && printf '%s\n' "$out3b" | grep -q '^usage:'; then
+if [ "$rc3b" = 0 ] && { printf '%s\n' "$out3b" 2>/dev/null || :; } | grep -q '^usage:'; then
   pass "T3: <2 total args -> usage on stderr, rc 0"
 else
   fail "T3: rc=$rc3b out=$out3b"
@@ -200,21 +200,21 @@ out3b2=$(
   export TMUX_CMD="$TMP/tmux-mock" TMUX_MOCK_STATE="$STATE3B" TMUX_SESSION=orch-panes-t3b PANE_VIEWER=none
   cmd_panes "$MEGA3B" "$FIX3B" 2>&1
 )
-if printf '%s' "$out3b2" | grep -q "$(printf '\x1b')"; then
+if { printf '%s' "$out3b2" 2>/dev/null || :; } | grep -q "$(printf '\x1b')"; then
   fail "T3b: raw ESC byte reached combined stdout+stderr: $(printf '%s' "$out3b2" | cat -v)"
 else
   pass "T3b: no raw ESC byte in combined output"
 fi
-printf '%s\n' "$out3b2" | grep -qF 'agent-??52?c?evil?x.jsonl' \
+{ printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -qF 'agent-??52?c?evil?x.jsonl' \
   && pass "T3b: ESC-embedded filename rendered sanitized ('?' replacement)" \
   || fail "T3b: sanitized filename not found: $out3b2"
-printf '%s\n' "$out3b2" | grep -q 'skip: symlink, not a real transcript file' \
+{ printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -q 'skip: symlink, not a real transcript file' \
   && pass "T3b: symlink target skipped with its own warning (not spawned then ghost-killed)" \
   || fail "T3b: no symlink-skip warning: $out3b2"
 [ ! -f "$STATE3B/win.orch-panes-t3b.sa-link" ] \
   && pass "T3b: no window created for the symlink target" \
   || fail "T3b: a window was created for the symlink target"
-printf '%s\n' "$out3b2" | grep -q 'spawned 2, skipped 1' \
+{ printf '%s\n' "$out3b2" 2>/dev/null || :; } | grep -q 'spawned 2, skipped 1' \
   && pass "T3b: summary counts symlink as skipped (2 spawned: badname + real)" \
   || fail "T3b: summary: $out3b2"
 
@@ -242,7 +242,7 @@ out4=$(
   || fail "T4: expected sa-new window; state: $(ls "$STATE4" 2>/dev/null)"
 [ ! -f "$STATE4/win.orch-panes-t4.sa-old" ] && pass "T4: --latest did NOT also spawn the older session's window" \
   || fail "T4: unexpectedly spawned sa-old too"
-printf '%s\n' "$out4" | grep -q 'spawned 1, skipped 0' \
+{ printf '%s\n' "$out4" 2>/dev/null || :; } | grep -q 'spawned 1, skipped 0' \
   && pass "T4: summary reflects exactly one resolved transcript" || fail "T4: summary: $out4"
 
 # --latest with no matching project dir: clean miss, warns, rc 0, no windows.
@@ -252,7 +252,7 @@ out4b=$(
   export HOME="$TMP/no-such-home" TMUX_CMD="$TMP/tmux-mock" TMUX_MOCK_STATE="$STATE4B" TMUX_SESSION=orch-panes-t4b PANE_VIEWER=none
   cmd_panes "$MEGA4" --latest 2>&1
 ); rc4b=$?
-if [ "$rc4b" = 0 ] && printf '%s\n' "$out4b" | grep -q -- '--latest:' && printf '%s\n' "$out4b" | grep -q 'spawned 0, skipped 0'; then
+if [ "$rc4b" = 0 ] && { printf '%s\n' "$out4b" 2>/dev/null || :; } | grep -q -- '--latest:' && { printf '%s\n' "$out4b" 2>/dev/null || :; } | grep -q 'spawned 0, skipped 0'; then
   pass "T4: --latest with no project dir is a clean miss (warns, rc 0, spawns nothing)"
 else
   fail "T4: rc=$rc4b out=$out4b"
@@ -266,7 +266,7 @@ VALID_JSONL="$FIX5/agent-valid.jsonl"
 printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}' >| "$VALID_JSONL"
 
 out=$(cmd_pane_tail "$FIX5" "$GOODFMT" 2>&1); rc=$?
-[ "$rc" = 64 ] && printf '%s\n' "$out" | grep -q 'not a regular file' \
+[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'not a regular file' \
   && pass "T5a: a directory is refused, exit 64" || fail "T5a: rc=$rc out=$out"
 
 UNREADABLE="$FIX5/agent-unreadable.jsonl"
@@ -274,23 +274,23 @@ printf '%s\n' '{"type":"assistant"}' >| "$UNREADABLE"
 chmod 000 "$UNREADABLE"
 out=$(cmd_pane_tail "$UNREADABLE" "$GOODFMT" 2>&1); rc=$?
 chmod 644 "$UNREADABLE"
-[ "$rc" = 64 ] && printf '%s\n' "$out" | grep -q 'not readable' \
+[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'not readable' \
   && pass "T5b: an unreadable file is refused, exit 64" || fail "T5b: rc=$rc out=$out"
 
 LINK="$FIX5/agent-link.jsonl"
 ln -sf "$VALID_JSONL" "$LINK"
 out=$(cmd_pane_tail "$LINK" "$GOODFMT" 2>&1); rc=$?
-[ "$rc" = 64 ] && printf '%s\n' "$out" | grep -q 'symlink' \
+[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'symlink' \
   && pass "T5c: a symlink is refused, exit 64 [SECURITY L4]" || fail "T5c: rc=$rc out=$out"
 
 WRONG="$FIX5/not-agent.jsonl"
 printf '%s\n' '{"type":"assistant"}' >| "$WRONG"
 out=$(cmd_pane_tail "$WRONG" "$GOODFMT" 2>&1); rc=$?
-[ "$rc" = 64 ] && printf '%s\n' "$out" | grep -q 'basename does not match' \
+[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'basename does not match' \
   && pass "T5d: a wrong-basename file is refused, exit 64" || fail "T5d: rc=$rc out=$out"
 
 out=$(cmd_pane_tail "$VALID_JSONL" "$FIX5/no-such.jq" 2>&1); rc=$?
-[ "$rc" = 64 ] && printf '%s\n' "$out" | grep -q 'formatter missing or unreadable' \
+[ "$rc" = 64 ] && { printf '%s\n' "$out" 2>/dev/null || :; } | grep -q 'formatter missing or unreadable' \
   && pass "T5e: a missing formatter is refused, exit 64" || fail "T5e: rc=$rc out=$out"
 
 # ================================ T6: formatter ================================
@@ -387,7 +387,7 @@ if [ ! -s "$POISON7" ] && [ ! -e "$PWNED7" ]; then
 else
   fail "T7: poison: $(cat "$POISON7" 2>/dev/null), pwned: $([ -e "$PWNED7" ] && echo YES || echo no)"
 fi
-printf '%s\n' "$out7" | grep -q 'charset gate' \
+{ printf '%s\n' "$out7" 2>/dev/null || :; } | grep -q 'charset gate' \
   && pass "T7: the refusal names the charset gate (loud)" || fail "T7: no charset-gate warning: $out7"
 
 echo "----"

--- a/tests/test-test-writer-contract.sh
+++ b/tests/test-test-writer-contract.sh
@@ -35,21 +35,21 @@ echo "=== AC1: agents/test-writer.md grants no bare Bash, only scoped test-runne
 # frontmatter = the block between the first and second '---' line
 FRONTMATTER="$(awk '/^---$/{c++; next} c==1' "$AGENT")"
 
-if { printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$'; then
+if { trap '' PIPE; printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$'; then
   RC=1
 else
   RC=0
 fi
 assert "no bare '- Bash' tools entry (list form)" $RC
 
-if { printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE ',[[:space:]]*Bash[[:space:]]*[,)]|\(Bash[[:space:]]*[,)]'; then
+if { trap '' PIPE; printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE ',[[:space:]]*Bash[[:space:]]*[,)]|\(Bash[[:space:]]*[,)]'; then
   RC=1
 else
   RC=0
 fi
 assert "no bare ' Bash,' / ' Bash)' token in an inline tools list either" $RC
 
-{ printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash\('
+{ trap '' PIPE; printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash\('
 assert "at least one scoped Bash(...) pattern is present (it must be able to run tests)" $?
 
 echo ""

--- a/tests/test-test-writer-contract.sh
+++ b/tests/test-test-writer-contract.sh
@@ -35,21 +35,21 @@ echo "=== AC1: agents/test-writer.md grants no bare Bash, only scoped test-runne
 # frontmatter = the block between the first and second '---' line
 FRONTMATTER="$(awk '/^---$/{c++; next} c==1' "$AGENT")"
 
-if printf '%s\n' "$FRONTMATTER" | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$'; then
+if { printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$'; then
   RC=1
 else
   RC=0
 fi
 assert "no bare '- Bash' tools entry (list form)" $RC
 
-if printf '%s\n' "$FRONTMATTER" | grep -qE ',[[:space:]]*Bash[[:space:]]*[,)]|\(Bash[[:space:]]*[,)]'; then
+if { printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE ',[[:space:]]*Bash[[:space:]]*[,)]|\(Bash[[:space:]]*[,)]'; then
   RC=1
 else
   RC=0
 fi
 assert "no bare ' Bash,' / ' Bash)' token in an inline tools list either" $RC
 
-printf '%s\n' "$FRONTMATTER" | grep -qE '^[[:space:]]*-[[:space:]]*Bash\('
+{ printf '%s\n' "$FRONTMATTER" 2>/dev/null || :; } | grep -qE '^[[:space:]]*-[[:space:]]*Bash\('
 assert "at least one scoped Bash(...) pattern is present (it must be able to run tests)" $?
 
 echo ""

--- a/tests/test-tier4-close.sh
+++ b/tests/test-tier4-close.sh
@@ -64,7 +64,7 @@ mk_mock() {  # path
   cat > "$1" <<'MOCK'
 #!/usr/bin/env bash
 prompt=$(cat)
-if { printf '%s' "$prompt" 2>/dev/null || :; } | grep -q 'TIER-4 MEGA-CLOSE VERIFIER'; then
+if { trap '' PIPE; printf '%s' "$prompt" 2>/dev/null || :; } | grep -q 'TIER-4 MEGA-CLOSE VERIFIER'; then
   n=$(printf '%s' "$prompt" | grep -oE 'VERIFIER [0-9]+/3' | head -1 | grep -oE '[0-9]+' | head -1)
   touch "${CLOSE_SENTINEL}.${n}"
   if [ -n "${MOCK_DISSENT:-}" ] && [ "$MOCK_DISSENT" = "$n" ]; then

--- a/tests/test-tier4-close.sh
+++ b/tests/test-tier4-close.sh
@@ -64,7 +64,7 @@ mk_mock() {  # path
   cat > "$1" <<'MOCK'
 #!/usr/bin/env bash
 prompt=$(cat)
-if printf '%s' "$prompt" | grep -q 'TIER-4 MEGA-CLOSE VERIFIER'; then
+if { printf '%s' "$prompt" 2>/dev/null || :; } | grep -q 'TIER-4 MEGA-CLOSE VERIFIER'; then
   n=$(printf '%s' "$prompt" | grep -oE 'VERIFIER [0-9]+/3' | head -1 | grep -oE '[0-9]+' | head -1)
   touch "${CLOSE_SENTINEL}.${n}"
   if [ -n "${MOCK_DISSENT:-}" ] && [ "$MOCK_DISSENT" = "$n" ]; then

--- a/tests/test-wave-rid-check.sh
+++ b/tests/test-wave-rid-check.sh
@@ -130,7 +130,7 @@ N1=$(START_LINES_FOR "$LOGDIR_NC" "rid-check-nc-sg-01")
 N2=$(START_LINES_FOR "$LOGDIR_NC" "rid-check-nc-sg-02")
 box1=$(_sg_line "$WM2/ROADMAP.md" SG-01); box2=$(_sg_line "$WM2/ROADMAP.md" SG-02)
 both_flipped=0
-{ printf '%s' "$box1" | grep -q '^\- \[x\]' && printf '%s' "$box2" | grep -q '^\- \[x\]'; } && both_flipped=1
+{ { printf '%s' "$box1" 2>/dev/null || :; } | grep -q '^\- \[x\]' && { printf '%s' "$box2" 2>/dev/null || :; } | grep -q '^\- \[x\]'; } && both_flipped=1
 
 if [ "$ncrc" = 0 ] && [ "$N1" = 0 ] && [ "$N2" = 0 ] && [ "$both_flipped" = 1 ]; then
   pass "wave-rid-check NEGATIVE CONTROL A: pre-fix-equivalent code (START call stubbed) completes the SAME wave (both boxes flip) but records ZERO START lines -- causal effect demonstrated"
@@ -161,7 +161,7 @@ nrrc=0
   _wave_run "$WM3" "$WM3/ROADMAP.md" ) > "$TMP/norid.out" 2>&1 || nrrc=$?
 
 box3=$(_sg_line "$WM3/ROADMAP.md" SG-01)
-box3_flipped=0; printf '%s' "$box3" | grep -q '^\- \[x\]' && box3_flipped=1
+box3_flipped=0; { printf '%s' "$box3" 2>/dev/null || :; } | grep -q '^\- \[x\]' && box3_flipped=1
 warned=0; grep -q "WARN: SG-01 goal file has no '\*\*Branch:\*\*' header" "$TMP/norid.out" && warned=1
 # No ledger dir for this run at all (no rid was ever derivable to key a file by).
 ledger_files=$(find "$LOGDIR_NORID/runs" -type f 2>/dev/null | wc -l | tr -d ' ')

--- a/tests/test-wave-rid-check.sh
+++ b/tests/test-wave-rid-check.sh
@@ -130,7 +130,7 @@ N1=$(START_LINES_FOR "$LOGDIR_NC" "rid-check-nc-sg-01")
 N2=$(START_LINES_FOR "$LOGDIR_NC" "rid-check-nc-sg-02")
 box1=$(_sg_line "$WM2/ROADMAP.md" SG-01); box2=$(_sg_line "$WM2/ROADMAP.md" SG-02)
 both_flipped=0
-{ { printf '%s' "$box1" 2>/dev/null || :; } | grep -q '^\- \[x\]' && { printf '%s' "$box2" 2>/dev/null || :; } | grep -q '^\- \[x\]'; } && both_flipped=1
+{ { trap '' PIPE; printf '%s' "$box1" 2>/dev/null || :; } | grep -q '^\- \[x\]' && { trap '' PIPE; printf '%s' "$box2" 2>/dev/null || :; } | grep -q '^\- \[x\]'; } && both_flipped=1
 
 if [ "$ncrc" = 0 ] && [ "$N1" = 0 ] && [ "$N2" = 0 ] && [ "$both_flipped" = 1 ]; then
   pass "wave-rid-check NEGATIVE CONTROL A: pre-fix-equivalent code (START call stubbed) completes the SAME wave (both boxes flip) but records ZERO START lines -- causal effect demonstrated"
@@ -161,7 +161,7 @@ nrrc=0
   _wave_run "$WM3" "$WM3/ROADMAP.md" ) > "$TMP/norid.out" 2>&1 || nrrc=$?
 
 box3=$(_sg_line "$WM3/ROADMAP.md" SG-01)
-box3_flipped=0; { printf '%s' "$box3" 2>/dev/null || :; } | grep -q '^\- \[x\]' && box3_flipped=1
+box3_flipped=0; { trap '' PIPE; printf '%s' "$box3" 2>/dev/null || :; } | grep -q '^\- \[x\]' && box3_flipped=1
 warned=0; grep -q "WARN: SG-01 goal file has no '\*\*Branch:\*\*' header" "$TMP/norid.out" && warned=1
 # No ledger dir for this run at all (no rid was ever derivable to key a file by).
 ledger_files=$(find "$LOGDIR_NORID/runs" -type f 2>/dev/null | wc -l | tr -d ' ')

--- a/tests/test-weekend-batch.sh
+++ b/tests/test-weekend-batch.sh
@@ -97,9 +97,9 @@ MARKPAID_RC=$?
 echo "=== AC1: collects the week's deferred+waved items + impl-notes + explainers ==="
 COLLECT_OUT="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
 assert "AC1a collect mentions ug-10-waved-item (waved)" \
-  "$(printf '%s\n' "$COLLECT_OUT" | grep -qE '^## ug-10-waved-item$' && printf '%s\n' "$COLLECT_OUT" | grep -q 'disposition: waved' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -qE '^## ug-10-waved-item$' && { printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -q 'disposition: waved' && echo 0 || echo 1)"
 assert "AC1b collect mentions ug-11-deferred-item (deferred)" \
-  "$(printf '%s\n' "$COLLECT_OUT" | grep -qE '^## ug-11-deferred-item$' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -qE '^## ug-11-deferred-item$' && echo 0 || echo 1)"
 assert "AC1c ug-10's impl-notes resolved as FOUND (rid-named file)" \
   "$(printf '%s\n' "$COLLECT_OUT" | grep -A6 '^## ug-10-waved-item$' | grep -q 'impl-notes: docs/implementation-notes/ug-10-waved-item.md (found)' && echo 0 || echo 1)"
 assert "AC1d ug-11's explainer resolved as FOUND (slug-named file, ug-NN- prefix stripped)" \
@@ -127,32 +127,32 @@ echo "=== AC3a: NEGATIVE CONTROL -- an already-engaged (paid) item is not re-col
 assert "AC3a mark-paid on ug-12-paid-item exited 0 (the real codepath ran)" "$([ "$MARKPAID_RC" -eq 0 ] && echo 0 || echo 1)"
 LIST_OUT="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo)"
 assert "AC3a [NC] ug-12-paid-item ABSENT from list after mark-paid" \
-  "$(printf '%s\n' "$LIST_OUT" | grep -q 'ug-12-paid-item' && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-12-paid-item' && echo 1 || echo 0)"
 
 echo ""
 echo "=== AC3b: NEGATIVE CONTROL -- a non-significant change never enters the collectible view ==="
 assert "AC3b the raw ledger DOES contain the not-significant DEBT line (sanity: it really was written)" \
   "$(grep -q 'verdict=not-significant' "$RUNS/ug-13-nonsig-item.log" && echo 0 || echo 1)"
 assert "AC3b [NC] ug-13-nonsig-item ABSENT from list (never collectible)" \
-  "$(printf '%s\n' "$LIST_OUT" | grep -q 'ug-13-nonsig-item' && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-13-nonsig-item' && echo 1 || echo 0)"
 assert "AC3b [NC, bonus] the still-open ug-16-pending-item (tap, no response) is ALSO absent" \
-  "$(printf '%s\n' "$LIST_OUT" | grep -q 'ug-16-pending-item' && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-16-pending-item' && echo 1 || echo 0)"
 
 echo ""
 echo "=== AC3c: window scoping -- an item older than --days is excluded ==="
 assert "AC3c default (--days 7) excludes the 30-day-old waved item" \
-  "$(printf '%s\n' "$LIST_OUT" | grep -q 'ug-14-old-item' && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-14-old-item' && echo 1 || echo 0)"
 LIST_WIDE="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
 assert "AC3c --days 400 INCLUDES the same item" \
-  "$(printf '%s\n' "$LIST_WIDE" | grep -q 'ug-14-old-item' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$LIST_WIDE" 2>/dev/null || :; } | grep -q 'ug-14-old-item' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC3d: repo scoping -- a different-repo item is excluded by default, included with --all-repos ==="
 assert "AC3d default (--repo fixture-repo) excludes the other-repo item" \
-  "$(printf '%s\n' "$LIST_OUT" | grep -q 'ug-15-otherrepo-item' && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-15-otherrepo-item' && echo 1 || echo 0)"
 LIST_ALL="$(cd "$KIT_DIR" && bash "$WB" list --all-repos --days 400)"
 assert "AC3d --all-repos INCLUDES the other-repo item" \
-  "$(printf '%s\n' "$LIST_ALL" | grep -q 'ug-15-otherrepo-item' && echo 0 || echo 1)"
+  "$({ printf '%s\n' "$LIST_ALL" 2>/dev/null || :; } | grep -q 'ug-15-otherrepo-item' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC4: NEGATIVE CONTROL (reuse) -- the skill invokes, does not fork a second engine ==="
@@ -193,7 +193,7 @@ assert "regression: mark-paid on a THIN response-only item exits 0 (was exit 64 
 
 LIST_AFTER_THIN="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo)"
 assert "regression: $RID_THIN is no longer collectible after mark-paid (disposed paid, never re-collected)" \
-  "$(printf '%s\n' "$LIST_AFTER_THIN" | grep -q "$RID_THIN" && echo 1 || echo 0)"
+  "$({ printf '%s\n' "$LIST_AFTER_THIN" 2>/dev/null || :; } | grep -q "$RID_THIN" && echo 1 || echo 0)"
 
 echo ""
 echo "=== Forward-carry: a FAT classifier line precedes a response line ==="
@@ -204,13 +204,13 @@ RID_FAT="ug-21-fat-then-response-$$"
 FAT_LOG="$RUNS/$RID_FAT.log"
 LAST_FAT_RESP_LINE="$(grep '| DEBT |' "$FAT_LOG" | tail -n1)"
 assert "forward-carry: the response line carries significance=high from the earlier classifier line" \
-  "$(printf '%s' "$LAST_FAT_RESP_LINE" | grep -q 'significance=high' && echo 0 || echo 1)"
+  "$({ printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'significance=high' && echo 0 || echo 1)"
 assert "forward-carry: the response line carries worthiness=high from the earlier classifier line" \
-  "$(printf '%s' "$LAST_FAT_RESP_LINE" | grep -q 'worthiness=high' && echo 0 || echo 1)"
+  "$({ printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'worthiness=high' && echo 0 || echo 1)"
 assert "forward-carry: the response line carries verdict=tap from the earlier classifier line" \
-  "$(printf '%s' "$LAST_FAT_RESP_LINE" | grep -q 'verdict=tap' && echo 0 || echo 1)"
+  "$({ printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'verdict=tap' && echo 0 || echo 1)"
 assert "forward-carry: the response line still carries its own response=defer" \
-  "$(printf '%s' "$LAST_FAT_RESP_LINE" | grep -q 'response=defer' && echo 0 || echo 1)"
+  "$({ printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'response=defer' && echo 0 || echo 1)"
 
 COLLECT_FAT="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
 assert "forward-carry: the digest shows real sig/wor for $RID_FAT (high / high), not blanks" \
@@ -265,7 +265,7 @@ assert "AC5a record's own stdout prints the verdict (tap, per this description's
 E2E_LOG="$RUNS/$RID_E2E.log"
 FIRST_DEBT_LINE="$(grep '| DEBT |' "$E2E_LOG" | head -n1)"
 assert "AC5b record wrote a FAT | DEBT | line grounded in the real classification (significance=high worthiness=high verdict=tap)" \
-  "$(printf '%s' "$FIRST_DEBT_LINE" | grep -q 'significance=high worthiness=high verdict=tap' && echo 0 || echo 1)"
+  "$({ printf '%s' "$FIRST_DEBT_LINE" 2>/dev/null || :; } | grep -q 'significance=high worthiness=high verdict=tap' && echo 0 || echo 1)"
 
 # An open tap with no human response yet is PENDING -- not yet collectible (still Flow A's to
 # resolve; matches AC3b's bonus check on ug-16-pending-item above).
@@ -278,7 +278,7 @@ assert "AC5c before any human response, $RID_E2E is PENDING (not yet collectible
 ( cd "$KIT_DIR" && bash "$GL" debt-response "$RID_E2E" defer "deferred to weekend batch" ) >/dev/null
 LAST_E2E_LINE="$(grep '| DEBT |' "$E2E_LOG" | tail -n1)"
 assert "AC5d the human's defer response line forward-carries record's significance=high/worthiness=high/verdict=tap" \
-  "$(printf '%s' "$LAST_E2E_LINE" | grep -q 'significance=high worthiness=high verdict=tap response=defer' && echo 0 || echo 1)"
+  "$({ printf '%s' "$LAST_E2E_LINE" 2>/dev/null || :; } | grep -q 'significance=high worthiness=high verdict=tap response=defer' && echo 0 || echo 1)"
 
 COLLECT_E2E="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
 assert "AC5e collect shows REAL significance/worthiness for $RID_E2E (high / high), not blank" \

--- a/tests/test-weekend-batch.sh
+++ b/tests/test-weekend-batch.sh
@@ -97,9 +97,9 @@ MARKPAID_RC=$?
 echo "=== AC1: collects the week's deferred+waved items + impl-notes + explainers ==="
 COLLECT_OUT="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
 assert "AC1a collect mentions ug-10-waved-item (waved)" \
-  "$({ printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -qE '^## ug-10-waved-item$' && { printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -q 'disposition: waved' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -qE '^## ug-10-waved-item$' && { trap '' PIPE; printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -q 'disposition: waved' && echo 0 || echo 1)"
 assert "AC1b collect mentions ug-11-deferred-item (deferred)" \
-  "$({ printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -qE '^## ug-11-deferred-item$' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$COLLECT_OUT" 2>/dev/null || :; } | grep -qE '^## ug-11-deferred-item$' && echo 0 || echo 1)"
 assert "AC1c ug-10's impl-notes resolved as FOUND (rid-named file)" \
   "$(printf '%s\n' "$COLLECT_OUT" | grep -A6 '^## ug-10-waved-item$' | grep -q 'impl-notes: docs/implementation-notes/ug-10-waved-item.md (found)' && echo 0 || echo 1)"
 assert "AC1d ug-11's explainer resolved as FOUND (slug-named file, ug-NN- prefix stripped)" \
@@ -127,32 +127,32 @@ echo "=== AC3a: NEGATIVE CONTROL -- an already-engaged (paid) item is not re-col
 assert "AC3a mark-paid on ug-12-paid-item exited 0 (the real codepath ran)" "$([ "$MARKPAID_RC" -eq 0 ] && echo 0 || echo 1)"
 LIST_OUT="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo)"
 assert "AC3a [NC] ug-12-paid-item ABSENT from list after mark-paid" \
-  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-12-paid-item' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-12-paid-item' && echo 1 || echo 0)"
 
 echo ""
 echo "=== AC3b: NEGATIVE CONTROL -- a non-significant change never enters the collectible view ==="
 assert "AC3b the raw ledger DOES contain the not-significant DEBT line (sanity: it really was written)" \
   "$(grep -q 'verdict=not-significant' "$RUNS/ug-13-nonsig-item.log" && echo 0 || echo 1)"
 assert "AC3b [NC] ug-13-nonsig-item ABSENT from list (never collectible)" \
-  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-13-nonsig-item' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-13-nonsig-item' && echo 1 || echo 0)"
 assert "AC3b [NC, bonus] the still-open ug-16-pending-item (tap, no response) is ALSO absent" \
-  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-16-pending-item' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-16-pending-item' && echo 1 || echo 0)"
 
 echo ""
 echo "=== AC3c: window scoping -- an item older than --days is excluded ==="
 assert "AC3c default (--days 7) excludes the 30-day-old waved item" \
-  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-14-old-item' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-14-old-item' && echo 1 || echo 0)"
 LIST_WIDE="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo --days 400)"
 assert "AC3c --days 400 INCLUDES the same item" \
-  "$({ printf '%s\n' "$LIST_WIDE" 2>/dev/null || :; } | grep -q 'ug-14-old-item' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$LIST_WIDE" 2>/dev/null || :; } | grep -q 'ug-14-old-item' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC3d: repo scoping -- a different-repo item is excluded by default, included with --all-repos ==="
 assert "AC3d default (--repo fixture-repo) excludes the other-repo item" \
-  "$({ printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-15-otherrepo-item' && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$LIST_OUT" 2>/dev/null || :; } | grep -q 'ug-15-otherrepo-item' && echo 1 || echo 0)"
 LIST_ALL="$(cd "$KIT_DIR" && bash "$WB" list --all-repos --days 400)"
 assert "AC3d --all-repos INCLUDES the other-repo item" \
-  "$({ printf '%s\n' "$LIST_ALL" 2>/dev/null || :; } | grep -q 'ug-15-otherrepo-item' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s\n' "$LIST_ALL" 2>/dev/null || :; } | grep -q 'ug-15-otherrepo-item' && echo 0 || echo 1)"
 
 echo ""
 echo "=== AC4: NEGATIVE CONTROL (reuse) -- the skill invokes, does not fork a second engine ==="
@@ -193,7 +193,7 @@ assert "regression: mark-paid on a THIN response-only item exits 0 (was exit 64 
 
 LIST_AFTER_THIN="$(cd "$KIT_DIR" && bash "$WB" list --repo fixture-repo)"
 assert "regression: $RID_THIN is no longer collectible after mark-paid (disposed paid, never re-collected)" \
-  "$({ printf '%s\n' "$LIST_AFTER_THIN" 2>/dev/null || :; } | grep -q "$RID_THIN" && echo 1 || echo 0)"
+  "$({ trap '' PIPE; printf '%s\n' "$LIST_AFTER_THIN" 2>/dev/null || :; } | grep -q "$RID_THIN" && echo 1 || echo 0)"
 
 echo ""
 echo "=== Forward-carry: a FAT classifier line precedes a response line ==="
@@ -204,13 +204,13 @@ RID_FAT="ug-21-fat-then-response-$$"
 FAT_LOG="$RUNS/$RID_FAT.log"
 LAST_FAT_RESP_LINE="$(grep '| DEBT |' "$FAT_LOG" | tail -n1)"
 assert "forward-carry: the response line carries significance=high from the earlier classifier line" \
-  "$({ printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'significance=high' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'significance=high' && echo 0 || echo 1)"
 assert "forward-carry: the response line carries worthiness=high from the earlier classifier line" \
-  "$({ printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'worthiness=high' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'worthiness=high' && echo 0 || echo 1)"
 assert "forward-carry: the response line carries verdict=tap from the earlier classifier line" \
-  "$({ printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'verdict=tap' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'verdict=tap' && echo 0 || echo 1)"
 assert "forward-carry: the response line still carries its own response=defer" \
-  "$({ printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'response=defer' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$LAST_FAT_RESP_LINE" 2>/dev/null || :; } | grep -q 'response=defer' && echo 0 || echo 1)"
 
 COLLECT_FAT="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
 assert "forward-carry: the digest shows real sig/wor for $RID_FAT (high / high), not blanks" \
@@ -265,7 +265,7 @@ assert "AC5a record's own stdout prints the verdict (tap, per this description's
 E2E_LOG="$RUNS/$RID_E2E.log"
 FIRST_DEBT_LINE="$(grep '| DEBT |' "$E2E_LOG" | head -n1)"
 assert "AC5b record wrote a FAT | DEBT | line grounded in the real classification (significance=high worthiness=high verdict=tap)" \
-  "$({ printf '%s' "$FIRST_DEBT_LINE" 2>/dev/null || :; } | grep -q 'significance=high worthiness=high verdict=tap' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$FIRST_DEBT_LINE" 2>/dev/null || :; } | grep -q 'significance=high worthiness=high verdict=tap' && echo 0 || echo 1)"
 
 # An open tap with no human response yet is PENDING -- not yet collectible (still Flow A's to
 # resolve; matches AC3b's bonus check on ug-16-pending-item above).
@@ -278,7 +278,7 @@ assert "AC5c before any human response, $RID_E2E is PENDING (not yet collectible
 ( cd "$KIT_DIR" && bash "$GL" debt-response "$RID_E2E" defer "deferred to weekend batch" ) >/dev/null
 LAST_E2E_LINE="$(grep '| DEBT |' "$E2E_LOG" | tail -n1)"
 assert "AC5d the human's defer response line forward-carries record's significance=high/worthiness=high/verdict=tap" \
-  "$({ printf '%s' "$LAST_E2E_LINE" 2>/dev/null || :; } | grep -q 'significance=high worthiness=high verdict=tap response=defer' && echo 0 || echo 1)"
+  "$({ trap '' PIPE; printf '%s' "$LAST_E2E_LINE" 2>/dev/null || :; } | grep -q 'significance=high worthiness=high verdict=tap response=defer' && echo 0 || echo 1)"
 
 COLLECT_E2E="$(cd "$KIT_DIR" && bash "$WB" collect --repo fixture-repo --repo-root "$FIXREPO")"
 assert "AC5e collect shows REAL significance/worthiness for $RID_E2E (high / high), not blank" \

--- a/tests/test-wrap.sh
+++ b/tests/test-wrap.sh
@@ -22,8 +22,8 @@ chk() {
   if [ "$2" -eq 0 ] 2>/dev/null; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1))
   else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi
 }
-chk_has() { chk "$1" "$({ printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$3"; echo $?)"; }
-chk_no()  { chk "$1" "$({ printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$3" && echo 1 || echo 0)"; }
+chk_has() { chk "$1" "$({ trap '' PIPE; printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$3"; echo $?)"; }
+chk_no()  { chk "$1" "$({ trap '' PIPE; printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$3" && echo 1 || echo 0)"; }
 
 TMPD="$(mktemp -d "${TMPDIR:-/tmp}/dk-wrap-test.XXXXXX")"
 TMPD="$(cd "$TMPD" && pwd)"
@@ -436,7 +436,7 @@ chk "log --date overrides the prefix" \
 DATE_BEFORE="$(cat "$LOGFILE")"
 out="$(wrap_log --date "$(printf '2026-01-01\nFORGED')" "wrap: forged date" 2>&1)"; rc=$?
 chk "log refuses a multi-line --date (exit 1)" "$([ "$rc" -eq 1 ]; echo $?)"
-chk "log names the --date format" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'wrap log: --date must be YYYY-MM-DD'; echo $?)"
+chk "log names the --date format" "$({ trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q 'wrap log: --date must be YYYY-MM-DD'; echo $?)"
 chk "log wrote nothing on the forged date" "$([ "$DATE_BEFORE" = "$(cat "$LOGFILE")" ]; echo $?)"
 out="$(wrap_log --date 2026-13-45 "wrap: impossible date" 2>&1)"; rc=$?
 chk "log refuses an out-of-range --date (exit 1)" "$([ "$rc" -eq 1 ]; echo $?)"
@@ -457,12 +457,12 @@ chk "log wrote nothing on the newline" "$([ "$BEFORE" = "$(cat "$LOGFILE")" ]; e
 LONG="wrap: $(head -c 320 < /dev/zero | tr '\0' 'x')"
 out="$(wrap_log "$LONG" 2>&1)"; rc=$?
 chk "log writes a 320-char text" "$rc"
-chk "log warns over the 300-char budget" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'over the 300-char routine budget'; echo $?)"
+chk "log warns over the 300-char budget" "$({ trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q 'over the 300-char routine budget'; echo $?)"
 
 set_log_key "$LOGHOME/no-such-file.md"
 out="$(wrap_log "wrap: missing target" 2>&1)"; rc=$?
 chk "log exits 1 on a missing file" "$([ "$rc" -eq 1 ]; echo $?)"
-chk "log names the resolved path" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'no-such-file.md'; echo $?)"
+chk "log names the resolved path" "$({ trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q 'no-such-file.md'; echo $?)"
 
 set_log_key "$TMPD/outside/ACTIVITY.md"
 out="$(wrap_log "wrap: outside home" 2>&1)"; rc=$?
@@ -483,8 +483,8 @@ printf 'untouched\n' > "$LOGHOME/PROJECT.md"
 printf '[wrap]\n' > "$KITROOT/kit.toml"
 out="$(cd "$TMPD/projrepo" && HOME="$LOGHOME" KIT_CONFIG_ROOT="$KITROOT" "$WRAP" log "wrap: project toml" 2>&1)"; rc=$?
 chk "log ignores a project .kit.toml key (exit 0)" "$rc"
-chk "log says the line did not land" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'no wrap.activity_log key in the kit-root kit.toml; line not written'; echo $?)"
-chk "log still prints the line it would have written" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q ' · wrap: project toml'; echo $?)"
+chk "log says the line did not land" "$({ trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q 'no wrap.activity_log key in the kit-root kit.toml; line not written'; echo $?)"
+chk "log still prints the line it would have written" "$({ trap '' PIPE; printf '%s' "$out" 2>/dev/null || :; } | grep -q ' · wrap: project toml'; echo $?)"
 chk "log left the project-named file untouched" "$([ "$(cat "$LOGHOME/PROJECT.md")" = "untouched" ]; echo $?)"
 
 # The operator config overlay (SPEC-248) owns this key too: it is as trusted as the kit root,

--- a/tests/test-wrap.sh
+++ b/tests/test-wrap.sh
@@ -22,8 +22,8 @@ chk() {
   if [ "$2" -eq 0 ] 2>/dev/null; then echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS+1))
   else echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); fi
 }
-chk_has() { chk "$1" "$(printf '%s' "$2" | grep -qF -- "$3"; echo $?)"; }
-chk_no()  { chk "$1" "$(printf '%s' "$2" | grep -qF -- "$3" && echo 1 || echo 0)"; }
+chk_has() { chk "$1" "$({ printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$3"; echo $?)"; }
+chk_no()  { chk "$1" "$({ printf '%s' "$2" 2>/dev/null || :; } | grep -qF -- "$3" && echo 1 || echo 0)"; }
 
 TMPD="$(mktemp -d "${TMPDIR:-/tmp}/dk-wrap-test.XXXXXX")"
 TMPD="$(cd "$TMPD" && pwd)"
@@ -436,7 +436,7 @@ chk "log --date overrides the prefix" \
 DATE_BEFORE="$(cat "$LOGFILE")"
 out="$(wrap_log --date "$(printf '2026-01-01\nFORGED')" "wrap: forged date" 2>&1)"; rc=$?
 chk "log refuses a multi-line --date (exit 1)" "$([ "$rc" -eq 1 ]; echo $?)"
-chk "log names the --date format" "$(printf '%s' "$out" | grep -q 'wrap log: --date must be YYYY-MM-DD'; echo $?)"
+chk "log names the --date format" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'wrap log: --date must be YYYY-MM-DD'; echo $?)"
 chk "log wrote nothing on the forged date" "$([ "$DATE_BEFORE" = "$(cat "$LOGFILE")" ]; echo $?)"
 out="$(wrap_log --date 2026-13-45 "wrap: impossible date" 2>&1)"; rc=$?
 chk "log refuses an out-of-range --date (exit 1)" "$([ "$rc" -eq 1 ]; echo $?)"
@@ -457,12 +457,12 @@ chk "log wrote nothing on the newline" "$([ "$BEFORE" = "$(cat "$LOGFILE")" ]; e
 LONG="wrap: $(head -c 320 < /dev/zero | tr '\0' 'x')"
 out="$(wrap_log "$LONG" 2>&1)"; rc=$?
 chk "log writes a 320-char text" "$rc"
-chk "log warns over the 300-char budget" "$(printf '%s' "$out" | grep -q 'over the 300-char routine budget'; echo $?)"
+chk "log warns over the 300-char budget" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'over the 300-char routine budget'; echo $?)"
 
 set_log_key "$LOGHOME/no-such-file.md"
 out="$(wrap_log "wrap: missing target" 2>&1)"; rc=$?
 chk "log exits 1 on a missing file" "$([ "$rc" -eq 1 ]; echo $?)"
-chk "log names the resolved path" "$(printf '%s' "$out" | grep -q 'no-such-file.md'; echo $?)"
+chk "log names the resolved path" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'no-such-file.md'; echo $?)"
 
 set_log_key "$TMPD/outside/ACTIVITY.md"
 out="$(wrap_log "wrap: outside home" 2>&1)"; rc=$?
@@ -483,8 +483,8 @@ printf 'untouched\n' > "$LOGHOME/PROJECT.md"
 printf '[wrap]\n' > "$KITROOT/kit.toml"
 out="$(cd "$TMPD/projrepo" && HOME="$LOGHOME" KIT_CONFIG_ROOT="$KITROOT" "$WRAP" log "wrap: project toml" 2>&1)"; rc=$?
 chk "log ignores a project .kit.toml key (exit 0)" "$rc"
-chk "log says the line did not land" "$(printf '%s' "$out" | grep -q 'no wrap.activity_log key in the kit-root kit.toml; line not written'; echo $?)"
-chk "log still prints the line it would have written" "$(printf '%s' "$out" | grep -q ' · wrap: project toml'; echo $?)"
+chk "log says the line did not land" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q 'no wrap.activity_log key in the kit-root kit.toml; line not written'; echo $?)"
+chk "log still prints the line it would have written" "$({ printf '%s' "$out" 2>/dev/null || :; } | grep -q ' · wrap: project toml'; echo $?)"
 chk "log left the project-named file untouched" "$([ "$(cat "$LOGHOME/PROJECT.md")" = "untouched" ]; echo $?)"
 
 # The operator config overlay (SPEC-248) owns this key too: it is as trusted as the kit root,


### PR DESCRIPTION
grep -q exits on the first match, printf then hits EPIPE, and set -o pipefail turns a matched grep into a failed pipeline (SIGPIPE default: subshell dies 141; SIGPIPE ignored on the GitHub runner: printf returns 1). The macOS job on #508 hit it in test-config-registry.sh. Every printf ... | grep -q site in tests/ (303 sites, 47 files) now wraps the producer as { trap '' PIPE; printf ... 2>/dev/null || :; }. Mechanical rewrite, no assertion changed. Proof: docs/verification/test-grep-pipefail.md (recorded runs, deterministic negative control on bash 3.2 and 5.3, the two local exceptions explained).