### PR TITLE
fix(precedent): accept bare-word find args, index extensionless scripts

### DIFF
--- a/bin/precedent
+++ b/bin/precedent
@@ -6,8 +6,8 @@
 # path. Forwards to the precedent subsystem entry, which owns the verb grammar.
 #
 # Usage:
-#   precedent find "<task description>" [--surface records|inventory|all] [--limit N]
-#                  [--quiet] [--json] [--registry <file>] [--repo-root <path>]
+#   precedent find "<task description>" | <bare words...> [--surface records|inventory|all]
+#                  [--limit N] [--quiet] [--json] [--registry <file>] [--repo-root <path>]
 #   precedent find --explain "<hit label as printed>"
 #
 # "have we done something like this before?" at intake: the records surface reads the

--- a/docs/verification/precedent-bare-words.md
+++ b/docs/verification/precedent-bare-words.md
@@ -1,0 +1,78 @@
+# Proof of done: precedent find bare-word args + extensionless script indexing
+
+## Claim
+
+1. `lib/precedent/precedent.sh` `cmd_find` accepts unquoted bare words in a `find` call.
+   Extra positional words fold into the description instead of erroring; a lone
+   digit-only extra word still sets the legacy `[max]` override.
+2. `lib/precedent/inventory.py` `scan_repo_tools` indexes a tool's top-level
+   extension-less executable (not only `.sh`/`.py`), matching the house convention
+   that launchd launchers carry no extension.
+
+## Green run
+
+```
+$ bash tests/test-precedent.sh
+...
+== summary ==
+  69/69 passed
+Exit: 0
+```
+
+Manual repro of the reported bug, against a real repo:
+
+```
+$ bash bin/precedent find --surface inventory --quiet mini run \
+    --repo-root /Users/tieubao/workspace/tieubao/ops-toolkit
+# precedent inventory: mini run
+...
+## tools
+  tools/mac-mini-substrate/mini-run  , mini-run: run a LOCAL script on the Mac Mini and get its real exit status.
+  ...
+precedent: N inventory hits in M sections; top: tools
+Exit: 0
+```
+
+Before the fix this call died with `inventory.py: error: argument --limit: invalid
+int value: 'run'` (the second bare word was forced into the legacy `[max]`
+positional and handed to `--limit`).
+
+`tools/mac-mini-substrate/mini-run` itself only surfaces once indexed; confirmed by
+name alone:
+
+```
+$ bash bin/precedent find --surface inventory --quiet "mini-run" \
+    --repo-root /Users/tieubao/workspace/tieubao/ops-toolkit
+## tools
+  tools/mac-mini-substrate/mini-run  , mini-run: run a LOCAL script on the Mac Mini and get its real exit status.
+```
+
+Note: the coordinator's exact 4-term repro query
+(`"mini-run scratch script Mini"`) still returns 0 hits for `mini-run`, but not
+because of this bug: `score()` is a strict AND across every query term (see the
+existing "AND semantics" test case), and the literal word "scratch" never appears
+in `mini-run`'s name or header comment. Dropping it
+(`"mini-run script Mini"`) surfaces the file as shown above.
+
+## Negative control
+
+```
+## Negative control (negctl)
+Command: bash tests/test-precedent.sh
+Exit: 0 (green before mutation)
+Mutation: git checkout HEAD~1 -- lib/precedent/precedent.sh lib/precedent/inventory.py
+Changed: lib/precedent/inventory.py, lib/precedent/precedent.sh
+Exit: 1 (under mutation, RED expected)
+Restore: git checkout HEAD -- lib/precedent/inventory.py lib/precedent/precedent.sh
+Exit: 0 (green after restore)
+Verdict: PASS
+```
+
+`HEAD~1` is the pre-fix commit (`e8a0fa3`, the branch's merge-base with master).
+
+## Reproducible
+
+Re-running `bash tests/test-precedent.sh` from a clean checkout of this branch
+reproduces the green 69/69 verdict above.
+
+## Verdict: PASS

--- a/lib/precedent/inventory.py
+++ b/lib/precedent/inventory.py
@@ -444,7 +444,8 @@ def scan_repo_tools(root: str, label_prefix: str, terms, sections: Sections, tit
                 cands += [(f"tools/{name}/{sub}/{fn}", os.path.join(subdir, fn))
                           for fn in sorted(os.listdir(subdir))]
         cands += [(f"tools/{name}/{fn}", os.path.join(tdir, fn))
-                  for fn in sorted(os.listdir(tdir)) if fn.endswith((".sh", ".py"))]
+                  for fn in sorted(os.listdir(tdir))
+                  if fn.endswith((".sh", ".py")) or os.access(os.path.join(tdir, fn), os.X_OK)]
         for rel, fp in cands:
             fn = os.path.basename(fp)
             if not os.path.isfile(fp) or fn.startswith(".") or fn.startswith("test"):

--- a/lib/precedent/precedent.sh
+++ b/lib/precedent/precedent.sh
@@ -22,6 +22,9 @@
 #                                [--json] [--registry <file>] [--repo-root <path>]
 #       -> `--surface` default `all`: records block, then inventory sections, then a
 #          summary line. `records` alone is byte-identical to the legacy call.
+#   precedent.sh find <bare words...> [--surface ...] [--limit N] ...
+#       -> unquoted words are also accepted: every extra positional folds into the
+#          description (a lone digit-only word still sets the legacy [max] as above).
 #   precedent.sh find --explain "<hit label as printed>"
 #       -> the header of the file behind an inventory hit label.
 #   precedent.sh -h | --help | help
@@ -44,7 +47,7 @@ source "$LIB_ROOT/config/kit-config.sh" || { echo "FATAL: lib/config/kit-config.
 ROOT=""  # resolved per-call in cmd_find, once --repo-root is known
 
 _usage() {
-  sed -n '2,29p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,31p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 # repo-root resolution precedence (lib/board/board.sh:158-168): --repo-root flag > REPO_ROOT
@@ -149,9 +152,15 @@ cmd_find() {
       -*)
         echo "precedent find: unknown flag '$1'" >&2; return 64 ;;
       *)
-        if [ "$desc_set" -eq 0 ]; then desc="$1"; desc_set=1
-        elif [ -z "$max" ]; then max="$1"
-        else echo "precedent find: unexpected argument '$1'" >&2; return 64
+        if [ "$desc_set" -eq 0 ]; then
+          desc="$1"; desc_set=1
+        elif [ -z "$max" ] && printf '%s' "$1" | grep -qE '^[1-9][0-9]*$'; then
+          # legacy call shape: a lone digit-only second positional is still the [max] override
+          max="$1"
+        else
+          # any other extra word (the documented `<two or three words>` bare-word call) folds
+          # into the description instead of erroring
+          desc="$desc $1"
         fi
         shift ;;
     esac
@@ -236,7 +245,7 @@ main() {
     -h|--help|help) _usage; return 0 ;;
     find) shift; cmd_find "$@" ;;
     *)
