### PR TITLE
test: make echo-into-grep-q safe under pipefail

### DIFF
--- a/docs/verification/test-echo-grep-pipefail-negctl.sh
+++ b/docs/verification/test-echo-grep-pipefail-negctl.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Negative control: a payload larger than the pipe buffer, spread across
+# multiple lines so grep -q can match on the first line and exit while the
+# writer is still blocked on the remaining ones, makes the race deterministic.
+# Same mechanism as docs/verification/test-grep-pipefail-negctl.sh (#510),
+# ported to `echo` producers instead of `printf`. A single giant line
+# (no embedded newline) does not reproduce it here: this darwin box's pipe
+# absorbs a solo 200-500KB write before grep even starts reading, so the
+# probe needs the same multi-line shape as the printf original.
+set -uo pipefail
+big=$(head -c 300000 /dev/zero | tr '\0' a)
+block="$big"$'\n'"$big"$'\n'"$big"
+echo "$block" | grep -q a; old_default=$?
+( trap '' PIPE; echo "$block" | grep -q a ); old_ignored=$?
+{ trap '' PIPE; echo "$block" 2>/dev/null || :; } | grep -q a; new_default=$?
+( trap '' PIPE; { trap '' PIPE; echo "$block" 2>/dev/null || :; } | grep -q a ); new_ignored=$?
+{ trap '' PIPE; echo "$big" 2>/dev/null || :; } | grep -q nomatch; new_miss=$?
+echo "old form, SIGPIPE default: exit=$old_default (RED expected)"
+echo "old form, SIGPIPE ignored (CI): exit=$old_ignored (RED expected)"
+echo "guarded form, SIGPIPE default: exit=$new_default (0 expected)"
+echo "guarded form, SIGPIPE ignored (CI): exit=$new_ignored (0 expected)"
+echo "guarded form, no match: exit=$new_miss (1 expected)"
+[ $old_default -ne 0 ] && [ $old_ignored -ne 0 ] && [ $new_default -eq 0 ] && [ $new_ignored -eq 0 ] && [ $new_miss -eq 1 ] && echo "CONTROL: PASS" || echo "CONTROL: FAIL"

