### PR TITLE
feat(wrap): carry union-marked logs across the ff-only pull

### DIFF
--- a/docs/verification/wrap-union-safe-pull.md
+++ b/docs/verification/wrap-union-safe-pull.md
@@ -1,0 +1,101 @@
+# Proof of done: `wrap apply` carries union-marked logs across the ff-only pull
+
+2026-09-11. Acceptance: on the default branch, `bin/wrap apply --apply` completes the pull when the
+only uncommitted tracked files are declared `merge=union`, keeps both the incoming lines and the
+local ones, and lands each carried line below the header anchor. Any other modified file, or a dirty
+index, keeps today's behavior and prints the blocking reason before the pull. HEAD prints in the same
+output block. Lane: full. Files: `lib/wrap/wrap.sh`, `tests/test-wrap.sh`.
+
+## Why this is safe to automate
+
+`.gitattributes` in the adopting repos marks the append-only logs `merge=union`. That declaration
+says keeping every line from both sides resolves the file. Carrying local lines across a pull is
+therefore the file's stated semantics, not a judgment. For every other path it stays a judgment, so
+one non-union modified file switches the whole run back to the old behavior.
+
+## The failure this replaces
+
+A shared checkout collects uncommitted lines from other sessions, most often in `_meta/LAB_LOG.md`.
+Git printed `Updating <a>..<b>`, then aborted the merge, and a `tail -1` hid the abort. An operator
+deployed a Cloudflare Worker from a checkout two commits behind and served the wrong version for
+about eleven minutes. The manual workaround ran six times by hand in one session.
+
+## Green run
+
+Command: `bash tests/test-wrap.sh`
+Exit: 0
+Output: `test-wrap: all 308 passed`
+Verdict: PASS. 278 assertions before the change, 308 after; the 30 new ones are the five contract
+cases plus the dry-run case, each against real git repos built on disk.
+
+Command: `bash tests/run-all.sh`
+Exit: 0
+Output: `run-all: FAILED -> test-orchestrate-gate-dispatch test-orchestrate-wavefront` /
+`run-all: 133 suites run, 1 skipped for missing tooling`
+Verdict: PASS, no regression. The same two suites fail identically on `master` at `cfb5448` before
+the change, so the counts match on both sides.
+
+| Suite run | Suites | Skipped | Failing suites |
+|---|---|---|---|
+| Before, `master` cfb5448 | 133 | 1 | test-orchestrate-gate-dispatch, test-orchestrate-wavefront |
+| After, `feat/wrap-union-safe-pull` | 133 | 1 | test-orchestrate-gate-dispatch, test-orchestrate-wavefront |
+
+## Cases the tests bind
+
+Each case builds a bare origin plus a clone with a real `.gitattributes`, a real commit, and a real
+incoming commit to fast-forward to. Nothing stubs `git`, because what git does to a dirty checkout
+during a pull is the whole subject.
+
+| Case | Setup | Asserted |
+|---|---|---|
+| Union log dirty | `_meta/LAB_LOG.md` modified locally and remotely | pull succeeds, HEAD moves to the incoming commit, both lines present, the local line still uncommitted |
+| Anchor rule | same fixture | line 1 is still the header, the carried line sits below the `---` separator and above the older entries |
+| Non-union dirty | `README.md` modified locally and remotely | the file is byte-identical after the run, the reason names `README.md` before the pull, `FAILED pull --ff-only`, exit 2 |
+| Mixed | one union file and one non-union file dirty | treated as the non-union case, nothing saved aside, no carry-back, the union file byte-identical |
+| Dirty index | a staged `_meta/LAB_LOG.md` | the index reason prints, nothing saved aside, the path is still staged, the file byte-identical |
+| Dry run | union file dirty, no `--apply` | the carry is announced only, nothing saved or checked out, the file byte-identical |
+
+## Negative control
+
+Command: `bash lib/gate/negctl.sh <worktree> "bash tests/test-wrap.sh" "<mutation>"`
+Mutation: force `_union_marked` to accept every path, which defeats the classification.
+
+```
+## Negative control (negctl)
+Command: bash tests/test-wrap.sh
+Exit: 0 (green before mutation)
+Mutation: perl -i -pe 's/\*"merge: union"\) return 0/*) return 0/' lib/wrap/wrap.sh
+Changed: lib/wrap/wrap.sh
+Exit: 1 (under mutation, RED expected)
+Restore: git checkout HEAD -- lib/wrap/wrap.sh
+Exit: 0 (green after restore)
+Verdict: PASS
+```
+
+Ten assertions go RED under that mutation, `test-wrap: 298 passed, 10 FAILED of 308`:
+
+```
+  FAIL non-union: apply exits 2 because the pull still aborts
+  FAIL non-union: the blocking file is named before the pull
+  FAIL non-union: the pull failure is still reported
+  FAIL non-union: nothing was saved aside
+  FAIL non-union: the dirty file is byte-identical
+  FAIL non-union: HEAD did not move
+  FAIL mixed: the non-union file is named
+  FAIL mixed: the union file was never saved aside
+  FAIL mixed: no carry-back happened
+  FAIL mixed: the union file is byte-identical
+```
+
+`the dirty file is byte-identical` is the load-bearing one. Without the classification the run checks
+out a file the operator never declared safe to discard. The gate holds because that assertion fails.
+
+## Reproduce
+
+```
+git -C <repo> switch feat/wrap-union-safe-pull
+bash tests/test-wrap.sh          # the feature, 308 assertions
+bash tests/run-all.sh            # no regression across 133 suites
+bash lib/gate/negctl.sh . 'bash tests/test-wrap.sh' \
+  'perl -i -pe '\''s/\*"merge: union"\) return 0/*) return 0/'\'' lib/wrap/wrap.sh'
+```

