### PR TITLE
feat(negctl): bounded retries so a flaky test can still prove a control

### DIFF
--- a/docs/verification/negctl-red-attempts.md
+++ b/docs/verification/negctl-red-attempts.md
@@ -1,0 +1,69 @@
+# Verification: negctl bounded retries for a probabilistic test
+
+`lib/gate/negctl.sh` ran the RED step exactly once and treated `run_test` as deterministic. A flaky suite could therefore come back green under a REAL mutation, and negctl recorded `test stayed green under the mutation (the check is vacuous)`. The mutation was real; the verdict said otherwise.
+
+This is not hypothetical. On 2026-09-11 a wavefront negative control passed at 1-minute load 11.4 and looked like it refuted a correct fix. Re-run under matched load it failed 3 of 3. The control was probabilistic and the tool had no way to say so.
+
+## Change
+
+`NEGCTL_RED_ATTEMPTS=<n>` (default 1) retries ONLY the RED step and takes the first non-zero exit as RED.
+
+Three properties hold it to the same standard as before:
+
+- **It cannot manufacture red.** A genuinely vacuous mutation stays green on every attempt and still FAILs. Pinned at 5 attempts by case [13].
+- **The default path is byte-identical**, including the single-attempt wording. Two dated proof records (`docs/verification/docs-scattered-ids.md`, `docs/verification/command-autonomy-knobs.md`) quote that line verbatim, so it is load-bearing text and is left alone.
+- **A bad value is rejected, never coerced.** Non-numeric and zero both exit 64 naming the variable. Silently becoming 1 would read as a clean single-attempt run and hide that the operator asked for more.
+
+Load is deliberately NOT an option here. Holding machine load from a proof tool is hostile on a shared box, so that half stays in `docs/verification/wavefront-startup-windows-negctl.sh`, which induces load around negctl rather than inside it.
+
+## Green run
+
+```
+Command: bash tests/test-proof-negctl.sh
+[11] a flaky test defeats the single-attempt control (documents the gap)
+  ok: one attempt calls a real mutation vacuous, and the default wording is unchanged
+[12] NEGCTL_RED_ATTEMPTS=3 catches the same real mutation
+  ok: retry reaches RED and names which attempt bit
+[13] retries never manufacture RED: a vacuous mutation stays FAIL at 5 attempts
+  ok: a genuinely vacuous mutation is still rejected
+[14] the default run is byte-identical: no attempt wording at all
+  ok: unset NEGCTL_RED_ATTEMPTS prints the original lines
+[15] a non-numeric or zero NEGCTL_RED_ATTEMPTS is REJECTED, never coerced to 1
+  ok: both bad values exit 64 naming the variable
+test-proof-negctl: all 16 passed
+Exit: 0
+Verdict: PASS
+```
+
+The fixture is deterministic, not actually flaky: under mutation it is green on the first red-step run and red from the second, which is a flake's shape without the coin flip. Its counter lives OUTSIDE the repo, because negctl treats an untracked leftover as a FAIL and a counter file inside the tree would trip that check rather than the one under test.
+
+## Negative control
+
+Revert ONLY the implementation and keep the new cases, so the cases prove they bite.
+
+```
+Command: git checkout HEAD~1 -- lib/gate/negctl.sh && bash tests/test-proof-negctl.sh; git checkout HEAD -- lib/gate/negctl.sh
+grep -c NEGCTL_RED_ATTEMPTS lib/gate/negctl.sh  ->  0
+[12] NEGCTL_RED_ATTEMPTS=3 catches the same real mutation
+  FAIL: rc=1
+[13] retries never manufacture RED: a vacuous mutation stays FAIL at 5 attempts
+  FAIL: rc=1
+[15] a non-numeric or zero NEGCTL_RED_ATTEMPTS is REJECTED, never coerced to 1
+  FAIL: rc=0 rc0=0
+test-proof-negctl: 13 passed, 3 FAILED
+restored: 0 dirty
+Verdict: RED as expected, then restored clean
+```
+
+Exactly the three cases that assert the new behaviour fail. Cases [11] and [14] pass against BOTH implementations, which is what proves the default path is unchanged rather than merely asserted to be.
+
+## Reproduce
+
+```bash
+bash tests/test-proof-negctl.sh
+NEGCTL_RED_ATTEMPTS=5 bash lib/gate/negctl.sh <root> "<test-cmd>" "<mutate-cmd>"
+```
+
+## Scope
+
+`docs/FEATURES.md` stays fresh: the cases were added to an existing suite rather than a new test file, so SPEC-219's freshness pin is untouched. `lib/gate/proof-ledger.sh`'s `negctl` verb forwards to this script and needed no change; case [2] still covers it.

