### PR TITLE
feat(kit): worker brief pattern and proof-gate skeleton

### DIFF
--- a/_meta/backlog-staging.md
+++ b/_meta/backlog-staging.md
@@ -85,3 +85,17 @@ Gitignored: may name unfiled work. NEVER the source of truth.
 - Home: dwarves-kit
 - Source: session 2026-09-10
 
+## [built 67cbc53] worker brief template for subagent dispatch
+- Intent: Twenty-plus dispatch prompts repeated the same preamble by hand: pwd, fetch origin main and merge, absolute paths, git -C, rename branch, do not edit shared modules, verification file required, LAB_LOG line, STE-lite, no dashes, commit not push, report in N lines. Drift between copies caused two real defects: workers blind to merged docs, and a fenced worker leaving stale doc lines. Fork: a kit doc the commands cite, versus a lib helper that emits the block, versus fields on the agent definitions.
+- Approach: Built as `docs/patterns/worker-brief.md`, the kit-doc-a-command-cites option (the reversible first step). The lib-helper and agent-definition-fields alternatives are still open; see the fork note above.
+- Tags: #u-lo #f-mid
+- Home: dwarves-kit
+- Source: session 2026-09-11
+
+## [built 4595dea] proof-gate contract emits the verification skeleton
+- Intent: Fifteen-plus workers each wrote docs/verification/<slug>.md from a prose description re-specified in every dispatch: run table with Command/Exit/Verdict, negative control, determinism hash, rollback note, Not proven. proof-gate.sh contract already tells a work type what it owes; it could emit the file skeleton too. Fork: contract prints it versus a separate verb writes the file, and whether the skeleton belongs in the kit or in each adopting repo.
+- Approach: Built as a new `proof-gate.sh skeleton "<slug>" ["<task>"]` subcommand; `contract` prints a pointer to it rather than the skeleton itself. Lives in the kit since proof-gate.sh already does. The determinism-hash field named in the intent did not carry into the built shape; the skeleton carries Green run, Negative control, Rollback (stateful only), and Not proven.
+- Tags: #u-lo #f-mid
+- Home: dwarves-kit
+- Source: session 2026-09-11
+

