### PR TITLE
fix(wrap): remove a locked worktree instead of declining

### DIFF
--- a/docs/verification/worktree-remove-lock.md
+++ b/docs/verification/worktree-remove-lock.md
@@ -1,0 +1,52 @@
+# Proof of done: remove a locked worktree instead of declining
+
+`wrap apply --worktrees` ran a bare `git worktree remove`, which leaves a LOCKED worktree in place
+and only prints a hint. The Agent tool locks every worktree it creates, so the tidy silently failed
+on exactly the worktrees it exists to clean.
+
+## Green run
+
+| | |
+|---|---|
+| Command | `bash tests/test-wrap.sh` |
+| Exit | 0 |
+| Result | `test-wrap: all 319 passed` |
+| Verdict | PASS |
+
+The regression proof is in the fixture, not a new assertion: `make_clone` now locks the clean
+worktree it builds, so the existing "apply --apply removed the clean worktree only" assertion
+covers the locked case. Test count went 317 to 319 with no assertion rewritten.
+
+## Negative control
+
+Revert the fix, confirm RED, restore, confirm the restore by an EMPTY diff rather than an exit code.
+
+| Step | Command | Result |
+|---|---|---|
+| Baseline | `git status --porcelain` | empty, committed tree clean |
+| Mutate | `worktree remove -f -f "$wt"` back to `worktree remove "$wt"` | 1 insertion, 1 deletion |
+| Red run | `bash tests/test-wrap.sh` | `test-wrap: 317 passed, 2 FAILED of 319` |
+| Restore | `git checkout -- lib/wrap/wrap.sh` | |
+| Postcondition | `git diff --stat` | **empty**, restored |
+| Green again | `bash tests/test-wrap.sh` | `test-wrap: all 319 passed` |
+
+Verdict: PASS. Two assertions fail without the fix and both pass with it, so the test is not
+vacuous. The failures are the clean-worktree removal check and the `apply --apply exits 0` check,
+which is the `run()` helper reporting the refused removal.
+
+## Reproducible
+
+`bash tests/test-wrap.sh` from the branch root. The negative control is the five steps above in
+order; the mutation is one word in `lib/wrap/wrap.sh`.
+
+## Scope left alone
+
+The three best-effort `worktree remove --force ... || true` prunes in `lib/board/board-writeback.sh`
+and `lib/queue/orchestrate.sh` drop scratch worktrees the kit creates itself without a lock, and
+they already tolerate failure. Changing them would widen the diff without fixing a live failure.
+
+## How it was found
+
+By hand, cleaning up after subagent worktrees about fifteen times in one session. The no-op once
+preserved an agent's later commits and once stranded a branch behind a
+`cannot delete branch ... used by worktree` error that read as an unrelated second problem.

--- a/lib/goal/wt.sh
+++ b/lib/goal/wt.sh
@@ -49,7 +49,9 @@ case "$verb" in
     st="$(gh pr list --state all --head "$br" --json state --jq '.[0].state' 2>/dev/null)"
     [ "$st" = "MERGED" ] || { echo "wt.sh: refusing to close: PR for $br is '${st:-none}', not MERGED" >&2; exit 1; }
     bash "$LIB/goal/goal-registry.sh" release "$slug" 2>/dev/null || true
-    [ -d "$wt" ] && git worktree remove --force "$wt"
+    # -f -f: a single --force no-ops on a locked worktree, and the `git branch -D` below then
+    # fails with "used by worktree", which reads as a second unrelated problem.
+    [ -d "$wt" ] && git worktree remove -f -f "$wt"
     git branch -D "$br" >/dev/null
     git push origin --delete "$br" >/dev/null 2>&1 || true
     git worktree prune

--- a/lib/wrap/wrap.sh
+++ b/lib/wrap/wrap.sh
@@ -17,7 +17,8 @@
 # --worktrees, pull --ff-only on the default branch, the activity-log prepend, the
 # knowledge-root project directory, the staging-file append, and one gh pr merge. Every
 # other action is a report line. The verbs never switch a branch, never touch a dirty