--- a/lib/gate/negctl.sh
+++ b/lib/gate/negctl.sh
@@ -12,6 +12,15 @@
 # CLOSED. Mixing the two behind one banner is the invariant a reader would trust and get
 # burned by. proof-ledger.sh keeps a `negctl` verb that forwards here.
 #
+# A PROBABILISTIC test breaks step 4. `run_test` is treated as deterministic, so a flaky
+# suite can come back green under the mutation and negctl calls the control vacuous when the
+# mutation was real. Set NEGCTL_RED_ATTEMPTS=<n> (default 1, byte-identical to before) to run
+# step 4 up to n times and take the FIRST non-zero as RED. It never makes a green test red:
+# a genuinely vacuous mutation stays green on every attempt and still FAILs.
+# Load is the other axis and is deliberately NOT here: holding machine load from a proof tool
+# is hostile on a shared box. Induce it around negctl instead, as
+# docs/verification/wavefront-startup-windows-negctl.sh does.
+#
 # Usage: negctl.sh <root> <test-cmd> <mutate-cmd>
 #   1. refuse if any tracked file is modified or staged (the restore would wipe it)
 #   2. snapshot the tree (tracked + untracked), run <test-cmd>: must be GREEN (exit 0)
@@ -29,6 +38,14 @@ root="${1:-}"; test_cmd="${2:-}"; mutate_cmd="${3:-}"
 [ -n "$root" ] && [ -n "$test_cmd" ] && [ -n "$mutate_cmd" ] \
   || { echo "usage: negctl.sh <root> <test-cmd> <mutate-cmd>" >&2; exit 64; }
 git -C "$root" rev-parse --git-dir >/dev/null 2>&1 || { echo "negctl: $root is not a git repo" >&2; exit 64; }