--- a/docs/patterns/worker-brief.md
+++ b/docs/patterns/worker-brief.md
@@ -1,0 +1,74 @@
+# The worker-brief pattern
+
+Every subagent dispatch needs the same preamble: where it runs, what it may touch, and what
+it owes back. A dispatching command used to retype that preamble by hand each time. This doc
+names the block once so a command can cite it instead.
+
+## What it is
+
+The block a dispatching command puts at the top of a worker prompt, before the task-specific
+instructions. It is not a template to fill in with placeholders; it is a checklist the
+dispatcher runs through and writes into the prompt in its own words.
+
+## The block
+
+- Run `pwd` first. Confirm the worktree the worker actually landed in before reading or
+  writing anything.
+- Fetch and merge `origin/main` before reading any prerequisite doc.
+- Use absolute paths for every write.
+- Run git as `git -C <worktree>`, never a bare `git` that assumes the caller's cwd.
+- Rename the branch to the repo's branch convention before the first commit.
+- Name the files the worker may modify, and the shared modules it may not touch.
+- For any behavioral change: require `docs/verification/<slug>.md` with a run table, a
+  negative control, and a `## Not proven` section. Add a rollback note when the change is
+  stateful.
+- Require an activity-log line (the repo's LAB_LOG or equivalent).
+- Commit, but never push.
+- Report in N lines or fewer.
+
+## Why each line is there
+
+- **`pwd` first**: a worker's worktree can be created before a merge lands, so the worker
+  needs to confirm where it is before trusting any relative assumption about what exists there.
+- **Fetch and merge `origin/main` before reading a prerequisite doc**: a worker whose
+  worktree predated a merge could not see the doc it was told to read. It read a stale copy,
+  answered from it, and the answer was wrong in a way that looked confident. This is a real
+  failure from the 2026-09-10 session.
+- **Absolute paths for every write**: a relative write resolves against whatever the shell's
+  cwd happens to be at that moment, not against the worktree the worker was told to use.
+- **`git -C <worktree>`**: same reason as absolute paths, for git specifically. A bare `git`
+  command trusts the ambient cwd, which drifts across a multi-step dispatch.
+- **Rename the branch**: a worker that keeps the scaffold branch name collides with the next
+  worker's scaffold, or ships a branch nobody can identify from the PR list later.
+- **Name the files a worker may modify, and the shared modules it may not**: a worker fenced
+  to a file set by exclusion ("don't touch the shared stuff") still edited a doc it thought
+  was in scope and left two stale lines behind, because "the shared stuff" was never named.
+  This is the second real failure from the 2026-09-10 session.
+- **`docs/verification/<slug>.md` with a run table, negative control, `## Not proven`**:
+  without this the worker's own claim of "done" is the only evidence, and a claim is not
+  proof. The rollback note is the stateful case's extra: a stateful change without a named
+  undo path is not reversible by anyone reading the record later.
+- **Activity-log line**: the log is the index across every worker's output; a change with no
+  log line is invisible to anyone scanning what happened this session.
+- **Commit but never push**: a worker's commit is reviewable before it becomes a push the
+  dispatcher did not look at.
+- **Report in N lines or fewer**: an unbounded report from twenty parallel workers is a
+  transcript nobody reads. A bound forces the worker to lead with the answer.
+
+## Fences that matter
+
+Name the files a worker may modify **positively**, as a list, not as "everything except
+X". An exclusion list is only as good as the dispatcher's memory of what is shared; a
+positive list is checkable by the worker without guessing. Say who owns the parts it may
+not touch, so a worker that finds a real problem there knows to report it rather than fix
+it.
+
+## The open fork
+
+This is a doc a command cites today: a dispatcher reads this file and writes the block into
+its own words. It could instead be a lib helper that emits the block programmatically, or a
+set of fields carried directly on the agent definitions. The doc is the reversible first
+step; a helper or a schema change costs more to undo if the shape turns out wrong. The
+alternatives, and which one to pick, are the dispatcher's call and are tracked in the
+backlog row this pattern was promoted from (`_meta/backlog-staging.md`, "worker brief
+template for subagent dispatch").

--- a/lib/gate/proof-gate.sh
+++ b/lib/gate/proof-gate.sh
@@ -30,6 +30,9 @@
 #   proof-gate.sh class "<task description>"        -> stateful | behavioral | inert
 #   proof-gate.sh requirement "<task description>"  -> the one-line proof requirement
 #   proof-gate.sh classes                            -> the three class names
+#   proof-gate.sh skeleton "<slug>" ["<task description>"]
+#                                                     -> a ready-to-fill docs/verification/<slug>.md,
+#                                                        printed to stdout, nothing written to disk
 
 set -euo pipefail
 
@@ -115,6 +118,53 @@ proof_contract() {
   echo "proof: $artifact"
   echo "owner: $skill"
   echo "rigor: $(proof_requirement "$desc")"
+  echo "hint: run 'proof-gate.sh skeleton <slug>' for a fillable verification file"
+}
+
+# proof_skeleton <slug> [<task description>] -- prints a ready-to-fill
+# docs/verification/<slug>.md to stdout (SPEC per _meta/backlog-staging.md "proof-gate
+# contract emits the verification skeleton"). Writes nothing to disk; the caller redirects
+# if it wants a file. Reuses proof_class so the skeleton always matches what `contract`
+# would say for the same task description, instead of a second classifier drifting from it.
+proof_skeleton() {
+  local slug="${1:-}" desc="${2:-}"
+  [ -n "$slug" ] || { echo "usage: proof-gate.sh skeleton \"<slug>\" [\"<task description>\"]" >&2; return 64; }
+  local class
+  if [ -n "$desc" ]; then
+    class="$(proof_class "$desc")"
+  else
+    class="behavioral"
+    echo "<!-- no task description given; emitting the behavioral shape -->"
+  fi
+
+  echo "# Verification -- $slug"
+  echo
+  echo "<one-line statement of what this change is>"
+  echo
+  echo "## Green run"
+  echo '```'
+  echo "Command:"
+  echo "Exit:"
+  echo "Verdict:"
+  echo '```'
+  echo
+  echo "## Negative control"
+  echo '```'
+  echo "Command:"
+  echo "Exit:"
+  echo "Verdict:"
+  echo '```'
+  echo "<what was broken, and confirmation it was restored>"
+  echo
+  if [ "$class" = "stateful" ]; then
+    echo "## Rollback"
+    echo "| Change | How to undo | Blast radius |"
+    echo "|---|---|---|"
+    echo "| | | |"
+    echo
+  fi
+  echo "## Not proven"
+  echo "- <what this run does not cover>"
 }
 
 # ID-466: test-plan -> proof-of-done coverage (ADVISORY; always exit 0). When the active
@@ -177,8 +227,9 @@ main() {
     requirement) proof_requirement "$@";;
     contract)    proof_contract "$@";;
     coverage)    proof_coverage "$@";;
+    skeleton)    proof_skeleton "$@";;
     classes)     printf 'stateful\nbehavioral\ninert\n';;
-    *) echo "usage: proof-gate.sh {class \"<desc>\"|requirement \"<desc>\"|contract \"<desc>\"|coverage <spec> [proof.md ...]|classes}" >&2; return 64;;
+    *) echo "usage: proof-gate.sh {class \"<desc>\"|requirement \"<desc>\"|contract \"<desc>\"|coverage <spec> [proof.md ...]|skeleton <slug> [\"<desc>\"]|classes}" >&2; return 64;;
   esac
 }
 