--- a/lib/wrap/wrap.sh
+++ b/lib/wrap/wrap.sh
@@ -308,6 +308,110 @@ _apply_branches() {
   done
 }
 
+# _union_marked <repo> <path> -- 0 when .gitattributes declares the path merge=union.
+# The repo declares which files resolve by keeping every line from both sides. That
+# declaration, not a guess, is what makes carrying local lines across a pull correct.
+_union_marked() {
+  case "$(git -C "$1" check-attr merge -- "$2" 2>/dev/null)" in
+    *"merge: union") return 0 ;;
+  esac
+  return 1
+}
+
+# _union_carry_back <saved-copy> <target> -- put back every line the saved copy holds and the
+# pulled file lacks. Prints the count. The insert point comes from _log_anchor_head_lines, so
+# a carried line lands below the header exactly where `wrap log` puts a new entry.
+_union_carry_back() {
+  local saved="$1" target="$2" add tmp head_n mode n
+  add="$(mktemp)"
+  grep -Fxv -f "$target" "$saved" > "$add" 2>/dev/null
+  n="$(grep -c '' "$add" 2>/dev/null)"; n="${n:-0}"
+  if [ "$n" -gt 0 ] 2>/dev/null; then
+    head_n="$(_log_anchor_head_lines "$target")"
+    tmp="$(mktemp)"
+    if [ "$head_n" -gt 0 ] 2>/dev/null; then
+      sed -n "1,${head_n}p" "$target" > "$tmp"
+      cat "$add" >> "$tmp"
+      tail -n "+$((head_n + 1))" "$target" >> "$tmp"
+    else
+      cat "$add" "$target" > "$tmp"
+    fi
+    mode="$(_fmode "$target")"
+    case "$mode" in ''|*[!0-7]*) mode="" ;; esac
+    [ -n "$mode" ] && chmod "$mode" "$tmp"   # mktemp opens 0600; carry the target's mode over
+    mv -f "$tmp" "$target"
+  fi
+  rm -f "$add"
+  printf '%s' "$n"
+}
+
+# _pull_default <repo> <branch> -- the ff-only pull, with the repo's own append-only logs
+# carried across it.
+#
+# Several sessions share one checkout, so uncommitted lines sit in log files nobody committed
+# yet. Git prints `Updating a..b`, then aborts the merge to protect them, and the checkout
+# stays behind. An operator who missed that abort deployed from a stale tree. Files marked
+# merge=union are the safe case: the repo declares that keeping both sides resolves them, so
+# this saves each one aside, restores the committed content, pulls, then carries the local
+# lines back. Any other modified file keeps today's behavior, with the reason printed before
+# the pull instead of buried under the abort.
+_pull_default() {
+  local repo="$1" cur="$2"
+  local verdict="pull --ff-only (checkout on ${cur})"
+  local staged modified f nonunion="" saved_dir="" n=0 before carried
+
+  staged="$(git -C "$repo" diff --cached --name-only 2>/dev/null)"
+  modified="$(git -C "$repo" diff --name-only 2>/dev/null)"
+
+  if [ -n "$staged" ]; then
+    echo "     NOTE: the index carries staged changes, so no log file is carried across (restoring an index is out of scope)"
+  elif [ -n "$modified" ]; then
+    while IFS= read -r -d '' f; do
+      # A path git reports as modified but that is not a regular file cannot be copied back,
+      # so it counts as a judgment call and stops the whole carry.
+      if [ -f "$repo/$f" ] && _union_marked "$repo" "$f"; then continue; fi
+      nonunion="${nonunion}${nonunion:+, }${f}"
+    done < <(git -C "$repo" diff --name-only -z 2>/dev/null)
+    if [ -n "$nonunion" ]; then
+      echo "     NOTE: uncommitted and not declared merge=union, so the pull aborts on: ${nonunion}"
+    elif [ "$APPLY" != 1 ]; then
+      echo "     NOTE: every modified file is merge=union; --apply would carry its local lines across the pull"
+    else
+      saved_dir="$(mktemp -d)"
+      while IFS= read -r -d '' f; do
+        n=$(( n + 1 ))
+        cp "$repo/$f" "${saved_dir}/${n}"
+        printf '%s\0' "$f" >> "${saved_dir}/list"
+        git -C "$repo" checkout -- "$f"
+      done < <(git -C "$repo" diff --name-only -z 2>/dev/null)
+      echo "     saved ${n} union-marked file(s) aside so the pull can fast-forward"
+    fi
+  fi
+
+  before="$FAILURES"
+  run "$repo" "$verdict" git -C "$repo" pull --ff-only
+
+  if [ -n "$saved_dir" ]; then
+    n=0
+    while IFS= read -r -d '' f; do
+      n=$(( n + 1 ))
+      if [ "$FAILURES" = "$before" ]; then
+        carried="$(_union_carry_back "${saved_dir}/${n}" "$repo/$f")"
+        echo "     carried ${carried} local line(s) back into ${f}"
+      else
+        # The operator's lines never stay only in a temp file, whatever failed the pull.
+        cp "${saved_dir}/${n}" "$repo/$f"
+        echo "     pull failed, restored ${f} to its pre-pull content"
+      fi
+    done < "${saved_dir}/list"
+    rm -rf "$saved_dir"
+  fi
+
+  # A pull that printed is not a pull that landed. HEAD prints in the same block so a stale
+  # checkout cannot hide behind an abort line the operator scrolled past.
+  echo "     HEAD: $(git -C "$repo" log --oneline -1 2>/dev/null)"
+}
+
 _apply_repo() {
   local repo="$1" ghs="$2"
   _is_repo "$repo" || { echo "== ${repo}: not a git repo, skipped"; return 0; }
@@ -337,7 +441,7 @@ _apply_repo() {
 
   echo "-- pull:"
   if [ "$cur" = "$def" ]; then
-    run "$repo" "pull --ff-only (checkout on ${cur})" git -C "$repo" pull --ff-only
+    _pull_default "$repo" "$cur"
   else
     echo "     SKIP pull: checkout on '${cur:-<detached>}', not the default branch ${def}"
     run "$repo" "fetch origin ${def}:${def} (ff-only by nature)" git -C "$repo" fetch origin "${def}:${def}"

--- a/tests/test-wrap.sh
+++ b/tests/test-wrap.sh
@@ -307,6 +307,128 @@ chk "apply: the broken-remote repo lost no branch" \
   "$([ "$BROKEN_BEFORE" = "$(git -C "$BROKEN" for-each-ref --format='%(refname:short)' refs/heads/ | sort)" ]; echo $?)"
 
 # ===========================================================================
+echo "=== apply: a union-marked log is carried across the pull, nothing else is ==="
+# ===========================================================================
+# Real repos on disk, not a stubbed `git`: the whole point is what git itself does to a dirty
+# checkout during a pull, which a command-text stub would never exercise.
+LAB_BASE=$'# Lab log\n\n---\n\n2026-09-01 · base: the first line\n'
+LAB_REMOTE=$'# Lab log\n\n---\n\n2026-09-02 · remote: the incoming line\n2026-09-01 · base: the first line\n'
+LAB_LOCAL=$'# Lab log\n\n---\n\n2026-09-03 · local: the other session line\n2026-09-01 · base: the first line\n'
+
+build_union_repo() { # build_union_repo <name> -- bare origin plus a clone on main
+  local name="$1" work clone
+  work="$TMPD/uwork-$name"; clone="$TMPD/uclone-$name"
+  mkdir -p "$work/_meta"
+  git -C "$work" init -q
+  gitc "$work"
+  git -C "$work" symbolic-ref HEAD refs/heads/main
+  printf '_meta/LAB_LOG.md merge=union\n' > "$work/.gitattributes"
+  printf '%s' "$LAB_BASE" > "$work/_meta/LAB_LOG.md"
+  printf 'readme base\n' > "$work/README.md"
+  git -C "$work" add -A; git -C "$work" commit -qm base
+  git clone -q --bare "$work" "$TMPD/ubare-$name"
+  git clone -q "$TMPD/ubare-$name" "$clone"
+  gitc "$clone"
+  git -C "$clone" remote set-head origin main >/dev/null 2>&1
+}
+
+advance_union_repo() { # advance_union_repo <name> -- one incoming commit touching both files
+  local name="$1" push
+  push="$TMPD/upush-$name"
+  git clone -q "$TMPD/ubare-$name" "$push"
+  gitc "$push"
+  printf '%s' "$LAB_REMOTE" > "$push/_meta/LAB_LOG.md"
+  printf 'readme remote\n' > "$push/README.md"
+  git -C "$push" commit -qam advance
+  git -C "$push" push -q origin main
+}
+
+echo "--- case 1+4: a dirty union log pulls clean, keeps both sides, anchors below the header"
+build_union_repo carry; advance_union_repo carry
+UC="$TMPD/uclone-carry"
+printf '%s' "$LAB_LOCAL" > "$UC/_meta/LAB_LOG.md"
+UC_TIP="$(git -C "$TMPD/ubare-carry" rev-parse main)"
+out="$("$WRAP" apply --apply "$UC" 2>&1)"; rc=$?
+chk "union carry: apply exits 0" "$rc"
+chk_no "union carry: the pull did not fail" "$out" "FAILED pull --ff-only"
+chk "union carry: HEAD moved to the incoming commit" \
+  "$([ "$(git -C "$UC" rev-parse HEAD)" = "$UC_TIP" ]; echo $?)"
+chk_has "union carry: HEAD prints in the pull block" "$out" "     HEAD: $(git -C "$UC" log --oneline -1)"
+chk_has "union carry: the save is reported" "$out" "saved 1 union-marked file(s) aside"
+chk_has "union carry: the carry-back count is reported" "$out" "carried 1 local line(s) back into _meta/LAB_LOG.md"
+chk "union carry: the incoming line landed" \
+  "$(grep -qF 'remote: the incoming line' "$UC/_meta/LAB_LOG.md"; echo $?)"
+chk "union carry: the local uncommitted line survived" \
+  "$(grep -qF 'local: the other session line' "$UC/_meta/LAB_LOG.md"; echo $?)"
+chk "union carry: the local line is still uncommitted" \
+  "$(git -C "$UC" diff --name-only | grep -qx '_meta/LAB_LOG.md'; echo $?)"
+chk "union carry: README took the incoming content" \
+  "$([ "$(cat "$UC/README.md")" = "readme remote" ]; echo $?)"
+# Anchor rule: the header and the `---` separator stay above every carried line.
+CARRY_LN="$(grep -n 'local: the other session line' "$UC/_meta/LAB_LOG.md" | cut -d: -f1)"
+SEP_LN="$(grep -n '^---$' "$UC/_meta/LAB_LOG.md" | head -1 | cut -d: -f1)"
+chk "union carry: line 1 is still the header" \
+  "$([ "$(sed -n 1p "$UC/_meta/LAB_LOG.md")" = "# Lab log" ]; echo $?)"
+chk "union carry: the carried line sits BELOW the --- anchor" \
+  "$([ "$CARRY_LN" -gt "$SEP_LN" ]; echo $?)"
+chk "union carry: the carried line sits ABOVE the older entries" \
+  "$([ "$CARRY_LN" -lt "$(grep -n 'remote: the incoming line' "$UC/_meta/LAB_LOG.md" | cut -d: -f1)" ]; echo $?)"
+
+echo "--- case 2: a dirty NON-union file is untouched and the pull behaves as it does today"
+build_union_repo nonunion; advance_union_repo nonunion
+UN="$TMPD/uclone-nonunion"
+printf 'readme local edit\n' > "$UN/README.md"
+UN_BEFORE="$(cksum < "$UN/README.md")"
+UN_HEAD="$(git -C "$UN" rev-parse HEAD)"
+out="$("$WRAP" apply --apply "$UN" 2>&1)"; rc=$?
+chk "non-union: apply exits 2 because the pull still aborts" "$([ "$rc" -eq 2 ]; echo $?)"
+chk_has "non-union: the blocking file is named before the pull" "$out" \
+  "NOTE: uncommitted and not declared merge=union, so the pull aborts on: README.md"
+chk_has "non-union: the pull failure is still reported" "$out" "FAILED pull --ff-only"
+chk_no "non-union: nothing was saved aside" "$out" "union-marked file(s) aside"
+chk "non-union: the dirty file is byte-identical" \
+  "$([ "$UN_BEFORE" = "$(cksum < "$UN/README.md")" ]; echo $?)"
+chk "non-union: HEAD did not move" "$([ "$(git -C "$UN" rev-parse HEAD)" = "$UN_HEAD" ]; echo $?)"
+
+echo "--- case 3: one union plus one non-union is treated as the non-union case"
+build_union_repo mixed; advance_union_repo mixed
+UM="$TMPD/uclone-mixed"
+printf '%s' "$LAB_LOCAL" > "$UM/_meta/LAB_LOG.md"
+printf 'readme local edit\n' > "$UM/README.md"
+UM_LAB_BEFORE="$(cksum < "$UM/_meta/LAB_LOG.md")"
+out="$("$WRAP" apply --apply "$UM" 2>&1)"
+chk_has "mixed: the non-union file is named" "$out" "not declared merge=union, so the pull aborts on: README.md"
+chk_no "mixed: the union file was never saved aside" "$out" "union-marked file(s) aside"
+chk_no "mixed: no carry-back happened" "$out" "carried"
+chk "mixed: the union file is byte-identical" \
+  "$([ "$UM_LAB_BEFORE" = "$(cksum < "$UM/_meta/LAB_LOG.md")" ]; echo $?)"
+
+echo "--- case 5: a dirty index is skipped with a reason, nothing is touched"
+build_union_repo staged; advance_union_repo staged
+US="$TMPD/uclone-staged"
+printf '%s' "$LAB_LOCAL" > "$US/_meta/LAB_LOG.md"
+git -C "$US" add _meta/LAB_LOG.md
+US_BEFORE="$(cksum < "$US/_meta/LAB_LOG.md")"
+out="$("$WRAP" apply --apply "$US" 2>&1)"
+chk_has "dirty index: the reason prints" "$out" "NOTE: the index carries staged changes"
+chk_no "dirty index: nothing was saved aside" "$out" "union-marked file(s) aside"
+chk "dirty index: the staged path is still staged" \
+  "$(git -C "$US" diff --cached --name-only | grep -qx '_meta/LAB_LOG.md'; echo $?)"
+chk "dirty index: the file is byte-identical" \
+  "$([ "$US_BEFORE" = "$(cksum < "$US/_meta/LAB_LOG.md")" ]; echo $?)"
+
+echo "--- dry-run: a dirty union log is announced, never saved or checked out"
+build_union_repo dry; advance_union_repo dry
+UD="$TMPD/uclone-dry"
+printf '%s' "$LAB_LOCAL" > "$UD/_meta/LAB_LOG.md"
+UD_BEFORE="$(cksum < "$UD/_meta/LAB_LOG.md")"
+out="$("$WRAP" apply "$UD" 2>&1)"
+chk_has "dry-run: the carry is announced only" "$out" "--apply would carry its local lines across the pull"
+chk_no "dry-run: nothing was saved aside" "$out" "union-marked file(s) aside"
+chk "dry-run: the union file is byte-identical" \
+  "$([ "$UD_BEFORE" = "$(cksum < "$UD/_meta/LAB_LOG.md")" ]; echo $?)"
+
+# ===========================================================================
 echo "=== gh absent: every non-ancestor is LEAVE, merge refuses ==="
 # ===========================================================================
 mkdir -p "$TMPD/nogh"


### PR DESCRIPTION
## What

`bin/wrap apply --apply <repo>` ends with a `pull --ff-only` on the default branch. In a shared
checkout that pull aborts routinely: other sessions leave uncommitted lines in append-only log
files. Git prints `Updating <a>..<b>`, then `error: Your local changes ... would be overwritten by
merge` plus `Aborting`, and the checkout silently stays behind. An operator missed that abort behind
a `tail -1`, deployed a Cloudflare Worker from a checkout two commits behind, and served the wrong
version for about eleven minutes. The manual workaround ran six times by hand in one session.

## Why this is safe to automate

`.gitattributes` already declares which files are append-only logs:

```
_meta/LAB_LOG.md merge=union
_meta/BACKLOG.md merge=union
_meta/learned-ledger.md merge=union
docs/implementation-notes/*.md merge=union
tools/*/docs/implementation-notes/*.md merge=union
tools/*/docs/proof-of-done.md merge=union
```

`merge=union` states that keeping every line from both sides resolves the file. Preserving local
lines across a pull is that file's declared semantics. For every other path it stays a judgment, and
nothing touches those.

## The rule as implemented

Before the pull, when the checkout is on the default branch:

1. A dirty index (`diff --cached --name-only` non-empty) skips the whole mechanism, prints why, and
   runs today's pull. Restoring an index is out of scope.
2. `diff --name-only` empty means nothing to do.
3. Each modified tracked file is classified with `check-attr merge`. A file is union-marked when the
   output ends in `merge: union`. A path git reports as modified but that is not a regular file
   counts as non-union, because it cannot be copied back.
4. One non-union file switches the whole run back to today's behavior. The blocking file names
   itself before the pull instead of after the abort. Nothing is moved, stashed, or checked out.
5. All union-marked: each file is copied aside, `checkout --`ed, and the pull runs. On success every
   line present in the saved copy and absent from the pulled file returns below the header anchor,
   reusing `_log_anchor_head_lines`. Each file reports how many lines came back.
6. A pull that fails for any other reason restores each saved file to its pre-pull content and says
   so. The operator's lines never live only in a temp file.
7. HEAD prints in the same output block. A pull is done when HEAD moves, not when it prints.

Dry-run announces the carry and touches nothing.

## Verification

Full proof: `docs/verification/wrap-union-safe-pull.md`.

- `bash tests/test-wrap.sh` -> `test-wrap: all 308 passed` (278 before this branch).
- `bash tests/run-all.sh` -> 133 suites, 1 skipped, the same two pre-existing failures
  (`test-orchestrate-gate-dispatch`, `test-orchestrate-wavefront`) on `master` cfb5448 and on this
  branch. No regression.
- Negative control: `Verdict: PASS`. Mutating `_union_marked` to accept every path drives ten
  assertions RED, `test-wrap: 298 passed, 10 FAILED of 308`, including
  `non-union: the dirty file is byte-identical`.

New tests build real repos on disk: a bare origin, a `.gitattributes` with a union line, a real
incoming commit. Nothing stubs the VCS by matching command text, because what it does to a dirty
checkout during a pull is the entire subject.

Cases bound: dirty union log carries across; dirty non-union file untouched byte for byte; mixed
treated as the non-union case; the carried line lands below the header anchor; a dirty index is
skipped with a reason.

## Scope

No new verb, no new file, no config knob. Bash stays 3.2 portable.