-      echo "usage: precedent.sh find \"<task description>\" [--surface records|inventory|all] [--limit N] [--quiet] [--json] [--registry <file>] [--repo-root <path>] [--explain <label>]" >&2
+      echo "usage: precedent.sh find \"<task description>\" | <bare words...> [--surface records|inventory|all] [--limit N] [--quiet] [--json] [--registry <file>] [--repo-root <path>] [--explain <label>]" >&2
       return 64 ;;
   esac
 }

--- a/tests/test-precedent.sh
+++ b/tests/test-precedent.sh
@@ -6,10 +6,12 @@
 # Proves, records-only (green at e07bc30, before lib/precedent/inventory.py exists):
 #   AC1 `find --surface records` byte-parity with the pre-move `lib/precedent.sh` (TASK-001)
 #   AC2 a stopword-only query prints the no-keywords line, exit 0
-#   AC3 an out-of-range positional [max] exits 64
+#   AC3 a non-numeric --limit flag exits 64
 #   AC4 an unknown --surface exits 64
 #   AC5 default surface (`all`) with inventory.py absent ends on the 0-inventory summary line
 #   AC6 --help exits 0 and documents --surface
+#   AC7 bare unquoted words fold into one description; a lone digit-only word still sets the
+#       legacy [max] override
 #
 # Run: bash tests/test-precedent.sh
 
@@ -155,6 +157,15 @@ FIX
 #!/usr/bin/env python3
 """omicron: piunique report builder."""
 FIX
+
+  # A top-level extension-less executable entry point (the house convention for launchd
+  # launchers carries no .sh, e.g. ops-toolkit's mac-mini-substrate/mini-run): must still
+  # surface via its executable bit, not just the .sh/.py suffix check.
+  cat > "$FIX_REPO/tools/alpha/zeta-run" <<'FIX'
+#!/usr/bin/env bash
+# zeta-run: zetaunique launcher, no extension by design
+FIX
+  chmod +x "$FIX_REPO/tools/alpha/zeta-run"
 
   # Restored iterator 3: an experiment whose README has no `title:` and no `description:`.
   # Its subject is only in the `tech:` tag list and the opening paragraph.
