### PR TITLE
docs(kit): repair doc drift from board-mint/changelog/precision merges

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -285,8 +285,8 @@ Related, **2b-0 role synthesis** (inside `/kit:execute`): each task is classifie
 ### `/kit:ship`
 
 **Phase:** review gate, version bump, changelog, commit, PR
-**Reads:** `docs/specs/SPEC-NNN-<slug>.md` (including its `## Review` verdict), `VERSION`, `CHANGELOG.md`
-**Writes:** bumped `VERSION`, new `CHANGELOG.md` entry, git tag, PR via `gh`
+**Reads:** `docs/specs/SPEC-NNN-<slug>.md` (including its `## Review` verdict), `VERSION`, the resolved changelog file (`docs/CHANGELOG.md` if it exists, SPEC-185, else root `CHANGELOG.md`)
+**Writes:** bumped `VERSION`, a new entry in the resolved changelog file, git tag, PR via `gh`
 **When to invoke:** review is green and docs are synced
 **Common gotcha:** blocks if the spec's `## Review` verdict is DO NOT SHIP. Use `/review-team` and `responding-to-review` to triage before re-running ship.
 **Release-hygiene warn (Step 4a):** at the version step it warns (never blocks) on a phantom cut, `VERSION` naming a version with no matching git tag, with a heads-up when `[Unreleased]` is accumulating above it. Warn-only; tag `v<version>` or confirm intentional, then continue.
@@ -459,9 +459,12 @@ mints the ID for you. Hand it freeform intent instead of an `ID-NNN`:
      2. approve              -> pause for your approval (approve-before-allocate: a vague
                                 brief never auto-creates a row)
      3. sanitize + allocate  -> escape `|`/newlines for the table cells; reduce the slug
