### PR TITLE
fix(run-all): report a timeout as its own fact, not a failed suite

### DIFF
--- a/docs/verification/run-all-timeout-vs-fail.md
+++ b/docs/verification/run-all-timeout-vs-fail.md
@@ -1,0 +1,70 @@
+# Verification: run-all reports a timeout as its own fact
+
+`tests/run-all.sh` accumulated timeouts and red assertions into one `failed` list, so the summary printed `run-all: FAILED -> <suite>` for both. They are different facts: a per-suite ceiling hit under load is not a broken suite.
+
+Line 49 already printed `TIMEOUT (300s)` vs `FAIL (rc=N)` per suite, so the information existed. It was the SUMMARY that flattened it, and the summary is what a reader keeps.
+
+## The incident this came from
+
+On 2026-09-12 a full run of the negctl branch printed `run-all: FAILED -> test-meta`. `test-meta` takes 142s on that Mac at 1-minute load ~9; the machine was at 26-55 and the cap is 300s. The suite was green: standalone it passed 851/851 (even with a dirty tree), and a re-run at a raised cap passed 137/137. Two full re-runs went into establishing that, because the summary said only "FAILED".
+
+## Change
+
+- Timeouts accumulate in their own list and get their own summary line, naming `RUN_ALL_TIMEOUT_SECS`.
+- A killed suite now says it ran out of time. Previously the FAIL grep ran against a killed suite's log, found no assertion, and printed nothing, which reads as "failed for no reason".
+- Both still exit 1. A timeout is still worth surfacing; it is just not the same claim as a red assertion.
+- **The default ceiling is unchanged at 300s.** Raising it would weaken the hang guard CI needs, and picking a new constant is the same trap as the one fixed elsewhere this session (a fixed timeout bounding an unbounded quantity). The fix is to say which of the two happened, not to move the number.
+
+## Green run
+
+```
+Command: bash tests/test-run-all-timeout.sh
+[1] a suite over the ceiling is TIMED OUT, never folded into FAILED
+  ok: timeout named on its own line, no FAILED line
+[2] the timeout line says what to do instead of treating it as broken
+  ok: hint names the knob and the distinction
+[3] a killed suite says it ran out of time rather than showing no assertion
+  ok: the empty-FAIL-grep confusion is named
+[4] a genuinely red suite is still FAILED, never TIMED OUT
+  ok: a real failure is untouched by this change
+[5] both at once are reported as two separate facts
+  ok: one line each, neither swallows the other
+[6] the all-green summary is unchanged (no new line on the happy path)
+  ok: green path byte-identical
+test-run-all-timeout: all 6 passed
+Exit: 0
+Verdict: PASS
+```
+
+Each case builds a throwaway kit-shaped dir holding the REAL `tests/run-all.sh` plus fixture suites, so nothing touches the repo's own `tests/`. The suite carries `# requires: timeout`, so on a runner without the binary run-all skips it rather than hanging on the `sleep 30` fixture.
+
+## Negative control
+
+Revert ONLY `tests/run-all.sh` and keep the new cases.
+
+```
+Command: git checkout HEAD~1 -- tests/run-all.sh && bash tests/test-run-all-timeout.sh; git checkout HEAD -- tests/run-all.sh
+timedout accumulator present: 0
+[3] FAIL: out=test-slowpoke   TIMEOUT (1s) ... run-all: FAILED -> test-slowpoke
+[4] ok: a real failure is untouched by this change
+[5] FAIL: run-all: FAILED -> test-redherring test-slowpoke
+[6] ok: green path byte-identical
+test-run-all-timeout: 2 passed, 4 FAILED
+restored: 0 dirty
+Verdict: RED as expected, then restored clean
+```
+
+The control's own output is the defect, stated by the old code: `run-all: FAILED -> test-redherring test-slowpoke` puts a genuinely red suite and a timed-out one on one line with no way to tell them apart.
+
+Cases [4] and [6] pass against BOTH implementations. That is what shows a real failure and the green path are untouched, rather than merely asserted to be.
+
+## Reproduce
+
+```bash
+bash tests/test-run-all-timeout.sh
+RUN_ALL_TIMEOUT_SECS=1 bash tests/run-all.sh --only <a slow suite>
+```
+
+## Scope
+
+`docs/FEATURES.md` stayed fresh: this suite tests `run-all.sh` itself rather than a `/kit:` command, so no registry row's test count moved and SPEC-219's pin is untouched. Verified by regenerating and diffing.

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -19,7 +19,11 @@ ONLY=""
 TIMEOUT_SECS="${RUN_ALL_TIMEOUT_SECS:-300}"
 _timeout() { if command -v timeout >/dev/null 2>&1; then timeout "$@"; else shift; "$@"; fi; }
 
