### PR TITLE
fix(mega): bin/mega status was blind to the current SG-NN grammar

### DIFF
--- a/docs/verification/mega-status-sg-grammar.md
+++ b/docs/verification/mega-status-sg-grammar.md
@@ -1,0 +1,45 @@
+# Verification log: bin/mega status and the SG-NN grammar
+
+Branch `fix/mega-status-sg-grammar`, base 24ac3a8 (origin/master at start).
+
+Two sub-goal id grammars are live in one subsystem. `/kit:mega` scaffolds `SG-NN`
+(`commands/mega.md`) and `lib/queue/orchestrate.sh:333` parses it. `lib/mega/mega.sh:282`
+required a digit immediately after the checkbox, so `SG-01` never matched.
+
+## The defect, reproduced before the fix
+
+Command: feed both grammars to the pre-fix regex `^-\ \[(.)\]\ ([0-9]+-[A-Za-z0-9_-]+)`
+Input: `- [x] SG-01 Collapse the module , auto` and `- [ ] SG-02 Wire the seam , gate`
+Output: `NO MATCH` for both lines
+Verdict: CONFIRMED. `bin/mega status` is the reconciler that flags `MERGED-UNCHECKED`,
+`CLAIM-UNVERIFIED` and `STALLED` by diffing a roadmap's claims against git and PR truth.
+Against a current-grammar roadmap it matched zero rows, found zero drift, and reported
+success. A checker that cannot see its input passes, which is the worst failure mode a
+reconciler has.
+
+## Green run (585b79d)
+
+Command: `bash tests/test-mega.sh`
+Exit: 0
+Output (excerpt): `ok - status parses the current SG-NN grammar (the form /kit:mega scaffolds)`;
+`ok - status sees an unchecked SG-NN row too, not just the checked one`; `PASS=18 FAIL=0`
+(16 before, 2 new)
+Verdict: PASS
+
+The new fixture is deliberately written in the CURRENT grammar. Every pre-existing fixture
+used `NN-slug`, and `SG-` appeared nowhere in the suite, which is precisely why the suite
+could not have caught this.
+
+## NEGATIVE CONTROL (585b79d)
+
+Command: `bash lib/gate/negctl.sh . "bash tests/test-mega.sh" "<sed reverting the regex to the old-only form>"`
+Exit: 0 green before; 1 under mutation; 0 after restore
+Output (excerpt): `Exit: 1 (under mutation, RED expected)`; `Verdict: PASS`
+Verdict: RED-as-expected. Restoring the old-only regex turns the suite red, so the new cases
+test the parser rather than the fixture.
+
+## Scope
+
+Latent, not live: no non-archived megagoal in this repo uses `SG-NN` yet, so nothing was
+mis-audited in practice. That makes this the cheapest moment to fix it. Both grammars are
+accepted; no archived roadmap changes behavior.

--- a/lib/mega/mega.sh
+++ b/lib/mega/mega.sh
@@ -30,7 +30,10 @@
 # RIGHT NOW is the runner's own journal/RUNNER_DONE job); this only ever points at git + gh.
 #
 # ROADMAP sub-goal line grammar parsed (documented convention, no fixed schema -- same judgment
-# call `lib/board/board-mirror.sh`'s `extract_megas` already documents for this same file):
+# call `lib/board/board-mirror.sh`'s `extract_megas` already documents for this same file).
+# BOTH id forms are accepted: `SG-NN` is what `/kit:mega` scaffolds today (commands/mega.md),
+# `NN-slug` is the older form every archived roadmap still carries.
+#   - [x] SG-01 Collapse the module , auto , PR #190 merged cb64f15
 #   - [x] 01-module-collapse (dwarves-kit), <prose>, PR #190 merged cb64f15 (<prose>)
 #   - [ ] 04-install-wire (dwarves-kit), <prose>, PR #
 #   - [~] 09-rehomed (dwarves-kit), rehomed into <other mega> (informational, never flagged)
