### PR TITLE
fix(kit): strip spec IDs from strings the operator actually reads

### DIFF
--- a/commands/next.md
+++ b/commands/next.md
@@ -53,7 +53,7 @@ For the selected task, gather:
 
 Say: "Ready to implement. Work through the acceptance criteria one by one. When done, run `/kit:next` again for the next task, or `/kit:review` to review your changes."
 
-**Also remind**: "As you implement, maintain `docs/implementation-notes/<spec-slug>.md`. Append an entry whenever you make a decision the spec did not pin down, deviate from the spec, hit a tradeoff worth surfacing, discover a missing constraint, or hit an open question you'd want the operator to confirm or revise. Entry shape: `## YYYY-MM-DD HH:MM <title>` with Context / Decision / Why / Alternatives considered / Impact / Open questions lines. If TASK-[ID] runs with zero deviations, append a one-line `TASK-[ID]: no deviations; matches <spec> verbatim` entry so the absence is intentional. The file is surfaced in the `/wrap-session` LAB_LOG line and the PR description."
+**Also remind**: "As you implement, maintain `docs/implementation-notes/<spec-slug>.md`. Append an entry whenever you make a decision the spec did not pin down, deviate from the spec, hit a tradeoff worth surfacing, discover a missing constraint, or hit an open question you'd want the operator to confirm or revise. Entry shape: `## YYYY-MM-DD HH:MM <title>` with Context / Decision / Why / Alternatives considered / Impact / Open questions lines. If the task runs with zero deviations, append a one-line `No deviations; matches the spec verbatim` entry so the absence is intentional. The file is surfaced in the `/wrap-session` LAB_LOG line and the PR description."
 
 If the file does not yet exist, create it with a short header (`# Implementation notes: <spec-slug>` + a one-line pointer to the spec path) before handing off, so the implementor only has to append.
 

--- a/docs/verification/ids-in-printed-strings.md
+++ b/docs/verification/ids-in-printed-strings.md
@@ -1,0 +1,58 @@
+# Verification log: spec IDs in printed strings
+
+Branch `fix/ids-in-printed-strings`, base 25177ab.
+
+The house rule bans scattered spec and ticket tags in comments and prose. The worst instance
+is a tag inside a string the code PRINTS: it reaches a human at a terminal who cannot open the
+spec, and two of them fired on every push.
+
+## Scope, and how it was bounded
+
+Three read-only agents swept the repo. The printed-string subset was the one they were asked
+to enumerate individually rather than classify, because it is small enough to fix completely
+and highest value per edit. Twenty-two strings, across `hooks/`, `lib/gate/`, `lib/telemetry/`,
+`lib/board/`, `lib/adopt.sh`, `lib/explain.sh`, `lib/queue/orchestrate.sh` and
+`lib/skill-curator/`.
+
+## Green run (90d28af)
+
+Command: `bash tests/test-meta.sh && bash tests/test-hooks.sh && bash tests/test-docs-wiring.sh && bash tests/test-command-emit-sweep.sh && bash tests/test-wrap.sh && bash tests/test-lane-telemetry.sh && bash tests/test-board.sh && bash tests/test-adopt.sh && bash tests/test-explain.sh`
+Exit: 0 for each suite
+Output (excerpt): `All meta tests passed.`; `All tests passed.` (hooks); docs-wiring `25/25 passed`;
+`All command-emit-sweep tests passed.`; `test-wrap: all 236 passed`; lane-telemetry, board,
+adopt and explain each exit 0
+Verdict: PASS
+
+Every touched shell file parses (`bash -n`). A grep for an ID inside an `echo` or `printf` in
+`hooks/` and `lib/` returns only test-progress echoes and the live `SPEC-%s` payload named below.
+
+## What was deliberately NOT changed
+
+- `lib/queue/orchestrate.sh` `printf 'This wave dispatch reserved SPEC-%s ...'`: the
+  substitution is the actual reserved number the worker must act on. Live payload, not a
+  citation. Only its decorative label line lost a tag.
+- `lib/bench/tool.toml` and `lib/webcheck/tool.toml` `board = ["ID-420", ...]`: literal
+  backlog-row keys the code reads to render a board section.
+- `docs/verification/explain-command/sample-explainer.md`: the explain test regenerates this
+  file against whatever sha is checked out. It is a dated record of a past run, so the
+  regeneration was reverted rather than committed.
+
+## The source, not just the symptom
+
+`commands/next.md` instructed the model to append a `TASK-[ID]: no deviations` line to every
+implementation-notes file it wrote, manufacturing the banned tag shape on every run. It now
+asks for a plain `No deviations; matches the spec verbatim` line. Removing the emitter is what
+stops this class regrowing.
+
+## NEGATIVE CONTROL
+
+Not applicable in the usual mutate-and-go-red form: no test asserts on these strings, which is
+precisely why the tags survived this long. The check that has teeth is the grep recorded above,
+and the honest statement is that a future edit could reintroduce a tag without any suite
+noticing. A lint over printed strings would close that, and is not built here.
+
+## Remaining, not done in this pass
+
+The sweep found roughly 2,650 strip-class hits overall. This branch fixes 22 plus the emitter.
+The rest is scoped in the session report: ~495 in living docs, ~578 in the prompt layer, ~925
+non-string code comments, ~637 test comments.