+# A timeout and a red assertion are DIFFERENT facts and are accumulated separately. Both
+# still exit 1, but a ceiling hit under load is not a broken suite, and flattening the two
+# into one "FAILED ->" line cost two full re-runs to tell apart on 2026-09-12.
 failed=""
+timedout=""
 count=0
 skipped=0
 for t in tests/test-*.sh; do
@@ -46,7 +50,17 @@ for t in tests/test-*.sh; do
     echo "ok"
   else
     rc=$?
-    [ "$rc" -eq 124 ] && echo "TIMEOUT (${TIMEOUT_SECS}s)" || echo "FAIL (rc=$rc)"
+    if [ "$rc" -eq 124 ]; then
+      echo "TIMEOUT (${TIMEOUT_SECS}s)"
+      timedout="$timedout $name"
+      # A killed suite printed no assertion, so the FAIL grep below would show nothing and
+      # read as "failed for no reason". Say what actually happened and skip it.
+      echo "      ! killed at ${TIMEOUT_SECS}s; no assertion failed, the suite ran out of time"
+      sed 's/^/      | /' /tmp/run-all-$$.log | tail -8
+      rm -f /tmp/run-all-$$.log
+      continue
+    fi
+    echo "FAIL (rc=$rc)"
     failed="$failed $name"
     # Show the FAILING lines, then a short tail for context. A plain tail hid the real
     # assertion in a suite with 840 of them: the failure was 700 lines above the summary.
@@ -64,8 +78,12 @@ for t in tests/test-*.sh; do
 done
 
 echo ""
-if [ -n "$failed" ]; then
-  echo "run-all: FAILED ->$failed"
+if [ -n "$failed" ] || [ -n "$timedout" ]; then
+  [ -n "$failed" ] && echo "run-all: FAILED ->$failed"
+  if [ -n "$timedout" ]; then
+    echo "run-all: TIMED OUT at ${TIMEOUT_SECS}s ->$timedout"
+    echo "run-all: a timeout is this runner's ceiling, NOT an assertion failure; re-run the suite alone, or with RUN_ALL_TIMEOUT_SECS=<n>, before treating it as broken"
+  fi
   echo "run-all: $count suites run${skipped:+, $skipped skipped for missing tooling}"
   exit 1
 fi