--- a/tests/test-meta.sh
+++ b/tests/test-meta.sh
@@ -2512,6 +2512,26 @@ assert_true "proof-gate contract names the recorded-run artifact + owning skill"
   "$({ trap '' PIPE; printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -qi 'recorded live run' && { trap '' PIPE; printf '%s' "$CONTRACT_OUT" 2>/dev/null || :; } | grep -qi 'ops-tool-shape' && echo 0 || echo 1)"
 assert_true "proof-gate contract upgrades a migration to stateful (class wins on rigor)" \
   "$(bash "$KIT_DIR/lib/gate/proof-gate.sh" contract 'migrate the database schema' 2>/dev/null | grep -q 'class=stateful' && echo 0 || echo 1)"
+assert_true "proof-gate contract points at the skeleton subcommand" \
+  "$(bash "$KIT_DIR/lib/gate/proof-gate.sh" contract 'add a flag to the CLI' 2>/dev/null | grep -q 'proof-gate.sh skeleton' && echo 0 || echo 1)"
+
+SKEL_BEHAVIORAL="$(bash "$KIT_DIR/lib/gate/proof-gate.sh" skeleton 'add-cli-flag' 'add a flag to the CLI' 2>/dev/null)"
+assert_true "proof-gate skeleton names the slug in the title" \
+  "$({ trap '' PIPE; printf '%s' "$SKEL_BEHAVIORAL" 2>/dev/null || :; } | grep -q '# Verification -- add-cli-flag' && echo 0 || echo 1)"
+assert_true "proof-gate skeleton carries Green run + Negative control" \
+  "$({ trap '' PIPE; printf '%s' "$SKEL_BEHAVIORAL" 2>/dev/null || :; } | grep -q '## Green run' && { trap '' PIPE; printf '%s' "$SKEL_BEHAVIORAL" 2>/dev/null || :; } | grep -q '## Negative control' && echo 0 || echo 1)"
+assert_true "proof-gate skeleton omits Rollback for a behavioral task" \
+  "$({ trap '' PIPE; printf '%s' "$SKEL_BEHAVIORAL" 2>/dev/null || :; } | grep -q '## Rollback' && echo 1 || echo 0)"
+
+SKEL_STATEFUL="$(bash "$KIT_DIR/lib/gate/proof-gate.sh" skeleton 'deploy-worker' 'deploy to production' 2>/dev/null)"
+assert_true "proof-gate skeleton adds Rollback for a stateful task" \
+  "$({ trap '' PIPE; printf '%s' "$SKEL_STATEFUL" 2>/dev/null || :; } | grep -q '## Rollback' && echo 0 || echo 1)"
+
+SKEL_NO_DESC="$(bash "$KIT_DIR/lib/gate/proof-gate.sh" skeleton 'no-desc-given' 2>/dev/null)"
+assert_true "proof-gate skeleton with no task arg says so in a comment line" \
+  "$({ trap '' PIPE; printf '%s' "$SKEL_NO_DESC" 2>/dev/null || :; } | grep -q 'no task description given' && echo 0 || echo 1)"
+assert_true "proof-gate skeleton with no task arg defaults to behavioral (no Rollback)" \
+  "$({ trap '' PIPE; printf '%s' "$SKEL_NO_DESC" 2>/dev/null || :; } | grep -q '## Rollback' && echo 1 || echo 0)"
 
 # ============================================================
 


### PR DESCRIPTION
Promotes two staged candidates from a 19-hour session that dispatched 20+ subagents and wrote 15+ verification files by hand.

**docs/patterns/worker-brief.md**: the preamble every dispatching command repeats, written once so callers cite it instead of retyping it. Carries the block itself, one clause of why per line, and the two real failures that produced it: a worker whose worktree predated a merge could not see the doc it was told to read, and a worker fenced to a file set left two stale lines in a doc it could not touch. The open fork (doc versus lib helper versus agent fields) is stated at the end, with the alternatives kept on the backlog row.

**proof-gate.sh skeleton**: a new subcommand printing a fillable docs/verification/<slug>.md to stdout, with green run and negative control blocks shaped Command/Exit/Verdict, a Not proven section, and a Rollback table only when the task classifies as stateful. It derives class from the same classifier contract uses rather than reimplementing it. contract gains one trailing hint line; its four existing lines are untouched, and no test asserted their count (both existing checks use head -1), so nothing that parses them changes.

Tests: test-meta.sh 851/851, up from 845, with 6 new assertions for the subcommand placed beside contract's own. Full run-all.sh shows the same three flaky suites before and after on unmodified master (git fixture and concurrency races, plus a live doc drift on the shared checkout); none touch the files in this PR.

Third commit flips both backlog rows from staged to built with their shas, per the repo's never-amend rule.