### PR TITLE
fix(recall): read a non-dict message as empty instead of crashing

### DIFF
--- a/docs/verification/recall-message-shape.md
+++ b/docs/verification/recall-message-shape.md
@@ -1,0 +1,49 @@
+# Verification: session-recall survives a non-dict message
+
+`lib/session/recall/session_recall.py` read `(entry.get("message") or {}).get(...)` in `_role`, `searchable_text` and `opening_ask`. A transcript line whose `message` is a string or a list is valid JSON and a valid object, so `load()` keeps it, and the first `.get` on it raised `AttributeError`. The observe and semantic readers received this guard on 2026-09-10 (`lib/session/observe/docs/implementation-notes/observe-nondict-crash.md`); recall was recorded there as the open follow-up.
+
+One helper `_msg(entry)` now returns the message when it is a dict and `{}` otherwise. All three readers call it, so the check lives in one place.
+
+## Green run
+
+| # | Command | Exit | Verdict |
+|---|---|---|---|
+| 1 | `cd lib/session/recall && python3 -m unittest discover -s tests` | 0 | PASS, 16 tests |
+
+```
+Command: python3 -m unittest discover -s tests
+................
+Ran 16 tests in 0.215s
+OK
+Exit: 0
+Verdict: PASS
+```
+
+The new case is `test_second_level_non_dict_message_never_crashes`. It loads `tests/nondict-edge/nondict-message.jsonl` (a string message, a list message, then a valid turn) and asserts every reader returns, `_role` falls back to the top-level `type`, `opening_ask` skips to the valid turn, and `search` still finds it.
+
+## Negative control
+
+Drop the `isinstance` check from `_msg` so it returns `m or {}`, run, restore.
+
+```
+Command: sed -i '' 's/    return m if isinstance(m, dict) else {}/    return m or {}/' session_recall.py \
+         && python3 -m unittest discover -s tests; git checkout -- session_recall.py
+ERROR: test_second_level_non_dict_message_never_crashes
+AttributeError: 'str' object has no attribute 'get'
+Ran 16 tests in 0.198s
+FAILED (errors=1)
+Exit: 1
+Verdict: RED as expected, then restored clean
+```
+
+Only the new case fails, so the fixture reaches exactly the path the guard protects.
+
+## Reproduce
+
+```bash
+cd lib/session/recall && python3 -m unittest discover -s tests
+```
+
+## Note on the glob
+
+`tests/run-all.sh` globs `tests/test-*.sh`. No shell suite runs the recall unittest, so a green `run-all.sh` says nothing about this module. The command above is the only way to run it.