@@ -279,7 +282,12 @@ cmd_status() {
   local -a detail_lines=()
 
   while IFS= read -r line; do
-    [[ "$line" =~ ^-\ \[(.)\]\ ([0-9]+-[A-Za-z0-9_-]+) ]] || continue
+    # Two grammars are live. The current one `/kit:mega` scaffolds is `SG-NN <title>`
+    # (commands/mega.md, and orchestrate.sh's own `_subgoals`); the older `NN-slug` form
+    # is still in every archived roadmap. Matching only the old one made this auditor
+    # silently find ZERO rows in a current roadmap and report nothing wrong, which is the
+    # worst failure available to a reconciler: a checker that cannot see its input passes.
+    [[ "$line" =~ ^-\ \[(.)\]\ (SG-[0-9]+|[0-9]+-[A-Za-z0-9_-]+) ]] || continue
     local box="${BASH_REMATCH[1]}" sub="${BASH_REMATCH[2]}"
     total=$((total + 1))
 

--- a/tests/test-mega.sh
+++ b/tests/test-mega.sh
@@ -228,6 +228,33 @@ else
   no "board board without --with-mega should not print a MEGA ROLLUP section"
 fi
 
+# --------------------------------------------------------------------------- SG-NN grammar
+# Every fixture above uses the OLDER `NN-slug` id form. `/kit:mega` scaffolds `SG-NN` today
+# (commands/mega.md), and mega.sh's parser matched only the old form, so `bin/mega status`
+# found ZERO rows in a current roadmap and reported nothing wrong. A reconciler that cannot
+# see its input passes, which is why this fixture exists in the CURRENT grammar.
+SGSLUG="sgmega"
+mkdir -p "$MEGAROOT/$SGSLUG/goals"
+cat > "$MEGAROOT/$SGSLUG/ROADMAP.md" <<'SGROADMAP'
+# Mega-goal: sgmega
+
+## Sub-goals
+
+- [x] SG-01 Collapse the module , auto , PR #101 merged abc123def0
+- [ ] SG-02 Wire the seam , gate , depends SG-01
+SGROADMAP
+SG_OUT="$(GH_BIN="$STUBGH" bash "$MEGA" status "$SGSLUG" --megagoals-root "$MEGAROOT" --code-root "$CODEROOT" 2>&1)"
+if { trap '' PIPE; printf '%s\n' "$SG_OUT" 2>/dev/null || :; } | grep -qE 'SG-01'; then
+  ok "status parses the current SG-NN grammar (the form /kit:mega scaffolds)"
+else
+  no "status did not see SG-01; the parser is blind to the current grammar: $SG_OUT"
+fi
+if { trap '' PIPE; printf '%s\n' "$SG_OUT" 2>/dev/null || :; } | grep -qE 'SG-02'; then
+  ok "status sees an unchecked SG-NN row too, not just the checked one"
+else
+  no "status did not see SG-02: $SG_OUT"
+fi
+
 echo "---"
 echo "Coverage delta: mega.sh had 0 tests before this file; now $((PASS + FAIL)) checks across the full drift-class taxonomy."
 echo "---"


### PR DESCRIPTION
Found by a read-only agent mapping the board plane, then reproduced directly.

## The defect

Two sub-goal id grammars are live in one subsystem:

| Reader | Regex | Matches |
|---|---|---|
| `commands/mega.md` (documented) + `orchestrate.sh:333` | `SG-[0-9]+` | `- [x] SG-01 Collapse the module` |
| `lib/mega/mega.sh:282` (`bin/mega status`) | `[0-9]+-[A-Za-z0-9_-]+` | `- [x] 01-module-collapse` |

The old regex requires a digit immediately after the checkbox, so `SG-01` fails it. Fed both current-grammar lines to the pre-fix regex: `NO MATCH` on both.

**Why this is worse than a cosmetic mismatch.** `bin/mega status` is the *reconciler*. It diffs a roadmap's claims against real git and PR state and flags `MERGED-UNCHECKED`, `CLAIM-UNVERIFIED`, `STALLED`. Against a roadmap `/kit:mega` scaffolded, it matched zero rows, found zero drift, and reported success. **A checker that cannot see its input passes.**

## The fix

The parser accepts both forms: `SG-NN` for what `/kit:mega` writes today, `NN-slug` for every archived roadmap. No archived roadmap changes behavior. The header comment now shows both.

## Verification

```
$ bash tests/test-mega.sh
ok - status parses the current SG-NN grammar (the form /kit:mega scaffolds)
ok - status sees an unchecked SG-NN row too, not just the checked one
PASS=18 FAIL=0                     # 16 before, 2 new
```

The new fixture is deliberately written in the **current** grammar. Every pre-existing fixture used `NN-slug` and `SG-` appeared nowhere in the suite, which is exactly why the suite could not have caught this.

Negative control (revert the regex to the old-only form): green, RED under mutation, green after restore, `Verdict: PASS`.

## Scope

Latent, not live: no non-archived megagoal in this repo uses `SG-NN` yet, so nothing was mis-audited in practice. That makes this the cheapest moment to fix it.

Proof of done: `docs/verification/mega-status-sg-grammar.md`.