--- a/tests/test-run-all-timeout.sh
+++ b/tests/test-run-all-timeout.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# requires: timeout
+# run-all.sh must report a per-suite TIMEOUT as a DIFFERENT fact from a red assertion.
+#
+# Both still exit 1, but they mean different things: a ceiling hit under load is not a broken
+# suite. Before this, both landed in one `run-all: FAILED ->` line, and on 2026-09-12 a green
+# test-meta (142s at low load, over the 300s cap at load 26-55) read as broken and cost two
+# full re-runs to tell apart.
+#
+# Each case builds a throwaway kit dir (tests/run-all.sh plus fixture suites) and runs the
+# REAL script against it, so nothing here touches the repo's own tests/.
+set -uo pipefail
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RA="$DIR/tests/run-all.sh"
+pass=0; fail=0
+ok(){ echo "  ok: $*"; pass=$((pass+1)); }
+no(){ echo "  FAIL: $*" >&2; fail=$((fail+1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkkit() {  # $1 = dir ; a kit-shaped tree holding the real run-all.sh
+  mkdir -p "$1/tests"
+  cp "$RA" "$1/tests/run-all.sh"
+}
+slow() { printf '#!/usr/bin/env bash\nsleep 30\n' > "$1/tests/test-slowpoke.sh"; }
+red()  { printf '#!/usr/bin/env bash\necho "FAIL: a real assertion"\nexit 1\n' > "$1/tests/test-redherring.sh"; }
+green(){ printf '#!/usr/bin/env bash\nexit 0\n' > "$1/tests/test-allgood.sh"; }
+
+echo "[1] a suite over the ceiling is TIMED OUT, never folded into FAILED"
+K="$TMP/k1"; mkkit "$K"; slow "$K"
+OUT="$(RUN_ALL_TIMEOUT_SECS=1 bash "$K/tests/run-all.sh" --only slowpoke 2>&1)"; RC=$?
+if [ "$RC" -eq 1 ] \
+   && grep -q 'TIMEOUT (1s)' <<<"$OUT" \
+   && grep -q '^run-all: TIMED OUT at 1s ->.*test-slowpoke' <<<"$OUT" \
+   && ! grep -q '^run-all: FAILED ->' <<<"$OUT"; then
+  ok "timeout named on its own line, no FAILED line"
+else no "rc=$RC out=$OUT"; fi
+
+echo "[2] the timeout line says what to do instead of treating it as broken"
+if grep -qi 'NOT an assertion failure' <<<"$OUT" && grep -q 'RUN_ALL_TIMEOUT_SECS' <<<"$OUT"; then
+  ok "hint names the knob and the distinction"
+else no "no actionable hint: $OUT"; fi
+
+echo "[3] a killed suite says it ran out of time rather than showing no assertion"
+if grep -q 'killed at 1s; no assertion failed' <<<"$OUT"; then
+  ok "the empty-FAIL-grep confusion is named"
+else no "out=$OUT"; fi
+
+echo "[4] a genuinely red suite is still FAILED, never TIMED OUT"
+K2="$TMP/k2"; mkkit "$K2"; red "$K2"
+OUT2="$(RUN_ALL_TIMEOUT_SECS=60 bash "$K2/tests/run-all.sh" --only redherring 2>&1)"; RC2=$?
+if [ "$RC2" -eq 1 ] \
+   && grep -q '^run-all: FAILED ->.*test-redherring' <<<"$OUT2" \
+   && ! grep -q 'TIMED OUT' <<<"$OUT2"; then
+  ok "a real failure is untouched by this change"
+else no "rc=$RC2 out=$OUT2"; fi
+
+echo "[5] both at once are reported as two separate facts"
+K3="$TMP/k3"; mkkit "$K3"; slow "$K3"; red "$K3"
+OUT3="$(RUN_ALL_TIMEOUT_SECS=1 bash "$K3/tests/run-all.sh" 2>&1)"; RC3=$?
+if [ "$RC3" -eq 1 ] \
+   && grep -q '^run-all: FAILED ->.*test-redherring' <<<"$OUT3" \
+   && grep -q '^run-all: TIMED OUT at 1s ->.*test-slowpoke' <<<"$OUT3"; then
+  ok "one line each, neither swallows the other"
+else no "rc=$RC3 out=$OUT3"; fi
+
+echo "[6] the all-green summary is unchanged (no new line on the happy path)"
+K4="$TMP/k4"; mkkit "$K4"; green "$K4"
+OUT4="$(bash "$K4/tests/run-all.sh" --only allgood 2>&1)"; RC4=$?
+if [ "$RC4" -eq 0 ] \
+   && grep -q '^run-all: all 1 suites passed' <<<"$OUT4" \
+   && ! grep -qi 'TIMED OUT\|FAILED' <<<"$OUT4"; then
+  ok "green path byte-identical"
+else no "rc=$RC4 out=$OUT4"; fi
+
+if [ "$fail" -gt 0 ]; then echo "test-run-all-timeout: $pass passed, $fail FAILED" >&2; exit 1; fi
+echo "test-run-all-timeout: all $pass passed"


### PR DESCRIPTION
## What

`tests/run-all.sh` accumulated timeouts and red assertions into ONE `failed` list, so the summary printed `run-all: FAILED -> <suite>` for both. A per-suite ceiling hit under load is not a broken suite.

Line 49 already printed `TIMEOUT (300s)` vs `FAIL (rc=N)` per suite, so the information existed. The SUMMARY flattened it, and the summary is what a reader keeps.

## Why now

On 2026-09-12 a full run printed `run-all: FAILED -> test-meta`. `test-meta` takes 142s on that Mac at 1-minute load ~9; the machine was at 26-55 against a 300s cap. The suite was green the whole time: standalone 851/851 even with a dirty tree, and 137/137 at a raised cap. Two full re-runs went into establishing that.

## Change

- Timeouts accumulate separately and get their own summary line naming `RUN_ALL_TIMEOUT_SECS`.
- A killed suite says it ran out of time. Before, the FAIL grep ran against a killed suite's log, found nothing, and printed nothing, which reads as "failed for no reason".
- Both still exit 1. A timeout is still worth surfacing, it is just not the same claim.
- **The 300s default is unchanged on purpose.** Raising it weakens the hang guard CI needs, and picking a new constant repeats the trap this session already fixed twice (a fixed timeout bounding an unbounded quantity). The fix is saying WHICH happened, not moving the number.

## Proof

`docs/verification/run-all-timeout-vs-fail.md`, with a new suite `tests/test-run-all-timeout.sh` (nothing covered run-all's own behaviour before).

- Green: 6/6.
- Negative control: revert ONLY `run-all.sh`, keep the cases: 2 passed, 4 FAILED. Its output is the defect quoted by the old code, `run-all: FAILED -> test-redherring test-slowpoke`, one line for a red suite and a timed-out one.
- Cases [4] and [6] pass against BOTH implementations, which is what shows a real failure and the green path are untouched rather than asserted to be.

Each case builds a throwaway kit-shaped dir holding the real `run-all.sh` plus fixtures, so the repo's own `tests/` is never touched. The suite carries `# requires: timeout` so a runner without the binary skips it instead of hanging on the `sleep 30` fixture.

## Scope

`docs/FEATURES.md` stayed fresh, verified by regenerate-and-diff: this suite tests `run-all.sh` itself rather than a `/kit:` command, so no registry row's test count moved and SPEC-219's pin is untouched.
