### PR TITLE
fix(precedent): widen the inventory scan back to whathas parity

### DIFF
--- a/docs/specs/SPEC-245-precedent-inventory.md
+++ b/docs/specs/SPEC-245-precedent-inventory.md
@@ -45,9 +45,10 @@ bin/precedent ──exec──▶ lib/precedent/precedent.sh
                  │ (bash, unchanged)          │ python3 lib/precedent/inventory.py
                  ▼                            ▼
    docs/specs  docs/decisions        built-in defaults           registry file
-   docs/retro  docs/verification     · this repo: tools/ scripts/ bin/ cli/ _meta/
-   $LOG_DIR/runs/*.log                 .claude/memory .claude/skills docs/FEATURES.md
-                                       experiments/*/README.md
+   docs/retro  docs/verification     · this repo: tools/ (tool.toml + bin/ scripts/ lib/
+   $LOG_DIR/runs/*.log                   + top-level *.sh|*.py) scripts/ bin/ cli/ _meta/
+                                       .claude/memory .claude/skills docs/FEATURES.md
+                                       experiments/*/README.md  research/*.md
                                      · the kit: bin/ + lib/** usage lines, skills/,
                                        docs/FEATURES.md
                                      · ~/.claude/skills, ~/.local/bin
@@ -119,7 +120,7 @@ Registry file: whitespace-delimited `<kind> <path>` rows, `#` comments, `~` expa
 
 | Kind | Scans |
 |---|---|
-| `repo <root>` | the same set the current repo gets by default: `tools/*/tool.toml` + `tools/*/bin/*`, `scripts/*`, `bin/*`, `cli/*`, `_meta/*` executables, `experiments/*/README.md`, `.claude/memory/*.md`, `.claude/skills/*/SKILL.md`, `docs/FEATURES.md` |
+| `repo <root>` | the same set the current repo gets by default: `tools/*/tool.toml` + every runnable script under `tools/*/{bin,scripts,lib}/` and at `tools/*/*.sh|*.py`, `scripts/*`, `bin/*`, `cli/*`, `_meta/*` executables, `experiments/*/README.md` (frontmatter, `tech:` tags and lede), `research/*.md` (frontmatter title, purpose, description), `.claude/memory/*.md`, `.claude/skills/*/SKILL.md`, `docs/FEATURES.md` |
 | `scripts <dir>` | every text file in the dir; summary = first comment block or docstring |
 | `skills <dir>` | `*/SKILL.md`, name + description from frontmatter, body as a low-rank haystack |
 | `crons <dir>` | every `wrangler.jsonc` under the dir: worker name + cron expressions |
@@ -195,7 +196,7 @@ bin/precedent find "board set" | grep -E '^precedent: [0-9]+ record matches'
 ## Out of Scope
 - Retiring `repo-sweep whathas` in ops-toolkit and pointing the operator's global instructions at `precedent find --surface inventory`: a follow-up ops-toolkit PR after this ships.
 - Renaming the `whathas` gate phase the dotfiles `new-tool-gate` hook reads: a dotfiles follow-up.
-- The house-CLI table and the git-native-features table from whathas: estate-specific and static; not ported.
+- The house-CLI table and the git-native-features table from whathas: estate-specific and static; both dropped on purpose, and this port never restores them.
 - Embeddings, an index, or a daemon: grep-class scan by design, as `lib/precedent.sh` already states.
 
 ## Decision Log
@@ -204,6 +205,7 @@ bin/precedent find "board set" | grep -E '^precedent: [0-9]+ record matches'
 - DEC-003: Registry kinds are a closed set with an exit-64 on unknown kinds, so a misspelled row never scans nothing silently.
 - DEC-004: Third copy of the redaction regex, pinned equal to `session_recall.py` by a test, instead of a shared import across two lib dirs. A shared module would be the right move at the fourth copy.
 - DEC-005: `lib/precedent.sh` is removed rather than left as a forwarder. It has two in-repo callers and no external adopters (research: no bin entry, no FEATURES row); a forwarder would keep the orphan alive.
+- DEC-006: memory notes are searched by BODY here, a deliberate widening over whathas's frontmatter-only scan, so a fact buried a few lines into a note still surfaces.
 
 ## Review
 

--- a/docs/verification/precedent-iterators.md
+++ b/docs/verification/precedent-iterators.md
@@ -99,11 +99,12 @@ the skill dedupe in turn; drop the research `README` skip.
 
 ## Live before / after
 
-Master's `inventory.py` and this branch's, run against the same on-disk ops-toolkit checkout:
+Master's `inventory.py` and this branch's, run against the same on-disk ops-toolkit checkout
+(the operator's, path elided here so the tree ships no personal path):
 
 ```
-python3 lib/precedent/inventory.py --root /Users/tieubao/workspace/tieubao/ops-toolkit \
-  --kit <worktree> --quiet -- discord post
+python3 lib/precedent/inventory.py --root <ops-toolkit checkout> \
+  --kit <this worktree> --quiet -- discord post
 ```
 
 BEFORE (master):

--- a/docs/verification/precedent-iterators.md
+++ b/docs/verification/precedent-iterators.md
@@ -1,0 +1,174 @@
+# Verification log: precedent inventory iterators restored
+
+Spec: `docs/specs/SPEC-245-precedent-inventory.md`. Branch `fix/precedent-iterators`, base `origin/master`.
+Lane: `normal` (`lib/classify/lane-classify.sh classify` -> `normal`).
+Proof-gate contract (`lib/gate/proof-gate.sh contract "restore precedent inventory iterators"`):
+`type=migration class=stateful`, so this log carries a recorded run AND a rollback path, even
+though the change itself is inert library code with no persisted state.
+
+Rollback: `git revert <merge sha>`. The change touches one Python module, one test file, and one
+spec paragraph. `inventory.py` is read-only over every source it scans, so no revert has to undo
+any written state.
+
+## What changed
+
+An audit compared `precedent find --surface inventory` against the `repo-sweep whathas` command
+it replaced, on the same on-disk state, and found five iterators narrower than the original.
+All five are restored:
+
+| # | Iterator | Before | After |
+|---|---|---|---|
+| 1 | research records | `research/` never read | `<repo>/research/*.md` scanned per `repo` registry row, indexed by frontmatter title, purpose, description |
+| 2 | tool helper scripts | `tool.toml` + `tools/<x>/bin/*` only | plus `tools/<x>/scripts/`, `tools/<x>/lib/`, and top-level `tools/<x>/*.sh` and `*.py` |
+| 3 | experiments | frontmatter title or description, else the first `#` heading | plus the `tech:` tag list and the README lede |
+| 4 | PEP-723 header | inline `# /// script` metadata indexed as the summary | the block is skipped, the docstring underneath is indexed |
+| 5 | duplicate skill label | one skill copied into two scanned dirs printed twice under an identical bare label | first dir wins, keyed on the resolved real path and on the directory name |
+
+## Run table
+
+| Command | Exit | Verdict |
+|---|---|---|
+| `bash tests/test-precedent.sh` | 0 (`64/64 passed`) | PASS |
+| `bash tests/test-meta.sh` | 0 (`Passed: 840 / 840`) | PASS |
+| `bash tests/test-hooks.sh` | 0 (`Passed: 497 / 497`) | PASS |
+| `bash tests/test-bin-forwarders.sh` | 0 (`all 41 passed, 0 skipped`) | PASS |
+| `bash tests/test-no-personal-paths.sh` | 0 (`Passed: 3 / 3`) | PASS |
+| `bash tests/run-workflow.sh` | 0 (`0 red of 70 steps`, first run; `1 red` on a later run, see below) | PASS |
+
+The one red on a later full-suite run is `tests/test-orchestrate-wavefront.sh`
+(`wave_run g: concurrency NOT proven`). It is environmental, not this diff: the branch touches
+no file under its subject, the same suite ran green on this branch earlier in the session, and
+run alone it passes twice in a row (`rc=0`, `rc=0`). SPEC-245's own proof of done records the
+same suite failing this way on this host with a run-to-run varying count, the timing signature
+of its mock-session markers.
+
+The sixteen new cases in `tests/test-precedent.sh` (48 before, 64 after) cover every restored
+iterator and every guard inside it: a research record reached only through `purpose:`, a
+`tools/<x>/scripts/` helper, a `tools/<x>/lib/` helper, a top-level `tools/<x>/*.py` entry
+point, an experiment whose subject lives only in `tech:`, the same experiment reached through
+its lede, a PEP-723 docstring hit, a PEP-723 dependency-list non-hit, a skill copied into two
+scanned dirs printing one label, a symlinked skill dir under another name collapsing by real
+path, a non-runnable file under `bin/` staying out, a `test`-prefixed helper staying out, the
+research dir's own `README.md` staying out, a stray `tools/.DS_Store` not aborting the scan,
+and redaction reaching both a research record's frontmatter and a tool helper's header.
+
+## Negative controls
+
+Each restored iterator was reverted one at a time on the branch, the suite re-run, and the file
+restored. Every revert turned its own case or cases red and left the rest green, so no case
+passes for a reason other than the fix.
+
+```
+=== negative control 1-research: rc=1 ['62/64 passed']
+    FAIL research records: a frontmatter purpose hit surfaces the research file
+    FAIL redaction reaches a research record's frontmatter
+=== negative control 2-tool-helper-subdirs: rc=1 ['61/64 passed']
+    FAIL tool helpers: a tools/<x>/scripts/ helper surfaces
+    FAIL tool helpers: a tools/<x>/lib/ helper surfaces
+    FAIL redaction reaches a tool helper script's comment header
+=== negative control 2b-toplevel-tool-scripts: rc=1 ['63/64 passed']
+    FAIL tool helpers: a top-level tools/<x>/*.py entry point surfaces
+=== negative control 2c-runnable-filter: rc=1 ['63/64 passed']
+    FAIL tool helpers: a non-executable, non-script file under bin/ is not indexed
+=== negative control 2d-test-prefix-skip: rc=1 ['63/64 passed']
+    FAIL tool helpers: a test-prefixed helper is not indexed
+=== negative control 2e-stray-file-guard: rc=1 ['20/64 passed']
+    (44 of 64 cases red: every query dies on NotADirectoryError; the one
+     new case for it is 'a stray non-directory entry under tools/ does not abort the scan')
+=== negative control 3-experiments: rc=1 ['62/64 passed']
+    FAIL experiments: a frontmatter tech: tag is searchable
+    FAIL experiments: the README lede is searchable
+=== negative control 4-pep723: rc=1 ['62/64 passed']
+    FAIL PEP-723: the docstring under a # /// script block is indexed
+    FAIL PEP-723: the inline dependency list is not indexed
+=== negative control 5a-skill-dedupe-dirname: rc=1 ['62/64 passed']
+    FAIL skills dedupe: a skill copied into two scanned dirs prints exactly one label
+    FAIL skills dedupe: a symlinked skill dir under another name collapses by real path
+=== negative control 5b-skill-dedupe-realpath: rc=1 ['62/64 passed']
+    FAIL skills dedupe: a skill copied into two scanned dirs prints exactly one label
+    FAIL skills dedupe: a symlinked skill dir under another name collapses by real path
+=== negative control 6-research-readme-skip: rc=1 ['63/64 passed']
+    FAIL research records: the dir's own README index is not indexed as a record
+```
+
+Mutations used, one per run: drop the `scan_repo_research` call; narrow the helper subdir tuple
+to `("bin",)`; drop the top-level `tools/<x>/*.sh|*.py` candidate list; drop the
+`is_executable_or_shell` filter; drop the `test`-prefix skip; drop the non-directory guard; drop
+`tech` and the lede from the experiment haystack; drop the `# /// script` skip; drop each arm of
+the skill dedupe in turn; drop the research `README` skip.
+
+## Live before / after
+
+Master's `inventory.py` and this branch's, run against the same on-disk ops-toolkit checkout:
+
+```
+python3 lib/precedent/inventory.py --root /Users/tieubao/workspace/tieubao/ops-toolkit \
+  --kit <worktree> --quiet -- discord post
+```
+
+BEFORE (master):
+
+```
+precedent: 88 inventory hits in 7 sections; top: skills
+```
+
+No `## research` section, no `## experiments` section.
+
+AFTER (branch):
+
+```
+## research
+  research/2026-09-07-foundation-ops-shared-lib-map.md  , foundation-ops shared-lib map, and why precedent could not see the duplication
+  research/2026-08-30-etl-and-discord-report-inventory.md  , Estate inventory, scheduled ETL pipelines and Discord reporting paths
+## experiments
+  experiments/discord-user-send/  , discord-user-send
+  experiments/fare-watch/  , fare-watch
+precedent: 95 inventory hits in 9 sections; top: skills
+```
+
+`research/2026-09-07-foundation-ops-shared-lib-map.md` and two of the three named experiments
+appear after and not before. `experiments/payout-batch-replay/` does not match this query in
+either implementation: its README frontmatter, `tech:` list, and first twelve body lines carry
+neither `discord` nor `post`, so the AND scorer gives it 0 under whathas's own rules too. It
+surfaces on a query its README does carry: `paginate notion` prints
+`experiments/payout-batch-replay/` on this branch and nothing on master, because the lede is the
+only place those words appear.
+
+Two more before/after pairs, same command shape:
+
+| Query | Before | After |
+|---|---|---|
+| `cf worker state` | `32 inventory hits in 2 sections` | plus `tools/vps-mon/scripts/cf-worker-state.sh` |
+| `benchmark ollama` | `3 inventory hits in 2 sections` | plus `tools/llm-bench/bench.py` (PEP-723 header skipped, docstring indexed) |
+| `scaffold tool` | `skill ops-tool-shape` printed twice | printed once |
+
+## Known deltas from the original whathas
+
+- Helper scripts now inherit whathas's own filter: a candidate must be executable or end in
+  `.sh` or `.py`, and a name starting with `test` or `.` is skipped. A non-executable,
+  extensionless file directly under `tools/<x>/bin/` is therefore no longer indexed.
+- `scan_repo_tools` skips a non-directory entry beside the tool dirs. A stray `.DS_Store` under
+  `tools/` crashed the scan before this guard.
+- Memory notes stay searched by body, wider than whathas's frontmatter-only scan. Recorded in the
+  spec as DEC-006.
+- A `tools/<x>/scripts` or `lib` symlinked outside the repo root is still followed and indexed,
+  as it was for `bin/` before this change. whathas had no confinement here either. Left as is
+  rather than adding a guard that would silently drop a legitimate symlinked helper; the review
+  raised it as LOW.
+
+## Review
+
+Three lenses, parallel, on the working tree before commit (the diff touches `lib/`, so AGENTS.md
+requires a multi-lens review). Security 8/10, architecture 7/10, test coverage 6/10.
+
+| # | Finding | Lens | Sev | Disposition |
+|---|---|---|---|---|
+| 1 | The dedupe keyed on the frontmatter `name:`, which the scanned repo controls, so a repo-local skill in any directory could suppress the operator's own skill of that name. Reproduced. | security | MEDIUM | fixed: key on the DIRECTORY name plus the real path, never the frontmatter name |
+| 2 | A symlinked `scripts`/`lib` under a tool is followed out of the repo root. | security | LOW | accepted, recorded above; pre-existing for `bin/`, matches whathas |
+| 3 | No case pinned redaction on the new hit surfaces. | security | LOW | fixed: two cases, a token in a research `title:` and one in a helper's header |
+| 4 | The new runnable-file check duplicated `is_executable_or_shell` inline and widened it to `.py`. | architecture | MEDIUM | fixed: one helper, `exts` parameter, both call sites |
+| 5 | The spec's Picture and registry-kinds table no longer described what a `repo` row scans. | architecture | MEDIUM | fixed: both list `research/*.md` and the widened tool-helper set |
+| 6 | The memory-body line sat under Out of Scope, a section of exclusions, while describing something the port DID. | architecture | LOW | fixed: moved to the Decision Log as DEC-006 |
+| 7 | `FRONTMATTER_PURPOSE_RE` declared mid-file, away from its three siblings. | architecture | LOW | fixed: moved to the constants block |
+| 8 | `--explain` cannot resolve a tag-prefixed label from a secondary `repo` registry row. | architecture | LOW | advisory, pre-existing for `bin/`, `cli/`, `experiments/`; not this diff's job |
+| 9 | Five behaviors inside the restored iterators had no case: the runnable-file filter, the `test`-prefix skip, the non-directory guard, the research `README` skip, and the realpath arm of the dedupe. Each survived deletion with the suite green. | test-coverage | HIGH / MEDIUM | fixed: six cases added, each proven red by its own mutation |

--- a/lib/precedent/inventory.py
+++ b/lib/precedent/inventory.py
@@ -120,6 +120,14 @@ def script_summary(fp: str):
     i = 0
     if i < len(lines) and lines[i].startswith("#!"):
         i += 1
+    # PEP 723 inline metadata: a `uv run` script opens with a `# /// script` block holding
+    # its dependencies. Skip it, or the script indexes on its package list instead of its
+    # docstring. Ported from repo-sweep `_script_summary`.
+    if i < len(lines) and lines[i].strip() == "# /// script":
+        i += 1
+        while i < len(lines) and lines[i].strip() != "# ///":
+            i += 1
+        i += 1
     while i < len(lines) and not lines[i].strip():
         i += 1
     if i >= len(lines):
@@ -154,6 +162,7 @@ def script_summary(fp: str):
 FRONTMATTER_NAME_RE = re.compile(r'^name:\s*(.+?)\s*$', re.MULTILINE)
 FRONTMATTER_DESC_RE = re.compile(r'^description:\s*(.+?)\s*$', re.MULTILINE)
 FRONTMATTER_TITLE_RE = re.compile(r'^title:\s*(.+?)\s*$', re.MULTILINE)
+FRONTMATTER_PURPOSE_RE = re.compile(r'^purpose:\s*(.+?)\s*$', re.MULTILINE)
 
 
 def skill_frontmatter(fp: str):
@@ -199,9 +208,11 @@ def note_frontmatter(fp: str):
     return stem, desc or "", body_flat
 
 
-def is_executable_or_shell(fp: str, name: str) -> bool:
+def is_executable_or_shell(fp: str, name: str, exts=(".sh",)) -> bool:
+    """One definition of "this file is a runnable script". `_meta/*` counts an executable bit
+    or a `.sh` name; a tool's helper dirs count `.py` too."""
     try:
-        return bool(os.stat(fp).st_mode & stat.S_IXUSR) or name.endswith(".sh")
+        return bool(os.stat(fp).st_mode & stat.S_IXUSR) or name.endswith(exts)
     except OSError:
         return False
 
@@ -399,6 +410,8 @@ def scan_repo_tools(root: str, label_prefix: str, terms, sections: Sections, tit
     sections.ensure(title)
     for name in sorted(os.listdir(tools_dir)):
         tdir = os.path.join(tools_dir, name)
+        if not os.path.isdir(tdir):
+            continue  # a stray file beside the tool dirs (.DS_Store, a README)
         toml_fp = os.path.join(tdir, "tool.toml")
         if os.path.isfile(toml_fp):
             desc, systems = "", ""
@@ -411,18 +424,29 @@ def scan_repo_tools(root: str, label_prefix: str, terms, sections: Sections, tit
                 systems = m.group(1)
             s = score(terms, name, f"{desc} {systems}")
             sections.add(title, s, f"{label_prefix}tools/{name}/" + suffix(desc))
-        bin_dir = os.path.join(tdir, "bin")
-        if os.path.isdir(bin_dir):
-            for fn in sorted(os.listdir(bin_dir)):
-                fp = os.path.join(bin_dir, fn)
-                if not os.path.isfile(fp):
-                    continue
-                got = script_summary(fp)
-                if got is None:
-                    continue
-                summary, searchable = got
-                s = score(terms, fn, searchable)
-                sections.add(title, s, f"{label_prefix}tools/{name}/bin/{fn}" + suffix(summary))
+        # bin/ is the CLI surface; scripts/ and lib/ hold the helpers a duplicate candidate
+        # usually overlaps with, and some tools keep a top-level *.sh / *.py entry point.
+        # Indexing bin/ alone made a session declare an existing helper missing.
+        cands = []
+        for sub in ("bin", "scripts", "lib"):
+            subdir = os.path.join(tdir, sub)
+            if os.path.isdir(subdir):
+                cands += [(f"tools/{name}/{sub}/{fn}", os.path.join(subdir, fn))
+                          for fn in sorted(os.listdir(subdir))]
+        cands += [(f"tools/{name}/{fn}", os.path.join(tdir, fn))
+                  for fn in sorted(os.listdir(tdir)) if fn.endswith((".sh", ".py"))]
+        for rel, fp in cands:
+            fn = os.path.basename(fp)
+            if not os.path.isfile(fp) or fn.startswith(".") or fn.startswith("test"):
+                continue
+            if not is_executable_or_shell(fp, fn, (".sh", ".py")):
+                continue
+            got = script_summary(fp)
+            if got is None:
+                continue
+            summary, searchable = got
+            s = score(terms, fn, searchable)
+            sections.add(title, s, f"{label_prefix}{rel}" + suffix(summary))
 
 
 def scan_repo_experiments(root: str, label_prefix: str, terms, sections: Sections, title: str):
@@ -440,8 +464,41 @@ def scan_repo_experiments(root: str, label_prefix: str, terms, sections: Section
         if not title_or_desc:
             m = re.search(r'^#\s*(.+)$', body, re.MULTILINE)
             title_or_desc = m.group(1).strip() if m else ""
-        s = score(terms, slug, title_or_desc)
+        # Most experiment READMEs carry neither `title:` nor `description:`; their subject
+        # lives in the `tech:` tag list and the opening paragraph. Search both, display the
+        # title/desc only. Ported from repo-sweep `_iter_experiments`.
+        m = re.search(r'^tech:\s*\[(.*)\]\s*$', fm, re.MULTILINE)
+        tech = m.group(1) if m else ""
+        lede = " ".join(ln.strip("# >*") for ln in body.strip().splitlines()[:12] if ln.strip())
+        s = score(terms, slug, f"{title_or_desc} {tech} {lede}")
         sections.add(title, s, f"{label_prefix}experiments/{slug}/" + suffix(title_or_desc))
+
+
+def scan_repo_research(root: str, label_prefix: str, terms, sections: Sections, title: str):
+    """`research/*.md` reference snapshots, indexed by frontmatter title + purpose +
+    description. A dated research record is often the earliest written home of a capability,
+    and the surface this port lost entirely."""
+    d = os.path.join(root, "research")
+    if not os.path.isdir(d):
+        return
+    sections.ensure(title)
+    for fn in sorted(os.listdir(d)):
+        fp = os.path.join(d, fn)
+        if not fn.endswith(".md") or not os.path.isfile(fp) or fn.startswith("README"):
+            continue
+        text = read_head(fp)
+        if text is None:
+            continue
+        fm, _body = split_frontmatter(text)
+        fields = []
+        for rx in (FRONTMATTER_TITLE_RE, FRONTMATTER_PURPOSE_RE, FRONTMATTER_DESC_RE):
+            m = rx.search(fm)
+            if m:
+                fields.append(m.group(1).strip().strip('"'))
+        head_field = fields[0] if fields else ""
+        stem = os.path.splitext(fn)[0]
+        s = score(terms, stem, " ".join(fields))
+        sections.add(title, s, f"{label_prefix}research/{fn}" + suffix(head_field))
 
 
 def add_memory_entries(sections: Sections, title: str, dirpath: str, label_prefix: str, terms):
@@ -477,25 +534,43 @@ def add_memory_entries(sections: Sections, title: str, dirpath: str, label_prefi
     return True
 
 
-def add_skill_entries(sections: Sections, title: str, dirpath: str, terms, label_tag: str = ""):
+def add_skill_entries(sections: Sections, title: str, dirpath: str, terms, label_tag: str = "",
+                      seen=None):
     """<dirpath>/*/SKILL.md. A name/description hit scores double; a body-only hit ranks a
-    flat 1, strictly below any description hit."""
+    flat 1, strictly below any description hit.
+
+    `seen` is a dict shared across every skills dir of one run. The same skill reaches this
+    scan from more than one dir (a repo's `.claude/skills` and the operator's
+    `~/.claude/skills` hold copies of the same skill, sometimes symlinked), and printing it
+    twice under an identical bare label tells the reader nothing. The first dir scanned wins,
+    keyed on the resolved real path (catches a symlinked copy) and on the DIRECTORY name
+    (catches an independent copy, whose real path differs). The key is deliberately not the
+    frontmatter `name:`, which the scanned repo controls: keying on it would let a repo-local
+    skill in any directory suppress the operator's own skill of that name from a digest whose
+    whole job is naming what already exists."""
     if not os.path.isdir(dirpath):
         return False
+    if seen is None:
+        seen = {}
     sections.ensure(title)
     for name in sorted(os.listdir(dirpath)):
         fp = os.path.join(dirpath, name, "SKILL.md")
         if not os.path.isfile(fp):
             continue
+        real = os.path.realpath(fp)
+        dir_key = ("dir", name)
+        if real in seen or dir_key in seen:
+            continue
         got = skill_frontmatter(fp)
         if got is None:
             continue
+        seen[real] = seen[dir_key] = True
         skill_name, desc, body = got
         skill_name = skill_name or name
+        label = f"skill {label_tag}{skill_name}" if label_tag else f"skill {skill_name}"
         head_score = score(terms, skill_name, desc)
         s = 2 * head_score if head_score else (1 if score(terms, "", body) else 0)
         if s:
-            label = f"skill {label_tag}{skill_name}" if label_tag else f"skill {skill_name}"
             sections.add(title, s, label + suffix(first_sentence(desc)))
     return True
 
@@ -545,7 +620,7 @@ def add_feature_registry(sections: Sections, title: str, fp: str, owner: str, te
     return True
 
 
-def scan_repo(sections: Sections, path: str, tag: str, terms):
+def scan_repo(sections: Sections, path: str, tag: str, terms, skills_seen=None):
     """One `repo` location (the built-in ROOT, or a registry `repo <path>` row). tag is ""
     for ROOT (bare section titles: "tools", "scripts", ...) or basename(path) for any other
     repo location (tagged titles: "<tag> tools", ...). memory/skills/feature-registry
@@ -562,10 +637,11 @@ def scan_repo(sections: Sections, path: str, tag: str, terms):
     scan_repo_files(os.path.join(path, "cli"), f"{label_prefix}cli/", terms, sections, "cli")
     scan_repo_meta(os.path.join(path, "_meta"), f"{label_prefix}_meta/", terms, sections, "meta scripts")
     scan_repo_experiments(path, label_prefix, terms, sections, "experiments")
+    scan_repo_research(path, label_prefix, terms, sections, "research")
     add_memory_entries(sections, "memory", os.path.join(path, ".claude", "memory"),
                         f"{label_prefix}.claude/memory/", terms)
     add_skill_entries(sections, "skills", os.path.join(path, ".claude", "skills"), terms,
-                       label_tag=f"{tag}/" if tag else "")
+                       label_tag=f"{tag}/" if tag else "", seen=skills_seen)
     add_feature_registry(sections, "feature registries", os.path.join(path, "docs", "FEATURES.md"),
                           tag or "repo", terms)
 
@@ -699,7 +775,8 @@ def build_sections(root: str, kit_root: str, home: str, registry_rows, terms) ->
     sections = Sections()
 
     seen_repo_paths = {os.path.realpath(root)}
-    scan_repo(sections, root, "", terms)
+    skills_seen = {}
+    scan_repo(sections, root, "", terms, skills_seen)
 
     repo_tag_counts = {}
     for kind, path in registry_rows:
@@ -714,16 +791,16 @@ def build_sections(root: str, kit_root: str, home: str, registry_rows, terms) ->
         repo_tag_counts[tag] = n + 1
         if n:
             tag = f"{tag}-{n + 1}"
-        scan_repo(sections, path, tag, terms)
+        scan_repo(sections, path, tag, terms, skills_seen)
 
     # kit at KIT_ROOT: verbs, skills, feature registry -- built-in, always attempted.
     scan_kit_verbs(sections, kit_root, terms)
-    add_skill_entries(sections, "skills", os.path.join(kit_root, "skills"), terms)
+    add_skill_entries(sections, "skills", os.path.join(kit_root, "skills"), terms, seen=skills_seen)
     add_feature_registry(sections, "feature registries", os.path.join(kit_root, "docs", "FEATURES.md"),
                           "kit", terms)
 
     # $HOME/.claude/skills
-    add_skill_entries(sections, "skills", os.path.join(home, ".claude", "skills"), terms)
+    add_skill_entries(sections, "skills", os.path.join(home, ".claude", "skills"), terms, seen=skills_seen)
 
     # Registry-only kinds: scripts/skills/memory fold into their shared global section;
     # crons has no repo-kind equivalent, so it is a section on its own.
@@ -741,7 +818,7 @@ def build_sections(root: str, kit_root: str, home: str, registry_rows, terms) ->
                 continue
             scan_repo_files(path, "", terms, sections, disamb_title)
         elif kind == "skills":
-            ok = add_skill_entries(sections, title, path, terms)
+            ok = add_skill_entries(sections, title, path, terms, seen=skills_seen)
             if not ok:
                 sections.set_skip(title, skip_note(path))
         elif kind == "memory":

--- a/tests/test-precedent.sh
+++ b/tests/test-precedent.sh
@@ -59,6 +59,10 @@ make_fixture() {
   mkdir -p "$FIX_REPO/tools/alpha/bin" "$FIX_REPO/scripts" "$FIX_REPO/.claude/memory" \
            "$FIX_REPO/.claude/skills/delta" "$FIX_REPO/docs/specs" "$FIX_REPO/docs/decisions" \
            "$FIX_REPO/experiments/eps"
+  # Restored-iterator fixtures (research records, tool helper dirs, a second experiment whose
+  # subject lives only in `tech:` + the lede, a PEP-723 script, a duplicate skill dir).
+  mkdir -p "$FIX_REPO/research" "$FIX_REPO/tools/alpha/scripts" "$FIX_REPO/tools/alpha/lib" \
+           "$FIX_REPO/experiments/kappa" "$FIX_HOME/.claude/skills/delta"
 
   cat > "$FIX_REPO/tools/alpha/tool.toml" <<'FIX'
 name = "alpha"
@@ -109,6 +113,110 @@ title: notion export experiment
 ---
 # notion export experiment
 FIX
+
+  # The token halves follow the gamma.md technique: each is under the pattern's threshold on
+  # its own, so the contiguous shape never appears in this script's source. It pins that the
+  # restored helper-script surface redacts like every older one.
+  local fake_token_e="ghp_abcdefghij" fake_token_f="klmnopqrstuvwxyz0123456789"
+
+  # Restored iterator 1: a dated research record. Its subject lives in frontmatter
+  # `title:` + `purpose:`, both carrying unique words.
+  cat > "$FIX_REPO/research/2026-01-01-lambdaunique.md" <<'FIX'
+---
+title: lambdaunique estate census
+date: 2026-01-01
+purpose: Census of the muunique reporting paths across the estate.
+---
+
+# lambdaunique estate census
+FIX
+
+  cat > "$FIX_REPO/research/2026-01-02-omeganeue.md" <<FIX
+---
+title: omeganeue census, sample token ${fake_token_e}${fake_token_f}
+date: 2026-01-02
+purpose: A research record whose frontmatter carries a secret shape.
+---
+
+# omeganeue census
+FIX
+
+  # Restored iterator 2: tool helper scripts under scripts/ and lib/, plus a top-level
+  # tools/<x>/*.py entry point. None of these live in tools/alpha/bin/.
+  cat > "$FIX_REPO/tools/alpha/scripts/theta-helper.sh" <<FIX
+#!/usr/bin/env bash
+# theta-helper: nuunique bundle grep, auth sample shape ${fake_token_e}${fake_token_f}
+FIX
+  cat > "$FIX_REPO/tools/alpha/lib/xiunique.sh" <<'FIX'
+#!/usr/bin/env bash
+# shared helper library for the alpha desk
+FIX
+  cat > "$FIX_REPO/tools/alpha/omicron.py" <<'FIX'
+#!/usr/bin/env python3
+"""omicron: piunique report builder."""
+FIX
+
+  # Restored iterator 3: an experiment whose README has no `title:` and no `description:`.
+  # Its subject is only in the `tech:` tag list and the opening paragraph.
+  cat > "$FIX_REPO/experiments/kappa/README.md" <<'FIX'
+---
+slug: kappa
+status: active
+tech: [rhounique, python, launchd]
+---
+
+# kappa
+
+A daily digest posted to the sigmaunique channel.
+FIX
+
+  # Restored iterator 4: a PEP-723 (`uv run`) script. The inline metadata block names a
+  # decoy word; the real subject is in the docstring underneath it.
+  cat > "$FIX_REPO/scripts/tauunique.py" <<'FIX'
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["upsilondecoy"]
+# ///
+"""phiunique: reconcile the payroll ledger."""
+FIX
+
+  # Restored iterator 5: the same skill DIRECTORY name in a second scanned dir (the
+  # operator's ~/.claude/skills), an independent copy rather than a symlink. Exercises the
+  # dir-name arm of the dedupe.
+  cat > "$FIX_HOME/.claude/skills/delta/SKILL.md" <<'FIX'
+---
+name: delta
+description: sync notion pages
+---
+A second copy of the delta skill, living in the operator's home skills dir.
+FIX
+
+  # Realpath arm of the same dedupe: a differently-named dir symlinked at the SAME skill.
+  # Its dir name never collides, so only the resolved real path can collapse it.
+  ln -s "$FIX_REPO/.claude/skills/delta" "$FIX_HOME/.claude/skills/delta-alias"
+
+  # Exclusion fixtures for the helper-script filter. None of these three may ever surface:
+  # a non-executable file with no .sh/.py name, a `test`-prefixed helper, and a research
+  # README (the index file for the research dir, not a record).
+  cat > "$FIX_REPO/tools/alpha/bin/notes.txt" <<'FIX'
+# psiunique notes, not a runnable script
+FIX
+  chmod 644 "$FIX_REPO/tools/alpha/bin/notes.txt"
+  cat > "$FIX_REPO/tools/alpha/scripts/test-chiunique.sh" <<'FIX'
+#!/usr/bin/env bash
+# test harness for chiunique, not a helper
+FIX
+  cat > "$FIX_REPO/research/README.md" <<'FIX'
+---
+title: omegaunique research index
+---
+
+# research
+FIX
+
+  # Crash guard: a stray non-directory entry beside the tool dirs.
+  printf 'stray\n' > "$FIX_REPO/tools/.DS_Store"
 
   cat > "$FIX_REPO/docs/specs/SPEC-001-notion-sync.md" <<'FIX'
 # Spec: notion sync
@@ -845,6 +953,178 @@ if ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '^## recor
 else
   assert "empty records surface: no ## records header under --quiet" 1
   echo "$OUT" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Restored iterator 1: `research/*.md` records are indexed by frontmatter title + purpose.
+# The port dropped this source entirely; the query hits only through `purpose:`.
+# ---------------------------------------------------------------------------
+OUT="$("$PRECEDENT_BIN" find "muunique reporting" --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'research/2026-01-01-lambdaunique.md'; then
+  assert "research records: a frontmatter purpose hit surfaces the research file" 0
+else
+  assert "research records: a frontmatter purpose hit surfaces the research file" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Restored iterator 2: tool helper scripts under tools/<x>/scripts/ and tools/<x>/lib/, plus
+# a top-level tools/<x>/*.py. The port read tool.toml and tools/<x>/bin/* only.
+# ---------------------------------------------------------------------------
+OUT="$("$PRECEDENT_BIN" find "nuunique bundle" --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'tools/alpha/scripts/theta-helper.sh'; then
+  assert "tool helpers: a tools/<x>/scripts/ helper surfaces" 0
+else
+  assert "tool helpers: a tools/<x>/scripts/ helper surfaces" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find xiunique --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'tools/alpha/lib/xiunique.sh'; then
+  assert "tool helpers: a tools/<x>/lib/ helper surfaces" 0
+else
+  assert "tool helpers: a tools/<x>/lib/ helper surfaces" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find "piunique report" --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'tools/alpha/omicron.py'; then
+  assert "tool helpers: a top-level tools/<x>/*.py entry point surfaces" 0
+else
+  assert "tool helpers: a top-level tools/<x>/*.py entry point surfaces" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Restored iterator 3: an experiment README with no `title:` and no `description:` is still
+# searchable by its `tech:` tag list and by its opening paragraph.
+# ---------------------------------------------------------------------------
+OUT="$("$PRECEDENT_BIN" find rhounique --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'experiments/kappa/'; then
+  assert "experiments: a frontmatter tech: tag is searchable" 0
+else
+  assert "experiments: a frontmatter tech: tag is searchable" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find "sigmaunique channel" --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'experiments/kappa/'; then
+  assert "experiments: the README lede is searchable" 0
+else
+  assert "experiments: the README lede is searchable" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Restored iterator 4: a PEP-723 inline metadata block is skipped, so the script indexes on
+# its docstring and never on its dependency list.
+# ---------------------------------------------------------------------------
+OUT="$("$PRECEDENT_BIN" find "phiunique payroll" --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'tauunique.py'; then
+  assert "PEP-723: the docstring under a # /// script block is indexed" 0
+else
+  assert "PEP-723: the docstring under a # /// script block is indexed" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find upsilondecoy --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'tauunique.py'; then
+  assert "PEP-723: the inline dependency list is not indexed" 0
+else
+  assert "PEP-723: the inline dependency list is not indexed" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Restored iterator 5: one skill present in two scanned dirs prints once, not twice.
+# ---------------------------------------------------------------------------
+DELTA_COUNT="$("$PRECEDENT_BIN" find "sync notion" --surface inventory --limit 50 2>&1 \
+  | grep -c 'skill delta' || true)"
+if [ "$DELTA_COUNT" -eq 1 ]; then
+  assert "skills dedupe: a skill copied into two scanned dirs prints exactly one label" 0
+else
+  assert "skills dedupe: a skill copied into two scanned dirs prints exactly one label" 1
+  echo "count=$DELTA_COUNT" | sed 's/^/      /'
+fi
+
+# The realpath arm of the same dedupe: ~/.claude/skills/delta-alias is a symlink at the repo's
+# own delta skill. Its DIRECTORY name never collides, so only the resolved real path collapses
+# it. With the dir-name arm alone the count above would be 2.
+ALIAS_JSON="$("$PRECEDENT_BIN" find "sync notion" --surface inventory --limit 50 --json 2>&1)"
+ALIAS_COUNT="$(printf '%s' "$ALIAS_JSON" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+hits = d.get("skills", {}).get("hits", [])
+print(sum(1 for h in hits if h.startswith("skill delta")))
+' 2>/dev/null)"
+if [ "$ALIAS_COUNT" = "1" ]; then
+  assert "skills dedupe: a symlinked skill dir under another name collapses by real path" 0
+else
+  assert "skills dedupe: a symlinked skill dir under another name collapses by real path" 1
+  echo "count=$ALIAS_COUNT" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Exclusions the widened helper scan must keep: a non-executable file with no .sh/.py name,
+# a `test`-prefixed helper, and the research dir's own README index file.
+# ---------------------------------------------------------------------------
+OUT="$("$PRECEDENT_BIN" find psiunique --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'notes.txt'; then
+  assert "tool helpers: a non-executable, non-script file under bin/ is not indexed" 0
+else
+  assert "tool helpers: a non-executable, non-script file under bin/ is not indexed" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find chiunique --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'test-chiunique.sh'; then
+  assert "tool helpers: a test-prefixed helper is not indexed" 0
+else
+  assert "tool helpers: a test-prefixed helper is not indexed" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find omegaunique --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'research/README.md'; then
+  assert "research records: the dir's own README index is not indexed as a record" 0
+else
+  assert "research records: the dir's own README index is not indexed as a record" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Crash guard: a stray non-directory entry under tools/ (a .DS_Store) must not abort the
+# scan. Without the guard os.listdir raises NotADirectoryError and every query dies.
+# ---------------------------------------------------------------------------
+OUT="$("$PRECEDENT_BIN" find alpha --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'tools/alpha/' \
+   && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'Traceback'; then
+  assert "a stray non-directory entry under tools/ does not abort the scan" 0
+else
+  assert "a stray non-directory entry under tools/ does not abort the scan" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Redaction reaches the restored sources too: a secret shape in a research record's
+# frontmatter and in a tool helper's comment header both print as [redacted].
+# ---------------------------------------------------------------------------
+OUT="$("$PRECEDENT_BIN" find "omeganeue census" --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '\[redacted\]' \
+   && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'ghp_abcdefghij'; then
+  assert "redaction reaches a research record's frontmatter" 0
+else
+  assert "redaction reaches a research record's frontmatter" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find "nuunique bundle" --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q '\[redacted\]' \
+   && ! { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'ghp_abcdefghij'; then
+  assert "redaction reaches a tool helper script's comment header" 0
+else
+  assert "redaction reaches a tool helper script's comment header" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
 fi
 
 echo


### PR DESCRIPTION
## What

A fresh-context audit compared `precedent find --surface inventory` against the `repo-sweep whathas` command it replaced, on the same on-disk state, and found five per-repo iterators narrower than the original. All five are restored, each with a test proven red by reverting that iterator.

| # | Iterator | Before | After |
|---|---|---|---|
| 1 | research records | `research/` never read | `<repo>/research/*.md` scanned per `repo` registry row, indexed by frontmatter title, purpose, description |
| 2 | tool helper scripts | `tool.toml` + `tools/<x>/bin/*` only | plus `tools/<x>/scripts/`, `tools/<x>/lib/`, and top-level `tools/<x>/*.sh` and `*.py` |
| 3 | experiments | frontmatter title or description, else the first heading | plus the `tech:` tag list and the README lede |
| 4 | PEP-723 header | a `uv run` script indexed on its inline dependency list | the `# /// script` block is skipped, the docstring underneath is indexed |
| 5 | duplicate skill label | one skill copied into two scanned dirs printed twice under an identical bare label | first dir wins, keyed on the resolved real path and on the directory name |

Also guards `scan_repo_tools` against a stray non-directory entry beside the tool dirs, which crashed every query in a repo with a `tools/.DS_Store`.

`docs/specs/SPEC-245-precedent-inventory.md` gains the two deliberate deltas from whathas that were unrecorded: memory notes are searched by body (DEC-006, a widening), and the house-CLI and git-native tables stay dropped. Its Picture and registry-kinds table now describe what a `repo` row actually scans.

## Verification

| Command | Exit | Verdict |
|---|---|---|
| `bash tests/test-precedent.sh` | 0 (`64/64 passed`, was 48) | PASS |
| `bash tests/test-meta.sh` | 0 (`840 / 840`) | PASS |
| `bash tests/test-hooks.sh` | 0 (`497 / 497`) | PASS |
| `bash tests/test-bin-forwarders.sh` | 0 (`41 passed, 0 skipped`) | PASS |
| `bash tests/test-no-personal-paths.sh` | 0 (`3 / 3`) | PASS |
| `bash tests/run-workflow.sh` | 0 (`0 red of 70 steps`) | PASS |

Eleven negative controls, one mutation per run, each turning only its own cases red. Full transcript, the live before/after against the operator's ops-toolkit checkout, and the review findings table: `docs/verification/precedent-iterators.md`.

Live before/after, same query on the same checkout: `research/2026-09-07-foundation-ops-shared-lib-map.md`, `experiments/discord-user-send/` and `experiments/fare-watch/` appear after and not before; `tools/vps-mon/scripts/cf-worker-state.sh` and `tools/llm-bench/bench.py` likewise; `skill ops-tool-shape` prints once instead of twice.

## Review

Three lenses in parallel on the working tree, as AGENTS.md requires for a diff touching `lib/`. Security 8/10, architecture 7/10, test coverage 6/10. Nine findings, eight fixed in the branch, two accepted and recorded:

- MEDIUM (security): the dedupe originally keyed on the frontmatter `name:`, which the scanned repo controls, so a repo-local skill in any directory could suppress the operator's own skill of that name. Now keyed on the directory name plus the real path.
- HIGH (test coverage): five behaviors inside the restored iterators survived deletion with the suite green. Six cases added, each with its own mutation proof.
- LOW (security), accepted: a `scripts`/`lib` symlinked out of the repo root is still followed, as it already was for `bin/` and as whathas did. A confinement guard would silently drop legitimate symlinked helpers.
- LOW (architecture), advisory: `--explain` cannot resolve a tag-prefixed label from a secondary `repo` registry row. Pre-existing for `bin/`, `cli/`, and `experiments/`; not this diff's job.

## Note

`experiments/payout-batch-replay/` was named in the audit but does not match `discord post` in either implementation: its README carries neither term. It surfaces on `paginate notion`, which the restored lede scan is what makes possible.