--- a/hooks/ship-gate.sh
+++ b/hooks/ship-gate.sh
@@ -103,7 +103,7 @@ fi
 # spec-less freeform pushes are exactly the work most likely to be un-boarded, and the
 # old placement exited before the nudge could fire.
 if [ -f "$ROOT/_meta/BACKLOG.md" ] && ! grep -E '^\|' "$ROOT/_meta/BACKLOG.md" 2>/dev/null | grep -qF -- "$SLUG"; then
-  echo "[advisory] branch slug '$SLUG' appears nowhere in _meta/BACKLOG.md; if this is real work, give it a board row (SPEC-069)" >&2
+  echo "[advisory] branch slug '$SLUG' appears nowhere in _meta/BACKLOG.md; if this is real work, give it a board row" >&2
 fi
 
 # Doc-projection gate (kit repo only): the drift class that shipped twice
@@ -150,7 +150,7 @@ if [ -f "$LEDGER62" ]; then
         if [ -n "$BASE62" ] && ! git -C "$ROOT" diff --name-only "$BASE62" HEAD 2>/dev/null \
             | grep -E '^docs/verification/.+\.md$|(^|/)proof-of-done\.md$' \
             | grep -vq '/README\.md$'; then
-          echo "[advisory] run '$SLUG' (lane $RLANE) recorded a build but this branch ships no docs/verification/ record; the session ledger is not committable evidence (SPEC-071/ID-062)" >&2
+          echo "[advisory] run '$SLUG' (lane $RLANE) recorded a build but this branch ships no docs/verification/ record; the session ledger is not committable evidence" >&2
         fi ;;
     esac
   fi
@@ -162,7 +162,7 @@ if [ -f "$LEDGER62" ] && [ -n "${RLANE:-}" ]; then
   DOUT=$(bash "$LEDGER62" descent "$SLUG" "$RLANE" 2>/dev/null || true)
   DN=$(printf '%s' "$DOUT" | grep -c '^DESCENT:' || true)
   if [ "${DN:-0}" -gt 0 ] 2>/dev/null; then
-    echo "[advisory] run '$SLUG': $DN descent violation(s), phases recorded before an earlier plan phase disposed; see: bash <kit>/lib/gate/gate-ledger.sh descent $SLUG $RLANE (SPEC-076)" >&2
+    echo "[advisory] run '$SLUG': $DN descent violation(s), phases recorded before an earlier plan phase disposed; see: bash <kit>/lib/gate/gate-ledger.sh descent $SLUG $RLANE" >&2
   fi
 fi
 

