### PR TITLE
chore(gitignore): ignore operator install state for a symlinked clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ __pycache__/
 lib/**/rust/target/
 lib/**/bin/*-rs
 .coverage
+
+# Operator-local install state when ~/.claude/dwarves-kit is a symlink to this clone (dev-machine layout, 2026-09-08).
+state/
+logs/
+INSTALL-STAMP


### PR DESCRIPTION
On the dev machine ~/.claude/dwarves-kit is a symlink to this clone, so the operator's state/, logs/ and INSTALL-STAMP live inside the checkout. Ignore them so the clone stays clean. install.sh must not be re-run in that layout: line 689 renders kit.toml onto the tracked source file.