### PR TITLE
fix(docs): drop an operator path from the precedent verification

### DIFF
--- a/docs/verification/precedent-bare-words.md
+++ b/docs/verification/precedent-bare-words.md
@@ -23,7 +23,7 @@ Manual repro of the reported bug, against a real repo:
 
 ```
 $ bash bin/precedent find --surface inventory --quiet mini run \
-    --repo-root /Users/tieubao/workspace/tieubao/ops-toolkit
+    --repo-root <consumer-repo>
 # precedent inventory: mini run
 ...
 ## tools
@@ -42,7 +42,7 @@ name alone:
 
 ```
 $ bash bin/precedent find --surface inventory --quiet "mini-run" \
-    --repo-root /Users/tieubao/workspace/tieubao/ops-toolkit
+    --repo-root <consumer-repo>
 ## tools
   tools/mac-mini-substrate/mini-run  , mini-run: run a LOCAL script on the Mac Mini and get its real exit status.
 ```


### PR DESCRIPTION
Master CI is red on test-no-personal-paths from 2a619fd (#566) on. docs/verification/precedent-bare-words.md carried two --repo-root lines with an absolute operator path. A <consumer-repo> placeholder replaces them. Local: test-no-personal-paths 3/3.