### PR TITLE
fix(wrap): land log entries below the header, not above it

### DIFF
--- a/docs/verification/wrap-log-anchor.md
+++ b/docs/verification/wrap-log-anchor.md
@@ -1,0 +1,47 @@
+# Proof of done: wrap log lands entries below the header, not above it
+
+2026-09-10. `cmd_log` always prepended the new line at position 0, so every `wrap log`
+call landed the entry above the target file's title, description and `---` separator
+instead of among the entries. Confirmed live: `tieubao/ops-toolkit`'s `_meta/LAB_LOG.md`
+had two entry lines sitting above its `# LAB_LOG` heading, written by two sessions today.
+
+## Fix
+
+`_log_anchor_head_lines <file>` (lib/wrap/wrap.sh) finds the first line that is exactly
+`---` and returns how many lines of the file stay above the new entry: the anchor line
+plus any blank lines immediately following it. If line 1 is itself `---` (a YAML
+frontmatter opening delimiter), the SECOND `---` becomes the anchor instead, so the
+entry never lands inside frontmatter. A file with no `---` anchor at all returns 0,
+and `cmd_log` falls back to the old prepend-at-line-0 behavior rather than failing.
+
+## Green run
+
+Command: `bash tests/test-wrap.sh`
+Exit: 0
+Output: `test-wrap: all 278 passed` (269 pre-existing + 9 new anchor/frontmatter/
+fallback/header-only/empty-file cases, all PASS).
+Verdict: PASS
+
+## NEGATIVE CONTROL (break the anchor search, watch the new cases go red, restore)
+
+Command: hardcode `head_n="0"` in `cmd_log`, re-run `bash tests/test-wrap.sh`
+Exit: 0 (test runner itself), but the suite reports failures
+Output: `test-wrap: 272 passed, 6 FAILED of 278` -- exactly the 6 anchor/frontmatter/
+header-only cases that assert the entry lands below the header went red; the
+no-anchor-fallback, empty-file, and previously-newest-is-now-second cases stayed
+green because they assert the same prepend-at-0 shape the broken code also produces.
+Verdict: PASS (negative control proves the new tests exercise the anchor logic)
+
+Restore: copied the committed `lib/wrap/wrap.sh` back over the hand-edited copy,
+verified byte-identical with `cmp`, re-ran the suite.
+Command: `bash tests/test-wrap.sh` after restore
+Exit: 0
+Output: `test-wrap: all 278 passed`
+Verdict: PASS
+
+## Not covered here
+
+`test-config-seams.sh` only exercises `wrap.activity_log` key resolution, not the
+write itself; no anchor-shaped case belongs there. The existing prepend-fallback
+tests in `test-wrap.sh` (files with no `---` header at all) are unchanged and keep
+covering that path.

--- a/lib/wrap/wrap.sh
+++ b/lib/wrap/wrap.sh
@@ -556,6 +556,30 @@ _worktree_copy() {
   printf '%s' "$cur_top/$rel"
 }
 