-                                to [a-z0-9-]+; re-read the max ID and write the next
-                                ID-NNN row into _meta/BACKLOG.md in the same step, with a
-                                loud equal-ID collision check (atomic-allocate)
+                                to [a-z0-9-]+; raise the mint floor past the working copy
+                                with the board file's own git history (history_max_id(),
+                                so a lagging or archived-row checkout cannot re-hand-out a
+                                taken ID); write the next ID-NNN row into _meta/BACKLOG.md
+                                in the same step, with a loud equal-ID collision check
+                                (atomic-allocate)
      4. rejoin the ID tail   -> write the goal draft, pick the lane, route (Scenario 2's
                                 flow), exactly as for an ID-NNN argument
 ```

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -506,8 +506,10 @@ it.
 -> `board promote`; `caught=bool` + override-rate per gate; delivery-ratio; kit-health;
 learn-propose precision tracking.
 
-**The gap:** the learning loop has one precision data point (calibrating, not yet trusted);
-review-economics unmeasured; context freshness is pull-based with no owner.
+**The gap:** the learning loop's one measured precision gap (ID-305, promote-precision on a
+labelled sample) has a fix plus a reconstructed-sample regression proof (24 -> 67 percent), but
+no live field remeasurement yet, so it is fixed, not yet trusted at scale; review-economics
+unmeasured; context freshness is pull-based with no owner.
 
 **A conforming proposal looks like:** it adds or consumes a measurable signal, feeds the Learn
 stage's staging file, and is itself measured (the meta-loop). **It would reject:** self-rewriting

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,8 @@ map, not per-dir READMEs , `specs/` and `verification/` keep their own, delibera
   proof-of-done marker the ship-gate keys on (`hooks/ship-gate.sh`) , link it, never move it.
   `verification/generated/` holds the machine-generated companion run-tables (`proof-table-gen.sh`
   writes here; this folded the old repo-root `docs/runs/` in , never overwrites a canonical
-  `proof-of-done.md`). There is no separate `docs/proof/`: that fold is complete, its content lives
-  under `verification/` too.
+  `proof-of-done.md`). `docs/proof/` still holds a handful of pre-convention captures
+  (never migrated); new proof output goes to `verification/` exclusively.
 - [`retro/`](retro/) , per-cycle retrospectives (output of `/kit:retro`).
 - [`releases/`](releases/) , per-version release artifacts (one dir per shipped version).
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -526,8 +526,9 @@ The gate-ledger's `RUN_REPORT.md` (`/kit:mega`'s per-sub-goal gate matrix) can o
 as covered if SOME command actually calls `gate-ledger.sh` for it. A 2026-07-04 audit of every
 file under `commands/` found 11 of 29 commands with a real `bash lib/gate/gate-ledger.sh <verb>` call
 and 18 dark, with no distinction between "this phase genuinely has no ledger concern" and "nobody
-wired it yet" -- the RUN_REPORT under-counts silently either way (`commands/` has since grown to
-36 files; 26 now match `gate-ledger.sh`). This section is the single
+wired it yet" -- the RUN_REPORT under-counts silently either way (`commands/` has grown since; the
+exemption table below plus `tests/test-command-emit-sweep.sh` are the live count, never this
+aside). This section is the single
 source of truth for that distinction (parsed by `tests/test-command-emit-sweep.sh`, no second
 copy): every command in `commands/` either contains a `gate-ledger` call, or is listed below with
 a reason it legitimately does not need one.

--- a/docs/tiers.md
+++ b/docs/tiers.md
@@ -1,7 +1,7 @@
 # Feature inventory by tier (canonical, DRAFT)
 
 Product-side source of truth for what ships in which tier. Consumed by: the pricing page, the
-ID-410 entitlement sets, and the FG-01 business brief (forge
+ID-426 entitlement sets, and the FG-01 business brief (forge
 `docs/briefs/DECISION-BRIEF-kit-monetization.md`, which owns pricing/model decisions; this file
 owns the FEATURE->TIER->MODULE mapping). Status column: shipped (exists today) / queued (board
 row) / planned (catalog, parked).
@@ -20,14 +20,14 @@ INTERPRETATION layer: "your data is free forever; our reading of it is the produ
 | Kanban board + pull flow (`board`, states, next) | board | shipped |
 | Session doctor `/start` (state + one next action, always-on onboarding) | onboard | shipped |
 | Guided first-run `/onboard` (previews every write, decline = no-op) | onboard/adopt | shipped |
-| Portable repo adopt (4 files, machine-independent) | adopt | queued ID-408 |
+| Portable repo adopt (4 files, machine-independent) | adopt | shipped (ID-408) |
 | Workflow gallery (generated ASCII flows per work type) | onboard | queued ID-407 |
 | Intake interview `/grill` (one question at a time, facts vs decisions) | grill | shipped (+ID-404) |
 | Spec pipeline: think / spec / spec-validate (adversarial, 6 lenses) / execute / review / ship | commands | shipped |
 | Verifier chain: task, integration, acceptance, system + recheck (fresh-context re-audit) | gate/agents | shipped |
 | Review teams (security / architecture / test-coverage lenses) + advisor extra lens | agents | shipped |
 | Debug loop (root cause before any fix) | commands | shipped |
-| Test-plan matrices + adversarial test-plan review team | test-plan | shipped (+ID-406) |
+| Test-plan matrices + adversarial test-plan review team | test-plan | shipped; default-flip queued as ID-406 |
 | Decision briefs (brief-on-file at intake) | assign/briefs | queued ID-409 |
 | Worktree isolation per parallel writer + disjointness gate | queue/gate | shipped |
 | Mega-goal roadmaps + wavefront orchestration + overnight queue | queue | shipped (ADR-0030) |
@@ -40,7 +40,7 @@ INTERPRETATION layer: "your data is free forever; our reading of it is the produ
 | Understanding axis: explain, quiz gates, debt ledger, weekend paydown | quiz_gate/weekend_batch | shipped |
 | Upstream absorb machinery + seed watch | absorb | shipped (+ID-403) |
 | Tool-selection ladders, BASIC set (browser use, memory, computer use, rendering, model routing: which tool when) | ladders (new) | queued ID-418 |
-| North-star alignment lens (proposals state the criterion they serve) | advisor | queued ID-397 |
+| North-star alignment lens (proposals state the criterion they serve) | advisor | shipped (+ID-397) |
 | Skill fleet: cross-runtime registry + `fleet sync` (one skill body -> every harness) + `fleet render` | fleet (new) | queued ID-431/432 · [docs/fleet/](fleet/) |
 
 ## Craft (perpetual license + update stream)
@@ -48,10 +48,10 @@ INTERPRETATION layer: "your data is free forever; our reading of it is the produ
 | Feature | Module/surface | Status |
 |---|---|---|
 | Workflow Insights: weekly report + the-one-thing-to-change recommendation | stats (paid layer) | queued ID-411 |
-| Greenlight loop: open PR driven to merge-ready (CI fix + comment triage) | ship | queued ID-401 |
-| One persona pack included (Frontend first: visual proof, design lenses, deslop, visual acceptance) | proof/packs | queued ID-395/402 |
+| Greenlight loop: open PR driven to merge-ready (CI fix + comment triage) | ship | executing ID-401 |
+| One persona pack included (Frontend first: visual proof, design lenses, deslop, visual acceptance) | proof/packs | queued ID-395 (deslop lens shipped, ID-402) |
 | Tool-selection ladders, MAINTAINED library (updated as the ecosystem moves; part of the stream) | ladders | queued ID-418 |
-| Private update channel + pack marketplace access | install | queued ID-410 |
+| Private update channel + pack marketplace access | install | queued ID-426 (supersedes dropped ID-410) |
 | Ambient module self-suggest | onboard | queued ID-405 |
 | Fleet skills ride the stream (maintained skills propagate to every harness in one pull) | fleet | queued ID-431 · [docs/fleet/PRIVATE-STREAM.md](fleet/PRIVATE-STREAM.md) |
 
@@ -62,7 +62,7 @@ INTERPRETATION layer: "your data is free forever; our reading of it is the produ
 | Funded workspaces: org token pool, allowances, rollover, never raw keys | gateway (server) | queued ID-412 |
 | Policy-as-code: model tiers by role, budget caps by lane, strictest-wins | gateway + policy | planned (team-mode SG-05) |
 | Attestation: every change attributed, human or agent, per-actor ledger | team-mode | planned (SG-01/02) |
-| Review-economics dashboard: first-pass acceptance, rework, reviewer minutes, cost per merged change | stats (team) | queued ID-392 |
+| Review-economics dashboard: first-pass acceptance, rework, reviewer minutes, cost per merged change | stats (team) | executing ID-392 |
 | Canary cards (planted-defect gate testing) | gate | queued ID-393 |
 | Morning digest (what your agents did overnight, per member + lead rollup) | stats (team) | planned |
 | Reviewer load balancing + assignment routing | board (team) | planned |


### PR DESCRIPTION
## Summary

Doc-drift audit over the living-doc item set (README/MANUAL/AGENTS/CLAUDE/CONTRIBUTING +
`docs/*.md` + `docs/patterns/*.md`), run after today's four merges (PR #535 changelog/version
surfaces, PR #535 SECRET_SHAPE_RE widening, PR #541 board-ID history mint, PR #542 learn-propose
precision). Tier 1 mechanical pass (paths, inventory tables, hardcoded counts, named
commands/flags) plus a Tier 2 model-read pass (`kit:audit-scanner`) on the flagged files and the
high-traffic operator surfaces.

- `docs/MANUAL.md`: the freeform `/kit:assign` ID-mint step described the pre-#541
  working-file-only read; reworded to name `history_max_id()`'s git-history floor. Also
  tightened `/kit:ship`'s Reads/Writes to name the SPEC-185 changelog resolution instead of a
  bare `CHANGELOG.md`.
- `docs/WORKFLOW.md`: dropped a hardcoded command-count aside (`36 files; 26 now match`) that had
  already drifted from the live count (39 commands, 29 matching `gate-ledger.sh`); points at
  `tests/test-command-emit-sweep.sh` and the exemption table instead of restating a number.
- `docs/PHILOSOPHY.md`: the N6 gap line said "one precision data point, not yet trusted"; PR #542
  closed ID-305 with a fix plus a reconstructed-sample regression proof (24 -> 67 percent).
  Reworded to "fixed, not yet field-remeasured" rather than overclaiming trust.
- `docs/README.md`: corrected a false claim that `docs/proof/` had been folded into
  `verification/`; it still holds two untouched pre-convention capture sets
  (`loop-07-mega-dashboard/`, `loop-09-onboard-wizard/`), tracked since PR #295.
- `docs/tiers.md`: five Status-column rows lagged `_meta/BACKLOG.md` and the live repo:
  - ID-408 (portable adopt) shipped, shown queued.
  - ID-397 (north-star alignment lens) shipped, shown queued.
  - ID-401 (greenlight loop) executing, shown queued.
  - ID-392 (review-economics telemetry) executing, shown queued.
  - ID-410 (private update channel) dropped/superseded by ID-426, still cited as the live driver
    (fixed in both the row and the file's own intro line).
  - Two annotation mismatches inside otherwise-correct rows: ID-402 (deslop) already shipped
    inside a row still marked queued for its sibling ID-395; ID-406 (test-plan-first default
    flip) still queued, annotated as if shipped alongside the already-shipped base feature.

No hardcoded count was reintroduced while fixing a stale one. Everything else in the item set
(29 files total) verdicted OK on both tiers.

## Test plan

- [x] `bash tests/test-meta.sh`, 840/840 green, before and after.
- [x] Tier 1 re-run on every touched file post-fix: paths resolve, no stale ID/count references
      remain (`grep -rn "ID-410"` and the WORKFLOW.md count strings both come back clean except
      the one intentional ID-426 pointer).
- [x] Every removed/changed claim cross-checked against `_meta/BACKLOG.md` and the live code
      (`lib/adopt.sh`, `commands/think.md`/`spec-validate.md`/`absorb.md`, `commands/greenlight.md`,
      `lib/telemetry/lane-telemetry.sh`, `lib/sync/sync_core.py`, `lib/board/bin/add-backlog`).

Not merging this PR per the audit run's instructions.