--- a/lib/session/observe/docs/implementation-notes/observe-nondict-crash.md
+++ b/lib/session/observe/docs/implementation-notes/observe-nondict-crash.md
@@ -19,3 +19,11 @@ Why: the transcript schema is untrusted input at every nesting level, not just t
 Alternatives: none considered; this is the same class of bug one level deeper.
 Impact: no caller's output changes for valid input. `session-recall`'s own `_role`/`searchable_text`/`opening_ask` have the same latent non-dict-message shape but were left untouched (out of the reported bug's scope); its `load()` was covered for the top-level fix only.
 Open questions: whether session-recall's second-level message-shape paths should get the same guard in a follow-up.
+
+## 2026-09-11 session-recall gets the same second-level guard
+
+Context: the open question above.
+Decision: `_msg(entry)` in `lib/session/recall/session_recall.py` returns the message when it is a dict and `{}` otherwise; `_role`, `searchable_text` and `opening_ask` all read through it.
+Why: one helper instead of three inline checks, so the untrusted-shape rule lives once per module, matching how `iter_entries()` owns the top-level case.
+Impact: no output change for valid input; proof in `docs/verification/recall-message-shape.md`.
+Open questions: none.

--- a/lib/session/recall/session_recall.py
+++ b/lib/session/recall/session_recall.py
@@ -47,8 +47,15 @@ from parse_transcript import load  # noqa: E402  (re-exported: session-recall's 
 # does.
 
 
+def _msg(entry) -> dict:
+    # The transcript is untrusted at every level: a `message` that is a string or a list
+    # (seen in the wild) reads as an empty message instead of crashing every reader.
+    m = entry.get("message")
+    return m if isinstance(m, dict) else {}
+
+
 def _role(entry):
-    return (entry.get("message") or {}).get("role") or entry.get("type") or "?"
+    return _msg(entry).get("role") or entry.get("type") or "?"
 
 
 def _ts(entry):
@@ -58,7 +65,7 @@ def _ts(entry):
 def searchable_text(entry) -> str:
     """All human-meaningful text in a turn: prose, thinking, tool inputs, tool results."""
     parts = []
-    msg = entry.get("message") or {}
+    msg = _msg(entry)
     content = msg.get("content")
     if isinstance(content, str):
         parts.append(content)
@@ -206,7 +213,7 @@ def opening_ask(entries, width: int = 110) -> str:
     for e in entries:
         if _role(e) != "user":
             continue
-        c = (e.get("message") or {}).get("content")
+        c = _msg(e).get("content")
         text = ""
         if isinstance(c, str):
             text = c

--- a/lib/session/recall/tests/test_recall.py
+++ b/lib/session/recall/tests/test_recall.py
@@ -15,6 +15,7 @@ import session_recall as r  # noqa: E402
 SEED = os.path.join(ROOT, "fixtures", "seed.jsonl")
 BIN = os.path.join(ROOT, "bin", "session-recall")
 NONDICT = os.path.join(ROOT, "tests", "nondict-edge", "nondict.jsonl")  # OUTSIDE fixtures/: hostile, not a seed
+NONDICT_MSG = os.path.join(ROOT, "tests", "nondict-edge", "nondict-message.jsonl")  # valid objects, hostile `message`
 
 
 class TestRecall(unittest.TestCase):
@@ -36,6 +37,19 @@ class TestRecall(unittest.TestCase):
         entries = r.load(NONDICT)
         self.assertEqual(len(entries), 1)
         self.assertEqual(r._role(entries[0]), "user")
+
+    def test_second_level_non_dict_message_never_crashes(self):
+        # A valid object whose `message` is a string or a list is one level deeper than
+        # the case above. Every reader must survive it and the valid entry after it
+        # must still be found. `_role` falls back to the top-level `type`.
+        entries = r.load(NONDICT_MSG)
+        self.assertEqual(len(entries), 3)
+        for e in entries:
+            self.assertIsInstance(r.searchable_text(e), str)
+        self.assertEqual(r._role(entries[0]), "user")
+        self.assertEqual(r._role(entries[1]), "assistant")
+        self.assertIn("still findable", r.opening_ask(entries))
+        self.assertEqual(len(r.search(entries, "still findable")), 1)
 
     # --- --project short names and --sessions -----------------------------------
     # Motivating miss: `session recall whathas --project ops-toolkit` printed


### PR DESCRIPTION
## What

Closes the open question left in `lib/session/observe/docs/implementation-notes/observe-nondict-crash.md` on 2026-09-10. `session-recall`'s `_role`, `searchable_text` and `opening_ask` each read `(entry.get("message") or {}).get(...)`, which raises on a `message` that is a string or a list. The observe and semantic readers got their guard that day; recall did not.

One `_msg(entry)` helper now returns the message when it is a dict and `{}` otherwise, and all three readers go through it. Same shape as `iter_entries()` owning the top-level case: the untrusted-shape check lives once.

## Proof

`docs/verification/recall-message-shape.md`. 16 tests green. Negative control drops the `isinstance` from the helper and only the new case errors with `AttributeError: 'str' object has no attribute 'get'`.

## Worth knowing

`tests/run-all.sh` does not reach `lib/session/recall/tests`. Nothing globs it. The proof names the by-hand command.