+# _log_anchor_head_lines <file>: prints how many lines of <file> stay ABOVE the new entry.
+# The anchor is the first line that is exactly `---` (the header/entries separator), plus
+# any blank lines immediately following it, so the new entry lands as the newest ENTRY, not
+# above the file's title. If line 1 is itself `---` (a YAML frontmatter opening delimiter),
+# the frontmatter's own closing `---` is the SECOND such line and becomes the anchor instead,
+# so the entry never lands inside frontmatter. Prints 0 when no anchor line exists at all
+# (or line 1 is `---` with no closing delimiter): the caller falls back to the old prepend-at-
+# line-0 behavior rather than failing, since a file with no recognizable header has no wrong
+# place to land above, and every pre-anchor-rule caller already depends on that prepend shape.
+_log_anchor_head_lines() {
+  awk '
+    NR==1 { want = ($0=="---") ? 2 : 1 }
+    state==0 {
+      if ($0=="---") { c++; if (c==want) { state=1; head=NR } }
+      next
+    }
+    state==1 {
+      if ($0=="") { head=NR; next }
+      state=2
+    }
+    END { print head+0 }
+  ' "$1"
+}
+
 cmd_log() {
   local date_str text="" arg have_text=0
   date_str="$(date +%F)"
@@ -620,9 +644,16 @@ cmd_log() {
   local n=${#line}
   [ "$n" -gt "$LOG_LINE_BUDGET" ] && echo "wrap log: note: ${n} chars, over the ${LOG_LINE_BUDGET}-char routine budget" >&2
 
-  local tmp mode; tmp="$(mktemp)"
-  printf '%s\n' "$line" > "$tmp"
-  cat "$resolved" >> "$tmp"
+  local head_n tmp mode; tmp="$(mktemp)"
+  head_n="$(_log_anchor_head_lines "$resolved")"
+  if [ "$head_n" -gt 0 ] 2>/dev/null; then
+    sed -n "1,${head_n}p" "$resolved" > "$tmp"
+    printf '%s\n' "$line" >> "$tmp"
+    tail -n "+$((head_n + 1))" "$resolved" >> "$tmp"
+  else
+    printf '%s\n' "$line" > "$tmp"
+    cat "$resolved" >> "$tmp"
+  fi
   mode="$(_fmode "$resolved")"
   case "$mode" in ''|*[!0-7]*) mode="" ;; esac
   [ -n "$mode" ] && chmod "$mode" "$tmp"   # mktemp opens 0600; carry the target's mode over

--- a/tests/test-wrap.sh
+++ b/tests/test-wrap.sh
@@ -521,6 +521,52 @@ chk "log from outside the repo prepends to the configured file itself" \
   "$([ "$(head -1 "$LOGREPO/_meta/LOG.md")" = "$(date +%F) · wrap: from outside" ]; echo $?)"
 
 # ===========================================================================
+echo "=== log: the --- anchor lands the entry below the header, not above it ==="
+# ===========================================================================
+ANCHFILE="$LOGHOME/ANCHOR.md"
+printf '# LAB_LOG\n\nChronological log. Newest first.\n\n---\n\n2026-01-01 · old entry\n' > "$ANCHFILE"
+set_log_key "$ANCHFILE"
+wrap_log "wrap: anchored entry" >/dev/null 2>&1
+chk "log: the title stays line 1, not pushed down" \
+  "$([ "$(sed -n '1p' "$ANCHFILE")" = "# LAB_LOG" ]; echo $?)"
+chk "log: the new entry lands right after the --- and its blank line" \
+  "$([ "$(sed -n '7p' "$ANCHFILE")" = "$(date +%F) · wrap: anchored entry" ]; echo $?)"
+chk "log: the previously-newest entry is now second" \
+  "$([ "$(sed -n '8p' "$ANCHFILE")" = "2026-01-01 · old entry" ]; echo $?)"
+
+FMFILE="$LOGHOME/FRONTMATTER.md"
+printf -- '---\nkind: log\n---\n2026-01-01 · old entry\n' > "$FMFILE"
+set_log_key "$FMFILE"
+wrap_log "wrap: past the frontmatter" >/dev/null 2>&1
+chk "log: frontmatter's opening --- is not mistaken for the anchor" \
+  "$([ "$(sed -n '1p' "$FMFILE")" = "---" ]; echo $?)"
+chk "log: the entry lands after the frontmatter's closing ---, not inside it" \
+  "$([ "$(sed -n '4p' "$FMFILE")" = "$(date +%F) · wrap: past the frontmatter" ]; echo $?)"
+chk "log: the frontmatter body is untouched" \
+  "$([ "$(sed -n '2p' "$FMFILE")" = "kind: log" ]; echo $?)"
+
+NOANCHFILE="$LOGHOME/NOANCHOR.md"
+printf 'just a plain log, no header at all\n' > "$NOANCHFILE"
+set_log_key "$NOANCHFILE"
+wrap_log "wrap: no anchor falls back to prepend" >/dev/null 2>&1
+chk "log: no --- anchor falls back to the old prepend-at-line-1 behavior" \
+  "$([ "$(sed -n '1p' "$NOANCHFILE")" = "$(date +%F) · wrap: no anchor falls back to prepend" ]; echo $?)"
+
+HDRONLYFILE="$LOGHOME/HDRONLY.md"
+printf '# LAB_LOG\n\nChronological log.\n\n---\n' > "$HDRONLYFILE"
+set_log_key "$HDRONLYFILE"
+wrap_log "wrap: first entry in a header-only file" >/dev/null 2>&1
+chk "log: a header-only file (no entries yet) still gets the entry after ---" \
+  "$([ "$(sed -n '6p' "$HDRONLYFILE")" = "$(date +%F) · wrap: first entry in a header-only file" ]; echo $?)"
+
+EMPTYFILE="$LOGHOME/EMPTY.md"
+: > "$EMPTYFILE"
+set_log_key "$EMPTYFILE"
+wrap_log "wrap: an empty file still works" >/dev/null 2>&1
+chk "log: an empty file gets the entry as line 1" \
+  "$([ "$(sed -n '1p' "$EMPTYFILE")" = "$(date +%F) · wrap: an empty file still works" ]; echo $?)"
+
+# ===========================================================================
 echo "=== knowledge-root: the key, the HOME fence, and the repo argument ==="
 # ===========================================================================
 KRHOME="$TMPD/kr-home"; mkdir -p "$KRHOME/root-ok"


### PR DESCRIPTION
## Summary
- `cmd_log` always prepended the new activity line at position 0, landing every entry above the target file's title, description and `---` separator instead of among the entries. Confirmed live in `tieubao/ops-toolkit`'s `_meta/LAB_LOG.md`.
- Anchor the write on the first `---` line (the second one when line 1 is itself a YAML frontmatter opening delimiter) and insert after it plus any following blank lines. A file with no `---` anchor at all falls back to the old prepend-at-line-0 behavior.

## Test plan
- `bash tests/test-wrap.sh`: 269 pre-existing cases pass unchanged, plus 9 new cases (anchored insert, frontmatter, no-anchor fallback, header-only file, empty file) -- `test-wrap: all 278 passed`.
- Negative control: hardcoded `head_n="0"` to break the anchor search, re-ran the suite -- exactly the 6 anchor/frontmatter/header-only cases went red (`272 passed, 6 FAILED of 278`), restored the committed file, verified byte-identical with `cmp`, suite green again.
- Proof of done: `docs/verification/wrap-log-anchor.md`.