-# file, never force, and never retry a failed git call.
+# file, never force a push or a pull, and never retry a failed git call. The one force is
+# `worktree remove -f -f`, which overrides a lock after the dirty and detached guards pass.
 #
 # Ported from the operator's repo-wrapup scripts. The default branch is DETECTED, never
 # assumed to be main.
@@ -261,8 +262,11 @@ _apply_worktrees() {
     elif [ -z "$(git -C "$wt" branch --show-current 2>/dev/null)" ]; then
       echo "     SKIP ${wt}: detached HEAD (removal could orphan the commit)"
     else
+      # `-f -f`, not `--force`: one --force leaves a LOCKED worktree in place and only prints a
+      # hint, so the call reports success while nothing moved. The Agent tool locks every
+      # worktree it creates. The dirty and detached guards above ran, so -f -f overrides the lock alone.
       run "$repo" "remove worktree ${wt} (clean; the branch survives removal)" \
-        git -C "$repo" worktree remove "$wt"
+        git -C "$repo" worktree remove -f -f "$wt"
     fi
   done < <(git -C "$repo" worktree list --porcelain -z 2>/dev/null)
 }

--- a/tests/test-wrap.sh
+++ b/tests/test-wrap.sh
@@ -120,6 +120,9 @@ make_clone() { # make_clone <name> <remote name> <default branch> <checkout bran
     git -C "$clone" branch "$b" "origin/$b" >/dev/null 2>&1
   done
   git -C "$clone" worktree add "$TMPD/wt-$name-clean" wt-clean >/dev/null 2>&1
+  # Locked, because the Agent tool locks every worktree it creates. A single `--force` declines
+  # to remove a locked worktree, so the clean case only tests the tidy once it survives a lock.
+  git -C "$clone" worktree lock "$TMPD/wt-$name-clean" >/dev/null 2>&1
   git -C "$clone" worktree add "$TMPD/wt-$name-dirty" wt-dirty >/dev/null 2>&1
   echo dirt > "$TMPD/wt-$name-dirty/dirt.txt"
   git -C "$clone" worktree add --detach "$TMPD/wt-$name-det" HEAD >/dev/null 2>&1


### PR DESCRIPTION
`git worktree remove` without a second force leaves a **locked** worktree in place, prints a hint, and the caller reads the call as having worked. The Agent tool locks every worktree it creates, so locked-and-clean is the common case on this code path, not an edge case.

## Two call sites

| File | Was | Problem |
|---|---|---|
| `lib/wrap/wrap.sh` | bare `worktree remove`, no force at all | `wrap apply --worktrees` silently failed on exactly the worktrees it exists to clean |
| `lib/goal/wt.sh` | single `--force` | the next line's `git branch -D` then fails with `used by worktree`, reading as an unrelated second problem |

`wrap.sh` already runs its dirty and detached guards ahead of the removal, so the second `-f` overrides the lock and nothing else. The `wt.sh` path is already gated on a MERGED PR.

## The test change is the regression proof

`make_clone` now **locks** the clean worktree it builds, so the existing `apply --apply removed the clean worktree only` assertion covers the locked case. No new branch, no rewritten assertion. Count went 317 to 319.

## Proof of done

`docs/verification/worktree-remove-lock.md`. Green run `all 319 passed`; negative control reverts the one word, goes `317 passed, 2 FAILED of 319`, and restores green on an **empty diff** rather than an exit code.

## Left alone

The three best-effort `worktree remove --force ... || true` prunes in `board-writeback.sh` and `orchestrate.sh` drop scratch worktrees the kit creates itself without a lock, and they already tolerate failure.

## How it was found

By hand, cleaning up after subagent worktrees about fifteen times in one session. The no-op once preserved an agent's later commits and once stranded a branch. The header's "never force" claim is corrected in the same commit, since `-f -f` is now the one force the verbs make.