--- a/docs/verification/test-echo-grep-pipefail.md
+++ b/docs/verification/test-echo-grep-pipefail.md
@@ -1,0 +1,79 @@
+# Proof of done: echo-into-grep-q under pipefail
+
+Scope: every `echo ... | grep -q` site in `tests/*.sh` and `tests/*.bats` (111 sites, 21 files) now wraps the producer as `{ trap '' PIPE; echo ... 2>/dev/null || :; }` so the pipeline exit is grep's. No assertion changed. Same defect class as #510 (`docs/verification/test-grep-pipefail.md`), which swept `printf ... | grep -q` sites and missed these because it grepped for `printf` only.
+
+## Root cause
+
+`grep -q` exits on the first match. `echo` then hits EPIPE writing to the closed pipe. With SIGPIPE at its default disposition the subshell running `echo` dies with 141 before any `|| :` can run; with SIGPIPE ignored (the GitHub runner) `echo` returns 1. Either way, `set -uo pipefail` (line 35 of `tests/test-kit-contract.sh`) turns a matched grep into a failed pipeline, so a real match reads as a miss. This produced a false FAIL on master run 34092722090 (merge of #511, macos-latest job):
+
+```
+line 235: echo: write error: Broken pipe
+FAIL: every staged-block writer goes through the one renderer (offenders: lib/learn/propose.py)
+```
+
+`lib/learn/propose.py` does import `staging_format` and call `sf.render_block`; the assertion misread the EPIPE-killed pipeline as a miss.
+
+## Green run
+
+| Command | Exit | Verdict |
+|---|---|---|
+| `bash tests/test-kit-contract.sh` | 0 | PASS (25/25, staged-block-writer check reads PASS) |
+| `bash tests/test-hooks.sh` | 0 | PASS (497/497) |
+| `bash tests/test-meta.sh` | 0 | PASS (840/840) |
+| `bash tests/test-orchestrate.sh` | 0 | PASS |
+| `bash tests/test-routing.sh` | 0 | PASS (14/14) |
+| `bash tests/test-learn-propose.sh` | 0 | PASS (42/42) |
+| `bash tests/test-intake-sweep.sh` | 0 | PASS (28/28) |
+| `bash tests/test-gate-ledger-history.sh` | 0 | PASS (9/9) |
+| `bash tests/test-gate-ledger-report.sh` | 0 | PASS (8/8) |
+| `bash tests/test-gate-outcome.sh` | 0 | PASS (25/25) |
+| `bash tests/test-config-stamp.sh` | 0 | PASS (17/17) |
+| `bash tests/test-every-step-review.sh` | 0 | PASS (17/17) |
+| `bash tests/test-agent-effectiveness.sh` | 0 | PASS (24/24) |
+| `bash tests/test-board-publish.sh` | 0 | PASS (19/19) |
+| `bash tests/test-break-it.sh` | 0 | PASS (68/68) |
+| `bash tests/test-meta-agent.sh` | 0 | PASS (72/72) |
+| `bash tests/test-picture-section.sh` | 0 | PASS (21/21) |
+| `bash tests/test-understanding-wiring.sh` | 0 | PASS (19/19) |
+| `bash tests/test-web-drift-refusal-guard.sh` | 0 | PASS (7/7) |
+| `bash tests/test-goal-dispatch.sh` | 1 | PASS (see caveat below, unrelated pre-existing fail) |
+| `bash docs/verification/test-echo-grep-pipefail-negctl.sh` | 0 | PASS (CONTROL: PASS, both signal regimes) |
+
+Recorded run:
+
+```
+- Command: bash tests/test-kit-contract.sh
+- Exit: 0
+- Verdict: PASS
+```
+
+`tests/test-goal-dispatch.sh` fails one unrelated assertion (`row13: exactly 5 forwarding branches use exec bash $GOAL_DIR/...`, a `grep -c` count against `lib/goal/goal.sh` with no echo/pipe in it) identically on unmodified `origin/master` (confirmed via `git stash`), so it is pre-existing drift, not a regression from this change. This branch's own `row12` assertion in the same file (an `echo | grep -q` site) is fixed and PASSes.
+
+Site census: `grep -rnE 'echo [^|]*\| *grep -q' tests/ | grep -v "trap '' PIPE"` returns 0 matches after the sweep. Total `{ trap '' PIPE; ... }` guards in `tests/`: 397 (286 pre-existing from the #510 printf sweep + 111 new from this sweep).
+
+Syntax check: `bash -n` on every changed `.sh` file, 0 errors.
+
+## NEGATIVE CONTROL
+
+The task-provided single-line 200-500 KB probe (`echo "$big" | grep -q a` with no embedded newline) does not reproduce the race on this host: a solo large write fits inside this darwin box's pipe buffer before grep starts reading, so `echo` never blocks and never sees EPIPE (`bare=0` at both 200 KB and 500 KB). The race needs the same shape #510's `printf` negctl used: multiple lines, so `grep -q` can match and exit after the first line while the writer is still blocked on the rest. `docs/verification/test-echo-grep-pipefail-negctl.sh` uses that shape (a 300 KB line repeated three times) and reproduces the exact failure signature from run 34092722090 (`echo: write error: Broken pipe`):
+
+```
+$ bash docs/verification/test-echo-grep-pipefail-negctl.sh
+old form, SIGPIPE default: exit=141 (RED expected)
+old form, SIGPIPE ignored (CI): exit=1 (RED expected)
+guarded form, SIGPIPE default: exit=0 (0 expected)
+guarded form, SIGPIPE ignored (CI): exit=0 (0 expected)
+guarded form, no match: exit=1 (1 expected)
+CONTROL: PASS
+```
+
+Same output under both bash builds on this host:
+
+```
+/bin/bash (GNU bash 3.2.57, Apple-signed): CONTROL: PASS
+/opt/homebrew/bin/bash (GNU bash 5.3.15): CONTROL: PASS
+```
+
+## Rollback
+
+`git revert` of this PR's commit restores the bare `echo | grep -q` form. Nothing else depends on the guarded shape; the tests assert the same things either way.

--- a/tests/test-agent-effectiveness.sh
+++ b/tests/test-agent-effectiveness.sh
@@ -41,8 +41,8 @@ if [ "${1:-}" != "" ] && [ -f "${1:-}" ]; then
   echo "=== agent-effectiveness GATE: $A ==="
   [ -z "$(tools_violation "$A")" ]; assert "gate: $N declares read-only tools only" $?
   MODEL=$(awk -F': *' '/^---$/{c++; if(c==2)exit} c==1 && /^model:/{print $2; exit}' "$A" | tr -d '[:space:]')
-  echo "$MODEL" | grep -qE '^(sonnet|haiku|opus)$'; assert "gate: $N model tier valid ($MODEL)" $?
-  if echo "$N" | grep -qE -- '-checker$|-auditor$|^reviewer$|-validate$'; then
+  { trap '' PIPE; echo "$MODEL" 2>/dev/null || :; } | grep -qE '^(sonnet|haiku|opus)$'; assert "gate: $N model tier valid ($MODEL)" $?
+  if { trap '' PIPE; echo "$N" 2>/dev/null || :; } | grep -qE -- '-checker$|-auditor$|^reviewer$|-validate$'; then
     assert "gate: $N name is not a retired review suffix" 1
   else
     assert "gate: $N name is not a retired review suffix" 0

--- a/tests/test-board-publish.sh
+++ b/tests/test-board-publish.sh
@@ -44,21 +44,21 @@ git -C "$WORK/r1.remote" log -1 --format=%s main 2>/dev/null | grep -q "chore(bo
   && ok "pushed to origin" || bad "remote missing the publish commit"
 git -C "$WORK/r1" status --porcelain | grep -q "other.txt" \
   && ok "unrelated dirt left untouched" || bad "unrelated file was swept into the commit"
-echo "$out" | grep -q "pushed" && ok "reports pushed" || bad "no pushed report: $out"
+{ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q "pushed" && ok "reports pushed" || bad "no pushed report: $out"
 
 echo "case AC2 (clean board -> no commit):"
 before="$(git -C "$WORK/r1" rev-parse HEAD)"
 out="$(cd "$WORK/r1" && bash "$BOARD_SH" publish --backlog-file "$WORK/r1/_meta/BACKLOG.md" 2>&1)"
 [ "$(git -C "$WORK/r1" rev-parse HEAD)" = "$before" ] \
   && ok "HEAD unchanged" || bad "a commit appeared with no board changes"
-echo "$out" | grep -q "no board changes" && ok "honest no-op report" || bad "no no-op report: $out"
+{ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q "no board changes" && ok "honest no-op report" || bad "no no-op report: $out"
 
 echo "case AC3 (worktree path refused):"
 mkdir -p "$WORK/r2/.claude/worktrees/x/_meta"
 printf '| ID | Item | Notes & source | Status |\n|---|---|---|---|\n' > "$WORK/r2/.claude/worktrees/x/_meta/BACKLOG.md"
 out="$(bash "$BOARD_SH" publish --backlog-file "$WORK/r2/.claude/worktrees/x/_meta/BACKLOG.md" 2>&1)"; rc=$?
 [ "$rc" -ne 0 ] && ok "nonzero exit" || bad "worktree path accepted (rc=0)"
-echo "$out" | grep -q "refusing a worktree" && ok "refusal names the fence" || bad "no refusal message: $out"
+{ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q "refusing a worktree" && ok "refusal names the fence" || bad "no refusal message: $out"
 
 echo "case AC4 (push failure -> commit kept, warn, exit 3):"
 mkrepo "$WORK/r3"
@@ -69,7 +69,7 @@ out="$(cd "$WORK/r3" && GIT_AUTHOR_EMAIL=t@t GIT_AUTHOR_NAME=t GIT_COMMITTER_EMA
 [ "$rc" -eq 3 ] && ok "exit 3 on push failure (monitoring signal, commit preserved)" || bad "expected rc 3, got: $rc"
 git -C "$WORK/r3" log -1 --format=%s | grep -q "chore(board)" \
   && ok "local commit kept" || bad "no local commit after push failure"
-echo "$out" | grep -q "WARN" && ok "push failure warns honestly" || bad "no push warning: $out"
+{ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q "WARN" && ok "push failure warns honestly" || bad "no push warning: $out"
 
 echo "case AC5 (diverged remote, NON-conflicting upstream edit -> rebase + push):"
 mkrepo "$WORK/r4"
@@ -108,7 +108,7 @@ git -C "$WORK/r1" checkout -q --detach HEAD
 printf '| ID-5 | detached row | x | queued |\n' >> "$WORK/r1/_meta/BACKLOG.md"
 out="$(bash "$BOARD_SH" publish --backlog-file "$WORK/r1/_meta/BACKLOG.md" 2>&1)"; rc=$?
 [ "$rc" -eq 2 ] && ok "detached HEAD exits 2" || bad "rc=$rc (want 2)"
-echo "$out" | grep -q "detached HEAD" && ok "refusal names detached HEAD" || bad "no detached-HEAD message: $out"
+{ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q "detached HEAD" && ok "refusal names detached HEAD" || bad "no detached-HEAD message: $out"
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/tests/test-break-it.sh
+++ b/tests/test-break-it.sh
@@ -100,9 +100,9 @@ sed -n '/## Lens escalation/,/^## /p' "$BAT" | grep -q 'break-it'
 assert "T2-AC1: the escalation table carries a break-it row" $?
 grep -q '## Probe rung' "$BAT"; assert "T2-AC2: commands/battery.md has a '## Probe rung' section" $?
 PROBE_SEC=$(sed -n '/## Probe rung/,/^## /p' "$BAT")
-echo "$PROBE_SEC" | grep -q 'mutation-smoke'; assert "T2-AC2: the probe rung names mutation-smoke as the next rung" $?
-echo "$PROBE_SEC" | grep -q '/kit:verify'; assert "T2-AC2: the probe rung names /kit:verify as mutation-smoke's owner" $?
-echo "$PROBE_SEC" | grep -qi 'stops the ladder'; assert "T2-AC2: a PROBE finding stops the ladder (DEC-005)" $?
+{ trap '' PIPE; echo "$PROBE_SEC" 2>/dev/null || :; } | grep -q 'mutation-smoke'; assert "T2-AC2: the probe rung names mutation-smoke as the next rung" $?
+{ trap '' PIPE; echo "$PROBE_SEC" 2>/dev/null || :; } | grep -q '/kit:verify'; assert "T2-AC2: the probe rung names /kit:verify as mutation-smoke's owner" $?
+{ trap '' PIPE; echo "$PROBE_SEC" 2>/dev/null || :; } | grep -qi 'stops the ladder'; assert "T2-AC2: a PROBE finding stops the ladder (DEC-005)" $?
 sed -n '/## After the legs return/,$p' "$BAT" | grep -q 'break-it'
 assert "T2-AC3: the after-the-legs step tells the lead to decide per probe finding" $?
 
@@ -240,9 +240,9 @@ grep -q '`break-it`' "$KIT_DIR/docs/architecture.md"; assert "T5-AC1: docs/archi
 # AC2: the three rungs appear in WORKFLOW.md's ladder paragraph, in ladder order.
 LADDER=$(sed -n '/three-rung ladder/,/^$/p' "$WF" | tr '\n' ' ')
 [ -n "$LADDER" ]; assert "T5-AC2: docs/WORKFLOW.md has a three-rung ladder paragraph" $?
-echo "$LADDER" | grep -q 'coverage.*probe.*mutation'
+{ trap '' PIPE; echo "$LADDER" 2>/dev/null || :; } | grep -q 'coverage.*probe.*mutation'
 assert "T5-AC2: the ladder names coverage, then probe, then mutation, in order" $?
-echo "$LADDER" | grep -qi 'stated, not enforced'
+{ trap '' PIPE; echo "$LADDER" 2>/dev/null || :; } | grep -qi 'stated, not enforced'
 assert "T5-AC2: the ladder states the order is not enforced (open question 1)" $?
 
 # --- TASK-004 AC5 [closing move]: the effectiveness gate ---------------------

--- a/tests/test-config-stamp.sh
+++ b/tests/test-config-stamp.sh
@@ -37,14 +37,14 @@ echo "=== config-stamp (ID-420 AC1-AC6) ==="
 new_log
 gl config c1 model=opus effort=high kit_version=9.9.9 modules=board,stats lane=full task_type=spec-feature suite_hash=abc123 session_id=sess-1 >/dev/null 2>&1
 LINE="$(gl show c1 2>&1 | grep '| CONFIG |')"
-echo "$LINE" | grep -q 'model=opus'          && assert "AC1 model round-trips"          0 || assert "AC1 model round-trips (got '$LINE')"          1
-echo "$LINE" | grep -q 'effort=high'         && assert "AC1 effort round-trips"         0 || assert "AC1 effort round-trips"         1
-echo "$LINE" | grep -q 'kit_version=9.9.9'   && assert "AC1 kit_version round-trips"    0 || assert "AC1 kit_version round-trips"    1
-echo "$LINE" | grep -q 'modules=board,stats' && assert "AC1 modules round-trips"        0 || assert "AC1 modules round-trips"        1
-echo "$LINE" | grep -q 'lane=full'           && assert "AC1 lane round-trips"           0 || assert "AC1 lane round-trips"           1
-echo "$LINE" | grep -q 'task_type=spec-feature' && assert "AC1 task_type round-trips"   0 || assert "AC1 task_type round-trips"      1
-echo "$LINE" | grep -q 'suite_hash=abc123'   && assert "AC1 suite_hash round-trips"     0 || assert "AC1 suite_hash round-trips"     1
-echo "$LINE" | grep -q 'session_id=sess-1'   && assert "AC1 session_id round-trips"     0 || assert "AC1 session_id round-trips"     1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q 'model=opus'          && assert "AC1 model round-trips"          0 || assert "AC1 model round-trips (got '$LINE')"          1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q 'effort=high'         && assert "AC1 effort round-trips"         0 || assert "AC1 effort round-trips"         1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q 'kit_version=9.9.9'   && assert "AC1 kit_version round-trips"    0 || assert "AC1 kit_version round-trips"    1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q 'modules=board,stats' && assert "AC1 modules round-trips"        0 || assert "AC1 modules round-trips"        1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q 'lane=full'           && assert "AC1 lane round-trips"           0 || assert "AC1 lane round-trips"           1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q 'task_type=spec-feature' && assert "AC1 task_type round-trips"   0 || assert "AC1 task_type round-trips"      1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q 'suite_hash=abc123'   && assert "AC1 suite_hash round-trips"     0 || assert "AC1 suite_hash round-trips"     1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q 'session_id=sess-1'   && assert "AC1 session_id round-trips"     0 || assert "AC1 session_id round-trips"     1
 
 # ---------------------------------------------------------------------------
 # AC2: kit_version defaults to $KIT_ROOT/VERSION when the caller omits it.
@@ -53,7 +53,7 @@ new_log
 gl config c2 model=sonnet >/dev/null 2>&1
 LINE="$(gl show c2 2>&1 | grep '| CONFIG |')"
 REAL_VER="$(cat "$KIT_DIR/VERSION" 2>/dev/null)"
-echo "$LINE" | grep -q "kit_version=$REAL_VER" && assert "AC2 kit_version defaults to VERSION file" 0 || assert "AC2 kit_version defaults to VERSION file (got '$LINE', want '$REAL_VER')" 1
+{ trap '' PIPE; echo "$LINE" 2>/dev/null || :; } | grep -q "kit_version=$REAL_VER" && assert "AC2 kit_version defaults to VERSION file" 0 || assert "AC2 kit_version defaults to VERSION file (got '$LINE', want '$REAL_VER')" 1
 
 # ---------------------------------------------------------------------------
 # AC3: suite_hash is never invented -- absent unless the caller passes it.

--- a/tests/test-every-step-review.sh
+++ b/tests/test-every-step-review.sh
@@ -25,7 +25,7 @@ for pair in "spec-validate" "review-team" "task-verifier" "integration-verifier"
 done
 # no review-bearing full-lane phase is skip: every 'required full' phase resolves in the plan
 REQ=$(bash "$GL" required full 2>/dev/null | tr '\n' ' ')
-[ -n "$REQ" ] && echo "$REQ" | grep -q 'spec' && echo "$REQ" | grep -q 'review' && echo "$REQ" | grep -q 'ship'
+[ -n "$REQ" ] && { trap '' PIPE; echo "$REQ" 2>/dev/null || :; } | grep -q 'spec' && { trap '' PIPE; echo "$REQ" 2>/dev/null || :; } | grep -q 'review' && { trap '' PIPE; echo "$REQ" 2>/dev/null || :; } | grep -q 'ship'
 assert "AC1: full lane's required set includes spec+review+ship (no review phase skipped)" $?
 
 # --- AC2 [NEGATIVE CONTROL]: ship-gate (gate-ledger check) BLOCKS a missing required review ---

--- a/tests/test-gate-ledger-history.sh
+++ b/tests/test-gate-ledger-history.sh
@@ -39,30 +39,30 @@ gl start r2 study study lesson lesson learning-kit >/dev/null 2>&1
 gl record r2 study ran >/dev/null 2>&1
 
 OUT="$(gl history)"
-echo "$OUT" | grep -q '^rid,lane,repo,first_ts,last_ts,gates_ran,gates_skipped$' \
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '^rid,lane,repo,first_ts,last_ts,gates_ran,gates_skipped$' \
   && assert "C1 CSV header" 0 || assert "C1 CSV header (got: $(echo "$OUT" | head -1))" 1
-echo "$OUT" | grep -q '^r1,full,dwarves-kit,.*,2,1$' \
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '^r1,full,dwarves-kit,.*,2,1$' \
   && assert "C1 r1 row: lane=full, 2 ran 1 skipped" 0 || assert "C1 r1 row (got: $(echo "$OUT" | grep '^r1,'))" 1
-echo "$OUT" | grep -q '^r2,study,learning-kit,.*,1,0$' \
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '^r2,study,learning-kit,.*,1,0$' \
   && assert "C1 r2 row: lane=study, 1 ran 0 skipped" 0 || assert "C1 r2 row (got: $(echo "$OUT" | grep '^r2,'))" 1
 
 # ---------------------------------------------------------------------------
 # C2: --lane filters to that lane only.
 # ---------------------------------------------------------------------------
 FULL="$(gl history --lane full)"
-echo "$FULL" | grep -q '^r1,' && [ -z "$(echo "$FULL" | grep '^r2,')" ] \
+{ trap '' PIPE; echo "$FULL" 2>/dev/null || :; } | grep -q '^r1,' && [ -z "$(echo "$FULL" | grep '^r2,')" ] \
   && assert "C2 --lane full excludes r2 (study)" 0 || assert "C2 --lane full excludes r2" 1
 STUDY="$(gl history --lane study)"
-echo "$STUDY" | grep -q '^r2,' && [ -z "$(echo "$STUDY" | grep '^r1,')" ] \
+{ trap '' PIPE; echo "$STUDY" 2>/dev/null || :; } | grep -q '^r2,' && [ -z "$(echo "$STUDY" | grep '^r1,')" ] \
   && assert "C2 --lane study excludes r1 (full)" 0 || assert "C2 --lane study excludes r1" 1
 
 # ---------------------------------------------------------------------------
 # C3: --json emits a JSON array with the same fields.
 # ---------------------------------------------------------------------------
 J="$(gl history --json)"
-echo "$J" | grep -q '"rid":"r1"' && echo "$J" | grep -q '"lane":"full"' \
-  && echo "$J" | grep -q '"repo":"dwarves-kit"' && echo "$J" | grep -q '"gates_ran":2' \
-  && echo "$J" | grep -q '"gates_skipped":1' \
+{ trap '' PIPE; echo "$J" 2>/dev/null || :; } | grep -q '"rid":"r1"' && { trap '' PIPE; echo "$J" 2>/dev/null || :; } | grep -q '"lane":"full"' \
+  && { trap '' PIPE; echo "$J" 2>/dev/null || :; } | grep -q '"repo":"dwarves-kit"' && { trap '' PIPE; echo "$J" 2>/dev/null || :; } | grep -q '"gates_ran":2' \
+  && { trap '' PIPE; echo "$J" 2>/dev/null || :; } | grep -q '"gates_skipped":1' \
   && assert "C3 JSON carries rid/lane/repo/counts" 0 || assert "C3 JSON fields (got: $J)" 1
 
 # ---------------------------------------------------------------------------
@@ -70,7 +70,7 @@ echo "$J" | grep -q '"rid":"r1"' && echo "$J" | grep -q '"lane":"full"' \
 # ---------------------------------------------------------------------------
 new_log
 EMPTY="$(gl history)"
-[ -n "$EMPTY" ] && echo "$EMPTY" | grep -q '^rid,lane,repo,first_ts,last_ts,gates_ran,gates_skipped$' \
+[ -n "$EMPTY" ] && { trap '' PIPE; echo "$EMPTY" 2>/dev/null || :; } | grep -q '^rid,lane,repo,first_ts,last_ts,gates_ran,gates_skipped$' \
   && assert "C4 empty dir -> header only (honest-empty)" 0 || assert "C4 empty dir -> header only" 1
 EJ="$(gl history --json)"
 [ "$(printf '%s' "$EJ" | tr -d '\n\t ')" = "[]" ] && assert "C4 empty dir --json -> []" 0 || assert "C4 empty dir --json -> [] (got: $EJ)" 1

--- a/tests/test-gate-ledger-report.sh
+++ b/tests/test-gate-ledger-report.sh
@@ -36,11 +36,11 @@ gl record r1 build ran >/dev/null 2>&1
 gl record r1 review skipped >/dev/null 2>&1
 
 OUT="$(gl report --period week)"
-echo "$OUT" | grep -q '^| rid | lane | repo | gates_ran | gates_skipped |$' \
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '^| rid | lane | repo | gates_ran | gates_skipped |$' \
   && assert "C1 markdown table header" 0 || assert "C1 markdown table header (got: $(echo "$OUT" | sed -n '3p'))" 1
-echo "$OUT" | grep -q '^| r1 | full | dwarves-kit | 2 | 1 |$' \
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '^| r1 | full | dwarves-kit | 2 | 1 |$' \
   && assert "C1 r1 row: 2 ran 1 skipped" 0 || assert "C1 r1 row (got: $(echo "$OUT" | grep '| r1 |'))" 1
-echo "$OUT" | grep -q '\*\*Totals:\*\* 1 runs, 2 gates ran, 1 gates skipped' \
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '\*\*Totals:\*\* 1 runs, 2 gates ran, 1 gates skipped' \
   && assert "C1 totals line" 0 || assert "C1 totals line (got: $(echo "$OUT" | grep Totals))" 1
 
 # ---------------------------------------------------------------------------
@@ -49,7 +49,7 @@ echo "$OUT" | grep -q '\*\*Totals:\*\* 1 runs, 2 gates ran, 1 gates skipped' \
 gl start r2 study study lesson lesson learning-kit >/dev/null 2>&1
 gl record r2 study ran >/dev/null 2>&1
 FULL="$(gl report --period week --lane full)"
-echo "$FULL" | grep -q '| r1 |' && [ -z "$(echo "$FULL" | grep '| r2 |')" ] \
+{ trap '' PIPE; echo "$FULL" 2>/dev/null || :; } | grep -q '| r1 |' && [ -z "$(echo "$FULL" | grep '| r2 |')" ] \
   && assert "C2 --lane full excludes r2 (study)" 0 || assert "C2 --lane full excludes r2" 1
 
 # ---------------------------------------------------------------------------
@@ -61,7 +61,7 @@ gl record rold spec ran >/dev/null 2>&1
 OLD_ISO="$(date -v-40d -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '-40 days' +%Y-%m-%dT%H:%M:%SZ)"
 sed -i.bak "1s/^[^ ]*/$OLD_ISO/" "$LOGD/runs/rold.log" && rm -f "$LOGD/runs/rold.log.bak"
 OUT3="$(gl report --period month)"
-echo "$OUT3" | grep -q 'No runs in this window' \
+{ trap '' PIPE; echo "$OUT3" 2>/dev/null || :; } | grep -q 'No runs in this window' \
   && assert "C3 40-day-old run excluded from a 30-day window" 0 || assert "C3 40-day-old run excluded (got: $OUT3)" 1
 
 # ---------------------------------------------------------------------------
@@ -69,8 +69,8 @@ echo "$OUT3" | grep -q 'No runs in this window' \
 # ---------------------------------------------------------------------------
 new_log
 EMPTY="$(gl report --period month)"
-echo "$EMPTY" | grep -q '^# Gate-ledger report (month, since' \
-  && echo "$EMPTY" | grep -q 'No runs in this window' \
+{ trap '' PIPE; echo "$EMPTY" 2>/dev/null || :; } | grep -q '^# Gate-ledger report (month, since' \
+  && { trap '' PIPE; echo "$EMPTY" 2>/dev/null || :; } | grep -q 'No runs in this window' \
   && assert "C4 empty dir -> honest-empty report" 0 || assert "C4 empty dir -> honest-empty report (got: $EMPTY)" 1
 
 # ---------------------------------------------------------------------------

--- a/tests/test-gate-outcome.sh
+++ b/tests/test-gate-outcome.sh
@@ -40,7 +40,7 @@ gl outcome rt ship start >/dev/null 2>&1
 sleep 1
 gl outcome rt ship end caught=true >/dev/null 2>&1
 RT="$(gl outcome-read rt ship 2>/dev/null)"
-echo "$RT" | grep -q '^ship caught=true dur_s=' && assert "AC1 round-trip: reads back phase+caught+dur_s" 0 || assert "AC1 round-trip: reads back phase+caught+dur_s (got '$RT')" 1
+{ trap '' PIPE; echo "$RT" 2>/dev/null || :; } | grep -q '^ship caught=true dur_s=' && assert "AC1 round-trip: reads back phase+caught+dur_s" 0 || assert "AC1 round-trip: reads back phase+caught+dur_s (got '$RT')" 1
 DUR="$(echo "$RT" | sed -nE 's/.*dur_s=([0-9]+).*/\1/p')"
 [ -n "$DUR" ] && [ "$DUR" -ge 1 ] 2>/dev/null && assert "AC1 duration derivable (dur_s>=1 after a 1s bracket)" 0 || assert "AC1 duration derivable (got dur_s='$DUR')" 1
 

--- a/tests/test-goal-dispatch.sh
+++ b/tests/test-goal-dispatch.sh
@@ -97,7 +97,7 @@ else
   chmod 000 "$d/goal-drafts.sh"
   out="$(bash "$d/goal.sh" draft dir 2>&1)"; ec=$?
   assert "row12: unreadable sibling surfaces bash's own 'Permission denied', exit 126" \
-    "$(echo "$out" | grep -q 'Permission denied' && [ "$ec" -eq 126 ] && echo 0 || echo 1)"
+    "$({ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'Permission denied' && [ "$ec" -eq 126 ] && echo 0 || echo 1)"
   rm -rf "$d"; trap - EXIT
 fi
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -37,7 +37,7 @@ assert_exit() {
 assert_output_contains() {
   local NAME="$1" EXPECTED="$2" ACTUAL="$3"
   TOTAL=$((TOTAL + 1))
-  if echo "$ACTUAL" | grep -q "$EXPECTED"; then
+  if { trap '' PIPE; echo "$ACTUAL" 2>/dev/null || :; } | grep -q "$EXPECTED"; then
     echo -e "  ${GREEN}PASS${NC} $NAME"
     PASS=$((PASS + 1))
   else
@@ -49,7 +49,7 @@ assert_output_contains() {
 assert_output_not_contains() {
   local NAME="$1" UNEXPECTED="$2" ACTUAL="$3"
   TOTAL=$((TOTAL + 1))
-  if echo "$ACTUAL" | grep -q "$UNEXPECTED"; then
+  if { trap '' PIPE; echo "$ACTUAL" 2>/dev/null || :; } | grep -q "$UNEXPECTED"; then
     echo -e "  ${RED}FAIL${NC} $NAME (output should NOT contain '$UNEXPECTED')"
     FAIL=$((FAIL + 1))
   else

--- a/tests/test-intake-sweep.sh
+++ b/tests/test-intake-sweep.sh
@@ -68,7 +68,7 @@ assert_true "command-adapter item staged" "$(grep -q '## \[staged\] Saved tab ab
 assert_true "NC: skip-verdict item NOT staged" "$(! grep -q 'skip-me' "$S"; echo $?)"
 assert_true "NC: board-title dup NOT staged" "$(! grep -q '## \[staged\] Already on the board' "$S"; echo $?)"
 assert_true "NC: staging-url dup NOT staged" "$(! grep -q 'Renamed since staged' "$S"; echo $?)"
-assert_true "summary line printed" "$(echo "$out" | grep -q 'intake-sweep: staged 2 candidate'; echo $?)"
+assert_true "summary line printed" "$({ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'intake-sweep: staged 2 candidate'; echo $?)"
 
 echo "== idempotence: a second forced run stages nothing new =="
 before="$(grep -c '^## \[staged\]' "$S")"
@@ -120,19 +120,19 @@ cat > "$R5/_meta/intake-sources.json" <<'EOF'
 ]}
 EOF
 err="$(REPO_ROOT="$R5" INTAKE_SWEEP_STATE_DIR="$R5/state" python3 "$SWEEP" --force 2>&1 >/dev/null)"
-assert_true "unknown kind warns on stderr" "$(echo "$err" | grep -q "typo-kind.*unknown kind 'jsonlines'"; echo $?)"
+assert_true "unknown kind warns on stderr" "$({ trap '' PIPE; echo "$err" 2>/dev/null || :; } | grep -q "typo-kind.*unknown kind 'jsonlines'"; echo $?)"
 assert_true "the good source still stages despite a broken sibling" \
   "$(grep -q 'Item A' "$R5/_meta/backlog-staging.md"; echo $?)"
 out="$(REPO_ROOT="$R5" INTAKE_SWEEP_STATE_DIR="$R5/state" python3 "$SWEEP" --check 2>&1)"; rc=$?
 assert_true "--check exits 0" "$rc"
-assert_true "--check reports the good source's raw yield" "$(echo "$out" | grep -qE 'ok +good \(jsonl\): 1 item'; echo $?)"
-assert_true "--check FAILs the unknown kind" "$(echo "$out" | grep -q 'FAIL typo-kind'; echo $?)"
-assert_true "--check WARNs the dead path (0 items)" "$(echo "$out" | grep -q 'WARN dead-path'; echo $?)"
-assert_true "--check counts what needs attention" "$(echo "$out" | grep -q '3 source(s), 2 needing attention'; echo $?)"
+assert_true "--check reports the good source's raw yield" "$({ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -qE 'ok +good \(jsonl\): 1 item'; echo $?)"
+assert_true "--check FAILs the unknown kind" "$({ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'FAIL typo-kind'; echo $?)"
+assert_true "--check WARNs the dead path (0 items)" "$({ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'WARN dead-path'; echo $?)"
+assert_true "--check counts what needs attention" "$({ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q '3 source(s), 2 needing attention'; echo $?)"
 assert_true "NC: --check stages nothing (report-only)" \
   "$(! grep -q 'dead-path\|typo-kind' "$R5/_meta/backlog-staging.md"; echo $?)"
 out="$(REPO_ROOT="$R2" INTAKE_SWEEP_STATE_DIR="$R2/state" python3 "$SWEEP" --check 2>&1)"
-assert_true "--check says so when no sources are configured" "$(echo "$out" | grep -q 'no sources configured'; echo $?)"
+assert_true "--check says so when no sources are configured" "$({ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'no sources configured'; echo $?)"
 
 echo "== surface wiring: backlog-stage.sh --surface runs the sweep then surfaces =="
 R4="$(mkrepo)"
@@ -147,7 +147,7 @@ out="$(REPO_ROOT="$R4" INTAKE_SWEEP_STATE_DIR="$R4/state" \
       bash "$KIT_DIR/hooks/backlog-stage.sh" --surface 2>&1)"; rc=$?
 assert_true "backlog-stage.sh --surface exits 0" "$rc"
 assert_true "sweep ran on the surface pass" "$(grep -q 'Via surface' "$R4/_meta/backlog-staging.md"; echo $?)"
-assert_true "surfaced count includes the swept candidate" "$(echo "$out" | grep -q '1 backlog candidate'; echo $?)"
+assert_true "surfaced count includes the swept candidate" "$({ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q '1 backlog candidate'; echo $?)"
 
 echo
 echo "intake-sweep: $PASS passed, $FAIL failed"

--- a/tests/test-kit-contract.sh
+++ b/tests/test-kit-contract.sh
@@ -145,7 +145,7 @@ WIRING_EXEMPT='session-observe|session-report|session-semantic|session-intel|ses
 unwired=""
 while IFS= read -r exe; do
   base="$(basename "$exe")"
-  echo "$base" | grep -qE "^($WIRING_EXEMPT)$" && continue
+  { trap '' PIPE; echo "$base" 2>/dev/null || :; } | grep -qE "^($WIRING_EXEMPT)$" && continue
   # A deprecated-alias shim (it warns and execs the canonical name) is reachable BY DEFINITION:
   # it exists so an old call-site keeps working. Requiring a bin/ shim for the shim is silly.
   grep -q 'is deprecated, use' "$exe" 2>/dev/null && continue
@@ -232,10 +232,10 @@ while IFS= read -r f; do
   # two proposals out, the forged one indistinguishable to `board promote`). A copy of a
   # shared grammar is not a copy for long (found 2026-07-15).
   body="$(grep -vE '^[[:space:]]*#' "$f")"
-  echo "$body" | grep -q 'staging-format\.py\|staging_format' || { bespoke="$bespoke$f\n"; continue; }
+  { trap '' PIPE; echo "$body" 2>/dev/null || :; } | grep -q 'staging-format\.py\|staging_format' || { bespoke="$bespoke$f\n"; continue; }
   # ... and it must not ALSO define its own renderer next to that import.
-  echo "$body" | grep -qE '^[[:space:]]*def (render_block|render_candidate)\(' \
-    && ! echo "$body" | grep -qE 'sf\.render_block|\.render_block\(\{' \
+  { trap '' PIPE; echo "$body" 2>/dev/null || :; } | grep -qE '^[[:space:]]*def (render_block|render_candidate)\(' \
+    && ! { trap '' PIPE; echo "$body" 2>/dev/null || :; } | grep -qE 'sf\.render_block|\.render_block\(\{' \
     && bespoke="$bespoke$f(defines-its-own)\n"
 # No --include: the kit's executables are EXTENSIONLESS by house rule, so filtering to
 # *.py/*.sh skipped session-audit, one of the very writers this rule governs. C6 had the same
@@ -366,7 +366,7 @@ nc1="$(cc_env "$TMP/nc")"
 [ "$(echo "$nc1" | grep -c CC_SNEAKY)" -eq 3 ] && ok "C1 catches all three unexpected CC_* shapes" || bad "C1 vacuous on unexpected shapes" "(caught: $nc1)"
 # and a NEW CC_SI_* must NOT be grandfathered by the stem
 printf 'z=${CC_SI_BRAND_NEW_FOSSIL}\n' > "$TMP/nc/plant2.sh"
-echo "$(cc_env "$TMP/nc")" | grep -q CC_SI_BRAND_NEW_FOSSIL && ok "C1 does not blanket-exempt the CC_SI_ namespace" || bad "C1 grandfathers a NEW CC_SI_ var"
+{ trap '' PIPE; echo "$(cc_env "$TMP/nc")" 2>/dev/null || :; } | grep -q CC_SI_BRAND_NEW_FOSSIL && ok "C1 does not blanket-exempt the CC_SI_ namespace" || bad "C1 grandfathers a NEW CC_SI_ var"
 rm -f "$TMP/nc/plant.py" "$TMP/nc/plant.sh" "$TMP/nc/plant2.sh"
 
 # C2: an unwired executable in a module bin/ (the session-audit / skill-improve shape)
@@ -385,7 +385,7 @@ else bad "C5 vacuous on the comment-mention evasion"; fi
 printf 'def render_block(c):\n    return "## [staged] " + c["title"] + "\\n"\n' \
   > "$TMP/nc/lib/private-renderer.py"
 nc5b="$(grep -vE '^[[:space:]]*#' "$TMP/nc/lib/private-renderer.py")"
-if ! echo "$nc5b" | grep -q 'staging-format\.py\|staging_format'; then
+if ! { trap '' PIPE; echo "$nc5b" 2>/dev/null || :; } | grep -q 'staging-format\.py\|staging_format'; then
   ok "C5 catches a writer that DEFINES its own renderer (the copy that drifted)"
 else bad "C5 vacuous on the private-renderer evasion"; fi
 

--- a/tests/test-learn-propose.sh
+++ b/tests/test-learn-propose.sh
@@ -81,7 +81,7 @@ echo '{"window":{"days":30,"megas":null,"rids":[],"n_rids":0},"signals":[]}' > "
 mock_interp '[{"title":"should not appear","intent":"x","approach":"y","u":"lo","f":"lo","home":"","signal":"S1"}]'
 OUT="$(python3 "$PROPOSE" --aggregate-file "$AGG" 2>&1)"; RC=$?
 assert_true "honest-empty: exit 0" "$([ $RC -eq 0 ]; echo $?)"
-assert_true "honest-empty: prints 0 candidates" "$(echo "$OUT" | grep -q '0 candidates'; echo $?)"
+assert_true "honest-empty: prints 0 candidates" "$({ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '0 candidates'; echo $?)"
 assert_true "honest-empty: staging file NOT created" "$([ ! -f "$STAGING" ]; echo $?)"
 
 # ============================================================
@@ -95,7 +95,7 @@ OUT="$(python3 "$PROPOSE" --aggregate-file "$AGG" 2>&1)"
 N2="$(grep -c '## \[staged\]' "$STAGING")"
 assert_true "idempotency: first run staged exactly 1" "$([ "$N1" -eq 1 ]; echo $?)"
 assert_true "idempotency: second run added nothing" "$([ "$N1" -eq "$N2" ]; echo $?)"
-assert_true "idempotency: re-run reports duplicate drop" "$(echo "$OUT" | grep -q 'duplicate'; echo $?)"
+assert_true "idempotency: re-run reports duplicate drop" "$({ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q 'duplicate'; echo $?)"
 
 # ============================================================
 echo "== grounding drop: a hypothesis citing an unknown signal id is dropped =="
@@ -104,7 +104,7 @@ setup
 mock_interp '[{"title":"Ungrounded proposal","intent":"x","approach":"y","u":"lo","f":"lo","home":"","signal":"S99"}]'
 OUT="$(python3 "$PROPOSE" --aggregate-file "$AGG" 2>&1)"
 assert_true "grounding: ungrounded proposal NOT staged" "$([ ! -f "$STAGING" ] || ! grep -q 'Ungrounded proposal' "$STAGING"; echo $?)"
-assert_true "grounding: reports ungrounded drop" "$(echo "$OUT" | grep -q '1 ungrounded'; echo $?)"
+assert_true "grounding: reports ungrounded drop" "$({ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '1 ungrounded'; echo $?)"
 
 # ============================================================
 echo "== adversarial drop: a REFUTED hypothesis is dropped (fail-closed also drops garbled) =="
@@ -114,7 +114,7 @@ mock_interp '[{"title":"Refuted proposal","intent":"x","approach":"y","u":"mid",
 export LEARN_PROPOSE_VERIFIER="$TD/verify-refute.sh"
 OUT="$(python3 "$PROPOSE" --aggregate-file "$AGG" 2>&1)"
 assert_true "adversarial: REFUTED proposal NOT staged" "$([ ! -f "$STAGING" ] || ! grep -q 'Refuted proposal' "$STAGING"; echo $?)"
-assert_true "adversarial: reports refuted drop" "$(echo "$OUT" | grep -q '1 refuted'; echo $?)"
+assert_true "adversarial: reports refuted drop" "$({ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '1 refuted'; echo $?)"
 setup
 mock_interp '[{"title":"Garbled-verdict proposal","intent":"x","approach":"y","u":"mid","f":"mid","home":"","signal":"S1"}]'
 export LEARN_PROPOSE_VERIFIER="$TD/verify-garbled.sh"
@@ -173,9 +173,9 @@ python3 "$SF" render > "$TD/block.md" <<'EOF'
 {"title":"Round trip","intent":"i","approach":"a","u":"hi","f":"lo","home":"h","source":"learn propose 2026-07-12 | lens=L figure=\"F\" rids=r1"}
 EOF
 PARSED="$(python3 "$SF" parse "$TD/block.md" 2>&1)"
-assert_true "round-trip: state is staged" "$(echo "$PARSED" | grep -q '\"state\": \"staged\"'; echo $?)"
-assert_true "round-trip: title recovered" "$(echo "$PARSED" | grep -q '\"title\": \"Round trip\"'; echo $?)"
-assert_true "round-trip: Source field recovered" "$(echo "$PARSED" | grep -q 'lens=L figure'; echo $?)"
+assert_true "round-trip: state is staged" "$({ trap '' PIPE; echo "$PARSED" 2>/dev/null || :; } | grep -q '\"state\": \"staged\"'; echo $?)"
+assert_true "round-trip: title recovered" "$({ trap '' PIPE; echo "$PARSED" 2>/dev/null || :; } | grep -q '\"title\": \"Round trip\"'; echo $?)"
+assert_true "round-trip: Source field recovered" "$({ trap '' PIPE; echo "$PARSED" 2>/dev/null || :; } | grep -q 'lens=L figure'; echo $?)"
 
 # ============================================================
 echo "== add-backlog compatibility: a staged block parses under the (unmodified) reader =="
@@ -184,7 +184,7 @@ setup
 mock_interp '[{"title":"Compat check","intent":"i","approach":"a","u":"mid","f":"mid","home":"dwarves-kit","signal":"S1"}]'
 python3 "$PROPOSE" --aggregate-file "$AGG" >/dev/null 2>&1
 LIST="$(BACKLOG_STAGE_STAGING="$STAGING" BACKLOG_STAGE_BACKLOG="$BACKLOG" python3 "$KIT_DIR/lib/board/bin/add-backlog" 2>&1)"
-assert_true "compat: add-backlog lists the staged block as a promotable row" "$(echo "$LIST" | grep -q 'Compat check'; echo $?)"
+assert_true "compat: add-backlog lists the staged block as a promotable row" "$({ trap '' PIPE; echo "$LIST" 2>/dev/null || :; } | grep -q 'Compat check'; echo $?)"
 
 # ============================================================
 echo "== rid fallback: TOKENS still land when the gate-rid call fails (master/detached) =="
@@ -204,7 +204,7 @@ print(rid)
 print("OK" if rid == "learn-propose-" + datetime.date.today().isoformat() else "BAD")
 PY
 )"
-assert_true "rid: falls back to a date slug when gate-rid is unavailable" "$(echo "$RID_OUT" | grep -q '^OK$'; echo $?)"
+assert_true "rid: falls back to a date slug when gate-rid is unavailable" "$({ trap '' PIPE; echo "$RID_OUT" 2>/dev/null || :; } | grep -q '^OK$'; echo $?)"
 
 # ============================================================
 echo "== empty-figure grounding: a signal present but with an empty figure is not evidence =="
@@ -214,7 +214,7 @@ echo '{"window":{"days":30,"megas":null,"rids":["r1"],"n_rids":1},"signals":[{"i
 mock_interp '[{"title":"Empty-figure proposal","intent":"x","approach":"y","u":"mid","f":"mid","home":"","signal":"S1"}]'
 OUT="$(python3 "$PROPOSE" --aggregate-file "$AGG" 2>&1)"
 assert_true "empty-figure: a hypothesis citing an empty-figure signal is dropped ungrounded" "$([ ! -f "$STAGING" ] || ! grep -q 'Empty-figure proposal' "$STAGING"; echo $?)"
-assert_true "empty-figure: reported as ungrounded" "$(echo "$OUT" | grep -q '1 ungrounded'; echo $?)"
+assert_true "empty-figure: reported as ungrounded" "$({ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '1 ungrounded'; echo $?)"
 
 # ============================================================
 echo "== figure sanitization: a multi-line / pipe-laden figure stays one Source line =="

--- a/tests/test-meta-agent.sh
+++ b/tests/test-meta-agent.sh
@@ -29,7 +29,7 @@ lint_agent_frontmatter() {
   [ "$name" = "1" ];  chk "$label: has name field" $?
   [ "$desc" = "1" ];  chk "$label: has description field" $?
   [ "$tools" = "1" ]; chk "$label: has tools field" $?
-  echo "$model" | grep -qE '^(sonnet|haiku|opus)$'; chk "$label: model is sonnet|haiku|opus ($model)" $?
+  { trap '' PIPE; echo "$model" 2>/dev/null || :; } | grep -qE '^(sonnet|haiku|opus)$'; chk "$label: model is sonnet|haiku|opus ($model)" $?
   # minimal tools: never a bare unscoped Bash entry
   if printf '%s\n' "$body" | awk '/^---$/{c++; if(c==2)exit} c==1' | grep -qE '^[[:space:]]*-[[:space:]]*Bash[[:space:]]*$'; then
     bad "$label: tools are minimal (no bare 'Bash')"

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -452,7 +452,7 @@ for AGENT_FILE in "$KIT_DIR/agents/"*.md; do
   # presence isn't enough, the value has to be in the real model surface.
   MODEL_VAL=$(awk -F': *' '/^---$/{c++; if(c==2)exit} c==1 && /^model:/{print $2; exit}' "$AGENT_FILE" | tr -d '[:space:]')
   TOTAL=$((TOTAL + 1))
-  if echo "$MODEL_VAL" | grep -qE '^(sonnet|haiku|opus)$'; then
+  if { trap '' PIPE; echo "$MODEL_VAL" 2>/dev/null || :; } | grep -qE '^(sonnet|haiku|opus)$'; then
     echo -e "  ${GREEN}PASS${NC} agent $AGENT model is sonnet|haiku|opus ($MODEL_VAL)"
     PASS=$((PASS + 1))
   else
@@ -1516,7 +1516,7 @@ while IFS= read -r phase; do
   # to "UI design (opt-in)"); all other names match verbatim.
   trimmed=$(echo "$phase" | sed 's/, downstream//')
   TOTAL=$((TOTAL + 1))
-  if echo "$LENS_SECTION" | grep -qF "$trimmed"; then
+  if { trap '' PIPE; echo "$LENS_SECTION" 2>/dev/null || :; } | grep -qF "$trimmed"; then
     echo -e "  ${GREEN}PASS${NC} V-model lens references cycle phase '$phase'"
     PASS=$((PASS + 1))
   else
@@ -1550,7 +1550,7 @@ while IFS= read -r entry; do
   # Strip wildcard suffix for matching (docs/retro/v*.md -> docs/retro/)
   base=$(echo "$entry" | sed 's/\*\.md[^)]*$//' | sed 's/v\*$//')
   TOTAL=$((TOTAL + 1))
-  if echo "$DOC_IMPACT_BLOCK" | grep -qF "$base"; then
+  if { trap '' PIPE; echo "$DOC_IMPACT_BLOCK" 2>/dev/null || :; } | grep -qF "$base"; then
     echo -e "  ${GREEN}PASS${NC} hands-off entry '$entry' appears in doc-impact map (SPEC-031)"
     PASS=$((PASS + 1))
   else
@@ -1617,7 +1617,7 @@ TOTAL=$((TOTAL + 1))
 MISSING_LEG_MODULES=""
 while IFS= read -r m; do
   [ -n "$m" ] || continue
-  echo "$FIVE_LEG_BLOCK" | grep -q "\`$m\`" || MISSING_LEG_MODULES="$MISSING_LEG_MODULES $m"
+  { trap '' PIPE; echo "$FIVE_LEG_BLOCK" 2>/dev/null || :; } | grep -q "\`$m\`" || MISSING_LEG_MODULES="$MISSING_LEG_MODULES $m"
 done <<< "$REGISTRY_MODULES"
 if [ -z "$MISSING_LEG_MODULES" ]; then
   echo -e "  ${GREEN}PASS${NC} README five-stage table covers every module-registry stage row"
@@ -2302,7 +2302,7 @@ GL_BADCELLS=$(awk '
 assert_eq "lane×phase matrix cells are all measure-twice|run-lite|skip" "0" "$GL_BADCELLS"
 
 GL_REQ="$(bash "$KIT_DIR/lib/gate/gate-ledger.sh" required normal 2>/dev/null | tr '\n' ' ')"
-assert_true "gate-ledger required(normal) derives spec+build+ship from the matrix" "$(echo "$GL_REQ" | grep -q 'spec' && echo "$GL_REQ" | grep -q 'build' && echo "$GL_REQ" | grep -q 'ship' && echo 0 || echo 1)"
+assert_true "gate-ledger required(normal) derives spec+build+ship from the matrix" "$({ trap '' PIPE; echo "$GL_REQ" 2>/dev/null || :; } | grep -q 'spec' && { trap '' PIPE; echo "$GL_REQ" 2>/dev/null || :; } | grep -q 'build' && { trap '' PIPE; echo "$GL_REQ" 2>/dev/null || :; } | grep -q 'ship' && echo 0 || echo 1)"
 assert_true "WORKFLOW documents the gate-ledger + ship-enforcement convention" "$(grep -q 'Gate ledger and ship enforcement' "$KIT_DIR/docs/WORKFLOW.md" && echo 0 || echo 1)"
 assert_true "ship.md records the Ship gate + names the override path" "$(grep -q 'gate-ledger.sh' "$KIT_DIR/commands/ship.md" && echo 0 || echo 1)"
 assert_true "AGENTS operate-contract points at the gate-ledger convention" "$(grep -q 'gate-ledger' "$KIT_DIR/AGENTS.md" && echo 0 || echo 1)"
@@ -2396,7 +2396,7 @@ assert_true "lib/gate/proof-gate.sh exists and is executable" \
   "$([ -x "$KIT_DIR/lib/gate/proof-gate.sh" ] && echo 0 || echo 1)"
 
 assert_true "proof-gate names the three proof classes (stateful, behavioral, inert)" \
-  "$(out=$(bash "$KIT_DIR/lib/gate/proof-gate.sh" classes 2>/dev/null); echo "$out" | grep -q stateful && echo "$out" | grep -q behavioral && echo "$out" | grep -q inert && echo 0 || echo 1)"
+  "$(out=$(bash "$KIT_DIR/lib/gate/proof-gate.sh" classes 2>/dev/null); { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q stateful && { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q behavioral && { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q inert && echo 0 || echo 1)"
 
 assert_true "convention defines the risk-class gate (stateful/behavioral/inert + proof-gate)" \
   "$(grep -qi 'proof class' "$KIT_DIR/docs/verification/README.md" && grep -q 'proof-gate.sh' "$KIT_DIR/docs/verification/README.md" && echo 0 || echo 1)"
@@ -3046,7 +3046,7 @@ assert_true "feature-registry generator is deterministic (double run byte-identi
 # (cap_list caps the shown names at 3 alphabetically then "+N" for the rest, so a fourth
 # dispatcher pushes the last name into the overflow count rather than dropping it silently).
 ASROW=$(grep -E '^\| `audit-scanner` ' "$KIT_DIR/docs/FEATURES.md")
-RC=0; { echo "$ASROW" | grep -q 'doc-drift (skill)' && echo "$ASROW" | grep -q 'ci-drift (skill)' && echo "$ASROW" | grep -qE '\+[0-9]+ *\|'; } || RC=1
+RC=0; { { trap '' PIPE; echo "$ASROW" 2>/dev/null || :; } | grep -q 'doc-drift (skill)' && { trap '' PIPE; echo "$ASROW" 2>/dev/null || :; } | grep -q 'ci-drift (skill)' && { trap '' PIPE; echo "$ASROW" 2>/dev/null || :; } | grep -qE '\+[0-9]+ *\|'; } || RC=1
 assert_eq "audit-scanner dispatched-by names doc-drift + ci-drift, overflow count covers the rest" 0 $RC
 rm -f "$REG_TMP" "$REG_TMP2"
 

--- a/tests/test-orchestrate.sh
+++ b/tests/test-orchestrate.sh
@@ -70,8 +70,8 @@ out=$(bash "$ORCH" next "$D")
 
 # ============================ TEST 2: dry-run plan ============================
 out=$(bash "$ORCH" run "$D" --dry-run)
-echo "$out" | grep -q 'SG-01 (auto)' && echo "$out" | grep -q 'SG-02 (auto)' \
-  && echo "$out" | grep -q 'STOP at SG-03 (gate' \
+{ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'SG-01 (auto)' && { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'SG-02 (auto)' \
+  && { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'STOP at SG-03 (gate' \
   && pass "dry-run lists SG-01, SG-02, STOP at gate SG-03" || { fail "dry-run plan wrong"; echo "$out"; }
 # dry-run must NOT invoke claude (no box flipped, no handoff written)
 grep -q '^- \[ \] SG-01' "$D/ROADMAP.md" && [ ! -f "$D/HANDOFF.md" ] \
@@ -213,9 +213,9 @@ EOF
 # TEST 7: --dry-run prints the chosen tier per sub-goal (and "inherit" when absent).
 DR="$TMP/mgr"; mk_routed "$DR"
 out=$(bash "$ORCH" run "$DR" --dry-run)
-echo "$out" | grep -qE 'SG-01 \(auto\).*model: sonnet, effort: low' \
+{ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -qE 'SG-01 \(auto\).*model: sonnet, effort: low' \
   && pass "dry-run shows SG-01 routed model/effort" || { fail "dry-run SG-01 tier wrong"; echo "$out"; }
-echo "$out" | grep -qE "SG-02 \(auto\).*model: ${DEF_MODEL:-inherit}, effort: inherit" \
+{ trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -qE "SG-02 \(auto\).*model: ${DEF_MODEL:-inherit}, effort: inherit" \
   && pass "dry-run shows SG-02 ${DEF_MODEL:-inherit} (no hints)" || { fail "dry-run SG-02 inherit wrong"; echo "$out"; }
 
 # TEST 8: real run passes --model/--effort for the hinted sub-goal, none for the inherit one.
@@ -256,8 +256,8 @@ fi
 # 9a: --step --dry-run annotates the plan with pause points (no claude invoked).
 DS="$TMP/mgs"; mk_megagoal "$DS"
 out=$(bash "$ORCH" run "$DS" --step --dry-run)
-{ echo "$out" | grep -q 'pause for the operator after each sub-goal' \
-  && echo "$out" | grep -q '\[--step\] pause here'; } \
+{ { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'pause for the operator after each sub-goal' \
+  && { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q '\[--step\] pause here'; } \
   && pass "--step --dry-run shows pause points" || { fail "--step dry-run missing pauses"; echo "$out"; }
 grep -q '^- \[ \] SG-01' "$DS/ROADMAP.md" && pass "--step --dry-run did not execute" || fail "--step dry-run had side effects"
 
@@ -317,7 +317,7 @@ bash "$ORCH" run "$DS" --bogus > "$TMP/bogus.out" 2>&1; rc=$?
 # 11a: detect default -> backlog.sh present => both; dry-run renders the board + derives BOARD.md.
 DB="$TMP/mgb"; mk_megagoal "$DB"
 out=$(bash "$ORCH" run "$DB" --dry-run)
-{ echo "$out" | grep -q 'board mode: both' && [ -f "$DB/BOARD.md" ] && grep -q '| SG-01 |' "$DB/BOARD.md"; } \
+{ { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'board mode: both' && [ -f "$DB/BOARD.md" ] && grep -q '| SG-01 |' "$DB/BOARD.md"; } \
   && pass "detect default -> both; dry-run derives BOARD.md" || { fail "board detect/derive wrong"; echo "$out"; }
 # dry-run must NOT write an events.log (board derived from ROADMAP only, no execution)
 [ ! -f "$DB/.orchestrate/events.log" ] && pass "dry-run board writes no events.log (no execution)" || fail "dry-run wrote events"
@@ -325,13 +325,13 @@ out=$(bash "$ORCH" run "$DB" --dry-run)
 # 11b: roadmap fallback -> no kanban tooling => roadmap mode, no board rendered.
 DBF="$TMP/mgbf"; mk_megagoal "$DBF"
 out=$(BACKLOG_LIB="$TMP/nope.sh" bash "$ORCH" run "$DBF" --dry-run)
-{ ! echo "$out" | grep -q 'board mode' && [ ! -f "$DBF/BOARD.md" ]; } \
+{ ! { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'board mode' && [ ! -f "$DBF/BOARD.md" ]; } \
   && pass "no backlog.sh -> detect fail-safes to roadmap (no board)" || { fail "roadmap fallback wrong"; echo "$out"; }
 
 # 11c: explicit --board=roadmap suppresses the board even when backlog.sh is present.
 DBR="$TMP/mgbr"; mk_megagoal "$DBR"
 out=$(bash "$ORCH" run "$DBR" --board=roadmap --dry-run)
-{ ! echo "$out" | grep -q 'board mode' && [ ! -f "$DBR/BOARD.md" ]; } \
+{ ! { trap '' PIPE; echo "$out" 2>/dev/null || :; } | grep -q 'board mode' && [ ! -f "$DBR/BOARD.md" ]; } \
   && pass "--board=roadmap suppresses the board" || { fail "--board=roadmap wrong"; echo "$out"; }
 
 # 11d: ready/blocked derivation from deps. SG-03 depends on unchecked SG-02 => blocked; SG-02 has

--- a/tests/test-picture-section.sh
+++ b/tests/test-picture-section.sh
@@ -111,7 +111,7 @@ LANE_4="$(spec_lane "$PROTOTYPE_FULL")"
 BODY_4="$(picture_section_body_nonblank "$PROTOTYPE_FULL")"
 VERDICT_4="$(reviewer4_picture_verdict "$PROTOTYPE_FULL")"
 assert_eq "fixture 4 is Lane: full" "full" "$LANE_4"
-RC=0; echo "$BODY_4" | grep -qF 'prototype/' || RC=1
+RC=0; { trap '' PIPE; echo "$BODY_4" 2>/dev/null || :; } | grep -qF 'prototype/' || RC=1
 assert_eq "fixture 4's Picture section names a prototype/<name> branch" 0 $RC
 assert_eq "Reviewer 4 PASSES a full-lane spec whose Picture points at a prototype run" "PASS" "$VERDICT_4"
 
@@ -148,7 +148,7 @@ assert_eq "commands/spec-validate.md Reviewer 4 names the picture-vs-task-list l
 # second one).
 RC=0
 PICTURE_BLOCK="$(awk '/Picture presence/{flag=1} flag{print} flag&&/^- /&&!/Picture/{exit}' "$VALIDATE_MD")"
-echo "$PICTURE_BLOCK" | grep -qiE 'BLOCKING' && RC=1
+{ trap '' PIPE; echo "$PICTURE_BLOCK" 2>/dev/null || :; } | grep -qiE 'BLOCKING' && RC=1
 assert_eq "Reviewer 4's Picture bullets carry no BLOCKING marker (Reviewer 6 stays the only one)" 0 $RC
 
 RC=0; grep -qE 'Reviewer 6.*BLOCKING' "$VALIDATE_MD" || RC=1

--- a/tests/test-queue.bats
+++ b/tests/test-queue.bats
@@ -83,7 +83,7 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
 
   run bash "$QUEUE" run "$WORK/q.tsv" --dry-run
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "WOULD LAUNCH"
+  { trap '' PIPE; echo "$output" 2>/dev/null || :; } | grep -q "WOULD LAUNCH"
   [ ! -f "$JOURNAL" ] || [ -z "$(jverdict d3)" ]        # no run row for d3
   ! grep -q "type slug=d3" "$QLOG"                       # no send-keys happened
 }
@@ -198,7 +198,7 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
   [ "$(jverdict err1)" = "error" ]
   [ "$(jverdict err2)" = "error" ]
   [ -z "$(jverdict err3)" ]                     # row 3 never attempted -> no journal row
-  echo "$output" | grep -q "STOP THE NIGHT"
+  { trap '' PIPE; echo "$output" 2>/dev/null || :; } | grep -q "STOP THE NIGHT"
 }
 
 # NC4 journal-done-idempotence: journal preseeded `slug done` -> row skipped, no window opened
@@ -211,7 +211,7 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
 
   run bash "$QUEUE" run "$WORK/q.tsv"
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "already done"
+  { trap '' PIPE; echo "$output" 2>/dev/null || :; } | grep -q "already done"
   ! grep -q "new-window slug=idem1" "$QLOG"             # never opened a window
   [ "$(grep -c 'idem1' "$JOURNAL")" -eq 1 ]             # no second row appended
 }
@@ -273,7 +273,7 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
   [ "$(jverdict s1n)" = "stalled" ]
   [ "$(jverdict s2n)" = "stalled" ]
   [ -z "$(jverdict s3n)" ]                       # row 3 never attempted -> no journal row
-  echo "$output" | grep -q "STOP THE NIGHT"
+  { trap '' PIPE; echo "$output" 2>/dev/null || :; } | grep -q "STOP THE NIGHT"
 }
 
 # =============================================================================================
@@ -352,7 +352,7 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
   seed_dead w1
   QUEUE_WAIT_POLL_SECS=0 run bash "$QUEUE" wait w1
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "	w1	done	"
+  { trap '' PIPE; echo "$output" 2>/dev/null || :; } | grep -q "	w1	done	"
 }
 
 # W2 new terminal row lands mid-wait (window alive) -> exit 0, prints the new row.
@@ -361,7 +361,7 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
   ( sleep 1; printf '%s\tw2\tgated\tneeds-human\n' "2026-08-10T00:00:01Z" >> "$JOURNAL" ) &
   QUEUE_WAIT_POLL_SECS=1 run bash "$QUEUE" wait w2 --timeout 10
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "	w2	gated	"
+  { trap '' PIPE; echo "$output" 2>/dev/null || :; } | grep -q "	w2	gated	"
 }
 
 # W3 window dies with no terminal row -> exit 1, residue to stderr.
@@ -370,7 +370,7 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
   seed_dead w3
   QUEUE_WAIT_POLL_SECS=0 run bash "$QUEUE" wait w3
   [ "$status" -eq 1 ]
-  echo "$output" | grep -q "gone with no terminal journal row"
+  { trap '' PIPE; echo "$output" 2>/dev/null || :; } | grep -q "gone with no terminal journal row"
 }
 
 # W4 timeout: window alive, no row ever -> exit 2.
@@ -378,7 +378,7 @@ jverdict() { awk -F'\t' -v s="$1" '$2==s{print $3}' "$JOURNAL"; }    # slug -> v
   : > "$JOURNAL"                                   # window alive (no .dead), never a row
   QUEUE_WAIT_POLL_SECS=1 run bash "$QUEUE" wait w4 --timeout 1
   [ "$status" -eq 2 ]
-  echo "$output" | grep -q "timeout after 1s"
+  { trap '' PIPE; echo "$output" 2>/dev/null || :; } | grep -q "timeout after 1s"
 }
 
 # W5 bad input: a slug with a tmux/path separator, and a missing slug -> usage exit 64.

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -24,31 +24,31 @@ echo "=== rich data: suggest measured-cheapest-at-parity ==="
 OUT=$(bash "$RS" "$FIX/rich-ledger.tsv" code-add-flag); RC=$?
 echo "  -> $OUT"
 [ "$RC" -eq 0 ]; chk "rich: exit 0 (a suggestion was made)" $?
-echo "$OUT" | grep -q '^SUGGEST'; chk "rich: line is SUGGEST" $?
-echo "$OUT" | grep -q 'model=haiku'; chk "rich: suggests haiku (cheapest PASS: 322602 < opus 901000)" $?
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q '^SUGGEST'; chk "rich: line is SUGGEST" $?
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q 'model=haiku'; chk "rich: suggests haiku (cheapest PASS: 322602 < opus 901000)" $?
 # negative control: the cheaper-but-FAILING sonnet arm (90000 tok) must not win
-echo "$OUT" | grep -q 'model=sonnet' && bad "rich: failing sonnet NOT suggested" || ok "rich: failing sonnet NOT suggested (infinite-cost guard)"
-echo "$OUT" | grep -q 'effort=abstain'; chk "rich: effort abstained (not in SG-09 schema)" $?
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q 'model=sonnet' && bad "rich: failing sonnet NOT suggested" || ok "rich: failing sonnet NOT suggested (infinite-cost guard)"
+{ trap '' PIPE; echo "$OUT" 2>/dev/null || :; } | grep -q 'effort=abstain'; chk "rich: effort abstained (not in SG-09 schema)" $?
 
 echo ""
 echo "=== thin data: abstain, do not overfit ==="
 OUT2=$(bash "$RS" "$FIX/thin-ledger.tsv" mini-mega); RC2=$?
 echo "  -> $OUT2"
 [ "$RC2" -eq 2 ]; chk "thin: exit 2 (abstained)" $?
-echo "$OUT2" | grep -q '^ABSTAIN'; chk "thin: line is ABSTAIN" $?
-echo "$OUT2" | grep -q 'thin-data'; chk "thin: reason names thin-data" $?
+{ trap '' PIPE; echo "$OUT2" 2>/dev/null || :; } | grep -q '^ABSTAIN'; chk "thin: line is ABSTAIN" $?
+{ trap '' PIPE; echo "$OUT2" 2>/dev/null || :; } | grep -q 'thin-data'; chk "thin: reason names thin-data" $?
 
 echo ""
 echo "=== no passing data: abstain ==="
 OUT3=$(bash "$RS" "$FIX/rich-ledger.tsv" no-such-task); RC3=$?
 echo "  -> $OUT3"
-[ "$RC3" -eq 2 ] && echo "$OUT3" | grep -q 'no-passing-data'; chk "unknown task: abstains with no-passing-data" $?
+[ "$RC3" -eq 2 ] && { trap '' PIPE; echo "$OUT3" 2>/dev/null || :; } | grep -q 'no-passing-data'; chk "unknown task: abstains with no-passing-data" $?
 
 echo ""
 echo "=== missing ledger file: abstain (no crash) ==="
 OUT4=$(bash "$RS" "$FIX/does-not-exist.tsv" any-task); RC4=$?
 echo "  -> $OUT4"
-[ "$RC4" -eq 2 ] && echo "$OUT4" | grep -q 'no-ledger'; chk "missing ledger: abstains with no-ledger" $?
+[ "$RC4" -eq 2 ] && { trap '' PIPE; echo "$OUT4" 2>/dev/null || :; } | grep -q 'no-ledger'; chk "missing ledger: abstains with no-ledger" $?
 
 echo ""
 echo "=== exact multi-model tie: deterministic (alphabetical) winner ==="
@@ -60,10 +60,10 @@ printf 'code-add-flag\tb-sonnet\tpass\t500000\t40\t900\t450000\t49060\t5\t0.2\ts
 T1=$(bash "$RS" "$TIE" code-add-flag)
 echo "  -> $T1"
 # Contract assertion: winner == alphabetically-first of the tied tiers (not a hash-order accident).
-echo "$T1" | grep -q 'model=haiku'; chk "tie: alphabetically-first tier (haiku) wins" $?
+{ trap '' PIPE; echo "$T1" 2>/dev/null || :; } | grep -q 'model=haiku'; chk "tie: alphabetically-first tier (haiku) wins" $?
 # Direct sort-ran proof: basis lists tiers in sorted order, so 'haiku=' precedes 'sonnet='. Without
 # the sort the basis follows assoc-array hash order (haiku AFTER sonnet on this host) -> this FAILs.
-echo "$T1" | grep -qE 'haiku=[0-9]+tok, sonnet=[0-9]+tok'; chk "tie: basis emitted in sorted (haiku-before-sonnet) order , proves the sort ran" $?
+{ trap '' PIPE; echo "$T1" 2>/dev/null || :; } | grep -qE 'haiku=[0-9]+tok, sonnet=[0-9]+tok'; chk "tie: basis emitted in sorted (haiku-before-sonnet) order , proves the sort ran" $?
 rm -f "$TIE"
 
 echo ""
@@ -73,7 +73,7 @@ printf 'code-add-flag\tb-haiku\tpass\t300000\t40\t900\t250000\t49060\t5\t0.1\tha
 printf 'code-add-flag\tb-haiku\tpass\n' >> "$BAD"   # short row: no numeric total_tokens column
 OUT5=$(bash "$RS" "$BAD" code-add-flag 2>&1); RC5=$?
 echo "  -> $OUT5"
-echo "$OUT5" | grep -qiE 'unary operator|integer expression'; if [ $? -eq 0 ]; then bad "malformed row: no bash arithmetic error"; else ok "malformed row: no bash arithmetic error (skipped)"; fi
+{ trap '' PIPE; echo "$OUT5" 2>/dev/null || :; } | grep -qiE 'unary operator|integer expression'; if [ $? -eq 0 ]; then bad "malformed row: no bash arithmetic error"; else ok "malformed row: no bash arithmetic error (skipped)"; fi
 rm -f "$BAD"
 
 echo ""

--- a/tests/test-understanding-wiring.sh
+++ b/tests/test-understanding-wiring.sh
@@ -89,10 +89,10 @@ assert "the understanding-axis section names ADR-0031" $RC
 
 RC=0
 SECTION="$(grep -A60 -E '^## The understanding axis' "$WORKFLOW")"
-echo "$SECTION" | grep -qiE 'design record'      || RC=1
-echo "$SECTION" | grep -qiE 'explain'            || RC=1
-echo "$SECTION" | grep -qiE 'quiz-gate|quiz'     || RC=1
-echo "$SECTION" | grep -qiE 'weekend.?batch'     || RC=1
+{ trap '' PIPE; echo "$SECTION" 2>/dev/null || :; } | grep -qiE 'design record'      || RC=1
+{ trap '' PIPE; echo "$SECTION" 2>/dev/null || :; } | grep -qiE 'explain'            || RC=1
+{ trap '' PIPE; echo "$SECTION" 2>/dev/null || :; } | grep -qiE 'quiz-gate|quiz'     || RC=1
+{ trap '' PIPE; echo "$SECTION" 2>/dev/null || :; } | grep -qiE 'weekend.?batch'     || RC=1
 assert "section covers design-record + explain + quiz-gate + weekend-batch (BEFORE + AFTER + debt-budget model)" $RC
 
 RC=0; grep -qiE 'ADR-0031' "$AGENTS" && grep -qiE 'advisory' "$AGENTS" || RC=1

--- a/tests/test-web-drift-refusal-guard.sh
+++ b/tests/test-web-drift-refusal-guard.sh
@@ -45,7 +45,7 @@ BOARDED="$(_mk)"; mkdir -p "$BOARDED/_meta"
 printf '# BACKLOG\n\n| ID | Item | Notes & source | Status |\n|---|---|---|---|\n' > "$BOARDED/_meta/BACKLOG.md"
 OUT1="$(cd "$BOARDED" && eval "$GUARD_LINE" 2>&1)"; rc1=$?
 [ "$rc1" -eq 0 ] && assert "C1 boarded consumer: guard passes (exit 0)" 0 || assert "C1 boarded consumer: guard passes (rc=$rc1)" 1
-echo "$OUT1" | grep -q REFUSE && assert "C1 boarded consumer: no REFUSE line" 1 || assert "C1 boarded consumer: no REFUSE line" 0
+{ trap '' PIPE; echo "$OUT1" 2>/dev/null || :; } | grep -q REFUSE && assert "C1 boarded consumer: no REFUSE line" 1 || assert "C1 boarded consumer: no REFUSE line" 0
 
 # ---------------------------------------------------------------------------
 # C2 NEGATIVE CONTROL: a target repo with NO _meta/BACKLOG.md refuses (exit 1) and names the fix.
@@ -53,8 +53,8 @@ echo "$OUT1" | grep -q REFUSE && assert "C1 boarded consumer: no REFUSE line" 1 
 BOARDLESS="$(_mk)"
 OUT2="$(cd "$BOARDLESS" && eval "$GUARD_LINE" 2>&1)"; rc2=$?
 [ "$rc2" -eq 1 ] && assert "C2 NC: boardless consumer refuses the run (exit 1)" 0 || assert "C2 NC: boardless consumer refuses (rc=$rc2)" 1
-echo "$OUT2" | grep -q '^REFUSE:' && assert "C2 NC: refusal names REFUSE + the fix" 0 || assert "C2 NC: refusal names REFUSE (got: $OUT2)" 1
-echo "$OUT2" | grep -q "bin/board init" && assert "C2 NC: refusal names the fix (bin/board init)" 0 || assert "C2 NC: refusal names the fix" 1
+{ trap '' PIPE; echo "$OUT2" 2>/dev/null || :; } | grep -q '^REFUSE:' && assert "C2 NC: refusal names REFUSE + the fix" 0 || assert "C2 NC: refusal names REFUSE (got: $OUT2)" 1
+{ trap '' PIPE; echo "$OUT2" 2>/dev/null || :; } | grep -q "bin/board init" && assert "C2 NC: refusal names the fix (bin/board init)" 0 || assert "C2 NC: refusal names the fix" 1
 
 echo ""
 echo "=== $PASS/$TOTAL passed, $FAIL failed ==="


### PR DESCRIPTION
## Summary
- `grep -q` exits on the first match, `echo` then hits EPIPE, and `set -uo pipefail` turns a matched grep into a failed pipeline. `#510` swept the same defect for `printf ... | grep -q` sites but grepped for `printf` only and missed the `echo` sites.
- Master run 34092722090 hit it in `tests/test-kit-contract.sh` line 235, producing a false FAIL on "every staged-block writer goes through the one renderer" even though `lib/learn/propose.py` does import `staging_format` and call `sf.render_block`.
- 111 `echo ... | grep -q` sites across 21 files in `tests/` now wrap the producer as `{ trap '' PIPE; echo ... 2>/dev/null || :; }`, mirroring `#510`'s fix. No assertion changed.

## Test plan
- [x] `bash tests/test-kit-contract.sh` exit 0, staged-block-writer check PASSes
- [x] Every other touched test script run individually, all PASS (see `docs/verification/test-echo-grep-pipefail.md`)
- [x] `tests/test-goal-dispatch.sh` has one unrelated pre-existing failure (confirmed identical on unmodified `origin/master` via `git stash`), not a regression
- [x] `bash -n` on every changed `.sh` file: 0 syntax errors
- [x] Negative control: `docs/verification/test-echo-grep-pipefail-negctl.sh` reproduces the exact `echo: write error: Broken pipe` failure signature on the bare form and confirms the guarded form is green, on both `/bin/bash` 3.2.57 and Homebrew bash 5.3.15
- [x] Site census: `grep -rnE 'echo [^|]*\| *grep -q' tests/ | grep -v "trap '' PIPE"` returns 0 matches

Claude-Session: worker-echo-grep-pipefail
