### PR TITLE
docs(security): the allowlist itself takes no untrusted input

### DIFF
--- a/docs/impl-playbook/security.md
+++ b/docs/impl-playbook/security.md
@@ -13,6 +13,7 @@ Distills OWASP Top 10:2025, ASVS 5.0.0 (levels 1-2), the OWASP Cheat Sheet Serie
 8. Supply-chain provenance is not optional: signed CI builds, pinned lockfiles, never `curl | bash`. OWASP ranks Software Supply Chain Failures #3 (A03:2025), up from a subset of #6 in 2021.
 9. Close default-misconfiguration gaps before shipping: no default/sample credentials, no verbose framework error pages in prod, no open cloud storage buckets, security headers set (OWASP A02:2025, #2 risk).
 10. Emit security-relevant logs, not just error logs: auth failures, access-control denials, and input-validation rejections need to exist and reach an alerting path, not just a log file nobody reads (OWASP A09:2025).
+11. **The allowlist itself takes no untrusted input.** Rule 1 says validate input with an allowlist; this is the failure one level up, where the allowlist is partly supplied by the thing it defends against, and rule 1 does not catch it because the validation looks correct. Where policy must vary per tenant, job or caller, untrusted input may SELECT among values the operator reviewed, never supply one. Two corollaries, both learned the expensive way: when a guard over an attacker-influenced surface fails twice, make the SURFACE smaller rather than the check stricter (shrinking converges, guarding does not), and a wildcard is not a scope (`tenant-*` reads as "this tenant" and means "any tenant"). Worked case: seven HIGH findings across eight review passes, all in one feature, closed only by deleting the input rather than validating it harder (`ops-toolkit tools/hermes/docs/decisions/0031-security-allowlists-take-no-untrusted-input.md`).
 
 ## Reference depth
 For a specific vulnerability class, read the matching OWASP Cheat Sheet (cheatsheetseries.owasp.org) rather than re-deriving the rule. Target ASVS 5.0.0 level 1 for anything personal-scale, level 2 once real user data or business logic is involved.
@@ -24,4 +25,4 @@ For a specific vulnerability class, read the matching OWASP Cheat Sheet (cheatsh
 - [PyPA pip-audit](https://github.com/pypa/pip-audit)
 - [Astral: vulnerability and malware checks in uv (`uv audit`)](https://astral.sh/blog/uv-audit)
 
-Verified: 2026-08-03.
+Verified: 2026-08-03; rule 11 added 2026-09-09.


### PR DESCRIPTION
docs(security): the allowlist itself takes no untrusted input

Rule 1 already says validate input at trust boundaries with allowlists. This
is the failure one level up, where the allowlist is partly supplied by the
thing it defends against, and rule 1 does not catch it because the validation
looks correct.

Worked case, in ops-toolkit: a runner mounted host paths into a sandbox, and
one term of its allowlist came from a job file the runner's own threat model
called untrusted. Seven HIGH findings across eight review passes, every one
in the checks defending that term. Four fixes made the checks stricter and
each shipped with tests that agreed with the remaining hole; the sequence
only converged when the input was deleted rather than validated harder, and
then when the allowlist was shrunk twice more.

Two corollaries ride the rule because both cost a review pass to learn. When
a guard over an attacker-influenced surface fails twice, make the surface
smaller rather than the check stricter: each removal strictly reduces what is
reachable, each new check is one more thing that can be wrong in a new way.
And a wildcard is not a scope, `tenant-*` reads as "this tenant" and means
"any tenant".

The full decision record stays with the tool that earned it
(ops-toolkit tools/hermes/docs/decisions/0031-...); this is the estate-level
one-liner so the next author meets it before writing the same shape.
