### PR TITLE
fix(ci): stop refreshing apt to reach a preinstalled jq

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,12 @@ jobs:
       # here); it only wires the one new test this PR added.
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
-      - name: Install jq (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y jq
-
+      # jq ships preinstalled on both hosted images, so the step below only verifies it.
+      # An `apt-get update` used to run first on Ubuntu, and it refreshed EVERY configured
+      # source, including the Google Chrome repo the image preinstalls. On 2026-09-09 that
+      # repo served a hash-mismatched index and exit 100 failed the whole run twice, on work
+      # that touches no package. Never refresh the index to reach a preinstalled tool: the
+      # verify step below is the real gate, and it fails loudly if an image ever drops jq.
       - name: Verify jq available
         run: jq --version
 


### PR DESCRIPTION
## Problem

The Ubuntu leg ran `sudo apt-get update && sudo apt-get install -y jq`. `apt-get update` refreshes EVERY configured source, and the GitHub hosted image preinstalls the Google Chrome repo. On 2026-09-09 that repo served a hash-mismatched `Packages.gz`:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download.
##[error]Process completed with exit code 100.
```

Exit 100 failed the whole job. It reproduced across two runs (jobs 102576068123 and 102580812389) on #551, a branch that touches no package. It blocks every PR in the repo until Google fixes their index.

## Change

Delete the install step. jq ships preinstalled on both hosted images, and the `Verify jq available` step immediately after is already the gate: it fails loudly if an image ever drops jq. The install bought nothing and coupled every CI run to a third-party apt index.

The macOS leg has never had an install step and passes `jq --version`, so the workflow already assumed a preinstalled jq on one platform.

## Verification

The PR's own check run is the proof; a hosted-runner workflow has no local harness. The negative control is already on record above: the same workflow WITH the step, RED twice. Gate override logged as `ci-jq-apt-flake` with that reason.

Merge this before #551, which is currently red on this and nothing else.