@@ -355,10 +366,34 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# AC3: out-of-range positional [max]
+# AC3: a non-numeric --limit flag exits 64 (a bare non-numeric positional no longer errors,
+# see AC7: it folds into the description instead)
 # ---------------------------------------------------------------------------
-"$PRECEDENT_BIN" find "notion" abc --surface records >/dev/null 2>&1
-assert "a non-numeric positional [max] exits 64" "$([ $? -eq 64 ]; echo $?)"
+"$PRECEDENT_BIN" find "notion" --limit abc --surface records >/dev/null 2>&1
+assert "a non-numeric --limit exits 64" "$([ $? -eq 64 ]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# AC7: bare unquoted words fold into one description reaching inventory.py; a lone
+# digit-only extra word still sets the legacy [max] override (records surface, no
+# inventory.py dependency).
+# ---------------------------------------------------------------------------
+BARE_OUT="$("$PRECEDENT_BIN" find mini run --surface inventory --quiet 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && printf '%s\n' "$BARE_OUT" | head -1 | grep -qF '# precedent inventory: mini run'; then
+  assert "bare words 'mini run' reach inventory.py as one description" 0
+else
+  assert "bare words 'mini run' reach inventory.py as one description" 1
+  echo "rc=$RC out=$BARE_OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find "notion" 3 --surface records 2>&1)"; RC=$?
+LIMIT_OK=1
+printf '%s\n' "$OUT" | grep -qE '^precedent find: --limit must be a positive integer$' && LIMIT_OK=0
+if [ "$RC" -eq 0 ] && [ "$LIMIT_OK" -eq 1 ]; then
+  assert "legacy \"desc\" 3 still sets limit 3, no error" 0
+else
+  assert "legacy \"desc\" 3 still sets limit 3, no error" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
 
 # ---------------------------------------------------------------------------
 # AC4: unknown --surface
@@ -1058,6 +1093,14 @@ if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | g
   assert "tool helpers: a top-level tools/<x>/*.py entry point surfaces" 0
 else
   assert "tool helpers: a top-level tools/<x>/*.py entry point surfaces" 1
+  echo "rc=$RC out=$OUT" | sed 's/^/      /'
+fi
+
+OUT="$("$PRECEDENT_BIN" find zetaunique --surface inventory 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && { trap '' PIPE; printf '%s' "$OUT" 2>/dev/null || :; } | grep -q 'tools/alpha/zeta-run'; then
+  assert "tool helpers: a top-level extension-less executable entry point surfaces" 0
+else
+  assert "tool helpers: a top-level extension-less executable entry point surfaces" 1
   echo "rc=$RC out=$OUT" | sed 's/^/      /'
 fi
 


### PR DESCRIPTION
## Summary

- `precedent find` now accepts unquoted bare words: extra positional words after the description fold into it instead of erroring on a third positional. A lone digit-only extra word still sets the legacy `[max]` override, so `precedent find "desc" 3` is unchanged. This fixes the documented call shape `precedent find --surface inventory --quiet <two or three words>`, which previously crashed with `inventory.py: error: argument --limit: invalid int value: '<word>'` because the second bare word was forced into the legacy `[max]` positional and handed straight to `--limit`.
- `inventory.py`'s `scan_repo_tools` now also indexes a tool's top-level extension-less executable (previously only `.sh`/`.py` top-level files were candidates), matching the house convention that launchd launchers carry no extension. Real miss this fixes: `tools/mac-mini-substrate/mini-run` (and its extension-less siblings) were never indexed at all.
- Usage comments updated in `lib/precedent/precedent.sh` and `bin/precedent` to show the bare-word call shape.
- `tests/test-precedent.sh`: updated AC3 (a non-numeric second positional no longer errors, it folds into the description; a non-numeric `--limit` flag still exits 64), added a case proving bare words `mini run` reach `inventory.py` as one description, a case proving the legacy `"desc" 3` numeric override still works, and a case proving a top-level extension-less executable now surfaces. 69/69 passing.

Proof of done: `docs/verification/precedent-bare-words.md` (green run + negative control, revert -> RED -> restore).

## Test plan

- [x] `bash tests/test-precedent.sh` — 69/69 passed
- [x] Manual repro: `bin/precedent find --surface inventory --quiet mini run --repo-root <ops-toolkit>` — produces a report, not an argparse error
- [x] Manual repro: `tools/mac-mini-substrate/mini-run` surfaces by name query
- [x] Negative control via `lib/gate/negctl.sh`: green -> revert both source files -> RED -> restore -> green