+
+# Bounded retries for the RED step only. Rejected rather than coerced: a typo that silently
+# became 1 would read as a clean single-attempt run and hide that the operator asked for more.
+red_attempts="${NEGCTL_RED_ATTEMPTS:-1}"
+case "$red_attempts" in
+  ''|*[!0-9]*) echo "negctl: NEGCTL_RED_ATTEMPTS must be a positive integer (got '$red_attempts')" >&2; exit 64 ;;
+esac
+[ "$red_attempts" -ge 1 ] || { echo "negctl: NEGCTL_RED_ATTEMPTS must be >= 1 (got '$red_attempts')" >&2; exit 64; }
 
 if [ -n "$(git -C "$root" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
   echo "negctl: REFUSED -- tracked files are modified or staged in $root; commit first (the restore step is 'git checkout HEAD --', it would wipe them)" >&2
@@ -68,9 +85,27 @@ else
   fail "the mutation changed no tracked file"
 fi
 
-run_test; rc_red=$?
-echo "Exit: $rc_red (under mutation, RED expected)"
-[ "$rc_red" -ne 0 ] || fail "test stayed green under the mutation (the check is vacuous)"
+red_used=0
+rc_red=0
+while [ "$red_used" -lt "$red_attempts" ]; do
+  red_used=$(( red_used + 1 ))
+  run_test; rc_red=$?
+  [ "$rc_red" -ne 0 ] && break
+done
+if [ "$red_attempts" -gt 1 ]; then
+  echo "Exit: $rc_red (under mutation, RED expected; attempt $red_used of $red_attempts)"
+else
+  echo "Exit: $rc_red (under mutation, RED expected)"
+fi
+if [ "$rc_red" -eq 0 ]; then
+  # The single-attempt wording is unchanged on purpose: the default path must stay
+  # byte-identical, and two dated proof records quote this exact line.
+  if [ "$red_attempts" -gt 1 ]; then
+    fail "test stayed green under the mutation on all $red_attempts attempts (the check is vacuous)"
+  else
+    fail "test stayed green under the mutation (the check is vacuous)"
+  fi
+fi
 
 restore
 echo "Restore: git checkout HEAD -- ${restore_files[*]:-<nothing>}"

--- a/tests/test-proof-negctl.sh
+++ b/tests/test-proof-negctl.sh
@@ -102,5 +102,55 @@ OUT="$(bash "$NC" "$REPO" 2>&1)"; RC=$?
 if [ "$RC" -eq 64 ] && grep -q 'usage: negctl.sh <root>' <<<"$OUT"; then ok "exit 64 with negctl usage"; else no "rc=$RC out=$OUT"; fi
 
 echo
+# --- NEGCTL_RED_ATTEMPTS: a PROBABILISTIC test must still be provable ---------------
+# `run_test` was treated as deterministic, so a flaky suite could come back green under a
+# REAL mutation and negctl called the control vacuous. The fixture below is deterministic,
+# not actually flaky: under mutation it is green on the first red-step run and red from the
+# second, which is the shape a flake has without the coin flip.
+FREPO="$TMP/flaky"; mkrepo "$FREPO"
+export FLAKY_COUNTER="$TMP/flaky-counter"
+cat > "$FREPO/flaky.sh" <<'FLAKY'
+#!/usr/bin/env bash
+source ./lib.sh
+[ "$(add 2 2)" = "4" ] && exit 0          # unmutated: green on every run
+n=$(cat "$FLAKY_COUNTER" 2>/dev/null || echo 0); n=$(( n + 1 )); printf '%s' "$n" > "$FLAKY_COUNTER"
+[ "$n" -ge 2 ] && exit 1 || exit 0        # mutated: green once, then red
+FLAKY
+git -C "$FREPO" add -A && git -C "$FREPO" -c user.name=t -c user.email=t@t commit -q -m flaky
+MUT="sed -i.bak 's/+/-/' lib.sh && rm -f lib.sh.bak"
+
+echo "[11] a flaky test defeats the single-attempt control (documents the gap)"
+: > "$FLAKY_COUNTER"
+OUT="$(bash "$NC" "$FREPO" "bash flaky.sh" "$MUT" 2>&1)"; RC=$?
+if [ "$RC" -ne 0 ] && grep -q 'Verdict: FAIL: test stayed green under the mutation (the check is vacuous)$' <<<"$OUT" && clean "$FREPO"; then
+  ok "one attempt calls a real mutation vacuous, and the default wording is unchanged"
+else no "rc=$RC out=$OUT"; fi
+
+echo "[12] NEGCTL_RED_ATTEMPTS=3 catches the same real mutation"
+: > "$FLAKY_COUNTER"
+OUT="$(NEGCTL_RED_ATTEMPTS=3 bash "$NC" "$FREPO" "bash flaky.sh" "$MUT" 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && grep -q '^Verdict: PASS$' <<<"$OUT" && grep -q 'attempt 2 of 3' <<<"$OUT" && clean "$FREPO"; then
+  ok "retry reaches RED and names which attempt bit"
+else no "rc=$RC out=$OUT"; fi
+
+echo "[13] retries never manufacture RED: a vacuous mutation stays FAIL at 5 attempts"
+OUT="$(NEGCTL_RED_ATTEMPTS=5 bash "$NC" "$REPO" "bash test.sh" "printf '\n# comment\n' >> lib.sh" 2>&1)"; RC=$?
+if [ "$RC" -ne 0 ] && grep -q 'on all 5 attempts' <<<"$OUT" && clean "$REPO"; then
+  ok "a genuinely vacuous mutation is still rejected"
+else no "rc=$RC out=$OUT"; fi
+
+echo "[14] the default run is byte-identical: no attempt wording at all"
+OUT="$(bash "$NC" "$REPO" "bash test.sh" "$MUT" 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && grep -q '^Exit: [1-9][0-9]* (under mutation, RED expected)$' <<<"$OUT" && ! grep -qi 'attempt' <<<"$OUT"; then
+  ok "unset NEGCTL_RED_ATTEMPTS prints the original lines"
+else no "rc=$RC out=$OUT"; fi
+
+echo "[15] a non-numeric or zero NEGCTL_RED_ATTEMPTS is REJECTED, never coerced to 1"
+OUT="$(NEGCTL_RED_ATTEMPTS=two bash "$NC" "$REPO" "bash test.sh" "$MUT" 2>&1)"; RC=$?
+OUT0="$(NEGCTL_RED_ATTEMPTS=0 bash "$NC" "$REPO" "bash test.sh" "$MUT" 2>&1)"; RC0=$?
+if [ "$RC" -eq 64 ] && grep -q 'NEGCTL_RED_ATTEMPTS' <<<"$OUT" && [ "$RC0" -eq 64 ] && grep -q 'NEGCTL_RED_ATTEMPTS' <<<"$OUT0"; then
+  ok "both bad values exit 64 naming the variable"
+else no "rc=$RC rc0=$RC0 out=$OUT out0=$OUT0"; fi
+
 if [ "$fail" -gt 0 ]; then echo "test-proof-negctl: $pass passed, $fail FAILED" >&2; exit 1; fi
 echo "test-proof-negctl: all $pass passed"


### PR DESCRIPTION
## What

`lib/gate/negctl.sh` ran the RED step once and treated `run_test` as deterministic. A flaky suite could come back green under a REAL mutation, and negctl recorded `test stayed green under the mutation (the check is vacuous)` when the mutation was real.

That cost a real diagnosis on 2026-09-11: a wavefront negative control passed at 1-minute load 11.4 and looked like it refuted a correct fix. Re-run under matched load it failed 3 of 3.

`NEGCTL_RED_ATTEMPTS=<n>` (default 1) retries ONLY the RED step and takes the first non-zero as RED.

## Three properties that keep the gate as strict as before

- **Cannot manufacture red.** A genuinely vacuous mutation stays green on every attempt and still FAILs, pinned at 5 attempts.
- **Default path byte-identical**, including the single-attempt wording, which two dated proof records quote verbatim.
- **A bad value is rejected, never coerced to 1.** Silently becoming 1 would read as a clean single-attempt run and hide that the operator asked for more.

## Proof

`docs/verification/negctl-red-attempts.md`. 16/16 green. Negative control reverts ONLY the implementation and keeps the new cases: 13 passed, 3 FAILED, exactly the three asserting new behaviour. Cases [11] and [14] pass against BOTH implementations, which is what proves the default is unchanged rather than merely asserted.

The fixture is deterministic, not flaky: green on the first red-step run, red from the second. Its counter lives outside the repo, because negctl treats an untracked leftover as a FAIL and an in-tree counter would trip that check instead of the one under test.

## Deliberately not included

Load induction. Holding machine load from a proof tool is hostile on a shared box, so that half stays in `docs/verification/wavefront-startup-windows-negctl.sh`, which induces load around negctl rather than inside it.

## Scope

Added to the existing `tests/test-proof-negctl.sh` rather than a new suite, so `docs/FEATURES.md` stays fresh and SPEC-219's pin is untouched. `proof-ledger.sh`'s `negctl` forwarder needed no change; case [2] still covers it.

## Found while verifying this (not fixed here)

`tests/run-all.sh` caps each suite at `RUN_ALL_TIMEOUT_SECS` (default 300) and reports a timeout as a failure. `test-meta` takes 142s on this Mac at 1-minute load ~9, and the first full run of this branch reported `FAILED -> test-meta` while the machine sat at load 26-55. Re-run at a raised cap on a quieter machine, `test-meta` passes; standalone it passes 851/851 even with a dirty tree.

So that failure was the cap, not an assertion. It is the same shape as the wavefront windows fixed earlier today: a fixed timeout that has to exceed an unbounded quantity. Worth a row on its own; not folded in here because this PR is about negctl.

Also worth knowing for the next person: `run-all.sh:49` already distinguishes `TIMEOUT (300s)` from `FAIL (rc=N)` per suite, but that line is easy to lose. Piping run-all through `tail` truncates exactly the evidence needed to tell them apart, which cost a re-run here.

## Dropped from this batch

A second candidate (a content-diff proof on `wrap scan`'s squash verdict) was investigated and dropped: `_squash_verdict` already requires `headRefOid == local tip`, `apply` names both SHAs on mismatch, and `tests/test-wrap.sh` stubs both cases. The filed premise was a misreading, and building on it would have added a redundant sibling.