--- a/lib/adopt.sh
+++ b/lib/adopt.sh
@@ -221,7 +221,7 @@ if [ -n "$kit_root_toml" ] && [ "$RESOLVER_OK" -eq 1 ]; then
       [ -n "$WITH_ARG" ] && with_norm=" $(echo "$WITH_ARG" | tr ',' ' ' | xargs) "
       tmp="$(mktemp)"
       {
-        echo "# .kit.toml -- this PROJECT's override of the kit-root defaults (SPEC-192)."
+        echo "# .kit.toml -- this PROJECT's override of the kit-root defaults."
         echo "# Only the keys you set here matter; every key you omit inherits the kit-root"
         echo "# default at $KIT_REF/kit.toml (lib/config/kit-config.sh: project keys WIN)."
         echo "# Re-run \`bash $KIT_REF/lib/adopt.sh --refresh <this repo>\` (or /kit:adopt) after"

--- a/lib/board/board.sh
+++ b/lib/board/board.sh
@@ -1016,7 +1016,7 @@ cmd_publish() {
 # legacy cockpit engine until the SPEC-002 P2 port (kit board ID-290).
 _legacy_bridge_note() {
   echo "note: mirror/status/writeback are the legacy cockpit engine (bridge)," >&2
-  echo "      folded into the sync module; port tracked as kit ID-290." >&2
+  echo "      folded into the sync module; the port is tracked on the kit board." >&2
 }
 
 usage() { sed -n '2,166p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }

--- a/lib/explain.sh
+++ b/lib/explain.sh
@@ -218,7 +218,7 @@ cmd_render() {
     echo "# Explainer for \`${ref}\`"
     echo
     echo "> Literate-diff explainer (base \`${base}\`). Grounded in the ACTUAL diff + recorded test"
-    echo "> results, NOT any agent/author narrative (ADR-0031 §2). Read top to bottom; the diff below is"
+    echo "> results, NOT any agent/author narrative. Read top to bottom; the diff below is"
     echo "> in READING order, not git's alphabetical order. The commit message is shown as UNVERIFIED"
     echo "> metadata only; where it disagrees with the code, the code below is the source of truth."
     echo

--- a/lib/gate/gate-ledger.sh
+++ b/lib/gate/gate-ledger.sh
@@ -446,7 +446,7 @@ override() {
           if (rr==r) found=1
         }
         END { exit !found }' "$f"; then
-    echo "override rejected: reason already used for another gate in run '$rid' -- each gate override needs its own reason (SPEC-097)" >&2
+    echo "override rejected: reason already used for another gate in run '$rid' -- each gate override needs its own reason" >&2
     return 65
   fi
   mkdir -p "$RUNS_DIR"
@@ -501,7 +501,7 @@ plan() {
   [ -n "$rows" ] || { echo "unknown lane '$lane' (not a column in the WORKFLOW matrix; no lanes.d drop-in)" >&2; return 1; }
   local i=0 ph cell mark
   if [ "$lane" != "tiny" ]; then
-    i=1; printf '%2d. %-18s %s\n' 1 "grill" "intake (universal, SPEC-058)"
+    i=1; printf '%2d. %-18s %s\n' 1 "grill" "intake (universal)"
   fi
   while IFS=$'\t' read -r ph cell; do
     case "$cell" in

--- a/lib/gate/proof-ledger.sh
+++ b/lib/gate/proof-ledger.sh
@@ -374,7 +374,7 @@ check() {
       echo "  Need: a docs/verification/<slug>.md added by this branch with a recorded run AND a rollback note, or [UNAVAILABLE: reason] if no such flow exists here."
       echo "        ('recorded run' = Command:/Exit: text OR a committed screenshot/GIF embed for visual/demo work.)"
     fi
-    echo "  Type-specific shape (SPEC-044): run 'bash lib/gate/proof-gate.sh contract \"<your task>\"' for the exact artifact this work-type owes + the skill that owns it (e.g. a data/CLI tool owes a recorded live run; an eval owes a TEST-REPORT)."
+    echo "  Type-specific shape: run 'bash lib/gate/proof-gate.sh contract \"<your task>\"' for the exact artifact this work-type owes + the skill that owns it (e.g. a data/CLI tool owes a recorded live run; an eval owes a TEST-REPORT)."
     echo "  Produce it via /kit:verify (or record it), or log an explicit override (audited):"
     echo "    bash lib/gate/proof-ledger.sh override '${slug:-<branch-slug>}' \"<reason>\""
     # ID-299 operator hint: an override for THIS slug exists in the log but is scoped to a
@@ -382,7 +382,7 @@ check() {
     # so it does not apply here. Say so, or the operator re-logs and it still "does nothing".
     if [ -n "$slug" ] && [ -f "$OVERRIDE_LOG" ] \
        && awk -F'|' -v s="$slug" 'function trim(x){gsub(/^[ \t]+|[ \t]+$/,"",x);return x} trim($3)==s && trim($4)=="OVERRIDE"{f=1;exit} END{exit(f?0:1)}' "$OVERRIDE_LOG"; then
-      echo "  Note: an override for '$slug' exists in the log but is scoped to a different repo; re-log it from THIS repo's root (ID-299)."
+      echo "  Note: an override for '$slug' exists in the log but is scoped to a different repo; re-log it from THIS repo's root."
     fi
   } >&2
   return 1

--- a/lib/gate/quiz-gate.sh
+++ b/lib/gate/quiz-gate.sh
@@ -81,7 +81,7 @@ cmd_questions() {
   local first_file="${order%% *}"
 
   echo "# 5-question understanding quiz for \`${ref}\`"
-  echo "# Grounded in the ACTUAL diff + recorded test results (SPEC-125), NOT any agent narrative."
+  echo "# Grounded in the ACTUAL diff + recorded test results, NOT any agent narrative."
   echo "# These questions are the payload for the deep-understand mastery gate, they are not scored here."
   echo
   echo "Q1. Background: this change is read in the order: ${order:-（no files）}. Start from \`${first_file:-（none）}\` -- what existing context does the change build on, and why is that the reader's first stop?"
@@ -103,7 +103,7 @@ cmd_route() {
   local ref="${1:-HEAD}"
   echo "ROUTE: deep-understand"
   echo "engine: deep-understand skill (its AskUserQuestion mastery-gate quiz)"
-  echo "material: the SPEC-124 literate explainer (lib/explain.sh render ${ref}); docs/verification/"
+  echo "material: the literate explainer (lib/explain.sh render ${ref}); docs/verification/"
   echo "instruction: hand these 5 diff-grounded questions to deep-understand; it runs the mastery gate,"
   echo "             shuffles answer slots, and gates each item on a demonstrated answer. The kit scores nothing."
   echo
@@ -153,7 +153,7 @@ cmd_tap() {
   echo "  This gate/gated-final PR is significant AND understanding-worthy. Before you merge, pick one"
   echo "  (all three are logged to the debt ledger; the quiz never blocks the merge):"
   echo "    engage  -- pull the 5-question quiz now (deep-understand mastery gate)"
-  echo "    defer   -- send it to the weekend batch (SG-05)"
+  echo "    defer   -- send it to the weekend batch"
   echo "    wave    -- accept the debt knowingly (the change still merges)"
   echo "  Respond: bash lib/gate/quiz-gate.sh respond ${rid} <engage|defer|wave> [--ref <ref>]"
 }
@@ -179,7 +179,7 @@ cmd_respond() {
         echo "ROUTE: deep-understand (no --ref given; run 'quiz-gate.sh route <ref>' to build the questions)"
       fi
       ;;
-    defer) echo "recorded: defer (rid=${rid}) -- queued for the weekend batch (SG-05). The change still merges." ;;
+    defer) echo "recorded: defer (rid=${rid}) -- queued for the weekend batch. The change still merges." ;;
     wave)  echo "recorded: wave (rid=${rid}) -- debt accepted knowingly. The change still merges." ;;
   esac
   return 0

--- a/lib/queue/orchestrate.sh
+++ b/lib/queue/orchestrate.sh
@@ -1803,7 +1803,7 @@ _wave_run() {  # megadir roadmap
     local reserved_spec
     if reserved_spec="$(_wave_reserve_spec)"; then
       {
-        printf '\n\n---\nRESERVED SPEC NUMBER (SPEC-128 wavefront reservation)\n'
+        printf '\n\n---\nRESERVED SPEC NUMBER\n'
         printf 'This wave dispatch reserved SPEC-%s for your sub-goal. When you run /kit:spec (or\n' "$reserved_spec"
         printf 'call lib/spec/spec-next.sh), USE SPEC-%s , it is already claimed for you under a lock, so\n' "$reserved_spec"
         printf 'no sibling wave worker can take it. Do NOT re-derive a different number.\n'

--- a/lib/skill-curator/bin/cc-improve
+++ b/lib/skill-curator/bin/cc-improve
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias of `skill-improve` (SPEC-200 I5: the kit speaks one language; the
 # `cc-` host-agent prefix is retired). Works for one release, then goes away.
-printf 'cc-improve is deprecated, use skill-improve (SPEC-200)\n' >&2
+printf 'cc-improve is deprecated, use skill-improve\n' >&2
 exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/skill-improve" "$@"

--- a/lib/skill-curator/lib/common.sh
+++ b/lib/skill-curator/lib/common.sh
@@ -26,7 +26,7 @@ for _v in STATE_DIR PROPOSALS_DIR SKILLS_DIR CONFIG SETTINGS MEMORY_LEDGER CURAT
           REVIEWER_CMD SIGNAL_MARKERS; do
   _new="SKILL_CURATOR_$_v"; _old="CC_SI_$_v"
   if [ -z "${!_new:-}" ] && [ -n "${!_old:-}" ]; then
-    printf 'skill-curator: %s is deprecated, use %s (SPEC-200)\n' "$_old" "$_new" >&2
+    printf 'skill-curator: %s is deprecated, use %s\n' "$_old" "$_new" >&2
     export "$_new=${!_old}"
   fi
 done
@@ -54,7 +54,7 @@ cfg() {
   legacy="CC_SI_$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
   if [ -n "${!envvar:-}" ]; then printf '%s' "${!envvar}"; return; fi
   if [ -n "${!legacy:-}" ]; then
-    printf 'skill-curator: %s is deprecated, use %s (SPEC-200)\n' "$legacy" "$envvar" >&2
+    printf 'skill-curator: %s is deprecated, use %s\n' "$legacy" "$envvar" >&2
     printf '%s' "${!legacy}"; return
   fi
   if [ -f "$SKILL_CURATOR_CONFIG" ]; then

--- a/lib/telemetry/lane-telemetry.sh
+++ b/lib/telemetry/lane-telemetry.sh
@@ -270,7 +270,7 @@ report() {
       printf '%s\n' "$tagg" | awk -F'\t' '$1!="__ALL__"{ printf "    %-12s %10d %7d%%\n", $1, $3, $4 }' | sort
       printf '    rework share (bug-lane tokens / total, run-granularity v1): %s%%\n' "${rework:-0}"
     fi
-    printf '    (no thresholds pinned; baseline forms after ~5 captured runs, SPEC-073 pattern)\n'
+    printf '    (no thresholds pinned; baseline forms after ~5 captured runs)\n'
   fi
 
   # Failure-policy breakdown (ID-398, docs/patterns/failure-policy.md): only over OUTCOME
@@ -278,7 +278,7 @@ report() {
   local pagg; pagg="$(_policy_agg)"
   if [ -n "$pagg" ]; then
     echo ""
-    echo "  failure policy (close/escalate/continue, ID-398):"
+    echo "  failure policy (close/escalate/continue):"
     printf '%s\n' "$pagg" | awk -F'\t' '{ printf "    %-10s %5d\n", $1, $2 }'
   fi
 
@@ -330,7 +330,7 @@ misfires() {
   fi
   local bl_list; bl_list="$(_boardless)"
   if [ -n "$bl_list" ]; then
-    echo "boardless runs (SPEC-069: work that never touched the board):"
+    echo "boardless runs (work that never touched the board):"
     printf '%s\n' "$bl_list" | sed 's/^/  /'; any=1
   fi
   local si_list; si_list="$(_shipped_incomplete)"
@@ -493,7 +493,7 @@ render() {
 
   echo ""
   printf '  legend: gates r/s/o = ran / skipped / override summed over those runs;\n'
-  printf '          "?" lane/type = runs with no START line (untracked; see ID-085).\n'
+  printf '          "?" lane/type = runs with no START line (untracked).\n'
   return 0
 }
 


### PR DESCRIPTION
Three read-only agents swept the repo for scattered spec and ticket tags. This PR fixes the highest-value bounded subset: **IDs inside strings the code prints.**

An ID in a printed string reaches a human standing at a terminal who cannot open the spec. It costs attention at the exact moment something is being reported, and answers nothing the reader can act on. Two of these fired **on every push**:

```
[advisory] branch slug 'x' appears nowhere in _meta/BACKLOG.md; ... give it a board row (SPEC-069)
[advisory] ... the session ledger is not committable evidence (SPEC-071/ID-062)
```

22 strings across `hooks/`, `lib/gate/`, `lib/telemetry/`, `lib/board/`, `lib/adopt.sh`, `lib/explain.sh`, `lib/queue/orchestrate.sh`, `lib/skill-curator/`. Each loses its tag and keeps its sentence; nothing else about the messages changes.

## The source, not just the symptom

`commands/next.md` told the model to append `TASK-[ID]: no deviations; matches <spec> verbatim` to **every** implementation-notes file it wrote, manufacturing the banned tag shape on every run. It now asks for a plain `No deviations; matches the spec verbatim` line. Removing the emitter is what stops this class regrowing.

## Deliberately kept

| Kept | Why |
|---|---|
| `printf 'This wave dispatch reserved SPEC-%s ...'` | live payload: the reserved number the worker must act on. Only its decorative label lost a tag. |
| `board = ["ID-420", ...]` in two `tool.toml` | literal backlog-row keys the code reads |
| `docs/verification/explain-command/sample-explainer.md` | the explain test regenerates it against the current sha; it is a dated record, so the regeneration was reverted rather than committed |

## Verification

```
$ bash tests/test-meta.sh && bash tests/test-hooks.sh && bash tests/test-docs-wiring.sh && bash tests/test-command-emit-sweep.sh
All meta tests passed.; All tests passed.; 25/25 passed; All command-emit-sweep tests passed.

$ bash tests/test-wrap.sh && bash tests/test-lane-telemetry.sh && bash tests/test-board.sh && bash tests/test-adopt.sh && bash tests/test-explain.sh
all green
```

Every touched shell file parses. A grep for an ID inside `echo`/`printf` under `hooks/` and `lib/` now returns only test-progress echoes and the live `SPEC-%s` payload.

**No negative control in the usual form, and that is the finding.** No test asserts on these strings, which is exactly why the tags survived. A future edit could reintroduce one and nothing would notice. A lint over printed strings would close it; not built here.

## Not in this PR

The sweep found ~2,650 strip-class hits total. Remaining: ~495 living docs, ~578 prompt layer, ~925 non-string code comments, ~637 test comments.

Proof of done: `docs/verification/ids-in-printed-strings.md`.