### PR TITLE
fix(wrap): make step 7b report an outcome the lint can check

### DIFF
--- a/commands/wrap.md
+++ b/commands/wrap.md
@@ -105,6 +105,8 @@ a. DEBT marker.
 rid=$(bash lib/gate/gate-ledger.sh rid)
 ```
 
+**Every skip in this sub-step skips ONLY this sub-step.** `a` is the DEBT marker and nothing else; `b` and `c` do not depend on a run id, a run log, or the classifier, and they run whatever `a` reported. A real session on 2026-09-09 read `skipped: no run id` as "step 7 does not apply" and never ran `b`, which is the step that builds rather than proposes. If `a` skips, say so and go straight to `b`.
+
 An empty `rid` prints `skipped: no run id`. Otherwise resolve the log dir with `logdir=$(bash -c 'source lib/telemetry/kit-log-dir.sh; kit_resolve_log_dir')` (the file is source-only and prints nothing when run as a command); a missing `runs/<rid>.log` prints `skipped: no run log`; a `| DEBT |` line already in it prints `skipped: DEBT marker present`. Otherwise `bash lib/classify/significance-classify.sh record <rid> "<one-line session description>"`; a non-zero exit prints `skipped: classifier failed (rc N)` and the step continues to b.
 
 b. Candidates. A candidate is anything this session BUILT or proposed to build that could outlive the session: a new script or tool, an enhancement the operator asked for and the session deferred, a manual multi-step procedure run three or more times, or a one-off script the operator called recurring. The check runs on the first one, not the third, because a single-purpose script written next to an existing tool is the fragment this step exists to prevent. `wrap.build_candidates` false: run the precedent check anyway, then stage every candidate with the `bin/wrap stage` line below and quote the top hit in the FYI bullet where one came back. Building is what the knob governs; checking precedent is not optional at either setting, because a staged row that does not name the tool it should have joined recreates the fragment one release later.
@@ -155,6 +157,10 @@ b. ...
    -- or --
 - NOTHING
 
+**Built:** <path + commit of what step 7b built or staged>
+   -- or -- NOTHING: no candidates
+   -- or -- SKIPPED: <why>
+
 **FYI:**
 - <what changes for the operator from now on>
 - <a state the operator will meet next time>
@@ -176,6 +182,7 @@ b. ...
 - **Every `FYI` bullet of the second kind NAMES ITS HOME**, the file or board where the follow-up already lives. That is this section's own admission test. A bullet carrying future work with no home is a task hiding in the read-only lane, which is how a good idea reaches the end of a session and dies there; give it a home first, then report the path. A bullet that needs a decision, a command, or a review FROM THE OPERATOR was misfiled and belongs in `Needs you` instead.
 - The lane is read-and-move-on, never do-nothing-forever. The operator picks the follow-up back up from its home, not from a report they would have to remember. A single `- NOTHING` bullet when there is nothing to report.
 - A staged candidate, a filed memory note, or a knowledge-root fallback from step 7 is an `FYI` bullet naming the file or the reason, in the existing `FYI` grammar.
+- **`**Built:**` is REQUIRED, and the lint fails without it.** One line, after `FYI`, reporting step 7b's outcome as exactly one of three: what was built or staged (name the path and the commit), `NOTHING: no candidates` when the precedent check ran and found none, or `SKIPPED: <why>` when the step did not run. The three must stay distinguishable. A skipped 7b and an empty 7b used to look identical, which is how the step that builds instead of proposing got silently dropped from a whole session. This line is the trace every other step already leaves.
 - An overlay (a consumer's own routing, distill, or knowledge-capture step) appends its own labelled sections after `FYI`, in the same shape: a bold label line followed by bullets, one item per note, candidate, or queue entry; the kit's grammar stops there. A `wrap.before` skill's report lines fold in at that same place.
 - No table unless the session touched four or more repos. No restating what each step did.
 

--- a/docs/verification/wrap-built-line.md
+++ b/docs/verification/wrap-built-line.md
@@ -1,0 +1,68 @@
+# Step 7b now reports an outcome the lint can check
+
+Step 7b of `/kit:wrap` builds the candidates a session produced rather than proposing them. It
+was the one step that left no trace when skipped AND no trace when it ran and found nothing.
+Those two outcomes were indistinguishable in the report, so skipping it was invisible.
+
+On 2026-09-09 it was skipped for a whole 20-hour session. Step 7a failed with `skipped: no run
+id`, that was read as "step 7 does not apply", and `b` never ran. `report-lint.sh` passed the
+report clean, because it only judged `Needs you` phrasing. The operator caught it by asking.
+
+That is the same defect the same session documented in
+`ops-toolkit/research/2026-09-09-checks-need-a-third-state.md`: a check whose "did not run" is
+byte-identical to "ran, found nothing". The wrap command had the bug it helped write up.
+
+## The change
+
+Three parts, one cause.
+
+1. `commands/wrap.md` step 7a now states that a skip in `a` skips only `a`. `b` and `c` do not
+   depend on a run id, a run log, or the classifier.
+2. The report template gains a required `**Built:**` line carrying exactly one of three
+   outcomes: what was built or staged, `NOTHING: no candidates`, or `SKIPPED: <why>`.
+3. `lib/wrap/report-lint.sh` fails the report when that line is absent or empty.
+
+The gate is the third part. The first two are prose, and prose is what lost here already.
+
+## Green run
+
+- Command: `report-lint.sh <report with '**Built:** tools/vps-mon/google-cred-probe (PR #2451)'>`
+- Exit: 0
+- Output: `report-lint: clean (0 warn(s))`
+- Verdict: PASS
+
+- Command: `report-lint.sh <report with '**Built:** NOTHING: no candidates'>`
+- Exit: 0
+- Verdict: PASS
+
+- Command: `report-lint.sh <report with '**Built:** SKIPPED: build_candidates knob is false'>`
+- Exit: 0
+- Verdict: PASS
+
+All three legitimate outcomes pass, so the gate constrains presence and not content.
+
+## Negative control
+
+The control is the real artifact, not a synthetic one: the actual wrap report printed earlier
+that day, the one that passed the old lint while 7b had been skipped.
+
+- Command: `report-lint.sh <the 2026-09-09 wrap report as printed>`
+- Exit: 1
+- Output: `line 0: no '**Built:**' line; step 7b (build the candidates) owes an outcome`
+- Verdict: RED as expected
+
+Second control, an empty header, since a bare `**Built:**` would otherwise satisfy a presence
+check and re-open the same hole.
+
+- Command: `report-lint.sh <report ending in a bare '**Built:**'>`
+- Exit: 1
+- Output: `line 0: '**Built:**' is empty; name what was built, or NOTHING, or SKIPPED with a reason`
+- Verdict: RED as expected
+
+## What this does not cover
+
+The lint checks that an outcome was REPORTED, never that the precedent check actually ran. An
+agent can still write `NOTHING: no candidates` without running `precedent find`. Closing that
+would mean the lint reading the run log for a precedent invocation, which is a bigger change
+than the hole justifies today. The line makes the claim explicit and attributable, which is the
+step that was missing.

--- a/lib/wrap/report-lint.sh
+++ b/lib/wrap/report-lint.sh
@@ -10,6 +10,16 @@
 # try. It catches the one shape that is always wrong: an item whose own text offers to do
 # the work itself.
 #
+# It also enforces that step 7b reported an outcome at all. Step 7b (build the candidates
+# this session produced, rather than proposing them) used to be the one step that left no
+# trace when skipped, and no trace when it ran and found nothing. Those two outcomes were
+# indistinguishable in the report, so skipping it was invisible: it was skipped in a real
+# 20-hour session on 2026-09-09 and only caught because the operator asked. Every other step
+# leaves evidence, a board flip, a merge sha, an activity line. This one now owes a `Built:`
+# line naming which of three things happened, so "did not run" can never read as "found
+# nothing". That distinction is the same one in
+# ops-toolkit/research/2026-09-09-checks-need-a-third-state.md, and this file had the bug.
+#
 # Usage: report-lint.sh [<file>]   (reads stdin when no file is given)
 # Exit:  0 clean, 1 a finding (each printed as `line <n>: <reason>` on stderr), 2 usage.
 
@@ -78,6 +88,19 @@ while IFS= read -r line; do
     warns=$((warns + 1))
   fi
 done <<< "$input"
+
+# Step 7b coverage. The line must be present AND carry one of the three outcomes, so an
+# empty `**Built:**` header cannot satisfy it. BUILT names what was built or staged;
+# NOTHING says the precedent check ran and produced no candidate; SKIPPED says the step did
+# not run and why. A report with no such line means nobody can tell which happened.
+if ! printf '%s' "$input" | grep -q '\*\*Built:\*\*'; then
+  echo "line 0: no '**Built:**' line; step 7b (build the candidates) owes an outcome" >&2
+  echo "  add one of: '**Built:** <what>', '**Built:** NOTHING: no candidates', '**Built:** SKIPPED: <why>'" >&2
+  findings=$((findings + 1))
+elif ! printf '%s' "$input" | grep -qE '\*\*Built:\*\*[[:space:]]*(NOTHING|SKIPPED|[^[:space:]])'; then
+  echo "line 0: '**Built:**' is empty; name what was built, or NOTHING, or SKIPPED with a reason" >&2
+  findings=$((findings + 1))
+fi
 
 if [ "$findings" -gt 0 ]; then
   echo "report-lint: ${findings} finding(s), ${warns} warn(s)" >&2


### PR DESCRIPTION
Step 7b builds the candidates a session produced instead of proposing them. It was the one step that left no trace when skipped AND no trace when it ran and found nothing, so the two were indistinguishable and skipping it was invisible.

It was skipped for a whole 20-hour session on 2026-09-09. Step 7a failed with `skipped: no run id`, that read as "step 7 does not apply", and `b` never ran. The lint passed the report clean because it only judged `Needs you` phrasing. The operator caught it by asking.

Same defect the same session documented: a check whose "did not run" is byte-identical to "ran, found nothing".

Three parts:
- 7a now states that a skip in `a` skips only `a`; `b` and `c` do not depend on a run id
- the report gains a required `**Built:**` line with one of three outcomes
- the lint fails when it is absent or empty

The lint is the part that matters. The other two are prose, and prose already lost here once.

Negative control is the real artifact: the actual report from that session now exits 1. Proof: `docs/verification/wrap-built-line.md`.